### PR TITLE
Hide the add and close buttons

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -13,6 +13,7 @@
                                 AddTab="@AddTabCallback"
                                 CloseTab="@CloseTabCallback"
                                 ActivePanelIndex="0"
+                                AddIconClass="d-none"
                                 AddIconToolTip="Click to open a new workflow tab" CloseIconToolTip="Close workflow"
                                 Elevation="0"
                                 ApplyEffectsToContainer>

--- a/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/View/Components/WorkflowInstanceWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Pages/WorkflowInstances/View/Components/WorkflowInstanceWorkspace.razor
@@ -10,13 +10,14 @@
                             CloseTab="@CloseTabCallback"
                             ActivePanelIndexChanged="OnActivePanelIndexChanged"
                             bind-ActivePanelIndex="@ActiveTabIndex"
+                            AddIconClass="d-none"
                             AddIconToolTip="Click to open a new workflow tab" CloseIconToolTip="Close workflow"
                             Elevation="0"
                             ApplyEffectsToContainer>
                 @foreach (var workflowInstance in WorkflowInstances)
                 {
                     var definition = WorkflowDefinitions.First(x => x.Id == workflowInstance.DefinitionVersionId);
-                    <MudTabPanel Text="@workflowInstance.Id" ShowCloseIcon="true" Style="height: 100%">
+                    <MudTabPanel Text="@workflowInstance.Id" ShowCloseIcon="false" Style="height: 100%">
                         <WorkflowInstanceViewer
                             WorkflowInstance="workflowInstance" 
                             WorkflowDefinition="definition" 


### PR DESCRIPTION
Hide the buttons for now till they are implemented.

### === auto-pr-body ===



Summary:
This pull request aims to refactor code by removing unnecessary and duplicate information.

List of changes: 
- Added `AddIconClass` attribute to `WorkflowDefinitionWorkspace.razor`, setting its class to `d-none`.
- Changed `WorkflowInstanceWorkspace.razor` to set `ShowCloseIcon` attribute to `false`.

Refactoring Target:
- Replace hard-coded string `d-none` in `WorkflowDefinitionWorkspace.razor` with a constant.
- Introduce boolean `showCloseIcon` in `WorkflowInstanceWorkspace.razor` and pass its value to `ShowCloseIcon` attribute.