### PR TITLE
Added tooltips to the workflow table cells that are too long

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowDefinitions/List/Index.razor
@@ -62,10 +62,22 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="ID">@context.DefinitionId</MudTd>
-            <MudTd DataLabel="Name" Style="text-overflow: ellipsis; overflow: hidden; max-width:200px; white-space: nowrap;">@context.Name</MudTd>
+            <MudTd DataLabel="Name">
+                <MudTooltip Text="@context.Name">
+                    <div style="text-overflow: ellipsis; overflow: hidden; max-width: 200px; white-space: nowrap;">
+                        @context.Name
+                    </div>
+                </MudTooltip>
+            </MudTd>
             <MudTd DataLabel="Latest version" Style="text-align:left">@context.LatestVersion</MudTd>
             <MudTd DataLabel="Published version" Style="text-align:left">@(context.PublishedVersion?.ToString() ?? "-")</MudTd>
-            <MudTd DataLabel="Description" Style="text-overflow: ellipsis; overflow: hidden; max-width:200px; white-space: nowrap;">@context.Description</MudTd>
+            <MudTd DataLabel="Description">
+                <MudTooltip Text="@context.Description">
+                    <div style="text-overflow: ellipsis; overflow: hidden; max-width: 200px; white-space: nowrap;">
+                        @context.Description
+                    </div>
+                </MudTooltip>
+            </MudTd>
             <MudTd DataLabel="" Style="text-align:right">
                 <MudMenu Icon="@Icons.Material.Filled.MoreVert">
                     <MudMenuItem Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => OnEditClicked(context.DefinitionId))">Edit</MudMenuItem>

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/List/Index.razor
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/List/Index.razor
@@ -13,7 +13,7 @@
     <div id="instance-file-upload-button-wrapper" class="d-none">
         <MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnFilesSelected"/>
     </div>
-    
+
     <MudTable
         @ref="_table"
         T="WorkflowInstanceRow"
@@ -115,18 +115,36 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="ID">@context.WorkflowInstanceId</MudTd>
-            <MudTd DataLabel="Correlation ID" Style="text-overflow: ellipsis; overflow: hidden; max-width:200px; white-space: nowrap;">@context.CorrelationId</MudTd>
-            <MudTd DataLabel="Workflow" Style="text-overflow: ellipsis; overflow: hidden; max-width:200px; white-space: nowrap;">@context.WorkflowDefinition.Name</MudTd>
+            <MudTd DataLabel="Correlation ID">
+                <MudTooltip Text="@context.CorrelationId">
+                    <div style="text-overflow: ellipsis; overflow: hidden; max-width: 200px; white-space: nowrap;">
+                        @context.CorrelationId
+                    </div>
+                </MudTooltip>
+            </MudTd>
+            <MudTd DataLabel="Workflow">
+                <MudTooltip Text="@context.WorkflowDefinition.Name">
+                    <div style="text-overflow: ellipsis; overflow: hidden; max-width: 200px; white-space: nowrap;">
+                        @context.WorkflowDefinition.Name
+                    </div>
+                </MudTooltip>
+            </MudTd>
             <MudTd DataLabel="Version">@context.Version</MudTd>
-            <MudTd DataLabel="Name" Style="text-overflow: ellipsis; overflow: hidden; max-width:200px; white-space: nowrap;">@context.Name</MudTd>
+            <MudTd DataLabel="Name">
+                <MudTooltip Text="@context.Name">
+                    <div style="text-overflow: ellipsis; overflow: hidden; max-width: 200px; white-space: nowrap;">
+                        @context.Name
+                    </div>
+                </MudTooltip>
+            </MudTd>
             <MudTd DataLabel="SubStatus">
                 <MudChip Color="@GetSubStatusColor(context.SubStatus)" Variant="Variant.Text">
                     @context.SubStatus
                 </MudChip>
             </MudTd>
             <MudTd DataLabel="IncidentCount">
-                <MudChip 
-                    Color="@(context.IncidentCount == 0 ? Color.Transparent : Color.Error)" 
+                <MudChip
+                    Color="@(context.IncidentCount == 0 ? Color.Transparent : Color.Error)"
                     Text="@context.IncidentCount.ToString()"
                     Variant="Variant.Text"
                     Size="Size.Small"/>


### PR DESCRIPTION
![image](https://github.com/elsa-workflows/elsa-studio/assets/96233009/f6a67ade-755e-4e7a-b4c1-de3d1f1dae13)

This was done so you can see the full value by hovering over the cell.
