### PR TITLE
Update version and activity registry request

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -65,7 +65,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.0-rc4.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.0-rc5.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Build workflow designer client assets
         working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -33,12 +33,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <!--    <ItemGroup Label="Elsa">-->
-    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-    <!--    </ItemGroup>-->
-
     <ItemGroup Label="Elsa">
-        <PackageReference Include="Elsa.Api.Client"/>
+        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
     </ItemGroup>
+
+    <!--    <ItemGroup Label="Elsa">-->
+    <!--        <PackageReference Include="Elsa.Api.Client"/>-->
+    <!--    </ItemGroup>-->
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteActivityRegistryProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteActivityRegistryProvider.cs
@@ -25,7 +25,11 @@ public class RemoteActivityRegistryProvider : IActivityRegistryProvider
     public async Task<IEnumerable<ActivityDescriptor>> ListAsync(CancellationToken cancellationToken = default)
     {
         var api = await _remoteBackendApiClientProvider.GetApiAsync<IActivityDescriptorsApi>(cancellationToken);
-        var response = await api.ListAsync(new ListActivityDescriptorsRequest(), cancellationToken);
+        var request = new ListActivityDescriptorsRequest
+        {
+            Refresh = true
+        };
+        var response = await api.ListAsync(request, cancellationToken);
         
         return response.Items;
     }


### PR DESCRIPTION
Updated the fallback version to 3.2.0-rc5 in the GitHub Actions workflow. Adjusted the remote activity registry provider to set the refresh flag on request.
