### PR TITLE
Add UI Hint Handler for Workflow Context Picker

### DIFF
--- a/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextProviderPicker.razor
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextProviderPicker.razor
@@ -1,0 +1,24 @@
+@using Elsa.Api.Client.Shared.UIHints.DropDown
+@inherits StudioComponentBase
+@{
+    var inputDescriptor = EditorContext.InputDescriptor;
+    var displayName = inputDescriptor.DisplayName;
+    var description = inputDescriptor.Description;
+    var selectedValue = GetSelectedValue();
+    var searchBox = _items.Count > 10;
+}
+
+<MudSelectExtended
+    T="SelectListItem"
+    Label="@displayName"
+    Variant="MudBlazor.Variant.Outlined"
+    HelperText="@description"
+    Margin="Margin.Dense"
+    Value="@selectedValue"
+    SearchBox="@searchBox"
+    ItemCollection="@_items"
+    ToStringFunc="@(item => item?.Text ?? "")"
+    ValueChanged="OnValueChanged"
+    ReadOnly="EditorContext.IsReadOnly"
+    Disabled="EditorContext.IsReadOnly">
+</MudSelectExtended>

--- a/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextProviderPicker.razor.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextProviderPicker.razor.cs
@@ -1,0 +1,52 @@
+using Elsa.Api.Client.Shared.UIHints.DropDown;
+using Elsa.Api.Client.Resources.WorkflowExecutionContexts.Models;
+using Elsa.Studio.Models;
+using Microsoft.AspNetCore.Components;
+using Elsa.Extensions;
+using Elsa.Studio.WorkflowContexts.Contracts;
+using Elsa.Api.Client.Resources.Scripting.Models;
+
+namespace Elsa.Studio.WorkflowContexts.Components;
+
+/// <summary>
+/// A component that renders the workflow context drop down.
+/// </summary>
+public partial class WorkflowContextProviderPicker
+{
+    private ICollection<SelectListItem> _items = Array.Empty<SelectListItem>();
+
+    /// <summary>
+    /// Gets or sets the editor context.
+    /// </summary>
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+
+    [Inject] private IWorkflowContextsProvider WorkflowContextsProvider { get; set; } = default!;
+
+    private ICollection<WorkflowContextProviderDescriptor> WorkflowContextDescriptors { get; set; } = new List<WorkflowContextProviderDescriptor>();
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        WorkflowContextDescriptors = (await WorkflowContextsProvider.ListAsync()).ToList();
+    }
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        var selectedContextProviders = EditorContext.WorkflowDefinition.GetWorkflowContextProviderTypes();
+        _items = WorkflowContextDescriptors.Where(descriptior => selectedContextProviders.Contains(descriptior.Type))
+            .Select(descriptior => new SelectListItem(descriptior.Name, descriptior.Type)).ToList();
+    }
+
+    private SelectListItem? GetSelectedValue()
+    {
+        var value = EditorContext.GetLiteralValueOrDefault();
+        return _items.FirstOrDefault(x => x.Value == value);
+    }
+    
+    private async Task OnValueChanged(SelectListItem? value)
+    {
+        var expression = Expression.CreateLiteral(value?.Value ?? "");
+        await EditorContext.UpdateExpressionAsync(expression);
+    }
+}

--- a/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.WorkflowContexts.Contracts;
+using Elsa.Studio.WorkflowContexts.Handlers;
 using Elsa.Studio.WorkflowContexts.Services;
+using Elsa.Studio.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.WorkflowContexts.Extensions;
@@ -18,6 +20,7 @@ public static class ServiceCollectionExtensions
         return services
                 .AddScoped<IFeature, Feature>()
                 .AddScoped<IWorkflowContextsProvider, RemoteWorkflowContextsProvider>()
+                .AddUIHintHandler<WorkflowContextProviderPickerHandler>()
             ;
     }
 }

--- a/src/modules/Elsa.Studio.WorkflowContexts/Handlers/WorkflowContextProviderPickerHandler.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Handlers/WorkflowContextProviderPickerHandler.cs
@@ -1,0 +1,26 @@
+﻿using Elsa.Studio.Contracts;
+using Elsa.Studio.Models;
+using Microsoft.AspNetCore.Components;
+using Elsa.Studio.WorkflowContexts.Components;
+
+namespace Elsa.Studio.WorkflowContexts.Handlers;
+
+public class WorkflowContextProviderPickerHandler : IUIHintHandler
+{
+    /// <inheritdoc />
+    public bool GetSupportsUIHint(string uiHint) => uiHint == "workflow-context-provider-picker";
+
+    /// <inheritdoc />
+    public string UISyntax => WellKnownSyntaxNames.Literal;
+
+    /// <inheritdoc />
+    public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
+    {
+        return builder =>
+        {
+            builder.OpenComponent(0, typeof(WorkflowContextProviderPicker));
+            builder.AddAttribute(1, nameof(WorkflowContextProviderPicker.EditorContext), context);
+            builder.CloseComponent();
+        };
+    }
+}


### PR DESCRIPTION
Adds the missing UI Hint Handler for Workflow Context. This solves half the problem with workflow contexts with the missing part of how to trigger context load/save before or after activity execution.