### PR TITLE
Change modifiers for Panning / Zooming / Selection

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -75,12 +75,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         width: 1000,
         panning: {
             enabled: true,
-            modifiers: ['ctrl', 'meta'],
         },
         mousewheel: {
             enabled: true,
             factor: 1.05,
-            modifiers: ['ctrl', 'meta'],
             minScale: 0.4,
             maxScale: 3,
         },
@@ -171,6 +169,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         new Selection({
             enabled: true,
             multiple: !readOnly,
+            modifiers: ['ctrl', 'shift'],
             rubberEdge: false,
             rubberNode: true,
             rubberband: true,


### PR DESCRIPTION
Attempt to change the defaults for panning / zooming / selection to address #49.

This is opinionated and users might have different preferences. For me it feels more natural this way.

### === auto-pr-body ===



Summary:
This pull request updates the selection modifier of the application to `ctrl`, `shift` and enables panning and mouse wheel with any modifier. 

List of Changes:
- Enabled panning with any modifier
- Enabled mouse wheel with any modifier
- Updated selection modifier to `ctrl`, `shift`

Refactoring Target: 
This pull request aims to refactor the code by grouping related modifiers together in one object and breaking out constants to indicate a clear meaning and improve readability of the code.