### PR TITLE
fixed bug where you were allowed to start a connection from an in port

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -74,8 +74,16 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                     zIndex: -1,
                 })
             },
-            validateConnection({targetMagnet}) {
-                return !!targetMagnet && targetMagnet.getAttribute('port-group') === 'in'
+            validateConnection({ sourceMagnet, targetMagnet }) {
+                if (!sourceMagnet || sourceMagnet.getAttribute('port-group') === 'in') {
+                    return false
+                }
+                
+                if (!targetMagnet || targetMagnet.getAttribute('port-group') !== 'in') {
+                    return false
+                }
+
+                return true
             },
         },
         highlighting: {


### PR DESCRIPTION
I observed that it was possible to connect from an 'in port' to another 'in port' (which included an 'in port' connecting to itself). I've fixed this behaviour, using the same code from an example provided in the X6 lib [here](https://github.com/antvis/X6/blob/23e9aa15442634c71368e3c377ea4827b3bbec3e/sites/x6-sites/examples/edge/tool/demo/arrowheads.ts#L63).