### PR TITLE
Fixed incidents bugs - merge in raspberry

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
@@ -31,10 +31,17 @@
                     <MudExpansionPanels>
                     @foreach (var incident in IncidentsData)
                     {
-                        <MudExpansionPanel Text="@incident["Message"].Text" Dense="false" Gutters="false" Class="incidents-custom-spacing">
-                            <Well>
-                                <DataPanel Data="incident" HideEmptyValues="true"/>
-                            </Well>
+                        <MudExpansionPanel Dense="false" Gutters="false" Class="incidents-custom-spacing">
+                            <TitleContent>
+                                <div class="truncate-text">
+                                    @incident["Message"].Text
+                                </div>
+                            </TitleContent>
+                            <ChildContent>
+                                <Well>
+                                    <DataPanel Data="incident" HideEmptyValues="true"/>
+                                </Well>
+                            </ChildContent>
                         </MudExpansionPanel>
                     }
                     </MudExpansionPanels>
@@ -121,5 +128,17 @@
 
     .incidents-custom-spacing .mud-expand-panel-header {
         padding: 6px 16px !important;
+    }
+
+    .incidents-custom-spacing .truncate-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .incidents-custom-spacing .mud-expand-panel-text {
+        width: 90%;
     }
 </style>

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -86,10 +86,10 @@ public partial class DiagramDesignerWrapper
         var activities = containerActivity.GetActivities();
         var activityToSelect = activities.FirstOrDefault(x => x.GetNodeId() == nodeId);
 
-        await SelectActivityAsync(activityToSelect);
+        await SelectActivityAsync(activityToSelect, nodeId);
     }
 
-    private async Task SelectActivityAsync(JsonObject? activityToSelect)
+    private async Task SelectActivityAsync(JsonObject? activityToSelect, string? nodeId = null)
     {
         if (activityToSelect != null)
         {
@@ -98,7 +98,7 @@ public partial class DiagramDesignerWrapper
         }
 
         // Load the selected node path from the backend.
-        var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, activityToSelect!.GetNodeId());
+        var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, nodeId);
 
         if (pathSegmentsResponse == null)
             return;

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -97,6 +97,9 @@ public partial class DiagramDesignerWrapper
             return;
         }
 
+        if (nodeId == null)
+            return;
+        
         // Load the selected node path from the backend.
         var pathSegmentsResponse = await WorkflowDefinitionService.GetPathSegmentsAsync(WorkflowDefinitionVersionId, nodeId);
 


### PR DESCRIPTION
Fixed the following bugs:

- If an incident message is too large, it will overflow but not in a pretty way.
- When you click on an activity from the journal that is part of a sub activity it doesn't go inside
    - This was introduced with the incidents feature.
- When you click on an activity id of an incident, on an activity that is part of a subworkflow an error will be thrown
    - This happened because you cannot properly link an activity id to a node id. It could be that we have multiple subworkflows of the same kind and the activity id will match all of them instead of just one. For now a null check was added and an improvement will be made to include the nodeid in the incident data.