### PR TITLE
Order storage drivers by priority and mark deprecated ones

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.0" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-preview.2169" />
     <PackageVersion Include="FluentValidation" Version="11.9.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-preview.2169" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-preview.2183" />
     <PackageVersion Include="FluentValidation" Version="11.9.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor
@@ -28,7 +28,8 @@
                 <MudSelect T="StorageDriverDescriptor" @bind-Value="_model.StorageDriver" ToStringFunc="@(x => x?.DisplayName!)" Variant="Variant.Outlined" Dense="false" Label="Storage">
                     @foreach (var storageDriver in _storageDriverDescriptors)
                     {
-                        <MudSelectItem T="StorageDriverDescriptor" Value="@storageDriver">@storageDriver.DisplayName</MudSelectItem>
+                        var displayName = storageDriver.Deprecated ? $"{storageDriver.DisplayName} (Deprecated)" : storageDriver.DisplayName;
+                        <MudSelectItem T="StorageDriverDescriptor" Value="@storageDriver">@displayName</MudSelectItem>
                     }
                 </MudSelect>
             </MudStack>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor.cs
@@ -44,7 +44,7 @@ public partial class EditVariableDialog
         _editContext = new EditContext(_model);
         _validator = new VariableModelValidator(WorkflowDefinition);
         
-        _storageDriverDescriptors = (await StorageDriverService.GetStorageDriversAsync()).ToList();
+        _storageDriverDescriptors = (await StorageDriverService.GetStorageDriversAsync()).OrderByDescending(x => x.Priority).ToList();
         _variableTypes = (await VariableTypeService.GetVariableTypesAsync()).ToList();
         _groupedVariableTypes = _variableTypes.GroupBy(x => x.Category).ToList();
 


### PR DESCRIPTION
Storage drivers are now ordered by their priority, and deprecated drivers are tagged with "(Deprecated)" in the UI. Additionally, upgraded the "Elsa.Api.Client" package to version "3.2.1-preview.2169".
