### PR TITLE
Update MudStack row property in ActivityExecutionsTab

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
@@ -1,7 +1,7 @@
 @inherits StudioComponentBase
 
 <ScrollableWell MaxHeight="VisiblePaneHeight">
-    <MudStack Row="true">
+    <MudStack Row="false">
         <MudTable
             T="ActivityExecutionRecordTableRow"
             Items="Items"


### PR DESCRIPTION
The MudStack row property in the ActivityExecutionsTab component has been updated from 'true' to 'false'. This change affects the layout orientation of the stack by changing it from a horizontal to a vertical layout.

Closes #164