### PR TITLE
Add activity execution summaries and API endpoints

### DIFF
--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -33,12 +33,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <!--    <ItemGroup Label="Elsa">-->
-    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-    <!--    </ItemGroup>-->
-
     <ItemGroup Label="Elsa">
-        <PackageReference Include="Elsa.Api.Client"/>
+        <ProjectReference Include="..\..\..\..\..\elsa-core\3.2.x\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
     </ItemGroup>
+
+    <!--    <ItemGroup Label="Elsa">-->
+    <!--        <PackageReference Include="Elsa.Api.Client"/>-->
+    <!--    </ItemGroup>-->
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityExecutionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityExecutionService.cs
@@ -17,4 +17,14 @@ public interface IActivityExecutionService
     /// Gets a list of activity execution records.
     /// </summary>
     Task<IEnumerable<ActivityExecutionRecord>> ListAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Gets a list of activity execution record summaries.
+    /// </summary>
+    Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Gets an individual activity execution record.
+    /// </summary>
+    Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteActivityExecutionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteActivityExecutionService.cs
@@ -49,4 +49,25 @@ public class RemoteActivityExecutionService : IActivityExecutionService
         var response = await api.ListAsync(request, cancellationToken);
         return response.Items;
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default)
+    {
+        var request = new ListActivityExecutionsRequest
+        {
+            WorkflowInstanceId = workflowInstanceId,
+            ActivityNodeId = activityNodeId
+        };
+        
+        var api = await _remoteBackendApiClientProvider.GetApiAsync<IActivityExecutionsApi>(cancellationToken);
+        var response = await api.ListSummariesAsync(request, cancellationToken);
+        return response.Items;
+    }
+
+    /// <inheritdoc />
+    public async Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var api = await _remoteBackendApiClientProvider.GetApiAsync<IActivityExecutionsApi>(cancellationToken);
+        return await api.GetAsync(id, cancellationToken);
+    }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -23,7 +23,7 @@ public partial class ActivityDetailsTab
     /// The activity to display details for.
     [Parameter] public JsonObject Activity { get; set; } = default!;
     
-    /// The activity execution records.
+    /// The latest activity execution record. Used for displaying the last state of the activity.
     [Parameter] public ActivityExecutionRecord? LastActivityExecution { get; set; }
 
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -24,16 +24,9 @@ public partial class ActivityDetailsTab
     [Parameter] public JsonObject Activity { get; set; } = default!;
     
     /// The activity execution records.
-    [Parameter] public ICollection<ActivityExecutionRecord> ActivityExecutions { get; set; } = new List<ActivityExecutionRecord>();
+    [Parameter] public ActivityExecutionRecord? LastActivityExecution { get; set; }
 
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;
-
-    private ActivityExecutionRecord? LastActivityExecution => ActivityExecutions.LastOrDefault();
-
-    private IEnumerable<ActivityExecutionRecordTableRow> Items
-    {
-        get { return ActivityExecutions.Select((x, i) => new ActivityExecutionRecordTableRow(i + 1, x)); }
-    }
 
     private ActivityExecutionRecord? SelectedItem { get; set; } = default!;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
@@ -23,7 +23,7 @@
             </HeaderContent>
             <RowTemplate>
                 @{
-                    var record = context.ActivityExecution;
+                    var record = context.ActivityExecutionSummary;
                 }
                 <MudTh>@context.Number</MudTh>
                 <MudTd><Timestamp Value="record.StartedAt"/> </MudTd>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
@@ -1,6 +1,8 @@
 using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityExecutions.Contracts;
 using Elsa.Api.Client.Resources.ActivityExecutions.Models;
 using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
@@ -12,7 +14,7 @@ public partial class ActivityExecutionsTab
     /// Represents a row in the table of activity executions.
     /// <param name="Number">The number of executions.</param>
     /// <param name="ActivityExecution">The activity execution.</param>
-    public record ActivityExecutionRecordTableRow(int Number, ActivityExecutionRecord ActivityExecution);
+    public record ActivityExecutionRecordTableRow(int Number, ActivityExecutionRecordSummary ActivityExecution);
 
     /// The height of the visible pane.
     [Parameter] public int VisiblePaneHeight { get; set; }
@@ -21,7 +23,9 @@ public partial class ActivityExecutionsTab
     [Parameter] public JsonObject Activity { get; set; } = default!;
 
     /// The activity execution records.
-    [Parameter] public ICollection<ActivityExecutionRecord> ActivityExecutions { get; set; } = new List<ActivityExecutionRecord>();
+    [Parameter] public ICollection<ActivityExecutionRecordSummary> ActivityExecutions { get; set; } = new List<ActivityExecutionRecordSummary>();
+    
+    [Inject] private IActivityExecutionService ActivityExecutionService { get; set; } = default!;
 
     private IEnumerable<ActivityExecutionRecordTableRow> Items => ActivityExecutions.Select((x, i) => new ActivityExecutionRecordTableRow(i + 1, x));
     private ActivityExecutionRecord? SelectedItem { get; set; } = default!;
@@ -67,11 +71,12 @@ public partial class ActivityExecutionsTab
         SelectedOutputData = outputData;
     }
 
