### PR TITLE
Added workflow instance and bulk cancellation to the UI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
         <PackageVersion Include="ShortGuid" Version="2.0.1"/>
         <PackageVersion Include="ThrottleDebounce" Version="2.0.0"/>
         <PackageVersion Include="BlazorMonaco" Version="3.1.0"/>
-        <PackageVersion Include="Elsa.Api.Client" Version="3.1.0-preview.1107"/>
+        <PackageVersion Include="Elsa.Api.Client" Version="3.1.0-preview.1133"/>
         <PackageVersion Include="Refit" Version="7.0.0"/>
         <PackageVersion Include="Refit.HttpClientFactory" Version="7.0.0"/>
     </ItemGroup>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
@@ -12,6 +12,7 @@ public interface IWorkflowInstanceService
     Task DeleteAsync(string instanceId, CancellationToken cancellationToken = default);
     Task BulkDeleteAsync(IEnumerable<string> instanceIds, CancellationToken cancellationToken = default);
     Task CancelAsync(string instanceId, CancellationToken cancellationToken = default);
+    Task BulkCancelAsync(BulkCancelWorkflowInstancesRequest request, CancellationToken cancellationToken = default);
     Task<WorkflowInstance?> GetAsync(string id, CancellationToken cancellationToken = default);
     Task<PagedListResponse<WorkflowExecutionLogRecord>> GetJournalAsync(string instanceId, JournalFilter? filter = default, int? skip = default, int? take = default, CancellationToken cancellationToken = default);
     Task<FileDownload> ExportAsync(string id, CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
@@ -11,6 +11,7 @@ public interface IWorkflowInstanceService
     Task<PagedListResponse<WorkflowInstanceSummary>> ListAsync(ListWorkflowInstancesRequest request, CancellationToken cancellationToken = default);
     Task DeleteAsync(string instanceId, CancellationToken cancellationToken = default);
     Task BulkDeleteAsync(IEnumerable<string> instanceIds, CancellationToken cancellationToken = default);
+    Task CancelAsync(string instanceId, CancellationToken cancellationToken = default);
     Task<WorkflowInstance?> GetAsync(string id, CancellationToken cancellationToken = default);
     Task<PagedListResponse<WorkflowExecutionLogRecord>> GetJournalAsync(string instanceId, JournalFilter? filter = default, int? skip = default, int? take = default, CancellationToken cancellationToken = default);
     Task<FileDownload> ExportAsync(string id, CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowInstanceService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowInstanceService.cs
@@ -51,10 +51,18 @@ public class RemoteWorkflowInstanceService : IWorkflowInstanceService
         await api.BulkDeleteAsync(request, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task CancelAsync(string instanceId, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
         await api.CancelAsync(instanceId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task BulkCancelAsync(BulkCancelWorkflowInstancesRequest request, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        await api.BulkCancelAsync(request, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowInstanceService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowInstanceService.cs
@@ -51,6 +51,12 @@ public class RemoteWorkflowInstanceService : IWorkflowInstanceService
         await api.BulkDeleteAsync(request, cancellationToken);
     }
 
+    public async Task CancelAsync(string instanceId, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        await api.CancelAsync(instanceId, cancellationToken);
+    }
+
     /// <inheritdoc />
     public async Task<WorkflowInstance?> GetAsync(string id, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -79,6 +79,7 @@
                 <MudMenu Icon="@Icons.Material.Filled.MoreVert">
                     <MudMenuItem Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => OnEditClicked(context.DefinitionId))">Edit</MudMenuItem>
                     <MudMenuItem Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => OnDeleteClicked(context))">Delete</MudMenuItem>
+                    <MudMenuItem Icon="@Icons.Material.Outlined.Cancel" OnClick="@(() => OnCancelClicked(context))">Cancel</MudMenuItem>
                     <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                     <MudMenuItem Icon="@Icons.Material.Outlined.CloudUpload" OnClick="@(() => OnPublishClicked(context.DefinitionId))">Publish</MudMenuItem>
                     <MudMenuItem Icon="@Icons.Material.Outlined.CloudDownload" OnClick="@(() => OnRetractClicked(context.DefinitionId))">Unpublish</MudMenuItem>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -169,7 +169,7 @@ public partial class WorkflowDefinitionList
     private async Task OnCancelClicked(WorkflowDefinitionRow workflowDefinitionRow)
     {
         var result = await DialogService.ShowMessageBox("Cancel running workflow instances?",
-            "Are you sure you want to cancel all running workflow instance of this workflow definition?", yesText: "Yes", cancelText: "No");
+            "Are you sure you want to cancel all running workflow instances of this workflow definition?", yesText: "Yes", cancelText: "No");
 
         if (result != true)
             return;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -1,5 +1,6 @@
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Enums;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Workflows.Domain.Contracts;
@@ -31,6 +32,7 @@ public partial class WorkflowDefinitionList
     [Inject] private IDialogService DialogService { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
+    [Inject] private IWorkflowInstanceService WorkflowInstanceService { get; set; } = default!;
     [Inject] private IFiles Files { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
 
@@ -164,6 +166,22 @@ public partial class WorkflowDefinitionList
         Reload();
     }
 
+    private async Task OnCancelClicked(WorkflowDefinitionRow workflowDefinitionRow)
+    {
+        var result = await DialogService.ShowMessageBox("Cancel running workflow instances?",
+            "Are you sure you want to cancel all running workflow instance of this workflow definition?", yesText: "Yes", cancelText: "No");
+
+        if (result != true)
+            return;
+
+        var request = new BulkCancelWorkflowInstancesRequest
+        {
+            DefinitionVersionId = workflowDefinitionRow.Id
+        };
+        await InvokeWithBlazorServiceContext(() => WorkflowInstanceService.BulkCancelAsync(request));
+        Reload();
+    }
+
     private async Task OnDownloadClicked(WorkflowDefinitionRow workflowDefinitionRow)
     {
         var download = await InvokeWithBlazorServiceContext(() => WorkflowDefinitionService.ExportDefinitionAsync(workflowDefinitionRow.DefinitionId, VersionOptions.Latest));
@@ -293,12 +311,14 @@ public partial class WorkflowDefinitionList
     {
         await InvokeWithBlazorServiceContext((Func<Task>)(() => WorkflowDefinitionService.PublishAsync(definitionId)));
         Snackbar.Add("Workflow published", Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
+        Reload();
     }
 
     private async Task OnRetractClicked(string definitionId)
     {
         await InvokeWithBlazorServiceContext((Func<Task>)(() => WorkflowDefinitionService.RetractAsync(definitionId)));
         Snackbar.Add("Workflow retracted", Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
+        Reload();
     }
 
     private record WorkflowDefinitionRow(

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -261,10 +261,7 @@
             <MudMenu Icon="@Icons.Material.Filled.MoreVert">
                 <MudMenuItem Icon="@Icons.Material.Outlined.ZoomIn" OnClick="@(() => OnViewClicked(context.WorkflowInstanceId))">View</MudMenuItem>
                 <MudMenuItem Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => OnDeleteClicked(context))">Delete</MudMenuItem>
-                @if (context.FinishedAt is null)
-                {
-                    <MudMenuItem Icon="@Icons.Material.Outlined.Cancel" OnClick="@(() => OnCancelClicked(context))">Cancel</MudMenuItem>
-                }
+                <MudMenuItem Icon="@Icons.Material.Outlined.Cancel" Disabled="@(context.FinishedAt != null)" OnClick="@(() => OnCancelClicked(context))">Cancel</MudMenuItem>
                 <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                 <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="@(() => OnDownloadClicked(context))">Export</MudMenuItem>
             </MudMenu>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -23,8 +23,8 @@
     <MudStack Row="true" Class="flex-wrap pl-2 pr-6 py-6" Justify="Justify.FlexEnd" AlignItems="AlignItems.End">
         <MudPaper Class="gap-3 d-flex" Elevation="0">
             <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="Bulk actions" Color="Color.Default" Variant="Variant.Filled" AnchorOrigin="Origin.BottomLeft">
-                <MudMenuItem OnClick="OnBulkDeleteClicked">Delete</MudMenuItem>
-                <MudMenuItem OnClick="OnBulkCancelClicked">Cancel</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkDeleteClicked">Delete</MudMenuItem>
+                <MudMenuItem OnClick="@OnBulkCancelClicked">Cancel</MudMenuItem>
                 <MudMenuItem Disabled="true">Retry</MudMenuItem>
                 <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem>
             </MudMenu>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -24,8 +24,8 @@
         <MudPaper Class="gap-3 d-flex" Elevation="0">
             <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="Bulk actions" Color="Color.Default" Variant="Variant.Filled" AnchorOrigin="Origin.BottomLeft">
                 <MudMenuItem OnClick="OnBulkDeleteClicked">Delete</MudMenuItem>
-                <MudMenuItem>Cancel</MudMenuItem>
-                <MudMenuItem>Retry</MudMenuItem>
+                <MudMenuItem OnClick="OnBulkCancelClicked">Cancel</MudMenuItem>
+                <MudMenuItem Disabled="true">Retry</MudMenuItem>
                 <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem>
             </MudMenu>
             <MudButton StartIcon="@Icons.Material.Filled.FileUpload" Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnImportClicked">Import</MudButton>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -261,6 +261,10 @@
             <MudMenu Icon="@Icons.Material.Filled.MoreVert">
                 <MudMenuItem Icon="@Icons.Material.Outlined.ZoomIn" OnClick="@(() => OnViewClicked(context.WorkflowInstanceId))">View</MudMenuItem>
                 <MudMenuItem Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => OnDeleteClicked(context))">Delete</MudMenuItem>
+                @if (context.FinishedAt is null)
+                {
+                    <MudMenuItem Icon="@Icons.Material.Outlined.Cancel" OnClick="@(() => OnCancelClicked(context))">Cancel</MudMenuItem>
+                }
                 <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                 <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="@(() => OnDownloadClicked(context))">Export</MudMenuItem>
             </MudMenu>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -197,6 +197,18 @@ public partial class WorkflowInstanceList
         await WorkflowInstanceService.DeleteAsync(instanceId);
         Reload();
     }
+    
+    private async Task OnCancelClicked(WorkflowInstanceRow row)
+    {
+        var result = await DialogService.ShowMessageBox("Cancel workflow instance?", "Are you sure you want to cancel this workflow instance?", yesText: "Yes", cancelText: "No");
+
+        if (result != true)
+            return;
+
+        var instanceId = row.WorkflowInstanceId;
+        await WorkflowInstanceService.CancelAsync(instanceId);
+        Reload();
+    }
 
     private async Task OnDownloadClicked(WorkflowInstanceRow workflowInstanceRow)
     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -229,6 +229,18 @@ public partial class WorkflowInstanceList
         Reload();
     }
 
+    private async Task OnBulkCancelClicked()
+    {
+        var confirmed = await DialogService.ShowMessageBox("Cancel selected versions", "Are you sure you want to cancel the selected versions?", yesText: "Yes", cancelText: "No");
+
+        if (confirmed != true)
+            return;
+
+        var workflowInstanceIds = _selectedRows.Select(x => x.WorkflowInstanceId).ToList();
+        await WorkflowInstanceService.BulkCancelAsync(workflowInstanceIds);
+        Reload();
+    }
+
     private Task OnImportClicked()
     {
         return DomAccessor.ClickElementAsync("#instance-file-upload-button-wrapper input[type=file]");

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -231,7 +231,7 @@ public partial class WorkflowInstanceList
 
     private async Task OnBulkCancelClicked()
     {
-        var confirmed = await DialogService.ShowMessageBox("Cancel selected versions", "Are you sure you want to cancel the selected versions?", yesText: "Yes", cancelText: "No");
+        var confirmed = await DialogService.ShowMessageBox("Cancel selected workflow instances?", "Are you sure you want to cancel the selected workflow instances?", yesText: "Yes", cancelText: "No");
 
         if (confirmed != true)
             return;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -237,7 +237,11 @@ public partial class WorkflowInstanceList
             return;
 
         var workflowInstanceIds = _selectedRows.Select(x => x.WorkflowInstanceId).ToList();
-        await WorkflowInstanceService.BulkCancelAsync(workflowInstanceIds);
+        var request = new BulkCancelWorkflowInstancesRequest
+        {
+            Ids = workflowInstanceIds
+        };
+        await WorkflowInstanceService.BulkCancelAsync(request);
         Reload();
     }
 


### PR DESCRIPTION
With this change it is possible to cancel a single workflow, select a number of workflows to cancel and cancel all instances of a definition from the UI.

Dependent on this PR from Elsa-core:
https://github.com/elsa-workflows/elsa-core/pull/4965