### PR TITLE
Check if username & password not empty

### DIFF
--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -37,6 +37,9 @@ public partial class Login
 
     private async Task<bool> ValidateCredentials(string username, string password)
     {
+        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+            return false;
+        
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);
 
         if (!result.IsAuthenticated)


### PR DESCRIPTION
When you try to login without filling a username and password you get an error.
Instead of throwing a error you now get the invalid credentials toast message.