### PR TITLE
Bulk Export/Import of Workflow Definitions

### DIFF
--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -25,12 +25,12 @@
         <PackageReference Include="ThrottleDebounce" Version="2.0.0"/>
     </ItemGroup>
 
-<!--    <ItemGroup Label="Elsa">-->
-<!--        <ProjectReference Include="..\..\..\..\..\elsa-core\v3\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-<!--    </ItemGroup>-->
+    <ItemGroup Label="Elsa">
+        <ProjectReference Include="..\..\..\..\..\elsa-core\v3\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
+    </ItemGroup>
 
-        <ItemGroup Label="Elsa">
-            <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.840"/>
-        </ItemGroup>
+    <!--        <ItemGroup Label="Elsa">-->
+    <!--            <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.840"/>-->
+    <!--        </ItemGroup>-->
 
 </Project>

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -25,12 +25,12 @@
         <PackageReference Include="ThrottleDebounce" Version="2.0.0"/>
     </ItemGroup>
 
-    <ItemGroup Label="Elsa">
-        <ProjectReference Include="..\..\..\..\..\elsa-core\v3\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
-    </ItemGroup>
+    <!--    <ItemGroup Label="Elsa">-->
+    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\v3\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
+    <!--    </ItemGroup>-->
 
-    <!--        <ItemGroup Label="Elsa">-->
-    <!--            <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.843"/>-->
-    <!--        </ItemGroup>-->
+    <ItemGroup Label="Elsa">
+        <PackageReference Include="Elsa.Api.Client" Version="3.0.0-preview.845"/>
+    </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
@@ -103,6 +103,11 @@ public interface IWorkflowDefinitionService
     Task<WorkflowDefinition> ImportDefinitionAsync(WorkflowDefinitionModel definitionModel, CancellationToken cancellationToken = default);
     
     /// <summary>
+    /// Exports a set of workflow definitions.
+    /// </summary>
+    Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
+    
+    /// <summary>
     /// Updates the references of a workflow definition.
     /// </summary>
     Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
@@ -4,6 +4,7 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Domain.Models;
+using Refit;
 
 namespace Elsa.Studio.Workflows.Domain.Contracts;
 
@@ -121,4 +122,9 @@ public interface IWorkflowDefinitionService
     /// Executes a workflow definition.
     /// </summary>
     Task<string> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Imports a set of files containing workflow definitions.
+    /// </summary>
+    Task<int> ImportFilesAsync(IEnumerable<StreamPart> streamParts, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/FileDownload.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/FileDownload.cs
@@ -3,4 +3,4 @@ namespace Elsa.Studio.Workflows.Domain.Models;
 /// <summary>
 /// Represents a file download.
 /// </summary>
-public record FileDownload(string? FileName, Stream Content);
+public record FileDownload(string FileName, Stream Content);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
@@ -295,5 +295,13 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
         return workflowInstanceId;
     }
 
+    /// <inheritdoc />
+    public async Task<int> ImportFilesAsync(IEnumerable<StreamPart> streamParts, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        var response = await api.ImportFilesAsync(streamParts.ToList(), cancellationToken);
+        return response.Count;
+    }
+
     private async Task<IWorkflowDefinitionsApi> GetApiAsync(CancellationToken cancellationToken = default) => await _remoteBackendApiClientProvider.GetApiAsync<IWorkflowDefinitionsApi>(cancellationToken);
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -5,44 +5,44 @@
 
 <RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height));" Resize="@OnResize">
     <RadzenSplitterPane Size="70%">
-        <DiagramDesignerWrapper @ref="_diagramDesigner" Activity="WorkflowDefinition?.Root" IsProgressing="_isProgressing" ActivitySelected="OnActivitySelected" GraphUpdated="OnGraphUpdated">
+        <DiagramDesignerWrapper @ref="_diagramDesigner" Activity="WorkflowDefinition?.Root" IsProgressing="_isProgressing" ActivitySelected="@OnActivitySelected" GraphUpdated="@OnGraphUpdated">
             <CustomToolbarItems>
