### PR TITLE
fix: remove useless input port in start node.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/Services/ActivityMapper.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Services/ActivityMapper.cs
@@ -125,19 +125,29 @@ internal class ActivityMapper : IActivityMapper
     public IEnumerable<X6Port> GetInPorts(JsonObject activity)
     {
         var displaySettings = _activityDisplaySettingsRegistry.GetSettings(activity.GetTypeName());
-
-        // Create default input port.
-        yield return new X6Port
+        var activityType = activity.GetTypeName();
+        var activityVersion = activity.GetVersion();
+        var activityDescriptor = _activityRegistry.Find(activityType, activityVersion)!;
+        
+        var ports = new List<X6Port>();
+        // Create default output port, except for terminal nodes.
+        var isStart = activityDescriptor.IsStart;
+        if (!isStart)
         {
-            Id = "In",
-            Group = "in",
-            Attrs = new X6Attrs
+            // Create default input port.
+            ports.Add(new X6Port
             {
-                ["circle"] = new X6Attrs
+                Id = "In",
+                Group = "in",
+                Attrs = new X6Attrs
                 {
-                    ["stroke"] = displaySettings.Color,
+                    ["circle"] = new X6Attrs
+                    {
+                        ["stroke"] = displaySettings.Color,
+                    }
                 }
-            }
-        };
+            });
+        }
+        return ports;
     }
 }


### PR DESCRIPTION
This pull request is based on another pr in elsa-core project. 
https://github.com/elsa-workflows/elsa-core/pull/5040/files

With this pr, the useless input port of start node will be removed.
<img width="570" alt="image" src="https://github.com/elsa-workflows/elsa-studio/assets/698746/a2de06a6-dce2-41b9-91ab-00f2592af8a7">
