### PR TITLE
Update Elsa.Api.Client to version 3.2.1-blueberry.2230

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
         See: https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/issues/345 
          -->
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="6.9.2" />
-    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-preview.2183" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.2.1-blueberry.2230" />
     <PackageVersion Include="FluentValidation" Version="11.9.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />


### PR DESCRIPTION
This update changes the version of the Elsa.Api.Client package from 3.2.1-preview.2183 to 3.2.1-blueberry.2230 in the Directory.Packages.props file. It ensures compatibility with the latest features and bug fixes provided by the new package version.
