### PR TITLE
Fixed incidents bugs - merge in main

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
@@ -5,111 +5,118 @@
 
 @if (WorkflowDefinition != null && WorkflowInstance != null)
 {
-    <MudTabs Elevation="0" ApplyEffectsToContainer="true">
-        <MudTabPanel Text="@Localizer["Details"]">
-            <Well>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Workflow"]</MudText>
-                    <DataPanel Data="WorkflowInstanceData" HideEmptyValues="true"/>
-                </div>
-            </Well>
+<MudTabs Elevation="0" ApplyEffectsToContainer="true">
+    <MudTabPanel Text="@Localizer["Details"]">
+        <Well>
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Workflow"]</MudText>
+                <DataPanel Data="WorkflowInstanceData" HideEmptyValues="true"/>
+            </div>
+        </Well>
 
-            @if (WorkflowInstanceSubWorkflowData.Any())
-            {
-                <Well>
-                    <div>
-                        <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow"]</MudText>
-                        <DataPanel Data="WorkflowInstanceSubWorkflowData" HideEmptyValues="true"/>
-                    </div>
-                </Well>
-            } 
-        </MudTabPanel>
-        <MudTabPanel Text="Incidents">
-            @if (IncidentsData.Any())
-            {
-                <VerticalWell ExtraPadding="50">
-                    <MudExpansionPanels>
-                    @foreach (var incident in IncidentsData)
-                    {
-                        <MudExpansionPanel Text="@incident.SingleOrDefault(i=>i.Label == "Message")?.Text" Dense="false" Gutters="false" Class="incidents-custom-spacing">
+        @if (WorkflowInstanceSubWorkflowData.Any())
+        {
+        <Well>
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow"]</MudText>
+                <DataPanel Data="WorkflowInstanceSubWorkflowData" HideEmptyValues="true"/>
+            </div>
+        </Well>
+        }
+    </MudTabPanel>
+    <MudTabPanel Text="Incidents">
+        @if (IncidentsData.Any())
+        {
+        <VerticalWell ExtraPadding="50">
+            <MudExpansionPanels>
+                @foreach (var incident in IncidentsData)
+                {
+                    <MudExpansionPanel Dense="false" Gutters="false" Class="incidents-custom-spacing">
+                        <TitleContent>
+                            <div class="truncate-text">
+                                @incident.SingleOrDefault(i=>i.Label == "Message")?.Text
+                            </div>
+                        </TitleContent>
+                        <ChildContent>
                             <Well>
                                 <DataPanel Data="incident" HideEmptyValues="true"/>
                             </Well>
-                        </MudExpansionPanel>
-                    }
-                    </MudExpansionPanels>
-                </VerticalWell>
-            }
-            else
-            {
+                        </ChildContent>
+                    </MudExpansionPanel>
+                }
+            </MudExpansionPanels>
+        </VerticalWell>
+        }
+        else
+        {
+        <Well>
+            No incidents
+        </Well>
+        }
+    </MudTabPanel>
+    <MudTabPanel Text="@Localizer["Variables"]">
+        <VerticalWell ExtraPadding="50">
+            <div>
+                @if (WorkflowVariableData.Any())
+                {
+                <DataPanel Data="WorkflowVariableData" HideEmptyValues="false"/>
+                }
+                else
+                {
                 <Well>
-                    No incidents
+                    @Localizer["No variables"]
                 </Well>
+                }
+            </div>
+        </VerticalWell>
+    </MudTabPanel>
+    <MudTabPanel Text="@Localizer["Input/output"]">
+        <Well>
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Inputs"]</MudText>
+                @if (WorkflowInputData.Any())
+                {
+                <DataPanel Data="WorkflowInputData" HideEmptyValues="false"/>
+                }
+                else
+                {
+                <Well>
+                    @Localizer["No inputs"]
+                </Well>
+                }
+            </div>
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outputs"]</MudText>
+                @if (WorkflowOutputData.Any())
+                {
+                <DataPanel Data="WorkflowOutputData" HideEmptyValues="false"/>
+                }
+                else
+                {
+                <Well>
+                    @Localizer["No outputs"]
+                </Well>
+                }
+            </div>
+        </Well>
+        <Well>
+            @if (SubWorkflowInputData.Any())
+            {
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Inputs"]</MudText>
+                <DataPanel Data="SubWorkflowInputData" HideEmptyValues="false"/>
+            </div>
             }
-        </MudTabPanel>
-        <MudTabPanel Text="@Localizer["Variables"]">
-            <VerticalWell ExtraPadding="50">
-                <div>
-                    @if (WorkflowVariableData.Any())
-                    {
-                        <DataPanel Data="WorkflowVariableData" HideEmptyValues="false"/>
-                    }
-                    else
-                    {
-                        <Well>
-                            @Localizer["No variables"]
-                        </Well>
-                    }
-                </div>
-            </VerticalWell>
-        </MudTabPanel>
-        <MudTabPanel Text="@Localizer["Input/output"]">
-            <Well>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Inputs"]</MudText>
-                    @if (WorkflowInputData.Any())
-                    {
-                        <DataPanel Data="WorkflowInputData" HideEmptyValues="false"/>
-                    }
-                    else
-                    {
-                        <Well>
-                            @Localizer["No inputs"]
-                        </Well>
-                    }
-                </div>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outputs"]</MudText>
-                    @if (WorkflowOutputData.Any())
-                    {
-                        <DataPanel Data="WorkflowOutputData" HideEmptyValues="false"/>
-                    }
-                    else
-                    {
-                        <Well>
-                             @Localizer["No outputs"]
-                        </Well>
-                    }
-                </div>
-            </Well>
-            <Well>
-                @if (SubWorkflowInputData.Any())
-                {
-                    <div>
-                        <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Inputs"]</MudText>
-                        <DataPanel Data="SubWorkflowInputData" HideEmptyValues="false"/>
-                    </div>
-                }
-                @if (SubWorkflowOutputData.Any())
-                {
-                    <div>
-                        <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Outputs"]</MudText>
-                        <DataPanel Data="SubWorkflowOutputData" HideEmptyValues="false"/>
-                    </div>
-                }
-            </Well>
-        </MudTabPanel>
-    </MudTabs>
+            @if (SubWorkflowOutputData.Any())
+            {
+            <div>
+                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Outputs"]</MudText>
+                <DataPanel Data="SubWorkflowOutputData" HideEmptyValues="false"/>
+            </div>
+            }
+        </Well>
+    </MudTabPanel>
+</MudTabs>
 }
 
 <style>
@@ -121,5 +128,17 @@
 
     .incidents-custom-spacing .mud-expand-panel-header {
         padding: 6px 16px !important;
+    }
+
+    .incidents-custom-spacing .truncate-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .incidents-custom-spacing .mud-expand-panel-text {
+        width: 90%;
     }
 </style>

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -86,10 +86,10 @@ public partial class DiagramDesignerWrapper
         var activities = containerActivity.GetActivities();
         var activityToSelect = activities.FirstOrDefault(x => x.GetNodeId() == nodeId);
 
-        await SelectActivityAsync(activityToSelect);
+        await SelectActivityAsync(activityToSelect, nodeId);
     }
 
-    private async Task SelectActivityAsync(JsonObject? activityToSelect)
+    private async Task SelectActivityAsync(JsonObject? activityToSelect, string? nodeId = null)
     {
         if (activityToSelect != null)
         {
@@ -98,7 +98,7 @@ public partial class DiagramDesignerWrapper
         }
 
         // Load the selected node path from the backend.
-        var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, activityToSelect!.GetNodeId());
+        var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, nodeId);
 
         if (pathSegmentsResponse == null)
             return;

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -97,6 +97,9 @@ public partial class DiagramDesignerWrapper
             return;
         }
 
+        if (nodeId == null)
+            return;
+        
         // Load the selected node path from the backend.
         var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, nodeId);
 


### PR DESCRIPTION
Fixed the following bugs:

- If an incident message is too large, it will overflow but not in a pretty way.
- When you click on an activity from the journal that is part of a sub activity it doesn't go inside
    - This was introduced with the incidents feature.
- When you click on an activity id of an incident, on an activity that is part of a subworkflow an error will be thrown
    - This happened because you cannot properly link an activity id to a node id. It could be that we have multiple subworkflows of the same kind and the activity id will match all of them instead of just one. For now a null check was added and an improvement will be made to include the nodeid in the incident data.