### PR TITLE
Add 'run' command item in the context menu in workflow defination list page.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -104,6 +104,7 @@
                     {
                         <MudMenuItem Icon="@Icons.Material.Outlined.Pageview" OnClick="@(() => OnEditClicked(context.DefinitionId))">View</MudMenuItem>
                     }
+                    <MudMenuItem Icon="@Icons.Material.Outlined.PlayArrow" OnClick="@(() => OnRunWorkflowClicked(context))">Run</MudMenuItem>
                     <MudMenuItem Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="IsReadOnlyMode || context.IsReadOnlyMode">Delete</MudMenuItem>
                     <MudMenuItem Icon="@Icons.Material.Outlined.Cancel" OnClick="@(() => OnCancelClicked(context))">Cancel</MudMenuItem>
                     <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
@@ -131,7 +132,7 @@
     .definitions-table .mud-table-cell .mud-checkbox {
         margin: 0;
     }
-    
+
     .definitions-table .mud-table-toolbar {
         margin-bottom: 12px; /*mb-3*/
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -154,6 +154,20 @@ public partial class WorkflowDefinitionList
         await EditAsync(e.Item.DefinitionId);
     }
 
+    private async Task OnRunWorkflowClicked(WorkflowDefinitionRow workflowDefinitionRow)
+    {
+
+        var request = new ExecuteWorkflowDefinitionRequest
+        {
+            VersionOptions = VersionOptions.Latest
+        };
+
+        var definitionId = workflowDefinitionRow!.DefinitionId;
+        await WorkflowDefinitionService.ExecuteAsync(definitionId, request);
+
+        Snackbar.Add("Successfully started workflow", Severity.Success);
+    }
+
     private async Task OnDeleteClicked(WorkflowDefinitionRow workflowDefinitionRow)
     {
         var result = await DialogService.ShowMessageBox("Delete workflow?",


### PR DESCRIPTION
I found the only way to run a workflow was to click the green arrow button in workflow design page.
So I add a "run" menu item in the workflow definition list page as shown below.
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/a890f1d6-b78e-4d03-b60c-a6066ca74d35">
