### PR TITLE
Configure Leading edge Debounce Strategy to allow refresh of dropdown at the first render of the activity

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -28,7 +28,7 @@ public partial class InputsTab
     /// <inheritdoc />
     public InputsTab()
     {
-        _rateLimitedInputPropertyRefreshAsync = Debouncer.Debounce<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>(RefreshDescriptor, TimeSpan.FromMilliseconds(100));
+        _rateLimitedInputPropertyRefreshAsync = Debouncer.Debounce<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>(RefreshDescriptor, TimeSpan.FromMilliseconds(100), true);
     }
 
     /// <summary>


### PR DESCRIPTION
This is necessary if the UI Handler use for example a User Token to call external API.

NB : __for further use, we need to check if debounce/throttle don't create issue when we have multiple Refreshable Field in the Activity.__