### PR TITLE
Update WorkflowDefinitionService to use LatestOrPublished

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -65,7 +65,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
 
     private async Task LoadWorkflowDefinitionsAsync()
     {
-        var workflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest(), VersionOptions.Published);
+        var workflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest(), VersionOptions.LatestOrPublished);
 
         WorkflowDefinitions = workflowDefinitionsResponse.Items;
     }


### PR DESCRIPTION
Replaced the version option from Published to LatestOrPublished when fetching workflow definitions. This ensures the list includes the latest versions if available, improving flexibility and accuracy in the workflow data displayed.