-                <MudSwitch T="bool?" Checked="@_autoSave" Color="Color.Primary" Label="Auto-save" LabelPosition="LabelPosition.Start" CheckedChanged="OnAutoSaveChanged"/>
+                <MudSwitch T="bool?" Checked="@_autoSave" Color="Color.Primary" Label="Auto-save" LabelPosition="LabelPosition.Start" CheckedChanged="@OnAutoSaveChanged"/>
                 <MudTooltip Text="Save" Delay="1000">
                     <MudBadge Color="@(_isDirty ? Color.Warning : Color.Success)" Dot="true" Overlap="true" Origin="Origin.BottomRight" Bordered="true" Class="elsa-toolbar-icon">
-                        <MudIconButton Icon="@Icons.Material.Outlined.Save" Title="Save" OnClick="OnSaveClick"/>
+                        <MudIconButton Icon="@Icons.Material.Outlined.Save" Title="Save" OnClick="@OnSaveClick"/>
                     </MudBadge>
                 </MudTooltip>
 
                 <div id="workflow-file-upload-button-wrapper" class="d-none">
-                    <MudFileUpload T="IBrowserFile" FilesChanged="OnFileSelected"/>
+                    <MudFileUpload T="IBrowserFile" FilesChanged="@OnFileSelected"/>
                 </div>
 
                 <MudTooltip Text="Publish the current workflow." Delay="1000">
                     <MudButtonGroup Color="Color.Default" Variant="Variant.Text" DisableElevation="true">
-                        <MudIconButton Icon="@Icons.Material.Filled.CloudUpload" Color="Color.Primary" Title="Publish" OnClick="OnPublishClicked"/>
+                        <MudIconButton Icon="@Icons.Material.Filled.CloudUpload" Color="Color.Primary" Title="Publish" OnClick="@OnPublishClicked"/>
                         <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown">
                             @if (WorkflowDefinition?.IsPublished == true)
                             {
                                 <MudTooltip Text="Unpublish the current workflow." Inline="false" Delay="1000">
-                                    <MudMenuItem Icon="@Icons.Material.Filled.CloudDownload" OnClick="OnRetractClicked">Unpublish</MudMenuItem>
+                                    <MudMenuItem Icon="@Icons.Material.Filled.CloudDownload" OnClick="@OnRetractClicked">Unpublish</MudMenuItem>
                                 </MudTooltip>
                                 <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                             }
                             <MudTooltip Text="Download the current workflow as a JSON file." Inline="false" Delay="1000">
-                                <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="OnDownloadClicked">Export</MudMenuItem>
+                                <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="@OnDownloadClicked">Export</MudMenuItem>
                             </MudTooltip>
                             <MudTooltip Text="Upload a JSON file containing workflow data to override the current workflow's contents." Inline="false" Delay="1000">
-                                <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="OnUploadClicked">Import</MudMenuItem>
+                                <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="@OnUploadClicked">Import</MudMenuItem>
                             </MudTooltip>
                         </MudMenu>
                     </MudButtonGroup>
                 </MudTooltip>
-                <MudIconButton Icon="@Icons.Material.Filled.PlayArrow" Color="Color.Success" Variant="Variant.Text" Title="Run workflow" Class="ml-4" OnClick="OnRunWorkflowClicked"/>
+                <MudIconButton Icon="@Icons.Material.Filled.PlayArrow" Color="Color.Success" Variant="Variant.Text" Title="Run workflow" Class="ml-4" OnClick="@OnRunWorkflowClicked"/>
             </CustomToolbarItems>
         </DiagramDesignerWrapper>
     </RadzenSplitterPane>
     <RadzenSplitterPane Size="30%" @ref="ActivityPropertiesPane">
-        <ActivityPropertiesPanel @ref="ActivityPropertiesPanel" WorkflowDefinition="@WorkflowDefinition" Activity="@SelectedActivity" ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnSelectedActivityUpdated" VisiblePaneHeight="@_activityPropertiesPaneHeight"/>
+        <ActivityPropertiesPanel @ref="ActivityPropertiesPanel" WorkflowDefinition="@WorkflowDefinition" Activity="@SelectedActivity" ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="@OnSelectedActivityUpdated" VisiblePaneHeight="@_activityPropertiesPaneHeight"/>
     </RadzenSplitterPane>
 </RadzenSplitter>

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
@@ -6,6 +6,10 @@
 
 <MudContainer MaxWidth="MaxWidth.False">
     <PageHeading Text="Workflow definitions"/>
