### PR TITLE
Implement copy/paste

### DIFF
--- a/src/framework/Elsa.Studio.Core/Contracts/IActivityIdGenerator.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IActivityIdGenerator.cs
@@ -1,6 +1,0 @@
-namespace Elsa.Studio.Contracts;
-
-public interface IActivityIdGenerator
-{
-    string GenerateId();
-}

--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,6 @@ public static class ServiceCollectionExtensions
             .AddScoped<IModuleService, DefaultModuleService>()
             .AddScoped<IUIHintService, DefaultUIHintService>()
             .AddScoped<ISyntaxService, DefaultSyntaxService>()
-            .AddScoped<IActivityIdGenerator, ShortGuidActivityIdGenerator>()
             .AddScoped<IStartupTaskRunner, DefaultStartupTaskRunner>()
             .AddScoped<IServerInformationProvider, EmptyServerInformationProvider>()
             ;

--- a/src/framework/Elsa.Studio.Core/Services/ShortGuidActivityIdGenerator.cs
+++ b/src/framework/Elsa.Studio.Core/Services/ShortGuidActivityIdGenerator.cs
@@ -1,9 +1,0 @@
-using DEDrake;
-using Elsa.Studio.Contracts;
-
-namespace Elsa.Studio.Services;
-
-public class ShortGuidActivityIdGenerator : IActivityIdGenerator
-{
-    public string GenerateId() => ShortGuid.NewGuid().ToString();
-}

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/HttpEndpointPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/HttpEndpointPortProvider.cs
@@ -30,11 +30,11 @@ public class HttpEndpointPortProvider : ActivityPortProviderBase
         if (ExposeInvalidFileMimeTypeOutcome(context.Activity)) yield return CreatePort(InvalidMimeType);
         yield return CreatePort(Done);
     }
-    
-    private bool ExposeFileTooLargeOutcome(JsonObject @case) => @case.GetProperty("exposeFileTooLargeOutcome")!.GetValue<bool>();
-    private bool ExposeRequestTooLargeOutcome(JsonObject @case) => @case.GetProperty("exposeRequestTooLargeOutcome")!.GetValue<bool>();
-    private bool ExposeInvalidFileExtensionOutcome(JsonObject @case) => @case.GetProperty("exposeInvalidFileExtensionOutcome")!.GetValue<bool>();
-    private bool ExposeInvalidFileMimeTypeOutcome(JsonObject @case) => @case.GetProperty("exposeInvalidFileMimeTypeOutcome")!.GetValue<bool>();
+
+    private bool ExposeFileTooLargeOutcome(JsonObject @case) => TryGetValue(@case, "exposeFileTooLargeOutcome", () => false);
+    private bool ExposeRequestTooLargeOutcome(JsonObject @case) => TryGetValue(@case, "exposeRequestTooLargeOutcome", () => false);
+    private bool ExposeInvalidFileExtensionOutcome(JsonObject @case) => TryGetValue(@case, "exposeInvalidFileExtensionOutcome", () => false);
+    private bool ExposeInvalidFileMimeTypeOutcome(JsonObject @case) => TryGetValue(@case, "exposeInvalidFileMimeTypeOutcome", () => false);
 
     private Port CreatePort(string name)
     {
@@ -46,4 +46,8 @@ public class HttpEndpointPortProvider : ActivityPortProviderBase
         };
     }
 
