### PR TITLE
Upgrade to MudBlazor 7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageVersion Include="MudBlazor" Version="7.3.0" />
     <PackageVersion Include="Radzen.Blazor" Version="5.2.12" />
-    <PackageVersion Include="Refit" Version="7.1.2" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="7.1.2" />
+    <PackageVersion Include="Refit" Version="7.2.1" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="7.2.1" />
     <PackageVersion Include="ShortGuid" Version="2.0.1" />
     <PackageVersion Include="ThrottleDebounce" Version="2.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8" />
-    <PackageVersion Include="MudBlazor" Version="7.9.0" />
+    <PackageVersion Include="MudBlazor" Version="7.3.0" />
     <PackageVersion Include="Radzen.Blazor" Version="5.2.12" />
     <PackageVersion Include="Refit" Version="7.1.2" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="7.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,14 +11,14 @@
         Version 6.6.4 and above contain an issue with the MudBlazor MudSelectExtended component.
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
-    <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-preview.2183" />
-    <PackageVersion Include="FluentValidation" Version="11.9.2" />
+    <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="7.0.1" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-blueberry.2230" />
+    <PackageVersion Include="FluentValidation" Version="11.10.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8" />
-    <PackageVersion Include="MudBlazor" Version="6.20.0" />
-    <PackageVersion Include="Radzen.Blazor" Version="5.0.7" />
+    <PackageVersion Include="MudBlazor" Version="7.9.0" />
+    <PackageVersion Include="Radzen.Blazor" Version="5.2.12" />
     <PackageVersion Include="Refit" Version="7.1.2" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="7.1.2" />
     <PackageVersion Include="ShortGuid" Version="2.0.1" />
@@ -38,16 +38,16 @@
     <PackageVersion Include="Microsoft.JSInterop" Version="7.0.20" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.JSInterop" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="8.0.10" />
   </ItemGroup>
 </Project>

--- a/src/framework/Elsa.Studio.Core/Contracts/IThemeService.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IThemeService.cs
@@ -26,7 +26,7 @@ public interface IThemeService
     /// Returns the current palette, depending on whether the dashboard is in dark mode.
     /// </summary>
 #pragma warning disable CS0618
-    Palette CurrentPalette => IsDarkMode ? CurrentTheme.PaletteDark : CurrentTheme.Palette;
+    Palette CurrentPalette => IsDarkMode ? CurrentTheme.PaletteDark : CurrentTheme.PaletteLight;
 #pragma warning restore CS0618
 
     /// <summary>

