### PR TITLE
Optimize rendering of ActivityWrapper.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-stats.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-stats.ts
@@ -27,5 +27,5 @@ export async function updateActivityStats(elementId: string, activityId: string,
         return;
     }
     
-    node.setProp('activityStats', activityStats)
+    node.setProp('activityStats', activityStats);
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor
@@ -1,35 +1,19 @@
 @using Elsa.Api.Client.Resources.ActivityDescriptors.Enums
-@using Humanizer
 @using Elsa.Api.Client.Extensions
-@using System.Text.Json
-@using Elsa.Api.Client.Converters
 @using Elsa.Studio.Workflows.Domain.Contexts
 @inherits StudioComponentBase
-@if (Stats != null)
-{
-    var color = Stats.Faulted ? Color.Error : Stats.Blocked ? Color.Warning : Stats.Uncompleted > Stats.Completed ? Color.Info : Stats.Completed > 0 ? Color.Success : Color.Default;
-    var content = Stats.Blocked ? default : Stats.Completed.ToString();
-    var icon = content == null ? Stats.Blocked ? Icons.Material.Outlined.HourglassTop : Stats.Uncompleted > 0 ? Icons.Material.Outlined.PlayArrow : default : default;
-    <MudBadge Color="color" Content="content" Overlap="true" Icon="@icon" Style="width: 100%; height: 100%;">
-        @DisplayActivityWrapper()
-    </MudBadge>
-}
-else
-{
-    @DisplayActivityWrapper()
-}
-
-@code
-{
-    private RenderFragment DisplayActivityWrapper()
-    {
-        const string white = "#ffffff";
-        var colorStyle = CanStartWorkflow ? $"color: {white};" : "";
-
-        return @<MudPaper
-                    Class="elsa-activity pa-3"
-                    Style="@($"border-left-color: {_color}; {(CanStartWorkflow ? $"background-color: {_color}" : "")};")"
-                    Outlined="true">
+@{
+    const string white = "#ffffff";
+    var color = Stats == null ? Color.Transparent : Stats.Faulted ? Color.Error : Stats.Blocked ? Color.Warning : Stats.Uncompleted > Stats.Completed ? Color.Info : Stats.Completed > 0 ? Color.Success : Color.Default;
+    var content = Stats == null ? null : Stats.Blocked ? null : Stats.Completed.ToString();
+    var icon = Stats == null ? null : content == null ? Stats.Blocked ? Icons.Material.Outlined.HourglassTop : Stats.Uncompleted > 0 ? Icons.Material.Outlined.PlayArrow : null : null;
+    var displayBadge = Stats != null;
+    var colorStyle = CanStartWorkflow ? $"color: {white};" : "";
+    <MudBadge Color="color" Content="content" Overlap="true" Icon="@icon" Style="width: 100%; height: 100%;" Visible="displayBadge">
+        <MudPaper
+            Class="elsa-activity pa-3"
+            Style="@($"border-left-color: {_color}; {(CanStartWorkflow ? $"background-color: {_color}" : "")};")"
+            Outlined="true">
             <MudStack Row="true" AlignItems="AlignItems.Center" Style="height:100%">
                 @if (_icon != null)
                 {
@@ -74,6 +58,6 @@ else
                     }
                 </MudStack>
             </MudStack>
-        </MudPaper>;
-    }
+        </MudPaper>
+    </MudBadge>
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor.cs
@@ -1,21 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Threading.Tasks;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
-using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Designer.Interop;
-using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Domain.Contexts;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace Elsa.Studio.Workflows.Designer.Components;
 


### PR DESCRIPTION
This change prevents the contents of the MudBadge component to not be re-rendered, which ought to improve re-rendering of the custom element as a whole.

However, it will not fix the re-rendering issue that is reported, given the fact that the entire custom element instance will be recreated by X6, when it receives the `stats` value.