+    
+    <div id="workflow-file-upload-button-wrapper" class="d-none">
+        <MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnFilesSelected"/>
+    </div>
 
     <MudTable
         @ref="_table"
@@ -27,7 +31,16 @@
                 <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem>
             </MudMenu>
             <MudSpacer/>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateWorkflowClicked">Create workflow</MudButton>
+            
+            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DisableElevation="false">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateWorkflowClicked">Create workflow</MudButton>
+                <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown">
+                    <MudTooltip Text="Upload JSON and/or ZIP files containing workflow data to import." Inline="false" Delay="1000">
+                        <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="@OnImportClicked">Import</MudMenuItem>
+                    </MudTooltip>
+                </MudMenu>
+            </MudButtonGroup>
+            
         </ToolBarContent>
         <HeaderContent>
             <MudTh>

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
@@ -21,9 +21,10 @@
         @bind-SelectedItems="_selectedRows">
         <ToolBarContent>
             <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="Bulk actions" Color="Color.Default" Variant="Variant.Filled">
-                <MudMenuItem OnClick="OnBulkDeleteClicked">Delete</MudMenuItem>
-                <MudMenuItem OnClick="OnBulkPublishClicked">Publish</MudMenuItem>
-                <MudMenuItem OnClick="OnBulkRetractClicked">Unpublish</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkDeleteClicked">Delete</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkPublishClicked">Publish</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkRetractClicked">Unpublish</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem>
             </MudMenu>
             <MudSpacer/>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateWorkflowClicked">Create workflow</MudButton>

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
@@ -53,7 +53,7 @@ public partial class Index
                     : publishedWorkflowDefinitions.Items.FirstOrDefault(x => x.DefinitionId == definition.DefinitionId);
                 var publishedVersionNumber = publishedVersion?.Version;
 
-                return new WorkflowDefinitionRow(definition.DefinitionId, latestVersionNumber, publishedVersionNumber, definition.Name, definition.Description, definition.IsPublished);
+                return new WorkflowDefinitionRow(definition.Id, definition.DefinitionId, latestVersionNumber, publishedVersionNumber, definition.Name, definition.Description, definition.IsPublished);
             })
             .ToList();
 
@@ -204,6 +204,14 @@ public partial class Index
 
         Reload();
     }
+    
+    private async Task OnBulkExportClicked()
+    {
+        var workflowVersionIds = _selectedRows.Select(x => x.Id).ToList();
+        var download = await WorkflowDefinitionService.BulkExportDefinitionsAsync(workflowVersionIds);
+        var fileName = download.FileName;
+        await Files.DownloadFileFromStreamAsync(fileName, download.Content);
+    }
 
     private void OnSearch(string text)
     {
@@ -223,5 +231,5 @@ public partial class Index
         Snackbar.Add("Workflow retracted", Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
     }
     
-    private record WorkflowDefinitionRow(string DefinitionId, int LatestVersion, int? PublishedVersion, string? Name, string? Description, bool IsPublished);
+    private record WorkflowDefinitionRow(string Id, string DefinitionId, int LatestVersion, int? PublishedVersion, string? Name, string? Description, bool IsPublished);
 }

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Api.Client.Converters;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.DomInterop.Contracts;
@@ -5,7 +9,9 @@ using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor;
+using Refit;
 
 namespace Elsa.Studio.Workflows.Pages.WorkflowDefinitions.List;
 
@@ -24,6 +30,7 @@ public partial class Index
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
     [Inject] private IFiles Files { get; set; } = default!;
