### PR TITLE
Refactor UIHintDescriptor naming in EditInputDialog

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
@@ -82,13 +82,13 @@ public partial class EditInputDialog
         // TODO: Get these from the backend.
         var descriptors = new[]
         {
-            new UIHintDescriptor("single-line", "Single line", "A single line of text input"),
-            new UIHintDescriptor("multi-line", "Multi line", "Multiple lines of text input"),
+            new UIHintDescriptor("singleline", "Single line", "A single line of text input"),
+            new UIHintDescriptor("multiline", "Multi line", "Multiple lines of text input"),
             new UIHintDescriptor("checkbox", "Checkbox", "A checkbox"),
             new UIHintDescriptor("checklist", "Checklist", "A list of checkboxes"),
-            new UIHintDescriptor("radio-list", "Radio list", "A list of radio buttons"),
+            new UIHintDescriptor("radiolist", "Radio list", "A list of radio buttons"),
             new UIHintDescriptor("dropdown", "Dropdown", "A dropdown list"),
-            new UIHintDescriptor("multi-text", "Multi text", "An input for multiple words, like a tagging input"),
+            new UIHintDescriptor("multitext", "Multi text", "An input for multiple words, like a tagging input"),
             new UIHintDescriptor("code-editor", "Code editor", "A code editor"),
             new UIHintDescriptor("variable-picker", "Variable picker", "A variable picker"),
             new UIHintDescriptor("workflow-definition-picker", "Workflow definition picker", "A workflow definition picker"),


### PR DESCRIPTION
This commit updates the nomenclature in the EditInputDialog component, removing hyphens from descriptor names for consistency and improved readability. Changes have been made to 'single-line', 'multi-line', 'radio-list', and 'multi-text' descriptors, ensuring a uniform naming convention across all instances.
