### PR TITLE
fix: Method parameters are incorrect in Snackbar.Add

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -412,7 +412,7 @@ public partial class WorkflowEditor
             await Retracted.InvokeAsync();
         }, async errors =>
         {
-            Snackbar.Add(string.Join(Environment.NewLine, errors, Severity.Error));
+            Snackbar.Add(string.Join(Environment.NewLine, errors), Severity.Error);
             await RetractingFailed.InvokeAsync(errors);
         }));
     }


### PR DESCRIPTION
- Correct typo in `OnRetractClicked` method's Snackbar message upon failure in `WorkflowEditor.razor.cs`.