### PR TITLE
Refactor args to include parent activity in workflow update

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
@@ -44,8 +44,8 @@ public partial class WorkflowInstanceWorkspace : IWorkspace
 
     private async Task OnPathChanged(DesignerPathChangedArgs args)
     {
-        await _workflowInstanceDetails.UpdateSubWorkflowAsync(args.ContainerActivity);
-        _workflowInstanceDesigner.UpdateSubWorkflow(args.ContainerActivity);
+        await _workflowInstanceDetails.UpdateSubWorkflowAsync(args.ParentActivity);
+        _workflowInstanceDesigner.UpdateSubWorkflow(args.ParentActivity);
         
         if(PathChanged.HasDelegate)
             await PathChanged.InvokeAsync(args);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Args/DesignerPathChangedArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Args/DesignerPathChangedArgs.cs
@@ -3,4 +3,4 @@ using System.Text.Json.Nodes;
 namespace Elsa.Studio.Workflows.Shared.Args;
 
 /// Represents the event arguments when the designer path changes.
-public record DesignerPathChangedArgs(JsonObject ContainerActivity);
+public record DesignerPathChangedArgs(JsonObject ParentActivity, JsonObject ContainerActivity);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -161,6 +161,15 @@ public partial class DiagramDesignerWrapper
 
         await _diagramDesigner!.UpdateActivityAsync(activityId, activity);
     }
+    
+    /// The parent activity of the current activity being loaded in the designer.
+    public JsonObject GetParentActivity()
+    {
+        var lastSegment = _pathSegments.FirstOrDefault();
+        var nodeId = lastSegment?.ActivityNodeId;
+        var node = nodeId != null ? _activityGraph.ActivityNodeLookup.TryGetValue(nodeId, out var nodeObject) ? nodeObject : null : null;
+        return node?.Activity ?? Activity;
+    }
 
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
@@ -168,7 +177,7 @@ public partial class DiagramDesignerWrapper
         await ActivityRegistry.EnsureLoadedAsync();
         await LoadActivityAsync(Activity);
     }
-
+    
     /// Updates the current path.
     /// <param name="action">A delegate that manipulates the path</param>
     private async Task UpdatePathSegmentsAsync(Action<Stack<ActivityPathSegment>> action)
@@ -178,8 +187,9 @@ public partial class DiagramDesignerWrapper
 
         if (PathChanged.HasDelegate)
         {
+            var parentActivity = GetParentActivity();
             var currentContainerActivity = GetCurrentContainerActivity();
-            await PathChanged.InvokeAsync(new DesignerPathChangedArgs(currentContainerActivity));
+            await PathChanged.InvokeAsync(new DesignerPathChangedArgs(parentActivity, currentContainerActivity));
         }
     }
 


### PR DESCRIPTION
Updated `DesignerPathChangedArgs` to include `ParentActivity` alongside `ContainerActivity`. Adjusted workflow instance details and designer to use `ParentActivity`, ensuring accurate path updates in the UI.
