### PR TITLE
Refactor activity ID to activity node ID

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -65,7 +65,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.0-rc2.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.0-rc3.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Build workflow designer client assets
         working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.0-rc2" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.0-rc3.1898" />
     <PackageVersion Include="FluentValidation" Version="11.9.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor.cs
@@ -12,9 +12,7 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 
-/// <summary>
 /// Displays the journal for a workflow instance.
-/// </summary>
 public partial class Journal : IAsyncDisposable
 {
     private MudTimeline _timeline = default!;
@@ -22,11 +20,8 @@ public partial class Journal : IAsyncDisposable
     private HubConnection? _hubConnection;
     private WorkflowInstance? _workflowInstance;
 
-    /// <summary>
-    /// Gets or sets a callback that is invoked when a journal entry is selected.
-    /// </summary>
-    [Parameter]
-    public Func<JournalEntry, Task>? JournalEntrySelected { get; set; }
+    /// Gets or sets a callback invoked when a journal entry is selected.
+    [Parameter] public Func<JournalEntry, Task>? JournalEntrySelected { get; set; }
 
     [Inject] private IWorkflowInstanceService WorkflowInstanceService { get; set; } = default!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;
@@ -43,9 +38,7 @@ public partial class Journal : IAsyncDisposable
     private Virtualize<JournalEntry> VirtualizeComponent { get; set; } = default!;
     private int SelectedIndex { get; set; } = -1;
 
-    /// <summary>
     /// Sets the workflow instance to display the journal for.
-    /// </summary>
     public async Task SetWorkflowInstanceAsync(WorkflowInstance workflowInstance, JournalFilter? filter = default)
     {
         WorkflowInstance = workflowInstance;
@@ -55,9 +48,7 @@ public partial class Journal : IAsyncDisposable
         StateHasChanged();
     }
 
-    /// <summary>
     /// Clears the selection.
-    /// </summary>
     public void ClearSelection()
     {
         SelectedEntry = null;
@@ -124,14 +115,11 @@ public partial class Journal : IAsyncDisposable
         var skip = request.StartIndex > 0 ? request.StartIndex - 1 : 0;
         var filter = new JournalFilter();
 
-        if (ShowScopedEvents)
-            filter.ActivityIds = JournalFilter?.ActivityIds;
-
-        if (ShowIncidents)
-            filter.EventNames = ["Faulted"];
+        if (ShowScopedEvents) filter.ActivityNodeIds = JournalFilter?.ActivityNodeIds;
+        if (ShowIncidents) filter.EventNames = ["Faulted"];
 
         filter.ExcludedActivityTypes = ["Elsa.Workflow", "Elsa.Flowchart"];
-        
+
         var response = await InvokeWithBlazorServiceContext(() => WorkflowInstanceService.GetJournalAsync(WorkflowInstance.Id, filter, skip, take));
         var totalCount = request.StartIndex > 0 ? response.TotalCount - 1 : response.TotalCount;
         var records = response.Items.ToArray();
@@ -155,7 +143,7 @@ public partial class Journal : IAsyncDisposable
 
         var selectedEntry = SelectedEntry;
         _currentEntries = entries;
-        
+
         // If the selected entry is still in the list, select it again.
         SelectedEntry = entries.FirstOrDefault(x => x.Record.Id == selectedEntry?.Record.Id);
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
@@ -42,11 +42,11 @@ public partial class WorkflowInstanceViewer
 
     private async Task SelectWorkflowInstanceAsync(WorkflowInstance instance)
     {
-        // Select activity IDs that are direct children of the root.
-        var activityIds = _workflowDefinition.Root.GetActivities().Select(x => x.GetId()).ToList();
+        // Select activity node IDs that are direct children of the root.
+        var activityNodeIds = _workflowDefinition.Root.GetActivities().Select(x => x.GetNodeId()).ToList();
         var filter = new JournalFilter
         {
-            ActivityIds = activityIds
+            ActivityNodeIds = activityNodeIds
         };
         await Journal.SetWorkflowInstanceAsync(instance, filter);
     }
@@ -58,10 +58,10 @@ public partial class WorkflowInstanceViewer
 
     private async Task OnDesignerPathChanged(DesignerPathChangedArgs args)
     {
-        var activityIds = args.ContainerActivity.GetActivities().Select(x => x.GetId()).ToList();
+        var activityNodeIds = args.ContainerActivity.GetActivities().Select(x => x.GetNodeId()).ToList();
         var filter = new JournalFilter
         {
-            ActivityIds = activityIds
+            ActivityNodeIds = activityNodeIds
         };
         await Journal.SetWorkflowInstanceAsync(_workflowInstance, filter);
     }


### PR DESCRIPTION
Updated the code to use `GetNodeId` instead of `GetId` for selecting activity node IDs. Removed redundant XML comments for better code readability and consistency.
