### PR TITLE
Enhancement/runtime options provider#51

### DIFF
--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\..\common.props"/>
-    <Import Project="..\..\..\configureawait.props"/>
+    <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
@@ -11,18 +11,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Blazored.FluentValidation" Version="2.1.0"/>
-        <PackageReference Include="CodeBeam.MudBlazor.Extensions" Version="6.6.0"/>
-        <PackageReference Include="FluentValidation" Version="11.7.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.12"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.CustomElements" Version="7.0.12"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.12"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.JSInterop" Version="7.0.12"/>
-        <PackageReference Include="MudBlazor" Version="6.11.0"/>
-        <PackageReference Include="Radzen.Blazor" Version="4.18.1"/>
-        <PackageReference Include="ShortGuid" Version="2.0.1"/>
-        <PackageReference Include="ThrottleDebounce" Version="2.0.0"/>
+        <PackageReference Include="Blazored.FluentValidation" Version="2.1.0" />
+        <PackageReference Include="CodeBeam.MudBlazor.Extensions" Version="6.6.0" />
+        <PackageReference Include="FluentValidation" Version="11.7.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.12" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.CustomElements" Version="7.0.12" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.12" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.JSInterop" Version="7.0.12" />
+        <PackageReference Include="MudBlazor" Version="6.11.0" />
+        <PackageReference Include="Radzen.Blazor" Version="4.18.1" />
+        <PackageReference Include="ShortGuid" Version="2.0.1" />
+        <PackageReference Include="ThrottleDebounce" Version="2.0.0" />
     </ItemGroup>
 
     <!--        <ItemGroup Label="Elsa">-->
@@ -30,7 +30,7 @@
     <!--        </ItemGroup>-->
 
     <ItemGroup Label="Elsa">
-        <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.824"/>
+        <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.827" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This first PR use the update of the Elsa.Api.Client to provide refresh of input options that use OptionsProvider using an API.

There is work to do for #67 in server side and Contract definition to get more informations about the input  like DependsOn etc... and fill the `Context` property with valuable data.

### === auto-pr-body ===



Summary: 
This Pull Request proposes several changes to improve the readability and maintainability of the code. The changes include: updating the version of the 'Elsa.Api.Client' package, adding the `RemoteBackendApiClientProvider` dependency, refresh the options for 'inputDescriptor', updating bullet points for each package to include a trailing slash, and creating a list of `ActivityInputDisplayModels` with modified `DisplayInputEditorContext`.

List of Changes:
- Added a private method `RefreshOptions` to populate options for an ActivityDescriptor's InputDescriptor
- Added a parameter to the `GetAsync` call in the `RefreshOptions` method
- Modified `ToWrappedInput` method to accept a new `ObjectConverterOptions` parameter
- Updated the version of the 'Elsa.Api.Client' package to '3.0.0-preview.827'
- Added `RemoteBackendApiClientProvider` dependency 
- Refreshed the options of the 'inputDescriptor' 
- Updated bullet points for each package to include a trailing slash
- Built and assigned a list of 'ActivityInputDisplayModels' with modified 'DisplayInputEditorContext'  

Refactoring Target:
- Separate the logic in the `RefreshOptions` method into its own unit of execution
- Consider using an existing `ObjectConverterOptions` type rather than creating a new one for the `ToWrappedInput` method