### PR TITLE
Make MenuItem.Href and NavigationManager.NavigateTo urls relative

### DIFF
--- a/src/modules/Elsa.Studio.Counter/Menu/CounterMenu.cs
+++ b/src/modules/Elsa.Studio.Counter/Menu/CounterMenu.cs
@@ -13,19 +13,19 @@ public class CounterMenu : IMenuProvider
             new()
             {
                 Icon = Icons.Material.Filled.Add,
-                Href = "/counter",
+                Href = "counter",
                 Text = "Counter",
                 GroupName = MenuItemGroups.General.Name,
                 SubMenuItems = new List<MenuItem>
                 {
                     new()
                     {
-                        Href = "/counter",
+                        Href = "counter",
                         Text = "Sub menu item 1",
                     },
                     new()
                     {
-                        Href = "/counter2",
+                        Href = "counter2",
                         Text = "Sub menu item 2",
                     },
                 }

--- a/src/modules/Elsa.Studio.Dashboard/Menu/DashboardMenu.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Menu/DashboardMenu.cs
@@ -14,7 +14,7 @@ public class DashboardMenu : IMenuProvider
             new()
             {
                 Icon = Icons.Material.Outlined.SpaceDashboard,
-                Href = "/",
+                Href = "",
                 Text = "Dashboard",
                 GroupName = MenuItemGroups.General.Name,
                 Match = NavLinkMatch.All

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -33,7 +33,7 @@ public partial class Login
         }
 
         ((AccessTokenAuthenticationStateProvider)AuthenticationStateProvider).NotifyAuthenticationStateChanged();
-        NavigationManager.NavigateTo("/", true);
+        NavigationManager.NavigateTo("", true);
     }
 
     private async Task<bool> ValidateCredentials(string username, string password)

--- a/src/modules/Elsa.Studio.Secrets/Menu/SecretsMenu.cs
+++ b/src/modules/Elsa.Studio.Secrets/Menu/SecretsMenu.cs
@@ -13,7 +13,7 @@ public class SecretsMenu : IMenuProvider
             new()
             {
                 Icon = Icons.Material.Filled.Key,
-                Href = "/secrets",
+                Href = "secrets",
                 Text = "Secrets",
                 GroupName = MenuItemGroups.Settings.Name
             }

--- a/src/modules/Elsa.Studio.Security/Menu/SecurityMenu.cs
+++ b/src/modules/Elsa.Studio.Security/Menu/SecurityMenu.cs
@@ -13,7 +13,7 @@ public class SecurityMenu : IMenuProvider
             new()
             {
                 Icon = Icons.Material.Filled.Security,
-                Href = "/security/users",
+                Href = "security/users",
                 Text = "Security",
                 GroupName = MenuItemGroups.Settings.Name,
                 SubMenuItems =
@@ -21,13 +21,13 @@ public class SecurityMenu : IMenuProvider
                     new MenuItem
                     {
                         Text = "Users",
-                        Href = "/security/users",
+                        Href = "security/users",
                         Icon = Icons.Material.Filled.Person
                     },
                     new MenuItem
                     {
                         Text = "Roles",
-                        Href = "/security/roles",
+                        Href = "security/roles",
                         Icon = Icons.Material.Filled.PeopleOutline
                     }
                 }

--- a/src/modules/Elsa.Studio.Webhooks/Menu/WebhooksMenu.cs
+++ b/src/modules/Elsa.Studio.Webhooks/Menu/WebhooksMenu.cs
@@ -13,7 +13,7 @@ public class WebhooksMenu : IMenuProvider
             new()
             {
                 Icon = Icons.Material.Filled.Http,
-                Href = "/webhooks",
+                Href = "webhooks",
                 Text = "Webhooks",
                 GroupName = MenuItemGroups.Settings.Name
             }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -431,6 +431,6 @@ public partial class WorkflowEditor
 
         Snackbar.Add("Successfully started workflow", Severity.Success);
 
-        NavigationManager.NavigateTo($"/workflows/instances/{workflowInstanceId}/view");
+        NavigationManager.NavigateTo($"workflows/instances/{workflowInstanceId}/view");
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Menu/WorkflowsMenu.cs
+++ b/src/modules/Elsa.Studio.Workflows/Menu/WorkflowsMenu.cs
@@ -20,12 +20,12 @@ public class WorkflowsMenu : IMenuProvider
                     new MenuItem()
                     {
                         Text = "Definitions",
-                        Href = "/workflows/definitions"
+                        Href = "workflows/definitions"
                     },
                     new MenuItem()
                     {
                         Text = "Instances",
-                        Href = "/workflows/instances"
+                        Href = "workflows/instances"
                     },
                 }
             }

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
@@ -93,7 +93,7 @@ public partial class Index
 
     private void Edit(string definitionId)
     {
-        NavigationManager.NavigateTo($"/workflows/definitions/{definitionId}/edit");
+        NavigationManager.NavigateTo($"workflows/definitions/{definitionId}/edit");
     }
     
     private void Reload()

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/List/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/List/Index.razor.cs
@@ -108,7 +108,7 @@ public partial class Index
         };
     }
 
-    private void View(string instanceId) => NavigationManager.NavigateTo($"/workflows/instances/{instanceId}/view");
+    private void View(string instanceId) => NavigationManager.NavigateTo($"workflows/instances/{instanceId}/view");
     private void Reload() => _table.ReloadServerData();
 
     private Color GetSubStatusColor(WorkflowSubStatus subStatus)

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/View/Components/WorkflowInstanceViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/View/Components/WorkflowInstanceViewer.razor.cs
@@ -253,7 +253,7 @@ public partial class WorkflowInstanceViewer : IAsyncDisposable
 
     private Task OnEditClicked(string definitionId)
     {
-        NavigationManager.NavigateTo($"/workflows/definitions/{definitionId}/edit");
+        NavigationManager.NavigateTo($"workflows/definitions/{definitionId}/edit");
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
I was trying to host the Studio app on a sub-path using the guide from [Multiple hosted WebAssembly apps](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/multiple-hosted-webassembly?view=aspnetcore-7.0&pivots=route-subpath).

I got the application to run, but the `<base>`-tag wasn't taken into account for the navigation menu. According to that [comment](https://github.com/dotnet/aspnetcore/issues/16135#issuecomment-384223553), the leading slash in the URLs is causing it to resolve against the origin root rather than the base href.

After updating the Hrefs to not have leading slashes, things worked like expected. I couldn't find another solution, maybe there's a config for this as well, as the example uses a `basePath` in the `getClientConfig` - which isn't used anywhere in the Studio code as far as I could tell.