### PR TITLE
Fix duplicate definition IDs in workflow instance list

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -90,7 +90,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
         try
         {
             var workflowInstancesResponse = await WorkflowInstanceService.ListAsync(request, cancellationToken);
-            var definitionVersionIds = workflowInstancesResponse.Items.Select(x => x.DefinitionVersionId).ToList();
+            var definitionVersionIds = workflowInstancesResponse.Items.Select(x => x.DefinitionVersionId).Distinct().ToList();
 
             var workflowDefinitionVersionsResponse = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
             {


### PR DESCRIPTION
Ensure the list of definition version IDs contains only distinct values when fetching workflow instances. This prevents redundant requests and improves efficiency during data processing.
