### PR TITLE
Prevent duplicate 'Default' switch cases

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'feature/*'
+      - 'issue/*'
       - 'enhancement/*'
       - 'patch/*'
       - 'fix/*'

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
@@ -5,12 +5,14 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Domain.Contexts;
 using Elsa.Studio.Workflows.Domain.Providers;
+using JetBrains.Annotations;
 
 namespace Elsa.Studio.ActivityPortProviders.Providers;
 
 /// <summary>
 /// Provides ports for the FlowSwitch activity based on its cases.
 /// </summary>
+[UsedImplicitly]
 public class FlowSwitchPortProvider : ActivityPortProviderBase
 {
     /// <inheritdoc />
@@ -23,7 +25,7 @@ public class FlowSwitchPortProvider : ActivityPortProviderBase
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        
+
         var cases = context.Activity.GetProperty<List<SwitchCase>>(options, "cases") ?? new List<SwitchCase>();
 
         foreach (var @case in cases)
@@ -35,6 +37,9 @@ public class FlowSwitchPortProvider : ActivityPortProviderBase
                 Type = PortType.Flow,
             };
         }
+
+        if (cases.Any(x => x.Label == "Default"))
+            yield break;
 
         yield return new Port
         {

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/SwitchPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/SwitchPortProvider.cs
@@ -18,7 +18,7 @@ public class SwitchPortProvider : ActivityPortProviderBase
     /// <inheritdoc />
     public override IEnumerable<Port> GetPorts(PortProviderContext context)
     {
-        var cases = GetCases(context.Activity);
+        var cases = GetCases(context.Activity).ToList();
 
         foreach (var @case in cases)
         {
@@ -30,6 +30,9 @@ public class SwitchPortProvider : ActivityPortProviderBase
                 Type = PortType.Embedded,
             };
         }
+        
+        if (cases.Any(x => GetLabel(x) == "Default"))
+            yield break;
         
         yield return new Port
         {


### PR DESCRIPTION
This PR prevents the system from yielding duplicate 'Default' switch cases.

Fixes #154