### PR TITLE
Update Custom Elements with Tenant ID Attribute

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,6 +10,7 @@ on:
       - 'feature/*'
       - 'issue/*'
       - 'patch/*'
+      - 'enh/*'
   release:
     types: [ prereleased, published ]
 env:

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendComponentBase.cs
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendComponentBase.cs
@@ -9,8 +9,11 @@ public abstract class BackendComponentBase : StudioComponentBase
     [Parameter] public string? RemoteEndpoint { get; set; }
     [Parameter] public string? ApiKey { get; set; }
     [Parameter] public string? AccessToken { get; set; }
-    [Inject] private BackendService BackendService { get; set; } = default!;
+    [Parameter] public string? TenantId { get; set; }
+    [Parameter] public string? TenantIdHeaderName { get; set; }
+    [Inject] private BackendService BackendService { get; set; } = null!;
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         if (!string.IsNullOrWhiteSpace(RemoteEndpoint))
@@ -21,5 +24,11 @@ public abstract class BackendComponentBase : StudioComponentBase
 
         if (!string.IsNullOrWhiteSpace(AccessToken))
             BackendService.AccessToken = AccessToken;
+        
+        if(!string.IsNullOrWhiteSpace(TenantId))
+            BackendService.TenantId = TenantId;
+        
+        if(!string.IsNullOrWhiteSpace(TenantIdHeaderName))
+            BackendService.TenantIdHeaderName = TenantIdHeaderName;
     }
 }

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendProvider.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendProvider.razor
@@ -1,8 +1,1 @@
-@using Elsa.Studio.Host.CustomElements.Services
-@using Elsa.Studio.Contracts
-@using Elsa.Studio.Options
-@using Microsoft.Extensions.Options
 @inherits BackendComponentBase
-
-@code {
-}

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Elsa.Studio.Host.CustomElements.csproj
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Elsa.Studio.Host.CustomElements.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/hosts/Elsa.Studio.Host.CustomElements/HttpMessageHandlers/ApiKeyHttpMessageHandler.cs
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/HttpMessageHandlers/ApiKeyHttpMessageHandler.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using Elsa.Studio.Host.CustomElements.Services;
 
 namespace Elsa.Studio.Host.CustomElements.HttpMessageHandlers;
@@ -23,11 +22,16 @@ public class AuthHttpMessageHandler : DelegatingHandler
     {
         var apiKey = _backendService.ApiKey;
         var accessToken = _backendService.AccessToken;
+        var tenantId = _backendService.TenantId;
+        var tenantIdHeaderName = _backendService.TenantIdHeaderName;
         
         if(!string.IsNullOrEmpty(apiKey))
-            request.Headers.Authorization = new AuthenticationHeaderValue("ApiKey", apiKey);
+            request.Headers.Authorization = new("ApiKey", apiKey);
         else if(!string.IsNullOrEmpty(accessToken))
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            request.Headers.Authorization = new("Bearer", accessToken);
+        
+        if(!string.IsNullOrEmpty(tenantId))
+            request.Headers.Add(tenantIdHeaderName, tenantId);
 
         return await base.SendAsync(request, cancellationToken);
     }

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Services/BackendService.cs
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Services/BackendService.cs
@@ -1,8 +1,65 @@
 namespace Elsa.Studio.Host.CustomElements.Services;
 
+/// <summary>
+/// Represents a service for backend configuration and information management.
+/// </summary>
+/// <remarks>
+/// The <see cref="BackendService"/> class provides properties to manage backend connectivity,
+/// including endpoint configuration, API key management, access token, and tenant identification.
+/// It acts as a centralized configuration point for backend communication settings.
+/// </remarks>
 public class BackendService
 {
-    public string RemoteEndpoint { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the remote endpoint URL for backend communication.
+    /// </summary>
+    /// <remarks>
+    /// The <c>RemoteEndpoint</c> property specifies the base URL of the backend service that the application interacts with.
+    /// It is used as a key configuration for defining the remote backend's address and is essential for facilitating communication with the service.
+    /// This property is typically configured during application initialization or dynamically at runtime.
+    /// </remarks>
+    public string RemoteEndpoint { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the API key used for authenticating requests to the backend service.
+    /// </summary>
+    /// <remarks>
+    /// The <c>ApiKey</c> property is used to supply authentication credentials in the form of an API key
+    /// when communicating with the backend service. It is typically included in the request headers to identify
+    /// and authorize the client. This property should hold a secure, non-empty value if API key-based authentication
+    /// is enabled for the backend. Configuring this property correctly is critical for ensuring authorized access
+    /// to backend resources.
+    /// </remarks>
     public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the access token used for authentication in backend communication.
+    /// </summary>
+    /// <remarks>
+    /// The <c>AccessToken</c> property specifies a bearer token used for authorizing requests to protected backend resources.
+    /// This property is typically set during initialization or dynamically updated to ensure proper authorization headers are sent with HTTP requests.
+    /// It is utilized when API key-based authentication is not provided, ensuring secure access through bearer token mechanisms.
+    /// </remarks>
     public string? AccessToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tenant identifier for backend communication.
+    /// </summary>
+    /// <remarks>
+    /// The <c>TenantId</c> property specifies the unique identifier associated with the tenant context in the backend service.
+    /// It is used to distinguish resources and operations specific to a particular tenant, enabling multi-tenancy support.
+    /// This property can be set during initialization or dynamically altered at runtime to switch between tenants.
+    /// Setting this property is not necessary if the <see cref="AccessToken"/> carries a claim that can be used on the back-end to determine the current tenant.
+    /// </remarks>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the HTTP header used for tenant identification during backend communication.
+    /// </summary>
+    /// <remarks>
+    /// The <c>TenantIdHeaderName</c> property defines the header key that carries the tenant identifier in HTTP requests.
+    /// It is essential for multi-tenant applications to distinguish between different tenants while interacting with the backend service.
+    /// This property can be customized to align with specific header naming conventions required by the backend.
+    /// </remarks>
+    public string TenantIdHeaderName { get; set; } = "X-Tenant-Id";
 }


### PR DESCRIPTION
This PR adds the capability to specify the current tenant ID on the backend provider component. When specified, this tenant ID will be attached as a header ("X-Tenant-Id" by default) to outbound HTTP requests to the backend API.

This is convenient, for example, when the tenant ID is included in the URL as a path segment.