### PR TITLE
Expose additional workflow definition editor events

### DIFF
--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
@@ -16,7 +16,11 @@
                               PublishingFailed="PublishingFailed"
                               Retracting="Retracting"
                               Retracted="Retracted"
-                              RetractingFailed="RetractingFailed"/>
+                              RetractingFailed="RetractingFailed"
+                              Exporting="Exporting"
+                              Exported="Exported"
+                              Importing="Importing"
+                              Imported="Imported"/>
 </ThemedComponentWrapper>
 
 @code
@@ -74,9 +78,25 @@
     [Parameter]
     public EventCallback<ValidationErrors> RetractingFailed { get; set; }
 
+    /// Gets or sets the event triggered when the workflow definition is being exported.
+    [Parameter]
+    public EventCallback Exporting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been exported.
+    [Parameter]
+    public EventCallback Exported { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being imported.
+    [Parameter]
+    public EventCallback Importing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been imported.
+    [Parameter]
+    public EventCallback Imported { get; set; }
+
     /// Gets the currently selected activity ID.
     public string? SelectedActivityId => WorkflowDefinitionEditor.SelectedActivityId;
-    
+
     private WorkflowDefinitionEditor WorkflowDefinitionEditor { get; set; } = default!;
 
     /// Gets the currently selected workflow definition version.

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
@@ -1,16 +1,27 @@
+@using System.Text.Json.Nodes
 @using Elsa.Api.Client.Resources.WorkflowDefinitions.Models
-@using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components
+@using Elsa.Studio.Workflows.Domain.Models
 @inherits BackendComponentBase
 
 <ThemedComponentWrapper>
-    <WorkflowDefinitionEditor DefinitionId="@DefinitionId" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted" WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected"/>
+    <WorkflowDefinitionEditor DefinitionId="@DefinitionId"
+                              WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
+                              WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected"
+                              ActivitySelected="ActivitySelected"
+                              Saving="Saving"
+                              Saved="Saved"
+                              SavingFailed="SavingFailed"
+                              Publishing="Publishing"
+                              Published="Published"
+                              PublishingFailed="PublishingFailed"
+                              Retracting="Retracting"
+                              Retracted="Retracted"
+                              RetractingFailed="RetractingFailed"/>
 </ThemedComponentWrapper>
 
 @code
 {
-    /// <summary>
     /// The ID of the workflow definition to edit.
-    /// </summary>
     [Parameter]
     public string DefinitionId { get; set; } = default!;
 
@@ -18,17 +29,56 @@
     /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
     [Parameter]
     public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
-    
-    /// <summary>
+
     /// Gets or sets the event that occurs when the workflow definition version is updated.
-    /// </summary>
     [Parameter]
     public EventCallback<WorkflowDefinition> WorkflowDefinitionVersionSelected { get; set; }
+
+    /// Gets or sets the event triggered when an activity is selected.
+    [Parameter]
+    public EventCallback<JsonObject> ActivitySelected { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being saved.
+    [Parameter]
+    public EventCallback Saving { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been saved.
+    [Parameter]
+    public EventCallback Saved { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to save.
+    [Parameter]
+    public EventCallback<ValidationErrors> SavingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being published.
+    [Parameter]
+    public EventCallback Publishing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been published.
+    [Parameter]
+    public EventCallback Published { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to publish.
+    [Parameter]
+    public EventCallback<ValidationErrors> PublishingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being retracted.
+    [Parameter]
+    public EventCallback Retracting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been retracted.
+    [Parameter]
+    public EventCallback Retracted { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to retract.
+    [Parameter]
+    public EventCallback<ValidationErrors> RetractingFailed { get; set; }
+
+    /// Gets the currently selected activity ID.
+    public string? SelectedActivityId => WorkflowDefinitionEditor.SelectedActivityId;
     
     private WorkflowDefinitionEditor WorkflowDefinitionEditor { get; set; } = default!;
-    
-    /// <summary>
+
     /// Gets the currently selected workflow definition version.
-    /// </summary>
     public WorkflowDefinition? GetSelectedWorkflowDefinitionVersion() => WorkflowDefinitionEditor.GetSelectedWorkflowDefinitionVersion();
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
@@ -27,7 +27,7 @@ public partial class WorkflowDefinitionVersionViewer
     [Parameter]
     public EventCallback<JsonObject> ActivitySelected { get; set; }
     
-    /// Gets or sets the ID of the selected activity.
+    /// Gets the ID of the selected activity.
     public string? SelectedActivityId { get; private set; }
 
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -33,7 +33,11 @@
                                             PublishingFailed="PublishingFailed"
                                             Retracting="Retracting"
                                             Retracted="Retracted"
-                                            RetractingFailed="RetractingFailed"/>
+                                            RetractingFailed="RetractingFailed"
+                                            Exporting="Exporting"
+                                            Exported="Exported"
+                                            Importing="Importing"
+                                            Imported="Imported"/>
                         }
                         else
                         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -19,11 +19,25 @@
                     <MudTabPanel Text="@SelectedWorkflowDefinition.Name" ShowCloseIcon="false" Style="height: 100%">
                         @if (!IsReadOnly)
                         {
-                            <WorkflowEditor @key="SelectedWorkflowDefinition.DefinitionId" @ref="WorkflowEditor" WorkflowDefinition="SelectedWorkflowDefinition" WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"/>
+                            <WorkflowEditor @key="SelectedWorkflowDefinition.DefinitionId" 
+                                            @ref="WorkflowEditor" 
+                                            WorkflowDefinition="SelectedWorkflowDefinition" 
+                                            WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated" 
+                                            WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
+                                            ActivitySelected="ActivitySelected"
+                                            Saving="Saving"
+                                            Saved="Saved"
+                                            SavingFailed="SavingFailed"
+                                            Publishing="Publishing"
+                                            Published="Published"
+                                            PublishingFailed="PublishingFailed"
+                                            Retracting="Retracting"
+                                            Retracted="Retracted"
+                                            RetractingFailed="RetractingFailed"/>
                         }
                         else
                         {
-                            <WorkflowDefinitionVersionViewer WorkflowDefinition="SelectedWorkflowDefinition"/>
+                            <WorkflowDefinitionVersionViewer WorkflowDefinition="SelectedWorkflowDefinition" ActivitySelected="ActivitySelected"/>
                         }
 
                     </MudTabPanel>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -1,6 +1,8 @@
+using System.Text.Json.Nodes;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
@@ -38,12 +40,57 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     public EventCallback<WorkflowDefinition> WorkflowDefinitionVersionSelected { get; set; }
 
     /// <summary>
+    /// Gets or sets the event that occurs when an activity is selected.
+    /// </summary>
+    [Parameter]
+    public EventCallback<JsonObject> ActivitySelected { get; set; }
+    
+    /// Gets or sets the event triggered when the workflow definition is being saved.
+    [Parameter]
+    public EventCallback Saving { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been saved.
+    [Parameter]
+    public EventCallback Saved { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to save.
+    [Parameter]
+    public EventCallback<ValidationErrors> SavingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being published.
+    [Parameter]
+    public EventCallback Publishing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been published.
+    [Parameter]
+    public EventCallback Published { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to publish.
+    [Parameter]
+    public EventCallback<ValidationErrors> PublishingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being retracted.
+    [Parameter]
+    public EventCallback Retracting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been retracted.
+    [Parameter]
+    public EventCallback Retracted { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to retract.
+    [Parameter]
+    public EventCallback<ValidationErrors> RetractingFailed { get; set; }
+
+    /// <summary>
     /// An event that is invoked when the workflow definition is updated.
     /// </summary>
     public event Func<Task>? WorkflowDefinitionUpdated;
 
     /// <inheritdoc />
     public bool IsReadOnly => SelectedWorkflowDefinition?.IsLatest == false;
+    
+    /// Gets the selected activity ID.
+    public string? SelectedActivityId => WorkflowEditor.SelectedActivityId;
 
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -80,6 +80,22 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     /// Gets or sets the event triggered when the workflow definition has failed to retract.
     [Parameter]
     public EventCallback<ValidationErrors> RetractingFailed { get; set; }
+    
+    /// Gets or sets the event triggered when the workflow definition is being exported.
+    [Parameter]
+    public EventCallback Exporting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been exported.
+    [Parameter]
+    public EventCallback Exported { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being imported.
+    [Parameter]
+    public EventCallback Importing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been imported.
+    [Parameter]
+    public EventCallback Imported { get; set; }
 
     /// <summary>
     /// An event that is invoked when the workflow definition is updated.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -1,4 +1,3 @@
-@using Elsa.Studio.Workflows.UI.Contracts
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties
 @using Orientation = Radzen.Orientation
 @using Variant = MudBlazor.Variant

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -111,14 +111,21 @@ public partial class WorkflowEditor
     [Parameter]
     public EventCallback<ValidationErrors> RetractingFailed { get; set; }
 
-    /// Gets or sets the event triggered when the workflow definition is being downloaded.
+    /// Gets or sets the event triggered when the workflow definition is being exported.
     [Parameter]
-    public EventCallback Downloading { get; set; }
+    public EventCallback Exporting { get; set; }
 
-    /// Gets or sets the event triggered when the workflow definition has been downloaded.
+    /// Gets or sets the event triggered when the workflow definition has been exported.
     [Parameter]
-    public EventCallback Downloaded { get; set; }
+    public EventCallback Exported { get; set; }
 
+    /// Gets or sets the event triggered when the workflow definition is being imported.
+    [Parameter]
+    public EventCallback Importing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been imported.
+    [Parameter]
+    public EventCallback Imported { get; set; }
 
     /// Gets the selected activity ID.
     public string? SelectedActivityId { get; private set; }
@@ -439,14 +446,18 @@ public partial class WorkflowEditor
 
     private async Task OnDownloadClicked()
     {
+        await Exporting.InvokeAsync();
         var download = await WorkflowDefinitionService.ExportDefinitionAsync(WorkflowDefinition!.DefinitionId, VersionOptions.Latest);
         var fileName = $"{WorkflowDefinition.Name.Kebaberize()}.json";
         await Files.DownloadFileFromStreamAsync(fileName, download.Content);
+        await Exported.InvokeAsync();
     }
 
     private async Task OnUploadClicked()
     {
+        await Importing.InvokeAsync();
         await DomAccessor.ClickElementAsync("#workflow-file-upload-button-wrapper input[type=file]");
+        await Imported.InvokeAsync();
     }
 
     private async Task OnFileSelected(IBrowserFile file)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -1,8 +1,10 @@
+@using System.Text.Json.Nodes
 @using Orientation = Radzen.Orientation
 @using Elsa.Studio.Workflows.Models
 @using Elsa.Api.Client.Resources.WorkflowDefinitions.Models
 @using Elsa.Api.Client.Shared.Models
 @using Elsa.Studio.Workflows.Domain.Contracts
+@using Elsa.Studio.Workflows.Domain.Models
 @inherits StudioComponentBase
 
 @inject IWorkflowDefinitionService WorkflowDefinitionService
@@ -13,7 +15,20 @@
             <ActivityPicker/>
         </RadzenSplitterPane>
         <RadzenSplitterPane Size="85%">
-            <WorkflowDefinitionWorkspace @ref="WorkflowDefinitionWorkspace" WorkflowDefinition="@_workflowDefinition" WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected" WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"/>
+            <WorkflowDefinitionWorkspace @ref="WorkflowDefinitionWorkspace" 
+                                         WorkflowDefinition="@_workflowDefinition" 
+                                         WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected" 
+                                         WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
+                                         ActivitySelected="ActivitySelected"
+                                         Saving="Saving"
+                                         Saved="Saved"
+                                         SavingFailed="SavingFailed"
+                                         Publishing="Publishing"
+                                         Published="Published"
+                                         PublishingFailed="PublishingFailed"
+                                         Retracting="Retracting"
+                                         Retracted="Retracted"
+                                         RetractingFailed="RetractingFailed"/>
         </RadzenSplitterPane>
     </RadzenSplitter>
 </CascadingValue>
@@ -22,30 +37,66 @@
 {
     private readonly DragDropManager _dragDropManager = new();
     private WorkflowDefinition? _workflowDefinition;
-    
     private WorkflowDefinitionWorkspace WorkflowDefinitionWorkspace { get; set; } = default!;
 
-    /// <summary>
     /// The ID of the workflow definition to load.
-    /// </summary>
     [Parameter]
     public string DefinitionId { get; set; } = default!;
-    
-    /// <summary>
+
     /// Gets or sets the event that occurs when the workflow definition version is updated.
-    /// </summary>
     [Parameter]
     public EventCallback<WorkflowDefinition> WorkflowDefinitionVersionSelected { get; set; }
+
+    /// Gets or sets the event triggered when an activity is selected.
+    [Parameter]
+    public EventCallback<JsonObject> ActivitySelected { get; set; }
     
-    /// <summary>
+    /// Gets or sets the event triggered when the workflow definition is being saved.
+    [Parameter]
+    public EventCallback Saving { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been saved.
+    [Parameter]
+    public EventCallback Saved { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to save.
+    [Parameter]
+    public EventCallback<ValidationErrors> SavingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being published.
+    [Parameter]
+    public EventCallback Publishing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been published.
+    [Parameter]
+    public EventCallback Published { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to publish.
+    [Parameter]
+    public EventCallback<ValidationErrors> PublishingFailed { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being retracted.
+    [Parameter]
+    public EventCallback Retracting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been retracted.
+    [Parameter]
+    public EventCallback Retracted { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has failed to retract.
+    [Parameter]
+    public EventCallback<ValidationErrors> RetractingFailed { get; set; }
+
     /// Gets the currently selected workflow definition version.
-    /// </summary>
     public WorkflowDefinition? GetSelectedWorkflowDefinitionVersion() => WorkflowDefinitionWorkspace.GetSelectedWorkflowDefinitionVersion();
 
     /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
     /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
     [Parameter]
     public EventCallback<string> WorkflowDefinitionExecuted { get; set; }
+    
+    /// Gets the currently selected activity ID.
+    public string? SelectedActivityId => WorkflowDefinitionWorkspace.SelectedActivityId;
 
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -28,7 +28,11 @@
                                          PublishingFailed="PublishingFailed"
                                          Retracting="Retracting"
                                          Retracted="Retracted"
-                                         RetractingFailed="RetractingFailed"/>
+                                         RetractingFailed="RetractingFailed"
+                                         Exporting="Exporting"
+                                         Exported="Exported"
+                                         Importing="Importing"
+                                         Imported="Imported"/>
         </RadzenSplitterPane>
     </RadzenSplitter>
 </CascadingValue>
@@ -86,6 +90,22 @@
     /// Gets or sets the event triggered when the workflow definition has failed to retract.
     [Parameter]
     public EventCallback<ValidationErrors> RetractingFailed { get; set; }
+    
+    /// Gets or sets the event triggered when the workflow definition is being exported.
+    [Parameter]
+    public EventCallback Exporting { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been exported.
+    [Parameter]
+    public EventCallback Exported { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition is being imported.
+    [Parameter]
+    public EventCallback Importing { get; set; }
+
+    /// Gets or sets the event triggered when the workflow definition has been imported.
+    [Parameter]
+    public EventCallback Imported { get; set; }
 
     /// Gets the currently selected workflow definition version.
     public WorkflowDefinition? GetSelectedWorkflowDefinitionVersion() => WorkflowDefinitionWorkspace.GetSelectedWorkflowDefinitionVersion();


### PR DESCRIPTION
This PR exposes additional events from the WorkflowEditor components:

- Saving
- Saved
- SavingFailed
- Publishing
- Published
- PublishingFailed
- Retracting
- Retracted
- RetractingFailed
- Importing
- Imported
- Exporting
- Exported