### PR TITLE
Select Activity node after Adding New Activity

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
@@ -14,4 +14,6 @@ export async function addActivityNode(graphId: string, node: Node.Properties) {
 
     // Add the node to the graph.
     graph.addNode(node);
+    graph.cleanSelection();
+    graph.select(node.id);
 }


### PR DESCRIPTION
### === auto-pr-body ===

 

Summary:
This Pull Request adds two lines to the addActivityNode function, one to clear the graph selection and another to select the newly added node. Additionally, this Pull Request suggests refactoring existing code to avoid duplication and adding additional validation to ensure the node being passed in has an ID. 

List of Changes:
- Added a line to the addActivityNode function that clears the graph selection
- Added a line to the addActivityNode function to select the newly added node 

Refactoring Target:
- Refactor existing graph.cleanSelection() and graph.select(node.id) lines into a separate function that takes the node as a parameter. 
- Consider adding additional validation to ensure the node being passed in has an ID before trying to select the node.