### PR TITLE
Update DesignerPathChangedArgs and method usages

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
@@ -44,8 +44,8 @@ public partial class WorkflowInstanceWorkspace : IWorkspace
 
     private async Task OnPathChanged(DesignerPathChangedArgs args)
     {
-        await _workflowInstanceDetails.UpdateSubWorkflowAsync(args.CurrentActivity);
-        _workflowInstanceDesigner.UpdateSubWorkflow(args.CurrentActivity);
+        await _workflowInstanceDetails.UpdateSubWorkflowAsync(args.ContainerActivity);
+        _workflowInstanceDesigner.UpdateSubWorkflow(args.ContainerActivity);
         
         if(PathChanged.HasDelegate)
             await PathChanged.InvokeAsync(args);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/DesignerPathChangedArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/DesignerPathChangedArgs.cs
@@ -2,4 +2,5 @@ using System.Text.Json.Nodes;
 
 namespace Elsa.Studio.Workflows.Shared.Args;
 
-public record DesignerPathChangedArgs(JsonObject ContainerActivity, JsonObject? CurrentActivity);
+/// Represents the event arguments when the designer path changes.
+public record DesignerPathChangedArgs(JsonObject ContainerActivity);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -174,6 +174,12 @@ public partial class DiagramDesignerWrapper
     {
         action(_pathSegments);
         await UpdateBreadcrumbItemsAsync();
+        
+        if (PathChanged.HasDelegate)
+        {
+            var currentContainerActivity = GetCurrentContainerActivity();
+            await PathChanged.InvokeAsync(new DesignerPathChangedArgs(currentContainerActivity));
+        }
     }
 
     private JsonObject GetCurrentContainerActivity()


### PR DESCRIPTION
Refactor DesignerPathChangedArgs to include only ContainerActivity and update method calls accordingly. Ensure path change events are invoked with the correct parameters in DiagramDesignerWrapper.razor.cs.

Fixes #241