+    [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
 
     private async Task<TableData<WorkflowDefinitionRow>> ServerReload(TableState state)
     {
@@ -95,7 +102,7 @@ public partial class Index
     {
         NavigationManager.NavigateTo($"workflows/definitions/{definitionId}/edit");
     }
-    
+
     private void Reload()
     {
         _table.ReloadServerData();
@@ -173,7 +180,7 @@ public partial class Index
 
         Reload();
     }
-    
+
     private async Task OnBulkRetractClicked()
     {
         var result = await DialogService.ShowMessageBox("Unpublish selected workflows?", "Are you sure you want to unpublish the selected workflows?", yesText: "Unpublish", cancelText: "Cancel");
@@ -204,13 +211,27 @@ public partial class Index
 
         Reload();
     }
-    
+
     private async Task OnBulkExportClicked()
     {
         var workflowVersionIds = _selectedRows.Select(x => x.Id).ToList();
         var download = await WorkflowDefinitionService.BulkExportDefinitionsAsync(workflowVersionIds);
         var fileName = download.FileName;
         await Files.DownloadFileFromStreamAsync(fileName, download.Content);
+    }
+
+    private Task OnImportClicked()
+    {
+        return DomAccessor.ClickElementAsync("#workflow-file-upload-button-wrapper input[type=file]");
+    }
+
+    private async Task OnFilesSelected(IReadOnlyList<IBrowserFile> files)
+    {
+        var streamParts = files.Select(x => new StreamPart(x.OpenReadStream(), x.Name, x.ContentType)).ToList();
+        var count = await WorkflowDefinitionService.ImportFilesAsync(streamParts);
+        var message = count == 1 ? "Successfully imported one workflow" : $"Successfully imported {count} workflows";
+        Snackbar.Add(message, Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
+        Reload();
     }
 
     private void OnSearch(string text)
@@ -230,6 +251,6 @@ public partial class Index
         await WorkflowDefinitionService.RetractAsync(definitionId);
         Snackbar.Add("Workflow retracted", Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
     }
-    
+
     private record WorkflowDefinitionRow(string Id, string DefinitionId, int LatestVersion, int? PublishedVersion, string? Name, string? Description, bool IsPublished);
 }


### PR DESCRIPTION
This PR updates the Workflow Definitions List view to add bulk export/import functionality.

### === auto-pr-body ===



Summary: This Pull Request introduces new functionality such as the ability to delete workflows, added new event handlers, adding parameters, and import new libraries. 

List of Changes:
- Changed event handler type for MudSwitch component from `CheckedChanged` to `@OnAutoSaveChanged`.
- Changed event handler type for MudFileUpload from `FilesChanged` to `@OnFileSelected`.
- Changed event handler type for MudIconButton inside MudButtonGroup from `OnClick` to `@OnPublishClicked`.
- Changed event handler type for MudIconButton inside MudButtonGroup from `OnClick` to `@OnRetractClicked`.
- Changed event handler type for MudMenuItem inside MudButtonGroup from `OnClick` to `@OnDownloadClicked`.
- Changed event handler type for MudMenuItem inside MudButtonGroup from `OnClick` to `@OnUploadClicked`.
- Changed event handler type for MudIconButton from `OnClick` to `@OnRunWorkflowClicked`.
- Changed event handler type for ActivityPropertiesPanel component from `OnActivityUpdated` to `@OnSelectedActivityUpdated`.
- Added `<MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnFilesSelected"/>` component.
- Added new `MudMenuItem` to enable users to delete workflows
- Added `OnBulkExportClicked` event handler
- Added `OnImportClicked` event handler
- Added `OnFilesSelected` event handler
- Added new `MudButton`Group containing both a Create Workflow button and an Import button 
- Updated `WorkflowDefinitionRow` to include a new `Id` parameter
- Imported new libraries, including `System.Text.Json`, `System.Text.Json.Serialization`, and `Refit` 

Refactoring Target:
- Replace usage of `OnClick` with `@onClick` for all components in the pull request diff for consistency. 
- Move the `<MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnFilesSelected"/>` component outside `Pages/WorkflowDefinitions/List/Index.razor` and add it to a separate shared partial or component. 
- Consider wrapping redundant code into objects and parameters in order to reduce code duplication.