### PR TITLE
Allow overriding redirects in WorkflowInstanceEditor and WorkflowInstanceDesigner.

### DIFF
--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
@@ -1,7 +1,7 @@
 @inherits BackendComponentBase
 
 <ThemedComponentWrapper>
-    <WorkflowDefinitionEditor DefinitionId="@DefinitionId"/>
+    <WorkflowDefinitionEditor DefinitionId="@DefinitionId" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"/>
 </ThemedComponentWrapper>
 
 @code
@@ -11,4 +11,9 @@
     /// </summary>
     [Parameter]
     public string DefinitionId { get; set; } = default!;
+
+    /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
+    /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
+    [Parameter]
+    public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
 }

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowInstanceViewerWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowInstanceViewerWrapper.razor
@@ -1,7 +1,7 @@
 @inherits BackendComponentBase
 
 <ThemedComponentWrapper>
-    <WorkflowInstanceViewer InstanceId="@InstanceId"/>
+    <WorkflowInstanceViewer InstanceId="@InstanceId" EditWorkflowDefinition="EditWorkflowDefinition"/>
 </ThemedComponentWrapper>
 
 @code
@@ -11,4 +11,10 @@
     /// </summary>
     [Parameter]
     public string InstanceId { get; set; } = default!;
+
+    /// <summary>
+    /// An event that is invoked when a workflow definition is edited.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string> EditWorkflowDefinition { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -21,7 +21,7 @@
                     <MudTabPanel Text="@WorkflowDefinition.Name" ShowCloseIcon="false" Style="height: 100%">
                         @if (!IsReadOnly)
                         {
-                            <WorkflowEditor @key="WorkflowDefinition.DefinitionId" @ref="WorkflowEditor" WorkflowDefinition="WorkflowDefinition" WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated"/>
+                            <WorkflowEditor @key="WorkflowDefinition.DefinitionId" @ref="WorkflowEditor" WorkflowDefinition="WorkflowDefinition" WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"/>
                         }
                         else
                         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -23,7 +23,12 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     /// Gets or sets a specific version of the workflow definition to view.
     /// </summary>
     [Parameter] public WorkflowDefinition? SelectedWorkflowDefinitionVersion { get; set; }
-    
+
+    /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
+    /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
+    [Parameter]
+    public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
+
     /// <summary>
     /// An event that is invoked when the workflow definition is updated.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -66,6 +66,11 @@ public partial class WorkflowEditor
     [Parameter]
     public Func<Task>? WorkflowDefinitionUpdated { get; set; }
 
+    /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
+    /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
+    [Parameter]
+    public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
+
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
     [Inject] private IActivityVisitor ActivityVisitor { get; set; } = default!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;
@@ -429,6 +434,11 @@ public partial class WorkflowEditor
 
         Snackbar.Add("Successfully started workflow", Severity.Success);
 
-        NavigationManager.NavigateTo($"workflows/instances/{workflowInstanceId}/view");
+        var workflowDefinitionExecuted = this.WorkflowDefinitionExecuted;
+
+        if (workflowDefinitionExecuted.HasDelegate)
+            await this.WorkflowDefinitionExecuted.InvokeAsync(workflowInstanceId);
+        else
+            NavigationManager.NavigateTo($"workflows/instances/{workflowInstanceId}/view");
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -13,7 +13,7 @@
             <ActivityPicker/>
         </RadzenSplitterPane>
         <RadzenSplitterPane Size="85%">
-            <WorkflowDefinitionWorkspace WorkflowDefinition="@_workflowDefinition"/>
+            <WorkflowDefinitionWorkspace WorkflowDefinition="@_workflowDefinition" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"/>
         </RadzenSplitterPane>
     </RadzenSplitter>
 </CascadingValue>
@@ -28,6 +28,11 @@
     /// </summary>
     [Parameter]
     public string DefinitionId { get; set; } = default!;
+
+    /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
+    /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
+    [Parameter]
+    public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
 
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -66,6 +66,11 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     [Parameter]
     public Func<JsonObject, Task>? ActivitySelected { get; set; }
 
+    /// <summary>
+    /// An event that is invoked when a workflow definition is edited.
+    /// </summary>
+    [Parameter] public EventCallback<string> EditWorkflowDefinition { get; set; }
+
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;
     [Inject] private IDiagramDesignerService DiagramDesignerService { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
@@ -251,6 +256,11 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
     private Task OnEditClicked(string definitionId)
     {
+        var editWorkflowDefinition = this.EditWorkflowDefinition;
+
+        if (editWorkflowDefinition.HasDelegate)
+            return editWorkflowDefinition.InvokeAsync(definitionId);
+
         NavigationManager.NavigateTo($"workflows/definitions/{definitionId}/edit");
         return Task.CompletedTask;
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor
@@ -24,6 +24,7 @@
                             PathChanged="OnPathChanged" 
                             ActivitySelected="ActivitySelected"
                             SelectedWorkflowExecutionLogRecord="SelectedWorkflowExecutionLogRecord"
+                            EditWorkflowDefinition="EditWorkflowDefinition"
                             />
                     </MudTabPanel>
                 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
@@ -23,6 +23,11 @@ public partial class WorkflowInstanceWorkspace : IWorkspace
     [Parameter] public Func<DesignerPathChangedArgs, Task>? PathChanged { get; set; }
     [Parameter] public Func<JsonObject, Task>? ActivitySelected { get; set; }
 
+    /// <summary>
+    /// An event that is invoked when a workflow definition is edited.
+    /// </summary>
+    [Parameter] public EventCallback<string> EditWorkflowDefinition { get; set; }
+
     public bool IsReadOnly => true;
     private int ActiveTabIndex { get; } = 0;
     private IDictionary<string, WorkflowEditor> WorkflowEditors { get; } = new Dictionary<string, WorkflowEditor>();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
@@ -13,6 +13,7 @@
             SelectedWorkflowInstanceChanged="OnSelectedWorkflowInstanceChanged" 
             PathChanged="OnDesignerPathChanged" 
             ActivitySelected="OnActivitySelected"
-            SelectedWorkflowExecutionLogRecord="SelectedJournalEntry"/>
+            SelectedWorkflowExecutionLogRecord="SelectedJournalEntry"
+            EditWorkflowDefinition="EditWorkflowDefinition"/>
     </RadzenSplitterPane>
 </RadzenSplitter>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
@@ -25,6 +25,11 @@ public partial class WorkflowInstanceViewer
     /// </summary>
     [Parameter] public string InstanceId { get; set; } = default!;
 
+    /// <summary>
+    /// An event that is invoked when a workflow definition is edited.
+    /// </summary>
+    [Parameter] public EventCallback<string> EditWorkflowDefinition { get; set; }
+
     [Inject] private IWorkflowInstanceService WorkflowInstanceService { get; set; } = default!;
 
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;


### PR DESCRIPTION
Adds parameters to the `WorkflowInstanceEditor` and `WorkflowInstanceDesigner` components that, when specified, will be invoked instead of the hard-coded redirect. Corresponding parameters have been added to all of the components that use those components both directly and indirectly, however, not to the pages.

Resolves: #115 