### PR TITLE
Disable "Retry" and "Export" options in bulk actions menu.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -40,8 +40,8 @@
         <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="@Localizer["Bulk actions"]" Color="Color.Default" Variant="Variant.Filled" AnchorOrigin="Origin.BottomLeft">
             <MudMenuItem OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
             <MudMenuItem OnClick="@OnBulkCancelClicked">@Localizer["Cancel"]</MudMenuItem>
-            <MudMenuItem Disabled="true">@Localizer["Retry"]</MudMenuItem>
-            <!--<MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem>-->
+            @* <MudMenuItem Disabled="true">@Localizer["Retry"]</MudMenuItem> *@
+            @* <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem> *@
         </MudMenu>
         <MudButton StartIcon="@Icons.Material.Filled.FileUpload" Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnImportClicked">@Localizer["Import"]</MudButton>
     </MudPaper>


### PR DESCRIPTION
Commented out the "Retry" and "Export" menu items to prevent them from being displayed. This ensures only functional options are available to the user.
