### PR TITLE
provide refresh behavior in case of Refresh UiSpecification is true

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
@@ -1,3 +1,5 @@
+@inherits StudioComponentBase
+
 <MudForm>
     <MudStack Spacing="5">
         @foreach (var inputModel in InputDisplayModels)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -76,7 +76,7 @@ public partial class InputsTab
             if (inputDescriptor.UISpecifications != null
                 && inputDescriptor.UISpecifications.TryGetValue("Refresh", out var refreshInput)
                 && bool.Parse(refreshInput.ToString()!))
-                await RefreshDescriptor(activity, activityDescriptor, inputDescriptors, inputDescriptor);
+                    await InvokeWithBlazorServiceContext(async ()=> await RefreshDescriptor(activity, activityDescriptor, inputDescriptors, inputDescriptor));
 
             var uiHintHandler = UIHintService.GetHandler(inputDescriptor.UIHint);
             object? input = inputDescriptor.IsWrapped ? wrappedInput : value;


### PR DESCRIPTION
This PR aims to give ability to refresh some property on the Input Tab Property of an activity in case of the UISpecification is present and set to true.

The first objective of this is to allow refresh of an Dropdown when a user select an activity.

The refresh is done with a call to the `Descriptor Activity Endpoint` (formerly `ActivityDescriptorOptions` used to Get Options for Dropdown). This Endpoint update the `uiSpecification` of the inputDescriptor.
To allow more scenario (but without any specific granularity) , the call to the API is done using a context which contains all the current value of the form (value of the different properties).

evolution of this PR (or futur PR) could be : 
- granularity of context
- refresh when a (specific?) property changed an not on the render of the form. This allow scenario like cascading drop down.