### PR TITLE
Add string trimming extensions and usage

### DIFF
--- a/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
@@ -1,5 +1,6 @@
 @using Elsa.Studio.Models
 @using Elsa.Api.Client.Resources.Scripting.Models
+@using Elsa.Studio.UIHints.Extensions
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
@@ -29,7 +30,7 @@
 
     private async Task OnValueChanged(string newValue)
     {
-        var expression = Expression.CreateLiteral(newValue);
+        var expression = Expression.CreateLiteral(newValue.TrimNull());
         
         await EditorContext.UpdateExpressionAsync(expression);
     }

--- a/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
@@ -45,7 +45,7 @@
 
     private async Task OnValueChanged(string newValue)
     {
-        var expression = Expression.CreateLiteral(newValue);
+        var expression = Expression.CreateLiteral(newValue.TrimWhitespace());
 
         await EditorContext.UpdateExpressionAsync(expression);
     }

--- a/src/modules/Elsa.Studio.UIHints/Extensions/StringExtensions.cs
+++ b/src/modules/Elsa.Studio.UIHints/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+namespace Elsa.Studio.UIHints.Extensions;
+
+/// <summary>
+/// Provides a set of extension methods for <see cref="string"/>.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Trims the whitespace from the string, including null characters and new lines.
+    /// </summary>
+    public static string TrimWhitespace(this string value)
+    {
+        return value.Trim(' ', '\0', '\n', '\r');
+    }
+    
+    /// <summary>
+    /// Trims the null characters from the string.
+    /// </summary>
+    public static string TrimNull(this string value)
+    {
+        return value.Trim('\0');
+    }
+}


### PR DESCRIPTION
Introduced two new string extension methods to trim whitespace and null characters. The `SingleLine.razor` and `MultiLine.razor` components are updated to use these methods, improving input handling by ensuring cleanliness of the string data before processing.

Fixes #178