+    private static T TryGetValue<T>(JsonObject model, string propName, Func<T> defaultValue)
+    {
+        return model.TryGetPropertyValue(propName, out var node) ? node != null ? node.GetValue<T>() : defaultValue() : defaultValue();
+    }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityIdGenerator.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityIdGenerator.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Generates unique activity IDs.
+/// </summary>
+public interface IActivityIdGenerator
+{
+    /// <summary>
+    /// Generates a unique activity ID.
+    /// </summary>
+    string GenerateId();
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityNameGenerator.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityNameGenerator.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Generates unique activity names.
+/// </summary>
+public interface IActivityNameGenerator
+{
+    /// <summary>
+    /// Returns true if the specified name already exists in the container.
+    /// </summary>
+    bool GetNameExists(IEnumerable<JsonObject> activities, string name);
+    
+    /// <summary>
+    /// Generates a unique name for the specified activity descriptor.
+    /// </summary>
+    string GenerateNextName(IEnumerable<JsonObject> activities, ActivityDescriptor activityDescriptor);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityNameGenerator.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityNameGenerator.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <inheritdoc />
+public class DefaultActivityNameGenerator : IActivityNameGenerator
+{
+    /// <inheritdoc />
+    public bool GetNameExists(IEnumerable<JsonObject> activities, string name)
+    {
+        return activities.Any(x => x.GetName() == name);
+    }
+
+    /// <inheritdoc />
+    public string GenerateNextName(IEnumerable<JsonObject> activities, ActivityDescriptor activityDescriptor)
+    {
+        var max = 10000;
+        var enumerable = activities as JsonObject[] ?? activities.ToArray();
+        var count = GetNextNumber(enumerable, activityDescriptor);
+
+        while (count++ < max)
+        {
+            var nextName = $"{activityDescriptor.Name}{count}";
+            if (!GetNameExists(enumerable, nextName))
+                return nextName;
+        }
+
+        throw new Exception("Could not generate a unique name.");
+    }
+    
+    private static int GetNextNumber(IEnumerable<JsonObject> activities, ActivityDescriptor activityDescriptor)
+    {
+        return activities.Count(x => x.GetTypeName() == activityDescriptor.TypeName);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/ShortGuidActivityIdGenerator.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/ShortGuidActivityIdGenerator.cs
@@ -1,0 +1,13 @@
+using DEDrake;
+using Elsa.Studio.Workflows.Domain.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <summary>
+/// Generates unique activity IDs using <see cref="ShortGuid"/>.
+/// </summary>
+public class ShortGuidActivityIdGenerator : IActivityIdGenerator
+{
+    /// <inheritdoc />
+    public string GenerateId() => ShortGuid.NewGuid().ToString();
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ public static class ServiceCollectionExtensions
             .AddScoped<IActivityRegistryProvider, RemoteActivityRegistryProvider>()
             .AddScoped<IActivityExecutionService, RemoteActivityExecutionService>()
             .AddScoped<IActivityRegistry, DefaultActivityRegistry>()
+            .AddScoped<IActivityIdGenerator, ShortGuidActivityIdGenerator>()
+            .AddScoped<IActivityNameGenerator, DefaultActivityNameGenerator>()
             .AddScoped<IStorageDriverService, RemoteStorageDriverService>()
             .AddScoped<IServerInformationProvider, RemoteServerInformationProvider>()
             .AddScoped<IVariableTypeService, RemoteVariableTypeService>()

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
@@ -12,6 +12,7 @@
     "@antv/x6-plugin-transform": "^2.1.7",
     "@antv/x6-plugin-keyboard": "^2.2.1",
     "@antv/x6-plugin-clipboard": "^2.1.6",
+    "@antv/x6-plugin-history": "^2.2.3",
     "lodash.camelcase": "^4.3.0",
     "uuid": "^9.0.0"
   },

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
@@ -10,6 +10,7 @@ export async function addActivityNode(graphId: string, node: Node.Properties) {
 
     node.position = {x, y};
     node.size = {width: 200, height: 50};
+    node.id = node.id!;
 
     // Add the node to the graph.
     graph.addNode(node);

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -210,20 +210,20 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         graph.bindKey(['ctrl+v', 'meta+v'], () => {
             if (!graph.isClipboardEmpty()) {
                 const cells = graph.getCellsInClipboard();
-                
-                if(cells.length == 0)
+
+                if (cells.length == 0)
                     return;
-                
+
                 const activityCells = cells.filter(x => x.shape == 'elsa-activity');
                 const edgeCells: Edge[] = cells.filter(x => x.shape == 'elsa-edge');
-                
+
                 interop.raisePasteCellsRequested(activityCells, edgeCells);
             }
         });
     }
 
     graph.on('blank:click', async () => {
-        if(!!lastSelectedNode) {
+        if (!!lastSelectedNode) {
             lastSelectedNode.setProp('selected-port', null);
         }
         await interop.raiseCanvasSelected();
@@ -278,19 +278,19 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                 continue;
 
             // Mark the node as unselected.
-            if(graph.isSelected(node)) {
+            if (graph.isSelected(node)) {
                 graph.unselect(node);
             }
 
             const embeddedPortName = embeddedPortElement.getAttribute('data-port-name');
             node.setProp('selected-port', embeddedPortName);
             lastSelectedNode = node;
-            
+
             await interop.raiseActivityEmbeddedPortSelected(activity, embeddedPortName);
             return;
         }
 
-        if(!graph.isSelected(node)) {
+        if (!graph.isSelected(node)) {
             silent = true;
             graph.select(node);
             silent = false;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -1,4 +1,4 @@
-import {Graph, Shape, Node} from '@antv/x6';
+import {Graph, Shape, Node, Edge} from '@antv/x6';
 import {Selection} from "@antv/x6-plugin-selection";
 import {Snapline} from "@antv/x6-plugin-snapline";
 import {Transform} from "@antv/x6-plugin-transform";
@@ -7,8 +7,7 @@ import {Clipboard} from '@antv/x6-plugin-clipboard'
 import camelCase from 'lodash.camelcase';
 import {DotNetComponentRef, graphBindings} from "./graph-bindings";
 import {DotNetFlowchartDesigner} from "./dotnet-flowchart-designer";
-import {Activity} from "../models";
-import {updateActivity} from "./update-activity";
+import {Activity, Connection} from "../models";
 
 export async function createGraph(containerId: string, componentRef: DotNetComponentRef, readOnly: boolean): Promise<string> {
     const containerElement = document.getElementById(containerId);
@@ -210,11 +209,16 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         // Paste the cells in the clipboard onto the graph.
         graph.bindKey(['ctrl+v', 'meta+v'], () => {
             if (!graph.isClipboardEmpty()) {
-                const cells = graph.paste({offset: 32})
-                graph.cleanSelection()
-                graph.select(cells)
+                const cells = graph.getCellsInClipboard();
+                
+                if(cells.length == 0)
+                    return;
+                
+                const activityCells = cells.filter(x => x.shape == 'elsa-activity');
+                const edgeCells: Edge[] = cells.filter(x => x.shape == 'elsa-edge');
+                
+                interop.raisePasteCellsRequested(activityCells, edgeCells);
             }
-            return false
         });
     }
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dotnet-flowchart-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dotnet-flowchart-designer.ts
@@ -35,7 +35,7 @@ export class DotNetFlowchartDesigner {
     }
 
     /// <summary>
-    /// Raises the <see cref="GraphUpdated"/> event.
+    /// Raises the <see cref="PasteCellsRequested"/> event.
     /// </summary>
     async raisePasteCellsRequested(activityCells: any[], edgeCells: any[]) : Promise<void> {
         await this.componentRef.invokeMethodAsync('HandlePasteCellsRequested', activityCells, edgeCells);

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dotnet-flowchart-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dotnet-flowchart-designer.ts
@@ -1,3 +1,4 @@
+import {Graph, Shape, Node} from '@antv/x6';
 import {DotNetComponentRef} from "./graph-bindings";
 import {Activity} from "../models";
 
@@ -31,5 +32,12 @@ export class DotNetFlowchartDesigner {
     /// </summary>
     async raiseGraphUpdated() : Promise<void> {
         await this.componentRef.invokeMethodAsync('HandleGraphUpdated');
+    }
+
+    /// <summary>
+    /// Raises the <see cref="GraphUpdated"/> event.
+    /// </summary>
+    async raisePasteCellsRequested(activityCells: any[], edgeCells: any[]) : Promise<void> {
+        await this.componentRef.invokeMethodAsync('HandlePasteCellsRequested', activityCells, edgeCells);
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
@@ -5,6 +5,7 @@ export * from './create-graph';
 export * from './dispose-graph';
 export * from './graph-bindings';
 export * from './load-graph';
+export * from './paste-cells';
 export * from './read-graph';
 export * from './raise-activity-selected';
 export * from './raise-activity-embedded-port-selected';

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/paste-cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/paste-cells.ts
@@ -1,0 +1,21 @@
+import {Cell, Node, Edge} from "@antv/x6";
+import {graphBindings} from "./graph-bindings";
+
+export async function pasteCells(graphId: string, nodeProps: Node.Properties[], edgeProps: Edge.Properties[]) {
+    // Get graph reference.
+    const {graph} = graphBindings[graphId];
+
+    // Create nodes and edges from node props and edge props.
+    const nodes = nodeProps.map(x => graph.createNode(x));
+    const edges = edgeProps.map(x => graph.createEdge(x));
+
+    // Add the nodes and edges to the graph.
+    graph.addCell(nodes);
+    graph.addCell(edges);
+
+    // Wait for the new cells to be rendered.
+    requestAnimationFrame(() => {
+        graph.cleanSelection();
+        graph.select([...nodes, ...edges]);
+    });
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/models/activity.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/models/activity.ts
@@ -1,10 +1,10 @@
-import {ActivityDisplayTextMetadata} from "./metadata";
+import {ActivityDesignerMetadata, ActivityDisplayTextMetadata} from "./metadata";
 
 export interface Activity {
     id: string;
     type: string;
     version: number;
-    metadata: any | ActivityDisplayTextMetadata;
+    metadata: any | ActivityDisplayTextMetadata | ActivityDesignerMetadata;
     canStartWorkflow?: boolean;
     runAsynchronously?: boolean;
     customProperties?: any;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/models/metadata.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/models/metadata.ts
@@ -1,3 +1,12 @@
 export interface ActivityDisplayTextMetadata {
     displayText?: string;
 }
+
+export interface ActivityDesignerMetadata {
+    designer: {
+        position: {
+            x: number;
+            y: number;
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -327,6 +327,10 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     {
         var activities = container.GetActivities().ToList();
         var activityLookup = new Dictionary<string, JsonObject>();
+        var newContainerId = ActivityIdGenerator.GenerateId();
+        
+        // Update the container ID.
+        container.SetId(newContainerId);
 
         foreach (var activity in activities)
         {
@@ -338,7 +342,7 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
             // Capture the original activity ID so we can update the edges.
             activityLookup[activity.GetId()] = activity;
 
-            // Update the activity ID and name.
+            // Update the activity ID.
             activity.SetId(newActivityId);
 
             // If the activity contains embedded ports, generate new IDs for the contained flowchart.

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
@@ -34,7 +34,6 @@ internal class DesignerJsInterop : JsInteropBase
             await module.InvokeAsync<string>("createGraph", containerId, componentRef, isReadOnly);
             return new X6GraphApi(module, _serviceProvider, containerId);
         });
-        
     }
 
     public async Task UpdateActivitySizeAsync(string elementId, JsonObject activity, Size? size = default) =>


### PR DESCRIPTION
### === auto-pr-body ===

 
Summary: 
This pull request removes duplicate files for Activity ID Generator and adds new files for Activity ID and Name Generators. It also refactors certain methods to introduce default values with TryGetValue(), adds node ID's in `addActivityNode` function, enables history plugin in `createGraph`, adds logic to `addActivityNode` to introduce a null-coalescing operator and logging in other functions for debugging, and adds key bindings for copy, cut, paste, undo and redo, delete, select all, and zooming. Refactoring suggestions are also provided.

List of Changes:
- Removed File Elsa.Studio.Core/Contracts/IActivityIdGenerator.cs
- Modified existing ServiceCollectionExtensions.cs to remove IActivityIdGenarator
- Removed File Elsa.Studio.Core/Services/ShortGuidActivityIdGenerator.cs
- Modified Method parameters in HttpEndpointPortProvider.cs to add default values with TryGetValue()
- Added Newfile Domain/Contracts/IActivityIdGenerator.cs 
- Added Newfile Domain/Contracts/IActivityNameGenerator.cs 
- Added Newfile Domain/Services/DefaultActivityNameGenerator.cs 
- Added a handler to blocking commands with `key == 'tools'` to `beforeAddCommand`
- Added key bindings for copy, cut, paste, undo and redo, delete, select all, and zooming
- Added logic to change edge color when connected to a magnet
- Added logic to delete a node when clicking delete key and also move it to the front to help when user clicks on a node behind another node
- Added logic to select an activity and its embedded port on click

Refactoring Target: 
- Refactor HttpEndpointPortProvider.cs inline TryGetValue to return the value of the property when present, and the provided default value when not.
- In DefaultActivityNameGenerator.cs, refactor the TryGetValue() method to also check the activityDescriptor instead of just the Activity JsonObject.
- Change event handling from `key == 'tools'` to an enum that allows for more flexibility
- Refactor the keybindings to use keymaps to serve better readability and flexibility, instead of a large list of individually named bindings. 
- Move the code responsible for raising C# events to an object orientated utility class to improve readability. 
- Change variables with unclear or short names such as "e" to a longer descriptive name for maintainability and readability.