### PR TITLE
Remove leading slash from URIs

### DIFF
--- a/src/modules/Elsa.Studio.Agents/UI/Pages/Agents.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Pages/Agents.razor.cs
@@ -83,7 +83,7 @@ public partial class Agents
 
     private async Task EditAsync(string id)
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/ai/agents/{id}"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"ai/agents/{id}"));
     }
 
     private void Reload()

--- a/src/modules/Elsa.Studio.Agents/UI/Pages/ApiKey.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Pages/ApiKey.razor.cs
@@ -56,6 +56,6 @@ public partial class ApiKey : StudioComponentBase
         }
 
         StateHasChanged();
-        NavigationManager.NavigateTo("/ai/api-keys");
+        NavigationManager.NavigateTo("ai/api-keys");
     }
 }

--- a/src/modules/Elsa.Studio.Agents/UI/Pages/ApiKeys.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Pages/ApiKeys.razor.cs
@@ -40,12 +40,12 @@ public partial class ApiKeys
 
     private async Task OnCreateClicked()
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/ai/api-keys/new"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"ai/api-keys/new"));
     }
 
     private async Task EditAsync(string id)
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/ai/api-keys/{id}"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"ai/api-keys/{id}"));
     }
 
     private void Reload()

--- a/src/modules/Elsa.Studio.Agents/UI/Pages/Service.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Pages/Service.razor.cs
@@ -57,10 +57,10 @@ public partial class Service : StudioComponentBase
         }
 
         StateHasChanged();
-        NavigationManager.NavigateTo("/ai/services");
+        NavigationManager.NavigateTo("ai/services");
     }
 
-    private MudBlazor.Converter<IDictionary<string,object>,string> GetSettingsConverter()
+    private MudBlazor.Converter<IDictionary<string, object>, string> GetSettingsConverter()
     {
         return new MudBlazor.Converter<IDictionary<string, object>, string>
         {

--- a/src/modules/Elsa.Studio.Agents/UI/Pages/Services.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Pages/Services.razor.cs
@@ -37,12 +37,12 @@ public partial class Services
 
     private async Task OnCreateClicked()
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/ai/services/new"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"ai/services/new"));
     }
 
     private async Task EditAsync(string id)
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/ai/services/{id}"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"ai/services/{id}"));
     }
 
     private void Reload()

--- a/src/modules/Elsa.Studio.Secrets/UI/Pages/Secret.razor.cs
+++ b/src/modules/Elsa.Studio.Secrets/UI/Pages/Secret.razor.cs
@@ -46,6 +46,6 @@ public partial class Secret : StudioComponentBase
         await apiClient.UpdateAsync(SecretId, _model);
         Snackbar.Add("Secret successfully updated.", Severity.Success);
         StateHasChanged();
-        NavigationManager.NavigateTo("/secrets");
+        NavigationManager.NavigateTo("secrets");
     }
 }

--- a/src/modules/Elsa.Studio.Secrets/UI/Pages/Secrets.razor.cs
+++ b/src/modules/Elsa.Studio.Secrets/UI/Pages/Secrets.razor.cs
@@ -79,7 +79,7 @@ public partial class Secrets
 
     private async Task EditAsync(string id)
     {
-        await InvokeAsync(() => NavigationManager.NavigateTo($"/secrets/{id}"));
+        await InvokeAsync(() => NavigationManager.NavigateTo($"secrets/{id}"));
     }
 
     private void Reload()


### PR DESCRIPTION
According to [Host and deploy ASP.NET Core Blazor](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/?view=aspnetcore-9.0&tabs=visual-studio#configure-the-app-base-path:~:text=%E2%9C%94%EF%B8%8F%20Correct%3A%20Navigation.NavigateTo(%22other%22)%3B), URIs shouldn't be prefixed with a slash. Currently, if hosting Elsa Studio with a different `<base>` tag, the navigation is broken due to this.
All existing calls to `NavigateTo` already don't use a leading slash.