### PR TITLE
Centralize Workflow Definition Management Events

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.0-rc3.1898" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.0-rc3.1908" />
     <PackageVersion Include="FluentValidation" Version="11.9.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />

--- a/Elsa.Studio-Core.sln
+++ b/Elsa.Studio-Core.sln
@@ -83,7 +83,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorApp1", "samples\Blazo
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "client", "client", "{F4B408E1-5169-4FA9-B2D7-2377634C4DEE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Api.Client", "..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj", "{26ECE061-0F39-4945-8356-EF14E67A8F39}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Api.Client", "..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj", "{26ECE061-0F39-4945-8356-EF14E67A8F39}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -33,12 +33,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <!--    <ItemGroup Label="Elsa">-->
-    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-    <!--    </ItemGroup>-->
-
     <ItemGroup Label="Elsa">
-        <PackageReference Include="Elsa.Api.Client"/>
+        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
     </ItemGroup>
+
+    <!--    <ItemGroup Label="Elsa">-->
+    <!--        <PackageReference Include="Elsa.Api.Client"/>-->
+    <!--    </ItemGroup>-->
 
 </Project>

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -33,12 +33,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <ItemGroup Label="Elsa">
-        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
-    </ItemGroup>
-
     <!--    <ItemGroup Label="Elsa">-->
-    <!--        <PackageReference Include="Elsa.Api.Client"/>-->
+    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
     <!--    </ItemGroup>-->
+
+    <ItemGroup Label="Elsa">
+        <PackageReference Include="Elsa.Api.Client"/>
+    </ItemGroup>
 
 </Project>

--- a/src/framework/Elsa.Studio.Core/Services/DefaultMediator.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultMediator.cs
@@ -43,10 +43,10 @@ public class DefaultMediator : IMediator
     /// <inheritdoc />
     public Task NotifyAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification
     {
-        // Collect handlers that were registered manually, and handlers registered via DI.
+        // Collect handlers registered manually, and handlers registered via DI.
         var manualHandlers = _handlers.OfType<INotificationHandler<TNotification>>().ToList();
-        var diHandlers = _serviceProvider.GetServices<INotificationHandler>().OfType<INotificationHandler<TNotification>>().ToList();
-        var handlers = manualHandlers.Concat(diHandlers).ToList();
+        var registeredHandlers = _serviceProvider.GetServices<INotificationHandler>().OfType<INotificationHandler<TNotification>>().ToList();
+        var handlers = manualHandlers.Concat(registeredHandlers).ToList();
         var tasks = handlers.Select(x => x.HandleAsync(notification, cancellationToken));
         return Task.WhenAll(tasks);
     }

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
@@ -10,23 +10,6 @@
                               WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
                               WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected"
                               ActivitySelected="ActivitySelected"
-                              Saving="Saving"
-                              Saved="Saved"
-                              SavingFailed="SavingFailed"
-                              Publishing="Publishing"
-                              Published="Published"
-                              PublishingFailed="PublishingFailed"
-                              Retracting="Retracting"
-                              Retracted="Retracted"
-                              RetractingFailed="RetractingFailed"
-                              Exporting="Exporting"
-                              Exported="Exported"
-                              Importing="Importing"
-                              Imported="Imported"
-                              WorkflowDefinitionReverting="WorkflowDefinitionReverting"
-                              WorkflowDefinitionReverted="WorkflowDefinitionReverted"
-                              WorkflowDefinitionVersionDeleting="WorkflowDefinitionVersionDeleting"
-                              WorkflowDefinitionVersionDeleted="WorkflowDefinitionVersionDeleted"
                               />
 </ThemedComponentWrapper>
 
