### PR TITLE
Refactor input editors to use unified value update method

### DIFF
--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -161,9 +161,18 @@ public class DisplayInputEditorContext
     /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
     /// </summary>
     /// <param name="value">The new value to be set, either directly or wrapped as an object expression.</param>
-    public Task UpdateValueOrObjectExpressionAsync(string value)
+    public async Task UpdateValueOrObjectExpressionAsync(object value)
     {
-        return UpdateValueOrExpressionAsync(value, "Object");
+        if(InputDescriptor.IsWrapped)
+        {
+            var json = JsonSerializer.Serialize(value);
+            var expression = Expression.CreateObject(json);
+
+            await UpdateExpressionAsync(expression);
+            return;
+        }
+
+        await UpdateValueAsync(value);
     }
 
     /// <summary>

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -145,6 +145,24 @@ public class DisplayInputEditorContext
         // Notify that the input has changed.
         await OnValueChanged(wrappedInput);
     }
+
+    /// <summary>
+    /// Updates the input value or sets it as a literal expression,
+    /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
+    /// </summary>
+    /// <param name="value">The new value to be set, either directly or wrapped as a literal expression.</param>
+    public async Task UpdateValueOrLiteralExpressionAsync(string value)
+    {
+        if(InputDescriptor.IsWrapped)
+        {
+            var expression = Expression.CreateLiteral(value);
+
+            await UpdateExpressionAsync(expression);
+            return;
+        }
+
+        await UpdateValueAsync(value);
+    }
     
     private static string Serialize(object? value)
     {

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -137,7 +137,7 @@ public class DisplayInputEditorContext
         var wrappedInput = Value as WrappedInput;
         
         // Update input.
-        wrappedInput ??= new WrappedInput();
+        wrappedInput ??= new();
         wrappedInput.Expression = expression;
 
         Value = wrappedInput;
@@ -151,11 +151,32 @@ public class DisplayInputEditorContext
     /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
     /// </summary>
     /// <param name="value">The new value to be set, either directly or wrapped as a literal expression.</param>
-    public async Task UpdateValueOrLiteralExpressionAsync(string value)
+    public Task UpdateValueOrLiteralExpressionAsync(string value)
+    {
+        return UpdateValueOrExpressionAsync(value, "Literal");
+    }
+    
+    /// <summary>
+    /// Updates the input value or sets it as an object expression,
+    /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
+    /// </summary>
+    /// <param name="value">The new value to be set, either directly or wrapped as an object expression.</param>
+    public Task UpdateValueOrObjectExpressionAsync(string value)
+    {
+        return UpdateValueOrExpressionAsync(value, "Object");
+    }
+
+    /// <summary>
+    /// Updates the input value or sets it as an expression,
+    /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
+    /// </summary>
+    /// <param name="value">The new value to be set, either directly or wrapped as an expression.</param>
+    /// <param name="expressionType">The expression type</param>
+    public async Task UpdateValueOrExpressionAsync(string? value, string expressionType)
     {
         if(InputDescriptor.IsWrapped)
         {
-            var expression = Expression.CreateLiteral(value);
+            var expression = new Expression(expressionType, value);
 
             await UpdateExpressionAsync(expression);
             return;

--- a/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
@@ -72,7 +72,7 @@ public partial class Cases
     {
         var defaultExpressionType = GetDefaultExpressionType();
 
-        return new SwitchCaseRecord
+        return new()
         {
             Label = @case.Label,
             Condition = @case.Condition.ToString(),
@@ -85,7 +85,7 @@ public partial class Cases
     {
         var expression = new Expression(switchCase.ExpressionType, switchCase.Condition);
 
-        return new SwitchCase
+        return new()
         {
             Label = switchCase.Label,
             Condition = expression,
@@ -111,7 +111,7 @@ public partial class Cases
     private void OnRowEditPreview(object obj)
     {
         var @case = (SwitchCaseRecord)obj;
-        _caseBeingEdited = new SwitchCaseRecord
+        _caseBeingEdited = new()
         {
             Label = @case.Label,
             Condition = @case.Condition,
@@ -171,7 +171,7 @@ public partial class Cases
 
     private string GetExpressionTypeDisplayName(string expressionType)
     {
-        var expressionDescriptor = ExpressionDescriptorProvider.GetByType(expressionType) ?? throw new Exception($"Could not find expression descriptor for expression type '{expressionType}'.");
+        var expressionDescriptor = ExpressionDescriptorProvider.GetByType(expressionType) ?? throw new($"Could not find expression descriptor for expression type '{expressionType}'.");
         return expressionDescriptor.DisplayName;
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor.cs
@@ -67,10 +67,7 @@ public partial class CheckList
         // Get selected values.
         var selectedValues = _checkListItems.Where(x => x.IsChecked).Select(x => x.Value).ToList();
 
-        // Serialize to JSON.
-        var json = JsonSerializer.Serialize(selectedValues);
-
-        // Update expression.
-        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
+        // Update state.
+        await EditorContext.UpdateValueOrObjectExpressionAsync(selectedValues);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor.cs
@@ -71,7 +71,6 @@ public partial class CheckList
         var json = JsonSerializer.Serialize(selectedValues);
 
         // Update expression.
-        var expression = Expression.CreateObject(json);
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Checkbox.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Checkbox.razor
@@ -29,7 +29,7 @@
     /// The editor context.
     /// </summary>
     [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     private async Task OnCheckChanged(bool? isChecked)
     {

--- a/src/modules/Elsa.Studio.UIHints/Components/Dropdown.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dropdown.razor.cs
@@ -1,4 +1,3 @@
-using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Shared.UIHints.DropDown;
 using Elsa.Studio.Models;
 using Elsa.Studio.UIHints.Extensions;
@@ -16,7 +15,7 @@ public partial class Dropdown
     /// <summary>
     /// The editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -33,7 +32,6 @@ public partial class Dropdown
     
     private async Task OnValueChanged(SelectListItem? value)
     {
-        var expression = Expression.CreateLiteral(value?.Value ?? "");
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(value?.Value ?? "");
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor.cs
@@ -49,8 +49,7 @@ public partial class DynamicOutcomes
     private async Task OnValuesChanges(List<string> arg)
     { 
         var json = JsonSerializer.Serialize(_items);
-        var expression = Expression.CreateObject(json);
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
     }
 
     private void OnKeyDown(KeyboardEventArgs arg)

--- a/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor.cs
@@ -48,8 +48,7 @@ public partial class DynamicOutcomes
 
     private async Task OnValuesChanges(List<string> arg)
     { 
-        var json = JsonSerializer.Serialize(_items);
-        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
+        await EditorContext.UpdateValueOrObjectExpressionAsync(_items);
     }
 
     private void OnKeyDown(KeyboardEventArgs arg)

--- a/src/modules/Elsa.Studio.UIHints/Components/ExpressionEditor.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/ExpressionEditor.razor
@@ -6,5 +6,5 @@
     
     /// Gets or sets the editor context.
     [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    public DisplayInputEditorContext EditorContext { get; set; } = null!;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Models;
-using Elsa.Studio.UIHints.Helpers;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudExtensions;
@@ -11,12 +10,12 @@ namespace Elsa.Studio.UIHints.Components;
 public partial class HttpStatusCodes
 {
     private List<HttpStatusCodeCase> _items = new();
-    private MudChipField<string> _chipField = default!;
+    private MudChipField<string> _chipField = null!;
 
     /// <summary>
     /// The editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnParametersSet()
@@ -28,11 +27,6 @@ public partial class HttpStatusCodes
     {
         var expectedStatusCodes = EditorContext.GetValueOrDefault<ICollection<HttpStatusCodeCase>>()?.ToList() ?? new List<HttpStatusCodeCase>();
         return expectedStatusCodes;
-    }
-
-    private List<HttpStatusCodeCase> ParseJson(string? json)
-    {
-        return JsonParser.ParseJson(json, () => new List<HttpStatusCodeCase>());
     }
 
     private async Task OnValuesChanges(List<string>? values)

--- a/src/modules/Elsa.Studio.UIHints/Components/Json.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Json.razor.cs
@@ -29,7 +29,7 @@ public partial class Json : IDisposable
     /// <summary>
     /// The context for the editor.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     private string InputValue => EditorContext.GetLiteralValueOrDefault();
 
@@ -43,13 +43,13 @@ public partial class Json : IDisposable
     {
         var language = _codeEditorOptions.Language ?? "javascript";
         
-        return new StandaloneEditorConstructionOptions
+        return new()
         {
             Language = language,
             Value = InputValue,
             FontFamily = "Roboto Mono, monospace",
             RenderLineHighlight = "none",
-            Minimap = new EditorMinimapOptions
+            Minimap = new()
             {
                 Enabled = false
             },

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
@@ -27,7 +27,7 @@
 @code {
 
     /// <summary>
-    /// The EditorContext provided by the input UI framework.`
+    /// The EditorContext provided by the input UI framework.
     /// </summary>
     [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
@@ -1,5 +1,4 @@
 @using Elsa.Studio.Models
-@using Elsa.Api.Client.Resources.Scripting.Models
 @using Elsa.Studio.UIHints.Extensions
 
 @{
@@ -27,14 +26,14 @@
 
 @code {
 
-    [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    /// <summary>
+    /// The EditorContext provided by the input UI framework.`
+    /// </summary>
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     private async Task OnValueChanged(string newValue)
     {
-        var expression = Expression.CreateLiteral(newValue.TrimNull());
-        
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(newValue.TrimNull());
     }
 
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor
@@ -19,7 +19,7 @@
             HelperText="@description"
             Immediate="true"
             AutoSize="true"
-            ForceShrink="true"
+            ShrinkLabel="true"
             ChipColor="Color.Primary"
             ChipSize="Size.Medium"
             ChipVariant="Variant.Filled"

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor.cs
@@ -48,8 +48,7 @@ public partial class MultiText
 
     private async Task OnValuesChanges(List<string> arg)
     {
-        var json = JsonSerializer.Serialize(_items);
-        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
+        await EditorContext.UpdateValueOrObjectExpressionAsync(_items);
     }
 
     private void OnKeyDown(KeyboardEventArgs arg)

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor.cs
@@ -16,12 +16,12 @@ namespace Elsa.Studio.UIHints.Components;
 public partial class MultiText
 {
     private List<string> _items = new();
-    private MudChipField<string> _chipField = default!;
+    private MudChipField<string> _chipField = null!;
 
     /// <summary>
     /// Gets or sets the editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -34,23 +34,22 @@ public partial class MultiText
         var input = EditorContext.GetObjectValueOrDefault();
         return ParseJson(input);
     }
-    
+
     private static List<string> ParseJson(string? json)
     {
         var options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        
+
         options.Converters.Add(new JsonPrimitiveToStringConverter());
         return JsonParser.ParseJson(json, () => new List<string>(), options);
     }
 
     private async Task OnValuesChanges(List<string> arg)
-    { 
+    {
         var json = JsonSerializer.Serialize(_items);
-        var expression = Expression.CreateObject(json);
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrObjectExpressionAsync(json);
     }
 
     private void OnKeyDown(KeyboardEventArgs arg)
@@ -58,7 +57,7 @@ public partial class MultiText
         // TODO: This is a hack to get the chips to update when the user presses enter.
         // Ideally, we can configure this on MudChipField, but this is not currently supported. 
         if (arg.Key is not ("Enter" or "Tab")) return;
-        
+
         var setChipsMethod = _chipField.GetType().GetMethod("SetChips", BindingFlags.Instance | BindingFlags.NonPublic);
         setChipsMethod!.Invoke(_chipField, null);
     }

--- a/src/modules/Elsa.Studio.UIHints/Components/OutcomePicker.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/OutcomePicker.razor.cs
@@ -1,4 +1,3 @@
-using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Shared.UIHints.DropDown;
 using Elsa.Studio.Models;
 using Microsoft.AspNetCore.Components;
@@ -15,7 +14,7 @@ public partial class OutcomePicker
     /// <summary>
     /// The editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     private ICollection<string> Outcomes => EditorContext.WorkflowDefinition.Outcomes;
 
@@ -30,11 +29,10 @@ public partial class OutcomePicker
         var value = EditorContext.GetLiteralValueOrDefault();
         return _items.FirstOrDefault(x => x.Value == value);
     }
-    
+
     private async Task OnValueChanged(SelectListItem? value)
     {
         var outcome = value?.Value ?? "";
-        var expression = Expression.CreateLiteral(outcome);
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(outcome);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/OutputPicker.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/OutputPicker.razor.cs
@@ -1,4 +1,3 @@
-using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.UIHints.DropDown;
 using Elsa.Studio.Models;
@@ -16,7 +15,7 @@ public partial class OutputPicker
     /// <summary>
     /// The editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     private ICollection<OutputDefinition> Outputs => EditorContext.WorkflowDefinition.Outputs;
 
@@ -24,7 +23,7 @@ public partial class OutputPicker
     protected override void OnParametersSet()
     {
         var items = Outputs.Select(x => new SelectListItem(x.DisplayName, x.Name)).OrderBy(x => x.Text).ToList();
-        items.Insert(0, new SelectListItem("(None)", ""));
+        items.Insert(0, new("(None)", ""));
         _items = items;
     }
 
@@ -33,10 +32,10 @@ public partial class OutputPicker
         var outputName = EditorContext.GetExpressionValueOrDefault();
         return _items.FirstOrDefault(x => x.Value == outputName);
     }
-    
+
     private async Task OnValueChanged(SelectListItem? value)
     {
         var outputName = value?.Value ?? "";
-        await EditorContext.UpdateExpressionAsync(Expression.CreateLiteral(outputName));
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(outputName);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
@@ -1,9 +1,7 @@
 @using Elsa.Studio.Models
-@using Elsa.Api.Client.Resources.Scripting.Models
 @using Elsa.Api.Client.Shared.UIHints.SingleLine
 @using Elsa.Studio.DomInterop.Contracts
 @using Elsa.Studio.UIHints.Extensions
-@using MudBlazor.Utilities
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
@@ -15,7 +13,7 @@
 
 <ExpressionInput EditorContext="@EditorContext">
     <ChildContent>
-        <MudTextFieldExtended 
+        <MudTextFieldExtended
             T="string"
             Label="@displayName"
             Variant="Variant.Outlined"
@@ -29,15 +27,15 @@
                 @if (!string.IsNullOrWhiteSpace(_singleLineProps.AdornmentText))
                 {
                     <MudText Color="Color.Info">@_singleLineProps.AdornmentText</MudText>
-                }  
+                }
             </AdornmentStart>
             <AdornmentEnd>
                 @if (_singleLineProps.EnableCopyAdornment)
                 {
                     <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                               OnClick="OnCopyClicked"
-                               Size="Size.Small"
-                               Class="mr-2"/>
+                                   OnClick="OnCopyClicked"
+                                   Size="Size.Small"
+                                   Class="mr-2"/>
                 }
             </AdornmentEnd>
         </MudTextFieldExtended>
@@ -49,10 +47,9 @@
     private SingleLineProps _singleLineProps = new();
 
     /// Gets or sets the editor context.
-    [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
-    [Inject] private IClipboard Clipboard { get; set; } = default!;
+    [Inject] private IClipboard Clipboard { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -62,13 +59,12 @@
 
     private async Task OnValueChanged(string newValue)
     {
-        var expression = Expression.CreateLiteral(newValue.TrimWhitespace());
-
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(newValue.TrimWhitespace());
     }
+
     private async Task OnCopyClicked()
     {
-        string value = (_singleLineProps.AdornmentText ?? String.Empty) + EditorContext.GetLiteralValueOrDefault();
+        var value = (_singleLineProps.AdornmentText ?? string.Empty) + EditorContext.GetLiteralValueOrDefault();
         await Clipboard.CopyText(value);
     }
 

--- a/src/modules/Elsa.Studio.UIHints/Components/TypePicker.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/TypePicker.razor.cs
@@ -1,6 +1,5 @@
 using Elsa.Studio.Models;
 using Microsoft.AspNetCore.Components;
-using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Resources.VariableTypes.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
 
@@ -13,13 +12,13 @@ public partial class TypePicker
 {
     private ICollection<VariableTypeDescriptor> _variableTypes = new List<VariableTypeDescriptor>();
     private ICollection<IGrouping<string, VariableTypeDescriptor>> _groupedVariableTypes = new List<IGrouping<string, VariableTypeDescriptor>>();
-    
+
     /// <summary>
     /// Gets or sets the editor context.
     /// </summary>
-    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
-    
-    [Inject] private IVariableTypeService VariableTypeService { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
+
+    [Inject] private IVariableTypeService VariableTypeService { get; set; } = null!;
 
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
@@ -33,10 +32,9 @@ public partial class TypePicker
         var value = EditorContext.GetLiteralValueOrDefault();
         return _variableTypes.FirstOrDefault(x => x.TypeName == value);
     }
-    
+
     private async Task OnValueChanged(VariableTypeDescriptor? value)
     {
-        var expression = Expression.CreateLiteral(value?.TypeName ?? "");
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(value?.TypeName ?? "");
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/VariablePicker.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/VariablePicker.razor.cs
@@ -1,9 +1,7 @@
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
-using Elsa.Api.Client.Shared.Models;
 using Elsa.Api.Client.Shared.UIHints.DropDown;
 using Elsa.Studio.Models;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 using System.Text.Json;
 
 namespace Elsa.Studio.UIHints.Components;
@@ -22,7 +20,7 @@ public partial class VariablePicker
 
     private ICollection<Variable> Variables => EditorContext.WorkflowDefinition.Variables;
 
-    private JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions()
+    private JsonSerializerOptions JsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
@@ -45,7 +43,7 @@ public partial class VariablePicker
             {
                 try
                 {
-                    value = System.Text.Json.JsonSerializer.Deserialize<Variable>(expressionValue, JsonSerializerOptions);
+                    value = JsonSerializer.Deserialize<Variable>(expressionValue, JsonSerializerOptions);
                 }
                 catch (Exception)
                 {
@@ -55,6 +53,7 @@ public partial class VariablePicker
         }
         else
             value = EditorContext.GetValueOrDefault<Variable>();
+        
         return _items.FirstOrDefault(x => x.Value == value?.Id);
     }
     
@@ -64,10 +63,7 @@ public partial class VariablePicker
         var variable = Variables.FirstOrDefault(x => x.Id == variableId);
 
         if(EditorContext.InputDescriptor.IsWrapped)
-           await EditorContext.UpdateExpressionAsync(
-                new Api.Client.Resources.Scripting.Models.Expression("Variable", System.Text.Json.JsonSerializer
-                .Serialize(variable, JsonSerializerOptions)
-                ));
+           await EditorContext.UpdateExpressionAsync(new("Variable", JsonSerializer.Serialize(variable, JsonSerializerOptions)));
         else
             await EditorContext.UpdateValueAsync(variable);
     }

--- a/src/modules/Elsa.Studio.UIHints/Components/WorkflowDefinitionPicker.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/WorkflowDefinitionPicker.razor.cs
@@ -1,4 +1,3 @@
-using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Api.Client.Shared.UIHints.DropDown;
@@ -18,10 +17,9 @@ public partial class WorkflowDefinitionPicker
     /// <summary>
     /// Gets or sets the editor context.
     /// </summary>
-    [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
-    [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
+    [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;
 
 
     /// <inheritdoc />
@@ -46,7 +44,6 @@ public partial class WorkflowDefinitionPicker
 
     private async Task OnValueChanged(SelectListItem? value)
     {
-        var expression = Expression.CreateLiteral(value?.Value ?? "");
-        await EditorContext.UpdateExpressionAsync(expression);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(value?.Value ?? "");
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -56,10 +56,10 @@ public partial class InputsTab
     public Func<JsonObject, Task>? OnActivityUpdated { get; set; }
 
     [CascadingParameter] private IWorkspace? Workspace { get; set; }
-    [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
-    [Inject] private IUIHintService UIHintService { get; set; } = default!;
+    [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = null!;
+    [Inject] private IUIHintService UIHintService { get; set; } = null!;
 
-    [Inject] private IBackendApiClientProvider BackendApiClientProvider { get; set; } = default!;
+    [Inject] private IBackendApiClientProvider BackendApiClientProvider { get; set; } = null!;
     private ICollection<InputDescriptor> InputDescriptors { get; set; } = new List<InputDescriptor>();
     private ICollection<OutputDescriptor> OutputDescriptors { get; set; } = new List<OutputDescriptor>();
     private ICollection<ActivityInputDisplayModel> InputDisplayModels { get; set; } = new List<ActivityInputDisplayModel>();
@@ -84,8 +84,8 @@ public partial class InputsTab
         {
             var inputName = inputDescriptor.Name.Camelize();
             var value = activity.GetProperty(inputName);
-            var wrappedInput = inputDescriptor.IsWrapped ? ToWrappedInput(value) : default;
-            var syntaxProvider = wrappedInput != null ? ExpressionDescriptorProvider.GetByType(wrappedInput.Expression.Type) : default;
+            var wrappedInput = inputDescriptor.IsWrapped ? ToWrappedInput(value) : null;
+            var syntaxProvider = wrappedInput != null ? ExpressionDescriptorProvider.GetByType(wrappedInput.Expression.Type) : null;
 
             // Check if refresh is needed.
             if (inputDescriptor.UISpecifications != null
@@ -114,7 +114,7 @@ public partial class InputsTab
 
             context.OnValueChanged = async v => await HandleValueChangedAsync(context, v);
             var editor = uiHintHandler.DisplayInputEditor(context);
-            models.Add(new ActivityInputDisplayModel(editor));
+            models.Add(new(editor));
         }
 
         return models;
@@ -137,7 +137,7 @@ public partial class InputsTab
 
         var api = await BackendApiClientProvider.GetApiAsync<IActivityDescriptorOptionsApi>();
 
-        var result = await api.GetAsync(activityTypeName, propertyName, new GetActivityDescriptorOptionsRequest()
+        var result = await api.GetAsync(activityTypeName, propertyName, new()
         {
             Context = contextDictionary
         });


### PR DESCRIPTION
### Summary
This PR resolves an issue where activity input property types without `Input<T>` wrappers were not stored correctly.

### Problem
For example, a property like this would fail to save properly due to missing `Input<T>` wrapping:
```csharp
public string FirstName { get; set; }
```

In contrast, this works as expected:
```csharp
public Input<string> FirstName { get; set; }
```

The issue stemmed from the `Singleline` component, which incorrectly created a `LiteralExpression` object even for unwrapped properties.

### Changes
- Replaced `UpdateExpressionAsync` with `UpdateValueOrLiteralExpressionAsync` across components for consistent behavior.
- Updated default initialization from `default!` to `null!` to better support nullable reference types.
- Cleaned up code by removing unused imports and simplifying object initializations where possible.