-    private Task OnActivityExecutionClicked(TableRowClickEventArgs<ActivityExecutionRecordTableRow> arg)
+    private async Task OnActivityExecutionClicked(TableRowClickEventArgs<ActivityExecutionRecordTableRow> arg)
     {
-        SelectedItem = arg.Item.ActivityExecution;
+        var id = arg.Item.ActivityExecution.Id;
+        var fullRecord = await ActivityExecutionService.GetAsync(id);
+        SelectedItem = fullRecord;
         CreateSelectedItemDataModels(SelectedItem);
         StateHasChanged();
-        return Task.CompletedTask;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Nodes;
-using Elsa.Api.Client.Resources.ActivityExecutions.Contracts;
 using Elsa.Api.Client.Resources.ActivityExecutions.Models;
 using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
@@ -13,8 +12,8 @@ public partial class ActivityExecutionsTab
 {
     /// Represents a row in the table of activity executions.
     /// <param name="Number">The number of executions.</param>
-    /// <param name="ActivityExecution">The activity execution.</param>
-    public record ActivityExecutionRecordTableRow(int Number, ActivityExecutionRecordSummary ActivityExecution);
+    /// <param name="ActivityExecutionSummary">The activity execution summary.</param>
+    public record ActivityExecutionRecordTableRow(int Number, ActivityExecutionRecordSummary ActivityExecutionSummary);
 
     /// The height of the visible pane.
     [Parameter] public int VisiblePaneHeight { get; set; }
@@ -22,12 +21,12 @@ public partial class ActivityExecutionsTab
     /// The activity to display executions for.
     [Parameter] public JsonObject Activity { get; set; } = default!;
 
-    /// The activity execution records.
-    [Parameter] public ICollection<ActivityExecutionRecordSummary> ActivityExecutions { get; set; } = new List<ActivityExecutionRecordSummary>();
+    /// The activity execution record summaries.
+    [Parameter] public ICollection<ActivityExecutionRecordSummary> ActivityExecutionSummaries { get; set; } = new List<ActivityExecutionRecordSummary>();
     
     [Inject] private IActivityExecutionService ActivityExecutionService { get; set; } = default!;
 
-    private IEnumerable<ActivityExecutionRecordTableRow> Items => ActivityExecutions.Select((x, i) => new ActivityExecutionRecordTableRow(i + 1, x));
+    private IEnumerable<ActivityExecutionRecordTableRow> Items => ActivityExecutionSummaries.Select((x, i) => new ActivityExecutionRecordTableRow(i + 1, x));
     private ActivityExecutionRecord? SelectedItem { get; set; } = default!;
     private IDictionary<string, DataPanelItem> SelectedActivityState { get; set; } = new Dictionary<string, DataPanelItem>();
     private IDictionary<string, DataPanelItem> SelectedOutcomesData { get; set; } = new Dictionary<string, DataPanelItem>();
@@ -73,9 +72,8 @@ public partial class ActivityExecutionsTab
 
     private async Task OnActivityExecutionClicked(TableRowClickEventArgs<ActivityExecutionRecordTableRow> arg)
     {
-        var id = arg.Item.ActivityExecution.Id;
-        var fullRecord = await ActivityExecutionService.GetAsync(id);
-        SelectedItem = fullRecord;
+        var id = arg.Item.ActivityExecutionSummary.Id;
+        SelectedItem = await ActivityExecutionService.GetAsync(id);
         CreateSelectedItemDataModels(SelectedItem);
         StateHasChanged();
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
@@ -43,7 +43,7 @@
                     </MudTabPanel>
 
                     <MudTabPanel Text="Executions" BadgeData="@SelectedActivityExecutions.Count">
-                        <ActivityExecutionsTab @ref="_activityExecutionsTab" Activity="@SelectedActivity" ActivityExecutions="SelectedActivityExecutions" VisiblePaneHeight="@_propertiesPaneHeight"/>
+                        <ActivityExecutionsTab @ref="_activityExecutionsTab" Activity="@SelectedActivity" ActivityExecutionSummaries="SelectedActivityExecutions" VisiblePaneHeight="@_propertiesPaneHeight"/>
                     </MudTabPanel>
                 }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
@@ -39,7 +39,7 @@
                 @if (SelectedActivity != null)
                 {
                     <MudTabPanel Text="Activity">
-                        <ActivityDetailsTab @ref="_activityDetailsTab" Activity="@SelectedActivity" ActivityExecutions="SelectedActivityExecutions" VisiblePaneHeight="@_propertiesPaneHeight"/>
+                        <ActivityDetailsTab @ref="_activityDetailsTab" Activity="@SelectedActivity" LastActivityExecution="LastActivityExecution" VisiblePaneHeight="@_propertiesPaneHeight"/>
                     </MudTabPanel>
 
                     <MudTabPanel Text="Executions" BadgeData="@SelectedActivityExecutions.Count">


### PR DESCRIPTION
Introduced the ActivityExecutionRecordSummary model and related API endpoints to support listing and retrieving activity execution summaries. Updated the workflow instance viewer and remote service to utilize the new summaries and provide detailed activity execution records on demand.
