### PR TITLE
Add `.vs/` folder to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# Visual Studio 2015/2017 cache/options directory
+.vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
Prevents the Visual Studio cache files from showing up in git changes.