@@ -44,57 +27,6 @@
 
     /// Gets or sets the event triggered when an activity is selected.
     [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being saved.
-    [Parameter] public EventCallback Saving { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been saved.
-    [Parameter] public EventCallback Saved { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to save.
-    [Parameter] public EventCallback<ValidationErrors> SavingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being published.
-    [Parameter] public EventCallback Publishing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been published.
-    [Parameter] public EventCallback Published { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to publish.
-    [Parameter] public EventCallback<ValidationErrors> PublishingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being retracted.
-    [Parameter] public EventCallback Retracting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been retracted.
-    [Parameter] public EventCallback Retracted { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to retract.
-    [Parameter] public EventCallback<ValidationErrors> RetractingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being exported.
-    [Parameter] public EventCallback Exporting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been exported.
-    [Parameter] public EventCallback Exported { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Importing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Imported { get; set; }
-    
-    /// Gets or sets the callback that is invoked when the workflow definition is about to be reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverting { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverted { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleting { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleted { get; set; }
 
     /// Gets the currently selected activity ID.
     public string? SelectedActivityId => WorkflowDefinitionEditor.SelectedActivityId;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
@@ -56,7 +56,7 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Deletes a workflow definition version.
     /// </summary>
-    Task<bool> DeleteVersionAsync(string id, CancellationToken cancellationToken = default);
+    Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Publishes a workflow definition.
@@ -76,7 +76,7 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Deletes multiple workflow definition versions.
     /// </summary>
-    Task<long> BulkDeleteVersionsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
+    Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Publishes multiple workflow definitions.
@@ -126,7 +126,7 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Reverts the specified workflow definition to the specified version.
     /// </summary>
-    Task<WorkflowDefinitionSummary> RevertVersionAsync(string definitionId, int  version, CancellationToken cancellationToken = default);
+    Task<WorkflowDefinitionSummary> RevertVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Executes a workflow definition.

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
@@ -126,7 +126,7 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Reverts the specified workflow definition to the specified version.
     /// </summary>
-    Task RevertVersionAsync(string definitionId, int  version, CancellationToken cancellationToken = default);
+    Task<WorkflowDefinitionSummary> RevertVersionAsync(string definitionId, int  version, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Executes a workflow definition.

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowDefinitionVersion.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowDefinitionVersion.cs
@@ -1,6 +1,6 @@
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
-namespace Elsa.Studio.Workflows.Shared.Args;
+namespace Elsa.Studio.Workflows.Domain.Models;
 
 public record WorkflowDefinitionVersion(string WorkflowDefinitionId, string WorkflowDefinitionVersionId, int Version)
 {
@@ -12,5 +12,10 @@ public record WorkflowDefinitionVersion(string WorkflowDefinitionId, string Work
     public static WorkflowDefinitionVersion FromDefinitionSummary(WorkflowDefinitionSummary workflowDefinitionSummary)
     {
         return new(workflowDefinitionSummary.DefinitionId, workflowDefinitionSummary.Id, workflowDefinitionSummary.Version);
+    }
+
+    public static WorkflowDefinitionVersion FromDefinitionModel(WorkflowDefinitionModel model)
+    {
+        return new(model.DefinitionId, model.Id, model.Version);
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverted.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionReverted(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverting.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionReverting(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleted.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record BulkWorkflowDefinitionVersionsDeleted(ICollection<WorkflowDefinitionVersion> Versions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleting.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record BulkWorkflowDefinitionVersionsDeleting(ICollection<WorkflowDefinitionVersion> Versions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleted.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionsDeleted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleting.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionsDeleting(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublished.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublished.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionsPublished(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracted.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionsRetracted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracting.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record BulkWorkflowDefinitionsRetracting(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleted.cs
@@ -2,4 +2,4 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionDeleted(string WorkflowDefinitionVersionId) : INotification;
+public record WorkflowDefinitionDeleted(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleting.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionDeleting(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExported.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExported.cs
@@ -1,0 +1,7 @@
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionExported(string WorkflowDefinitionId, VersionOptions? VersionOptions, FileDownload FileDownload) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExporting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExporting.cs
@@ -1,0 +1,6 @@
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionExporting(string WorkflowDefinitionId, VersionOptions? VersionOptions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionImported.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionImported.cs
@@ -1,0 +1,6 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionImported(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionImporting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionImporting.cs
@@ -1,0 +1,6 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionImporting(WorkflowDefinitionModel WorkflowDefinitionModel) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublished.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublished.cs
@@ -1,9 +1,6 @@
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-/// <summary>
-/// Represents a notification that is sent when a workflow definition is published.
-/// </summary>
-public record WorkflowDefinitionPublished(WorkflowDefinition WorkflowDefinition) : INotification;
+/// Represents a notification sent when a workflow definition is published.
+public record WorkflowDefinitionPublished(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishing.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishing.cs
@@ -1,0 +1,6 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+/// Represents a notification sent when a workflow definition is about to be published.
+public record WorkflowDefinitionPublishing(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishingFailed.cs
@@ -1,0 +1,6 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionPublishingFailed(WorkflowDefinitionVersion WorkflowDefinitionVersion, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracted.cs
@@ -1,6 +1,5 @@
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionRetracted(WorkflowDefinition WorkflowDefinition) : INotification;
+public record WorkflowDefinitionRetracted(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracting.cs
@@ -1,0 +1,5 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionRetracting(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetractingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetractingFailed.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record WorkflowDefinitionRetractingFailed(string WorkflowDefinitionId, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverted.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record WorkflowDefinitionReverted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverting.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record WorkflowDefinitionReverting(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSaved.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSaved.cs
@@ -1,0 +1,7 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+/// Represents a notification sent when a workflow definition has been saved.
+public record WorkflowDefinitionSaved(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSaving.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSaving.cs
@@ -1,0 +1,7 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+/// Represents a notification sent when a workflow definition is about to be saved.
+public record WorkflowDefinitionSaving(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSavingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSavingFailed.cs
@@ -1,0 +1,6 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Notifications;
+
+public record WorkflowDefinitionSavingFailed(WorkflowDefinitionVersion WorkflowDefinitionVersion, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleting.cs
@@ -3,4 +3,4 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;
+public record WorkflowDefinitionVersionDeleting(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionsBulkDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionsBulkDeleted.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Contracts;
-
-namespace Elsa.Studio.Workflows.Domain.Notifications;
-
-public record WorkflowDefinitionVersionsBulkDeleted(ICollection<string> Ids) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkDeleted.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Contracts;
-
-namespace Elsa.Studio.Workflows.Domain.Notifications;
-
-public record WorkflowDefinitionsBulkDeleted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkPublished.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkPublished.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Contracts;
-
-namespace Elsa.Studio.Workflows.Domain.Notifications;
-
-public record WorkflowDefinitionsBulkPublished(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkRetracted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionsBulkRetracted.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Contracts;
-
-namespace Elsa.Studio.Workflows.Domain.Notifications;
-
-public record WorkflowDefinitionsBulkRetracted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
@@ -299,10 +299,10 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task RevertVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
+    public async Task<WorkflowDefinitionSummary> RevertVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
-        await api.RevertVersionAsync(definitionId, version, cancellationToken);
+        return await api.RevertVersionAsync(definitionId, version, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteWorkflowDefinitionService.cs
@@ -19,22 +19,8 @@ namespace Elsa.Studio.Workflows.Domain.Services;
 /// <summary>
 /// A workflow definition service that uses a remote backend to retrieve workflow definitions.
 /// </summary>
-public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
+public class RemoteWorkflowDefinitionService(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IIdentityGenerator identityGenerator, IMediator mediator) : IWorkflowDefinitionService
 {
-    private readonly IRemoteBackendApiClientProvider _remoteBackendApiClientProvider;
-    private readonly IIdentityGenerator _identityGenerator;
-    private readonly IMediator _mediator;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RemoteWorkflowDefinitionService"/> class.
-    /// </summary>
-    public RemoteWorkflowDefinitionService(IRemoteBackendApiClientProvider remoteBackendApiClientProvider, IIdentityGenerator identityGenerator, IMediator mediator)
-    {
-        _remoteBackendApiClientProvider = remoteBackendApiClientProvider;
-        _identityGenerator = identityGenerator;
-        _mediator = mediator;
-    }
-
     /// <inheritdoc />
     public async Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default)
     {
@@ -70,7 +56,7 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
         var api = await GetApiAsync(cancellationToken);
         return await api.GetSubgraphAsync(id, parentNodeId, cancellationToken);
     }
-    
+
     /// <inheritdoc />
     public async Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default)
     {
@@ -82,21 +68,23 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     public async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(SaveWorkflowDefinitionRequest request, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
-
+        var workflowDefinitionVersion = WorkflowDefinitionVersion.FromDefinitionModel(request.Model);
+        
         try
         {
+            if (request.Publish == true) await mediator.NotifyAsync(new WorkflowDefinitionPublishing(workflowDefinitionVersion.WorkflowDefinitionId), cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionSaving(workflowDefinitionVersion), cancellationToken);
             var response = await api.SaveAsync(request, cancellationToken);
-
-            if (request.Publish == true)
-            {
-                await _mediator.NotifyAsync(new WorkflowDefinitionPublished(response.WorkflowDefinition), cancellationToken);
-            }
-
+            var newWorkflowDefinitionVersion = WorkflowDefinitionVersion.FromDefinition(response.WorkflowDefinition);
+            await mediator.NotifyAsync(new WorkflowDefinitionSaved(newWorkflowDefinitionVersion), cancellationToken);
+            if (request.Publish == true) await mediator.NotifyAsync(new WorkflowDefinitionPublished(newWorkflowDefinitionVersion.WorkflowDefinitionId), cancellationToken);
             return new(response);
         }
         catch (ValidationApiException e)
         {
             var errors = e.GetValidationErrors();
+            await mediator.NotifyAsync(new WorkflowDefinitionSavingFailed(workflowDefinitionVersion, errors), cancellationToken);
+            if (request.Publish == true) await mediator.NotifyAsync(new WorkflowDefinitionPublishingFailed(workflowDefinitionVersion, errors), cancellationToken);
             return new(errors);
         }
     }
@@ -105,8 +93,9 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     public async Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionPublishing(definitionId), cancellationToken);
         var response = await api.PublishAsync(definitionId, new PublishWorkflowDefinitionRequest(), cancellationToken);
-        await _mediator.NotifyAsync(new WorkflowDefinitionPublished(response.WorkflowDefinition), cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionPublished(definitionId), cancellationToken);
         return response;
     }
 
@@ -116,14 +105,15 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
         try
         {
             var api = await GetApiAsync(cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionRetracting(definitionId), cancellationToken);
             var definition = await api.RetractAsync(definitionId, new RetractWorkflowDefinitionRequest(), cancellationToken);
-
-            await _mediator.NotifyAsync(new WorkflowDefinitionRetracted(definition), cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionRetracted(definitionId), cancellationToken);
             return new(definition);
         }
         catch (ValidationApiException e)
         {
             var errors = e.GetValidationErrors();
+            await mediator.NotifyAsync(new WorkflowDefinitionRetractingFailed(definitionId, errors), cancellationToken);
             return new(errors);
         }
     }
@@ -135,8 +125,9 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
 
         try
         {
+            await mediator.NotifyAsync(new WorkflowDefinitionDeleting(definitionId), cancellationToken);
             await api.DeleteAsync(definitionId, cancellationToken);
-            await _mediator.NotifyAsync(new WorkflowDefinitionDeleted(definitionId), cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionDeleted(definitionId), cancellationToken);
             return true;
         }
         catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -146,14 +137,15 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DeleteVersionAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
 
         try
         {
-            await api.DeleteVersionAsync(id, cancellationToken);
-            await _mediator.NotifyAsync(new WorkflowDefinitionVersionDeleted(id), cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionVersionDeleting(workflowDefinitionVersion), cancellationToken);
+            await api.DeleteVersionAsync(workflowDefinitionVersion.WorkflowDefinitionVersionId, cancellationToken);
+            await mediator.NotifyAsync(new WorkflowDefinitionVersionDeleted(workflowDefinitionVersion), cancellationToken);
             return true;
         }
         catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -166,23 +158,24 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     public async Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default)
     {
         var definitionIdList = definitionIds.ToList();
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionsDeleting(definitionIdList), cancellationToken);
         var request = new BulkDeleteWorkflowDefinitionsRequest(definitionIdList);
         var api = await GetApiAsync(cancellationToken);
         var response = await api.BulkDeleteAsync(request, cancellationToken);
-
-        await _mediator.NotifyAsync(new WorkflowDefinitionsBulkDeleted(definitionIdList), cancellationToken);
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionsDeleted(definitionIdList), cancellationToken);
         return response.Deleted;
     }
 
     /// <inheritdoc />
-    public async Task<long> BulkDeleteVersionsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    public async Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default)
     {
-        var idList = ids.ToList();
-        var request = new BulkDeleteWorkflowDefinitionVersionsRequest(idList);
+        var versions = workflowDefinitionVersions.ToList();
+        var ids = versions.Select(x => x.WorkflowDefinitionVersionId).ToList();
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionVersionsDeleting(versions), cancellationToken);
+        var request = new BulkDeleteWorkflowDefinitionVersionsRequest(ids);
         var api = await GetApiAsync(cancellationToken);
         var response = await api.BulkDeleteVersionsAsync(request, cancellationToken);
-
-        await _mediator.NotifyAsync(new WorkflowDefinitionVersionsBulkDeleted(idList), cancellationToken);
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionVersionsDeleted(versions), cancellationToken);
         return response.Deleted;
     }
 
@@ -193,18 +186,19 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
         var api = await GetApiAsync(cancellationToken);
         var response = await api.BulkPublishAsync(request, cancellationToken);
 
-        await _mediator.NotifyAsync(new WorkflowDefinitionsBulkPublished(response.Published), cancellationToken);
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionsPublished(response.Published), cancellationToken);
         return response;
     }
 
     /// <inheritdoc />
     public async Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default)
     {
-        var request = new BulkRetractWorkflowDefinitionsRequest(definitionIds);
+        var definitionIdList = definitionIds.ToList();
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionsRetracting(definitionIdList), cancellationToken);
+        var request = new BulkRetractWorkflowDefinitionsRequest(definitionIdList);
         var api = await GetApiAsync(cancellationToken);
         var response = await api.BulkRetractAsync(request, cancellationToken);
-
-        await _mediator.NotifyAsync(new WorkflowDefinitionsBulkPublished(response.Retracted), cancellationToken);
+        await mediator.NotifyAsync(new BulkWorkflowDefinitionsRetracted(response.Retracted), cancellationToken);
         return response;
     }
 
@@ -250,7 +244,7 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
                 IsPublished = false,
                 Root = new JsonObject(new Dictionary<string, JsonNode?>
                 {
-                    ["id"] = _identityGenerator.GenerateId(),
+                    ["id"] = identityGenerator.GenerateId(),
                     ["type"] = "Elsa.Flowchart",
                     ["version"] = 1,
                     ["name"] = "Flowchart1"
@@ -268,17 +262,25 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     public async Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionExporting(definitionId, versionOptions), cancellationToken);
         var response = await api.ExportAsync(definitionId, versionOptions, cancellationToken);
         var fileName = response.GetDownloadedFileNameOrDefault($"workflow-definition-{definitionId}.json");
-
-        return new FileDownload(fileName, response.Content!);
+        var fileDownload = new FileDownload(fileName, response.Content!);
+        await mediator.NotifyAsync(new WorkflowDefinitionExported(definitionId, versionOptions, fileDownload), cancellationToken);
+        
+        return fileDownload;
     }
 
     /// <inheritdoc />
     public async Task<WorkflowDefinition> ImportDefinitionAsync(WorkflowDefinitionModel definitionModel, CancellationToken cancellationToken = default)
     {
+        var workflowDefinitionVersion = WorkflowDefinitionVersion.FromDefinitionModel(definitionModel);
+        await mediator.NotifyAsync(new WorkflowDefinitionSaving(workflowDefinitionVersion), cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionImporting(definitionModel), cancellationToken);
         var api = await GetApiAsync(cancellationToken);
-        return await api.ImportAsync(definitionModel, cancellationToken);
+        var newWorkflowDefinition = await api.ImportAsync(definitionModel, cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionImported(newWorkflowDefinition), cancellationToken);
+        return newWorkflowDefinition;
     }
 
     /// <inheritdoc />
@@ -299,10 +301,14 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task<WorkflowDefinitionSummary> RevertVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
+    public async Task<WorkflowDefinitionSummary> RevertVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default)
     {
         var api = await GetApiAsync(cancellationToken);
-        return await api.RevertVersionAsync(definitionId, version, cancellationToken);
+        await mediator.NotifyAsync(new WorkflowDefinitionReverting(workflowDefinitionVersion), cancellationToken);
+        var newWorkflowDefinitionSummary = await api.RevertVersionAsync(workflowDefinitionVersion.WorkflowDefinitionId, workflowDefinitionVersion.Version, cancellationToken);
+        var newWorkflowDefinitionVersion = WorkflowDefinitionVersion.FromDefinitionSummary(newWorkflowDefinitionSummary);
+        await mediator.NotifyAsync(new WorkflowDefinitionReverted(newWorkflowDefinitionVersion), cancellationToken);
+        return newWorkflowDefinitionSummary;
     }
 
     /// <inheritdoc />
@@ -324,11 +330,11 @@ public class RemoteWorkflowDefinitionService : IWorkflowDefinitionService
 
     private async Task<IWorkflowDefinitionsApi> GetApiAsync(CancellationToken cancellationToken = default)
     {
-        return await _remoteBackendApiClientProvider.GetApiAsync<IWorkflowDefinitionsApi>(cancellationToken);
+        return await remoteBackendApiClientProvider.GetApiAsync<IWorkflowDefinitionsApi>(cancellationToken);
     }
-    
+
     private async Task<IExecuteWorkflowApi> GetExecuteWorkflowApiAsync(CancellationToken cancellationToken = default)
     {
-        return await _remoteBackendApiClientProvider.GetApiAsync<IExecuteWorkflowApi>(cancellationToken);
+        return await remoteBackendApiClientProvider.GetApiAsync<IExecuteWorkflowApi>(cancellationToken);
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -56,12 +56,6 @@
                 <WorkflowProperties 
                     WorkflowDefinition="@SelectedWorkflowDefinition" 
                     WorkflowDefinitionUpdated="OnWorkflowDefinitionPropsUpdated"
-                    WorkflowDefinitionReverting="WorkflowDefinitionReverting"
-                    WorkflowDefinitionReverted="WorkflowDefinitionReverted"
-                    WorkflowDefinitionVersionDeleting="WorkflowDefinitionVersionDeleting"
-                    WorkflowDefinitionVersionDeleted="WorkflowDefinitionVersionDeleted"
-                    WorkflowDefinitionVersionBulkDeleting="WorkflowDefinitionVersionBulkDeleting"
-                    WorkflowDefinitionVersionBulkDeleted="WorkflowDefinitionVersionBulkDeleted"
                     />
             }
         </RadzenSplitterPane>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -24,20 +24,7 @@
                                             WorkflowDefinition="SelectedWorkflowDefinition" 
                                             WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated" 
                                             WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
-                                            ActivitySelected="ActivitySelected"
-                                            Saving="Saving"
-                                            Saved="Saved"
-                                            SavingFailed="SavingFailed"
-                                            Publishing="Publishing"
-                                            Published="Published"
-                                            PublishingFailed="PublishingFailed"
-                                            Retracting="Retracting"
-                                            Retracted="Retracted"
-                                            RetractingFailed="RetractingFailed"
-                                            Exporting="Exporting"
-                                            Exported="Exported"
-                                            Importing="Importing"
-                                            Imported="Imported"/>
+                                            ActivitySelected="ActivitySelected"/>
                         }
                         else
                         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -60,6 +60,8 @@
                     WorkflowDefinitionReverted="WorkflowDefinitionReverted"
                     WorkflowDefinitionVersionDeleting="WorkflowDefinitionVersionDeleting"
                     WorkflowDefinitionVersionDeleted="WorkflowDefinitionVersionDeleted"
+                    WorkflowDefinitionVersionBulkDeleting="WorkflowDefinitionVersionBulkDeleting"
+                    WorkflowDefinitionVersionBulkDeleted="WorkflowDefinitionVersionBulkDeleted"
                     />
             }
         </RadzenSplitterPane>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -42,63 +42,11 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     /// </summary>
     [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
 
-    /// Gets or sets the event triggered when the workflow definition is being saved.
-    [Parameter] public EventCallback Saving { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been saved.
-    [Parameter] public EventCallback Saved { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to save.
-    [Parameter] public EventCallback<ValidationErrors> SavingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being published.
-    [Parameter] public EventCallback Publishing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been published.
-    [Parameter] public EventCallback Published { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to publish.
-    [Parameter] public EventCallback<ValidationErrors> PublishingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being retracted.
-    [Parameter] public EventCallback Retracting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been retracted.
-    [Parameter] public EventCallback Retracted { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to retract.
-    [Parameter] public EventCallback<ValidationErrors> RetractingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being exported.
-    [Parameter] public EventCallback Exporting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been exported.
-    [Parameter] public EventCallback Exported { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Importing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Imported { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is about to be reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverting { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverted { get; set; }
-
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleting { get; set; }
-
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleted { get; set; }
-
     /// An event that is invoked when the workflow definition is updated.
     public event Func<Task>? WorkflowDefinitionUpdated;
 
     /// <inheritdoc />
-    public bool IsReadOnly => SelectedWorkflowDefinition?.IsLatest == false
-                              || (SelectedWorkflowDefinition?.Links?.Count(l => l.Rel == "publish") ?? 0) == 0;
+    public bool IsReadOnly => SelectedWorkflowDefinition?.IsLatest == false || (SelectedWorkflowDefinition?.Links?.Count(l => l.Rel == "publish") ?? 0) == 0;
 
     /// <inheritdoc />
     public bool HasWorkflowEditPermission => (SelectedWorkflowDefinition?.Links?.Count(l => l.Rel == "publish") ?? 0) > 0;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -3,7 +3,7 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
-using Elsa.Studio.Workflows.Shared.Args;
+using Elsa.Studio.Workflows.Domain.Models;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
@@ -14,25 +14,7 @@ public partial class VersionHistoryTab : IDisposable
 {
     /// Gets or sets the definition ID.
     [Parameter] public string DefinitionId { get; set; } = default!;
-
-    /// Gets or sets a callback invoked when the workflow definition is about to be reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverting { get; set; }
-
-    /// Gets or sets a callback invoked when the workflow definition is reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverted { get; set; }
-
-    /// Gets or sets a callback invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleting { get; set; }
-
-    /// Gets or sets a callback invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleted { get; set; }
-
-    /// Gets or sets a callback invoked when workflow definition versions are about to be deleted in bulk.
-    [Parameter] public EventCallback<BulkWorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionBulkDeleting { get; set; }
-
-    /// Gets or sets a callback invoked when workflow definition versions have been deleted in bulk.
-    [Parameter] public EventCallback<BulkWorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionBulkDeleted { get; set; }
-
+    
     [CascadingParameter] private WorkflowDefinitionWorkspace Workspace { get; set; } = default!;
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
@@ -111,12 +93,9 @@ public partial class VersionHistoryTab : IDisposable
 
         if (confirmed != true)
             return;
-
-        var definitionVersion = new WorkflowDefinitionVersion(workflowDefinitionSummary.DefinitionId, workflowDefinitionSummary.Id, workflowDefinitionSummary.Version);
-        var eventArgs = new WorkflowDefinitionVersionEventArgs(definitionVersion);
-        if (WorkflowDefinitionVersionDeleting.HasDelegate) await WorkflowDefinitionVersionDeleting.InvokeAsync(eventArgs);
-        await WorkflowDefinitionService.DeleteVersionAsync(workflowDefinitionSummary.Id);
-        if (WorkflowDefinitionVersionDeleting.HasDelegate) await WorkflowDefinitionVersionDeleted.InvokeAsync(eventArgs);
+        
+        var workflowDefinitionVersion = WorkflowDefinitionVersion.FromDefinitionSummary(workflowDefinitionSummary);
+        await WorkflowDefinitionService.DeleteVersionAsync(workflowDefinitionVersion);
         await ReloadTableAsync();
     }
 
@@ -133,35 +112,7 @@ public partial class VersionHistoryTab : IDisposable
             return;
 
         var definitionVersions = SelectedDefinitions.Select(WorkflowDefinitionVersion.FromDefinitionSummary).ToList();
-
-        if (WorkflowDefinitionVersionBulkDeleting.HasDelegate)
-            await WorkflowDefinitionVersionBulkDeleting.InvokeAsync(new BulkWorkflowDefinitionVersionEventArgs(definitionVersions));
-
-        if (WorkflowDefinitionVersionDeleting.HasDelegate)
-        {
-            foreach (var definition in SelectedDefinitions)
-            {
-                var definitionVersion = new WorkflowDefinitionVersion(definition.DefinitionId, definition.Id, definition.Version);
-                var eventArgs = new WorkflowDefinitionVersionEventArgs(definitionVersion);
-                await WorkflowDefinitionVersionDeleting.InvokeAsync(eventArgs);
-            }
-        }
-
-        var ids = SelectedDefinitions.Select(x => x.Id).ToList();
-        await WorkflowDefinitionService.BulkDeleteVersionsAsync(ids);
-
-        if (WorkflowDefinitionVersionDeleting.HasDelegate)
-        {
-            foreach (var definition in SelectedDefinitions)
-            {
-                var definitionVersion = new WorkflowDefinitionVersion(definition.DefinitionId, definition.Id, definition.Version);
-                var eventArgs = new WorkflowDefinitionVersionEventArgs(definitionVersion);
-                await WorkflowDefinitionVersionDeleted.InvokeAsync(eventArgs);
-            }
-        }
-
-        if (WorkflowDefinitionVersionBulkDeleted.HasDelegate)
-            await WorkflowDefinitionVersionBulkDeleted.InvokeAsync(new BulkWorkflowDefinitionVersionEventArgs(definitionVersions));
+        await WorkflowDefinitionService.BulkDeleteVersionsAsync(definitionVersions);
         await ReloadTableAsync();
     }
 
@@ -171,12 +122,7 @@ public partial class VersionHistoryTab : IDisposable
         var definitionId = workflowDefinition.DefinitionId;
         var version = workflowDefinition.Version;
         var revertingVersion = new WorkflowDefinitionVersion(definitionVersionId, definitionId, version);
-        var revertingEventArgs = new WorkflowDefinitionVersionEventArgs(revertingVersion);
-        if (WorkflowDefinitionReverting.HasDelegate) await WorkflowDefinitionReverting.InvokeAsync(revertingEventArgs);
-        var newDefinition = await WorkflowDefinitionService.RevertVersionAsync(definitionId, version);
-        var revertedVersion = new WorkflowDefinitionVersion(definitionId, newDefinition.Id, newDefinition.Version);
-        var revertedEventArgs = new WorkflowDefinitionVersionEventArgs(revertedVersion);
-        if (WorkflowDefinitionReverting.HasDelegate) await WorkflowDefinitionReverted.InvokeAsync(revertedEventArgs);
+        await WorkflowDefinitionService.RevertVersionAsync(revertingVersion);
         await Workspace.RefreshActiveWorkflowAsync();
         await ReloadTableAsync();
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor
@@ -16,12 +16,6 @@
         <InputOutputTab WorkflowDefinition="@WorkflowDefinition" WorkflowDefinitionUpdated="WorkflowDefinitionUpdated"/>
     </MudTabPanel>
     <MudTabPanel Text="Version history">
-        <VersionHistoryTab 
-            DefinitionId="@WorkflowDefinition.DefinitionId" 
-            WorkflowDefinitionReverting="WorkflowDefinitionReverting" 
-            WorkflowDefinitionReverted="WorkflowDefinitionReverted"
-            WorkflowDefinitionVersionDeleting="WorkflowDefinitionVersionDeleting"
-            WorkflowDefinitionVersionDeleted="WorkflowDefinitionVersionDeleted"
-            />
+        <VersionHistoryTab DefinitionId="@WorkflowDefinition.DefinitionId"/>
     </MudTabPanel>
 </MudTabs>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor.cs
@@ -8,16 +8,4 @@ public partial class WorkflowProperties
 {
     [Parameter] public WorkflowDefinition WorkflowDefinition { get; set; } = default!;
     [Parameter] public EventCallback WorkflowDefinitionUpdated { get; set; }
-    
-    /// Gets or sets the callback that is invoked when the workflow definition is about to be reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverting { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverted { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleting { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleted { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -27,23 +27,6 @@
                 WorkflowDefinitionVersionSelected="WorkflowDefinitionVersionSelected"
                 WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
                 ActivitySelected="ActivitySelected"
-                Saving="Saving"
-                Saved="Saved"
-                SavingFailed="SavingFailed"
-                Publishing="Publishing"
-                Published="Published"
-                PublishingFailed="PublishingFailed"
-                Retracting="Retracting"
-                Retracted="Retracted"
-                RetractingFailed="RetractingFailed"
-                Exporting="Exporting"
-                Exported="Exported"
-                Importing="Importing"
-                Imported="Imported"
-                WorkflowDefinitionReverting="WorkflowDefinitionReverting"
-                WorkflowDefinitionReverted="WorkflowDefinitionReverted"
-                WorkflowDefinitionVersionDeleting="WorkflowDefinitionVersionDeleting"
-                WorkflowDefinitionVersionDeleted="WorkflowDefinitionVersionDeleted"
                 />
         </RadzenSplitterPane>
     </RadzenSplitter>
@@ -63,57 +46,6 @@
 
     /// Gets or sets the event triggered when an activity is selected.
     [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being saved.
-    [Parameter] public EventCallback Saving { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been saved.
-    [Parameter] public EventCallback Saved { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to save.
-    [Parameter] public EventCallback<ValidationErrors> SavingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being published.
-    [Parameter] public EventCallback Publishing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been published.
-    [Parameter] public EventCallback Published { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to publish.
-    [Parameter] public EventCallback<ValidationErrors> PublishingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being retracted.
-    [Parameter] public EventCallback Retracting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been retracted.
-    [Parameter] public EventCallback Retracted { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has failed to retract.
-    [Parameter] public EventCallback<ValidationErrors> RetractingFailed { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being exported.
-    [Parameter] public EventCallback Exporting { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been exported.
-    [Parameter] public EventCallback Exported { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition is being imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Importing { get; set; }
-
-    /// Gets or sets the event triggered when the workflow definition has been imported.
-    [Parameter] public EventCallback<IReadOnlyList<IBrowserFile>> Imported { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is about to be reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverting { get; set; }
-
-    /// Gets or sets the callback that is invoked when the workflow definition is reverted to an earlier version.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionReverted { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleting { get; set; }
-    
-    /// Gets or sets a callback that is invoked when the workflow definition version is about to be deleted.
-    [Parameter] public EventCallback<WorkflowDefinitionVersionEventArgs> WorkflowDefinitionVersionDeleted { get; set; }
 
     /// Gets the currently selected workflow definition version.
     public WorkflowDefinition? GetSelectedWorkflowDefinitionVersion() => WorkflowDefinitionWorkspace.GetSelectedWorkflowDefinitionVersion();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -13,18 +13,14 @@ using Refit;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
 
-/// <summary>
 /// Displays a list of workflow definitions.
-/// </summary>
 public partial class WorkflowDefinitionList
 {
     private MudTable<WorkflowDefinitionRow> _table = null!;
     private HashSet<WorkflowDefinitionRow> _selectedRows = new();
     private long _totalCount;
-
-    /// <summary>
+    
     /// An event that is invoked when a workflow definition is edited.
-    /// </summary>
     [Parameter] public EventCallback<string> EditWorkflowDefinition { get; set; }
     
     [Inject] private IDialogService DialogService { get; set; } = default!;
@@ -34,7 +30,7 @@ public partial class WorkflowDefinitionList
     [Inject] private IFiles Files { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
     private string SearchTerm { get; set; } = string.Empty;
-    public bool IsReadOnlyMode = false;
+    private bool IsReadOnlyMode { get; set; }
     private const string ReadonlyWorkflowsExcluded = "The read-only workflows will not be affected.";
 
     private async Task<TableData<WorkflowDefinitionRow>> ServerReload(TableState state)
@@ -54,9 +50,7 @@ public partial class WorkflowDefinitionList
         var workflowDefinitionRows = await InvokeWithBlazorServiceContext(async () =>
         {
             var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest);
-            
             IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l=> l.Rel == "bulk-publish") ?? 0) == 0;
-            
             var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitionsResponse.Items.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 
             var publishedWorkflowDefinitions = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest

--- a/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
+++ b/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
@@ -1,19 +1,19 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Notifications;
+using JetBrains.Annotations;
 
 namespace Elsa.Studio.Workflows.Handlers;
 
-/// <summary>
 /// A handler that refreshes the activity registry when a workflow definition is deleted, published or retracted.
-/// </summary>
-public class RefreshActivityRegistry :INotificationHandler<WorkflowDefinitionDeleted>,
+[UsedImplicitly]
+public class RefreshActivityRegistry : INotificationHandler<WorkflowDefinitionDeleted>,
     INotificationHandler<WorkflowDefinitionPublished>,
     INotificationHandler<WorkflowDefinitionRetracted>,
-    INotificationHandler<WorkflowDefinitionsBulkDeleted>,
-    INotificationHandler<WorkflowDefinitionVersionsBulkDeleted>,
-    INotificationHandler<WorkflowDefinitionsBulkPublished>,
-    INotificationHandler<WorkflowDefinitionsBulkRetracted>
+    INotificationHandler<BulkWorkflowDefinitionsDeleted>,
+    INotificationHandler<BulkWorkflowDefinitionVersionsDeleted>,
+    INotificationHandler<BulkWorkflowDefinitionsPublished>,
+    INotificationHandler<BulkWorkflowDefinitionsRetracted>
 {
     private readonly IActivityRegistry _activityRegistry;
 
@@ -24,14 +24,14 @@ public class RefreshActivityRegistry :INotificationHandler<WorkflowDefinitionDel
     {
         _activityRegistry = activityRegistry;
     }
-    
+
     async Task INotificationHandler<WorkflowDefinitionDeleted>.HandleAsync(WorkflowDefinitionDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
     async Task INotificationHandler<WorkflowDefinitionPublished>.HandleAsync(WorkflowDefinitionPublished notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
     async Task INotificationHandler<WorkflowDefinitionRetracted>.HandleAsync(WorkflowDefinitionRetracted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
-    async Task INotificationHandler<WorkflowDefinitionsBulkDeleted>.HandleAsync(WorkflowDefinitionsBulkDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
-    async Task INotificationHandler<WorkflowDefinitionVersionsBulkDeleted>.HandleAsync(WorkflowDefinitionVersionsBulkDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
-    async Task INotificationHandler<WorkflowDefinitionsBulkPublished>.HandleAsync(WorkflowDefinitionsBulkPublished notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
-    async Task INotificationHandler<WorkflowDefinitionsBulkRetracted>.HandleAsync(WorkflowDefinitionsBulkRetracted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
+    async Task INotificationHandler<BulkWorkflowDefinitionsDeleted>.HandleAsync(BulkWorkflowDefinitionsDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
+    async Task INotificationHandler<BulkWorkflowDefinitionVersionsDeleted>.HandleAsync(BulkWorkflowDefinitionVersionsDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
+    async Task INotificationHandler<BulkWorkflowDefinitionsPublished>.HandleAsync(BulkWorkflowDefinitionsPublished notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
+    async Task INotificationHandler<BulkWorkflowDefinitionsRetracted>.HandleAsync(BulkWorkflowDefinitionsRetracted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
 
     private async Task RefreshActivityRegistryAsync(CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
@@ -1,3 +1,5 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
 namespace Elsa.Studio.Workflows.Shared.Args;
 
 public record BulkWorkflowDefinitionVersionEventArgs(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Studio.Workflows.Shared.Args;
+
+public record BulkWorkflowDefinitionVersionEventArgs(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/BulkWorkflowDefinitionVersionEventArgs.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Workflows.Domain.Models;
-
-namespace Elsa.Studio.Workflows.Shared.Args;
-
-public record BulkWorkflowDefinitionVersionEventArgs(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
@@ -1,3 +1,3 @@
 namespace Elsa.Studio.Workflows.Shared.Args;
 
-public record WorkflowDefinitionVersionEventArgs(string WorkflowDefinitionVersionId, string WorkflowDefinitionId, int Version);
+public record WorkflowDefinitionVersionEventArgs(WorkflowDefinitionVersion WorkflowDefinitionVersion);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
@@ -1,3 +1,5 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
 namespace Elsa.Studio.Workflows.Shared.Args;
 
 public record WorkflowDefinitionVersionEventArgs(WorkflowDefinitionVersion WorkflowDefinitionVersion);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionReversionEventArgs.cs
@@ -1,5 +1,0 @@
-using Elsa.Studio.Workflows.Domain.Models;
-
-namespace Elsa.Studio.Workflows.Shared.Args;
-
-public record WorkflowDefinitionVersionEventArgs(WorkflowDefinitionVersion WorkflowDefinitionVersion);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionVersion.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/WorkflowDefinitionVersion.cs
@@ -1,0 +1,16 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+
+namespace Elsa.Studio.Workflows.Shared.Args;
+
+public record WorkflowDefinitionVersion(string WorkflowDefinitionId, string WorkflowDefinitionVersionId, int Version)
+{
+    public static WorkflowDefinitionVersion FromDefinition(WorkflowDefinition workflowDefinition)
+    {
+        return new(workflowDefinition.DefinitionId, workflowDefinition.Id, workflowDefinition.Version);
+    }
+    
+    public static WorkflowDefinitionVersion FromDefinitionSummary(WorkflowDefinitionSummary workflowDefinitionSummary)
+    {
+        return new(workflowDefinitionSummary.DefinitionId, workflowDefinitionSummary.Id, workflowDefinitionSummary.Version);
+    }
+}


### PR DESCRIPTION
This PR refactors the events published by the workflow definition editor component by leveraging the mediator service. This new approach centralizes event handling, making it more flexible and significantly simplifying maintenance.

### Key Changes
- **Event Handling**: Previously, components had to expose multiple events each, requiring cascading through the component tree. Now, central services raise notifications via the mediator, eliminating the need for components to manage events individually.
- **Flexibility and Maintenance**: The new system allows any component or domain service to handle notifications they are interested in, improving flexibility and simplifying maintenance.
- **Issue Fix**: Resolves the issue where events like "WorkflowDeleted" were only fired from specific components (e.g., WorkflowDefinitionEditor) and not from others (e.g., WorkflowDefinitionListView).

This change ensures more consistent and manageable event handling across the application.