--- a/src/framework/Elsa.Studio.Core/Services/DefaultThemeService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultThemeService.cs
@@ -8,7 +8,7 @@ namespace Elsa.Studio.Services;
 public class DefaultThemeService : IThemeService
 {
     private MudTheme _currentTheme = CreateDefaultTheme();
-    private bool _isDarkMode = false;
+    private bool _isDarkMode;
 
     /// <inheritdoc />
     public event Action? CurrentThemeChanged;
@@ -46,7 +46,7 @@ public class DefaultThemeService : IThemeService
             {
                 DefaultBorderRadius = "4px",
             },
-            Palette =
+            PaletteLight = 
             {
                 Primary = new MudColor("0ea5e9"),
                 DrawerBackground = new MudColor("#f8fafc"),

--- a/src/framework/Elsa.Studio.Shared/Layouts/BasicLayout.razor
+++ b/src/framework/Elsa.Studio.Shared/Layouts/BasicLayout.razor
@@ -4,6 +4,7 @@
 @inject IThemeService ThemeService
 
 <MudThemeProvider Theme="CurrentTheme" IsDarkMode="@true"/>
+<MudPopoverProvider/>
 <MudSnackbarProvider/>
 
 <MudLayout>

--- a/src/framework/Elsa.Studio.Shared/Layouts/MainLayout.razor
+++ b/src/framework/Elsa.Studio.Shared/Layouts/MainLayout.razor
@@ -1,6 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
 <MudThemeProvider IsDarkMode="@IsDarkMode" Theme="CurrentTheme"/>
+<MudPopoverProvider/>
 <MudDialogProvider/>
 <MudSnackbarProvider/>
 

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
@@ -20,7 +20,7 @@
                                 <DataAnnotationsValidator/>
                                 <MudTextField Label="Username" Required="true" Variant="Variant.Outlined" For="@(() => _model.Username)" @bind-Value="_model.Username" autocomplete="username"/>
                                 <MudTextField Label="Password" Required="true" Variant="Variant.Outlined" For="@(() => _model.Password)" @bind-Value="_model.Password" InputType="InputType.Password" autocomplete="current-password"/>
-                                <MudCheckBox @bind-Checked="_model.RememberMe" Label="Remember me"/>
+                                <MudCheckBox @bind-Value="_model.RememberMe" Label="Remember me"/>
                                 <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary" Class="mt-3 align-self-end">Login</MudButton>
                             </div>
                         </EditForm>

--- a/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor
@@ -10,7 +10,7 @@
         <MudField Label="@displayName" Variant="Variant.Outlined" HelperText="@description" Margin="Margin.Dense" Disabled="EditorContext.IsReadOnly">
             @foreach (var item in _checkListItems)
             {
-                <MudCheckBox T="bool" Label="@item.Text" Checked="@item.IsChecked" CheckedChanged="@(state => OnCheckedChanged(item, state))" Dense="true" Disabled="EditorContext.IsReadOnly"></MudCheckBox>
+                <MudCheckBox T="bool" Label="@item.Text" Value="@item.IsChecked" ValueChanged="@(state => OnCheckedChanged(item, state))" Dense="true" Disabled="EditorContext.IsReadOnly"></MudCheckBox>
             }
         </MudField>
     </ChildContent>

--- a/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextsEditor.razor
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Components/WorkflowContextsEditor.razor
@@ -5,7 +5,7 @@
     <MudStack Spacing="0">
         @foreach (var descriptor in WorkflowContextDescriptors)
         {
-            <MudCheckBox T="bool" Label="@descriptor.Name" Checked="@(SelectedWorkflowContextTypes.Contains(descriptor.Type))" CheckedChanged="@(isChecked => OnCheckChanged(descriptor, isChecked == true))"/>
+            <MudCheckBox T="bool" Label="@descriptor.Name" Value="@(SelectedWorkflowContextTypes.Contains(descriptor.Type))" ValueChanged="@(isChecked => OnCheckChanged(descriptor, isChecked))"/>
         }
     </MudStack>
 </MudPaper>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -383,7 +383,7 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     private async void OnDarkModeChanged()
     {
         var palette = ThemeService.CurrentPalette;
-        var gridColor = palette.BackgroundGrey;
+        var gridColor = palette.BackgroundGray;
         await SetGridColorAsync(gridColor.ToString(MudColorOutputFormats.HexA));
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/VersionTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/VersionTab.razor.cs
@@ -45,7 +45,7 @@ public partial class VersionTab
     
     private IEnumerable<int> _versionsUsableAsActivity = [];
 
-    private async Task<TableData<WorkflowDefinitionSummary>> LoadVersionsAsync(TableState tableState)
+    private async Task<TableData<WorkflowDefinitionSummary>> LoadVersionsAsync(TableState tableState, CancellationToken cancellationToken)
     {
         if (Activity == null! || ActivityDescriptor == null!)
             return new TableData<WorkflowDefinitionSummary>();
@@ -65,7 +65,7 @@ public partial class VersionTab
 
         _versionsUsableAsActivity = ActivityRegistry.FindAll(CurrentActivityType).Select(d => d.Version);
         
-        var response = await InvokeWithBlazorServiceContext(() => WorkflowDefinitionService.ListAsync(request, VersionOptions.All));
+        var response = await InvokeWithBlazorServiceContext(() => WorkflowDefinitionService.ListAsync(request, VersionOptions.All, cancellationToken));
 
         return new TableData<WorkflowDefinitionSummary>
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -35,7 +35,7 @@ public partial class VersionHistoryTab : IDisposable
         Workspace.WorkflowDefinitionUpdated -= OnWorkflowDefinitionUpdated;
     }
 
-    private async Task<TableData<WorkflowDefinitionSummary>> LoadVersionsAsync(TableState tableState)
+    private async Task<TableData<WorkflowDefinitionSummary>> LoadVersionsAsync(TableState tableState, CancellationToken cancellationToken)
     {
         var page = tableState.Page;
         var pageSize = tableState.PageSize;
@@ -49,7 +49,7 @@ public partial class VersionHistoryTab : IDisposable
             PageSize = pageSize
         };
 
-        var response = await InvokeWithBlazorServiceContext(() => WorkflowDefinitionService.ListAsync(request, VersionOptions.All));
+        var response = await InvokeWithBlazorServiceContext(() => WorkflowDefinitionService.ListAsync(request, VersionOptions.All, cancellationToken));
 
         _recordCount = response.TotalCount;
         return new TableData<WorkflowDefinitionSummary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -36,7 +36,7 @@ public partial class WorkflowDefinitionList
     private bool IsReadOnlyMode { get; set; }
     private const string ReadonlyWorkflowsExcluded = "The read-only workflows will not be affected.";
 
-    private async Task<TableData<WorkflowDefinitionRow>> ServerReload(TableState state)
+    private async Task<TableData<WorkflowDefinitionRow>> ServerReload(TableState state, CancellationToken cancellationToken)
     {
         var request = new ListWorkflowDefinitionsRequest
         {
@@ -52,7 +52,7 @@ public partial class WorkflowDefinitionList
 
         var workflowDefinitionRows = await InvokeWithBlazorServiceContext(async () =>
         {
-            var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest);
+            var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest, cancellationToken);
             IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l => l.Rel == "bulk-publish") ?? 0) == 0;
             var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitionsResponse.Items.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -1,13 +1,10 @@
 @inherits StudioComponentBase
 
-@using System.Globalization
 @using Elsa.Api.Client.Resources.WorkflowDefinitions.Models
 @using Elsa.Api.Client.Resources.WorkflowInstances.Enums
 @using Elsa.Api.Client.Resources.WorkflowInstances.Models
 @using Elsa.Api.Client.Shared.Enums
 @using Elsa.Studio.Workflows.Components.WorkflowInstanceList.Models
-@using MudExtensions.Enums
-@using AlignItems = MudBlazor.AlignItems
 @using Variant = MudBlazor.Variant
 
 <PageTitle>Workflow instances</PageTitle>
@@ -247,12 +244,13 @@
             </MudTooltip>
         </MudTd>
         <MudTd DataLabel="SubStatus">
-            <MudChip Color="@GetSubStatusColor(context.SubStatus)" Variant="Variant.Text">
+            <MudChip T="WorkflowSubStatus" Color="@GetSubStatusColor(context.SubStatus)" Variant="Variant.Text">
                 @context.SubStatus
             </MudChip>
         </MudTd>
         <MudTd DataLabel="IncidentCount">
             <MudChip
+                T="int"
                 Color="@(context.IncidentCount == 0 ? Color.Transparent : Color.Error)"
                 Text="@context.IncidentCount.ToString()"
                 Variant="Variant.Text"

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -91,7 +91,7 @@ public class FlowchartDiagramDesigner : IDiagramDesignerToolboxProvider
             {
                 childBuilder.OpenComponent<MudIconButton>(0);
                 childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
-                childBuilder.AddAttribute(2, nameof(MudIconButton.Title), title);
+                childBuilder.AddAttribute(2, "title", title);
                 childBuilder.AddAttribute(3, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, onClick));
                 childBuilder.CloseComponent();
             }));


### PR DESCRIPTION
This PR upgrades to MudBlazor from 6.x to 7.x

The latest version of MudBlzor is 7.9.0, but because MudBlazorExtensions still targets 7.3.0, we can't go all the way to 7.9.0 for now, due to an API change introduced after 7.3.0 that causes a Missing Method exception at runtime.

I created a PR for that here: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/pull/472