### PR TITLE
update login logic to match other API calls

### DIFF
--- a/src/modules/Elsa.Studio.Login/Elsa.Studio.Login.csproj
+++ b/src/modules/Elsa.Studio.Login/Elsa.Studio.Login.csproj
@@ -15,7 +15,6 @@
 
     <ItemGroup>
         <PackageReference Include="Blazored.LocalStorage" Version="4.4.0"/>
-        <PackageReference Include="Refit" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
@@ -3,8 +3,6 @@ using Elsa.Api.Client.Resources.Identity.Requests;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.Models;
-using Refit;
-using System.Net.Http;
 
 namespace Elsa.Studio.Login.Services;
 
@@ -14,16 +12,14 @@ namespace Elsa.Studio.Login.Services;
 public class DefaultCredentialsValidator : ICredentialsValidator
 {
     private readonly IRemoteBackendApiClientProvider _remoteBackendApiClientProvider;
-    private readonly IHttpClientFactory _httpClientFactory;
-
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultCredentialsValidator"/> class.
     /// </summary>
-    public DefaultCredentialsValidator(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IHttpClientFactory httpClientFactory)
+    public DefaultCredentialsValidator(IRemoteBackendApiClientProvider remoteBackendApiClientProvider)
     {
         _remoteBackendApiClientProvider = remoteBackendApiClientProvider;
-        _httpClientFactory = httpClientFactory;
-
+    
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
@@ -12,14 +12,12 @@ namespace Elsa.Studio.Login.Services;
 public class DefaultCredentialsValidator : ICredentialsValidator
 {
     private readonly IRemoteBackendApiClientProvider _remoteBackendApiClientProvider;
-    
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultCredentialsValidator"/> class.
     /// </summary>
     public DefaultCredentialsValidator(IRemoteBackendApiClientProvider remoteBackendApiClientProvider)
     {
         _remoteBackendApiClientProvider = remoteBackendApiClientProvider;
-    
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/DefaultCredentialsValidator.cs
@@ -4,6 +4,7 @@ using Elsa.Studio.Contracts;
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.Models;
 using Refit;
+using System.Net.Http;
 
 namespace Elsa.Studio.Login.Services;
 
@@ -13,20 +14,23 @@ namespace Elsa.Studio.Login.Services;
 public class DefaultCredentialsValidator : ICredentialsValidator
 {
     private readonly IRemoteBackendApiClientProvider _remoteBackendApiClientProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultCredentialsValidator"/> class.
     /// </summary>
-    public DefaultCredentialsValidator(IRemoteBackendApiClientProvider remoteBackendApiClientProvider)
+    public DefaultCredentialsValidator(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IHttpClientFactory httpClientFactory)
     {
         _remoteBackendApiClientProvider = remoteBackendApiClientProvider;
+        _httpClientFactory = httpClientFactory;
+
     }
 
     /// <inheritdoc />
     public async ValueTask<ValidateCredentialsResult> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)
     {
-        var serverUrl = _remoteBackendApiClientProvider.Url.ToString();
-        var api = RestService.For<ILoginApi>(serverUrl);
+        var api = await _remoteBackendApiClientProvider.GetApiAsync<ILoginApi>(cancellationToken);
+
         var request = new LoginRequest(username, password);
         var response = await api.LoginAsync(request, cancellationToken);
 

--- a/src/modules/Elsa.Studio.Workflows/Extensions/HubConnectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/HubConnectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.SignalR.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elsa.Studio.Workflows.Extensions
+{
+    public static class HubConnectionExtensions
+    {
+        public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder builder, string url, IHttpMessageHandlerFactory clientFactory)
+        {
+            return builder.WithUrl(url, options =>
+            {
+                options.HttpMessageHandlerFactory = _ => clientFactory.CreateHandler();
+            });
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Services/WorkflowInstanceObserverFactory.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/WorkflowInstanceObserverFactory.cs
@@ -1,5 +1,6 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Extensions;
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace Elsa.Studio.Workflows.Services;
@@ -9,14 +10,16 @@ public class WorkflowInstanceObserverFactory : IWorkflowInstanceObserverFactory
 {
     private readonly IRemoteBackendApiClientProvider _remoteBackendApiClientProvider;
     private readonly IRemoteFeatureProvider _remoteFeatureProvider;
+    private readonly IHttpMessageHandlerFactory _httpMessageHandlerFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WorkflowInstanceObserverFactory"/> class.
     /// </summary>
-    public WorkflowInstanceObserverFactory(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IRemoteFeatureProvider remoteFeatureProvider)
+    public WorkflowInstanceObserverFactory(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IRemoteFeatureProvider remoteFeatureProvider, IHttpMessageHandlerFactory httpMessageHandlerFactory)
     {
         _remoteBackendApiClientProvider = remoteBackendApiClientProvider;
         _remoteFeatureProvider = remoteFeatureProvider;
+        _httpMessageHandlerFactory = httpMessageHandlerFactory;
     }
 
     /// <inheritdoc />
@@ -30,7 +33,7 @@ public class WorkflowInstanceObserverFactory : IWorkflowInstanceObserverFactory
         var baseUrl = _remoteBackendApiClientProvider.Url;
         var hubUrl = new Uri(baseUrl, "hubs/workflow-instance").ToString();
         var connection = new HubConnectionBuilder()
-            .WithUrl(hubUrl)
+            .WithUrl(hubUrl, _httpMessageHandlerFactory)            
             .Build();
 
         var observer = new WorkflowInstanceObserver(connection);


### PR DESCRIPTION
This fix change login api calls to match with other API calls generated by Elsa-Studio. The objective is that Server URL should always be set as the base address which allows things like [Service Discovery](https://learn.microsoft.com/en-us/dotnet/core/extensions/service-discovery?tabs=dotnet-cli) to work. This will make it easy to deploy Elsa using .NET Aspire.