### PR TITLE
Downgrade MudBlazor to v7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,15 +10,15 @@
         <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0"/>
         <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0"/>
         <PackageVersion Include="BlazorMonaco" Version="3.3.0"/>
-        <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.0.0"/>
+        <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="7.1.0"/>
         <PackageVersion Include="FluentValidation" Version="11.10.0"/>
         <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
         <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8"/>
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24605.2"/>
-        <PackageVersion Include="MudBlazor.Translations" Version="2.0.0"/>
-        <PackageVersion Include="MudBlazor" Version="8.1.0"/>
+        <PackageVersion Include="MudBlazor.Translations" Version="1.6.0"/>
+        <PackageVersion Include="MudBlazor" Version="7.16.0"/>
         <PackageVersion Include="Radzen.Blazor" Version="5.9.5"/>
         <PackageVersion Include="ShortGuid" Version="2.0.1"/>
         <PackageVersion Include="ThrottleDebounce" Version="2.0.0"/>

--- a/src/framework/Elsa.Studio.Shared/Components/ProductInfoDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ProductInfoDialog.razor
@@ -11,7 +11,7 @@
 </MudDialog>
 
 @code {
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
 
     void Close() => MudDialog.Close(DialogResult.Ok(true));
 }

--- a/src/modules/Elsa.Studio.Agents/UI/Components/CreateAgentDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Agents/UI/Components/CreateAgentDialog.razor.cs
@@ -21,7 +21,7 @@ public partial class CreateAgentDialog
     
     /// The default name of the agent to create.
     [Parameter] public string AgentName { get; set; } = "";
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = null!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
     [Inject] private IActivityDisplaySettingsRegistry ActivityDisplaySettingsRegistry { get; set; } = null!;

--- a/src/modules/Elsa.Studio.Secrets/UI/Components/CreateSecretDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Secrets/UI/Components/CreateSecretDialog.razor.cs
@@ -19,7 +19,7 @@ public partial class CreateSecretDialog
     
     /// The default name of the agent to create.
     [Parameter] public string SecretName { get; set; } = "";
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = null!;
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
@@ -25,7 +25,7 @@ public partial class EditInputDialog
 
     [Parameter] public WorkflowDefinition WorkflowDefinition { get; set; } = default!;
     [Parameter] public InputDefinition? Input { get; set; }
-    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
     [Inject] private IStorageDriverService StorageDriverService { get; set; } = default!;
     [Inject] private IVariableTypeService VariableTypeService { get; set; } = default!;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/EditOutputDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/EditOutputDialog.razor.cs
@@ -34,7 +34,7 @@ public partial class EditOutputDialog
     /// The output to edit.
     /// </summary>
     [Parameter] public OutputDefinition? Output { get; set; }
-    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IStorageDriverService StorageDriverService { get; set; } = null!;
     [Inject] private IVariableTypeService VariableTypeService { get; set; } = null!;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableDialog.razor.cs
@@ -32,7 +32,7 @@ public partial class EditVariableDialog
     /// The variable to edit. If null, a new variable will be created.
     /// </summary>
     [Parameter] public Variable? Variable { get; set; }
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IStorageDriverService StorageDriverService { get; set; } = null!;
     [Inject] private IVariableTypeService VariableTypeService { get; set; } = null!;
     [Inject] private IIdentityGenerator IdentityGenerator { get; set; } = null!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
@@ -22,7 +22,7 @@ public partial class CreateWorkflowDialog
     /// The name of the workflow to create.
     /// </summary>
     [Parameter] public string WorkflowName { get; set; } = "New workflow";
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;
 
     /// <inheritdoc />


### PR DESCRIPTION
Replaced `IMudDialogInstance` with `MudDialogInstance` across multiple components for consistency and improved type safety. Additionally, downgraded several `MudBlazor` package versions and updated logging configurations in `appsettings.json`.

We'll upgrade to v8 for Elsa 3.4.
