### PR TITLE
Increase max upload size on WorkflowDefinitionEditor 

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -422,10 +422,10 @@ public partial class WorkflowEditor
         _isDirty = true;
         _isProgressing = true;
         StateHasChanged();
-
+        var maxAllowedSize = 1024 * 1024 * 10; // 10 MB
         foreach (var file in files)
         {
-            var stream = file.OpenReadStream();
+            var stream = file.OpenReadStream(maxAllowedSize);
 
             if (file.ContentType == MediaTypeNames.Application.Zip || file.Name.EndsWith(".zip"))
             {


### PR DESCRIPTION
WorkflowDefinitionList has a set upload limit of 10MB. Uploading trough the WorkflowDefinitionEditor did not have this limit. This is an issue when uploading larger workflows.

This commit adds the same size restriction to the WorkflowDefinitionEditor as the WorkflowDefinitionList