### PR TITLE
Bug - JavaScript Editor Autocomplete Issue

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Monaco/Handlers/JavaScriptMonacoHandler.cs
+++ b/src/framework/Elsa.Studio.Shared/Monaco/Handlers/JavaScriptMonacoHandler.cs
@@ -15,20 +15,18 @@ public class JavaScriptMonacoHandler(IJSRuntime jsRuntime, TypeDefinitionService
     /// <inheritdoc />
     public async ValueTask InitializeAsync(MonacoContext context)
     {
+        if (context.ExpressionDescriptor.Type != "JavaScript")
+            return;
+
         var activityDescriptor = context.CustomProperties.TryGetValue(nameof(ActivityDescriptor), out var activityDescriptorObj) ? (ActivityDescriptor)activityDescriptorObj : null;
         var propertyDescriptor = context.CustomProperties.TryGetValue(nameof(PropertyDescriptor), out var propertyDescriptorObj) ? (PropertyDescriptor)propertyDescriptorObj : null;
         var workflowDefinitionId = context.CustomProperties.TryGetValue("WorkflowDefinitionId", out var workflowDefinitionIdObj) ? (string)workflowDefinitionIdObj : null;
-        var expressionDescriptor = context.ExpressionDescriptor;
-        
-        if(expressionDescriptor.Type != "JavaScript" && activityDescriptor?.TypeName != "Elsa.RunJavaScript")
-            return;
-        
         var activityTypeName = activityDescriptor?.TypeName;
         var propertyName = propertyDescriptor?.Name;
-        
-        if (activityTypeName == null || propertyName == null || workflowDefinitionId == null)
+
+        if (activityTypeName == null || workflowDefinitionId == null)
             return;
-        
+
         var data = await typeDefinitionService.GetTypeDefinition(workflowDefinitionId, activityTypeName, propertyName);
         await jsRuntime.InvokeVoidAsync("monaco.languages.typescript.javascriptDefaults.addExtraLib", data, null);
     }

--- a/src/framework/Elsa.Studio.Shared/Services/TypeDefinitionService.cs
+++ b/src/framework/Elsa.Studio.Shared/Services/TypeDefinitionService.cs
@@ -1,5 +1,4 @@
 using Elsa.Api.Client.Resources.Scripting.Contracts;
-using Elsa.Api.Client.Resources.Scripting.Requests;
 using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Services;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExpressionDescriptorProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExpressionDescriptorProvider.cs
@@ -23,11 +23,6 @@ public class ExpressionDescriptorProvider
     /// Gets an expression descriptor by type.
     /// </summary>
     public ExpressionDescriptor? GetByType(string type) => _expressionDescriptors.TryGetValue(type, out var descriptor) ? descriptor : default;
-    
-    /// <summary>
-    /// Gets an expression descriptor by editor language.
-    /// </summary>
-    public ExpressionDescriptor? GetByLanguage(string? language) => _expressionDescriptors.Values.FirstOrDefault(descriptor => descriptor.Properties.TryGetValue("MonacoLanguage", out var monacoLanguage) && monacoLanguage == language);
 
     /// <summary>
     /// Adds a range of expression descriptors.

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExpressionDescriptorProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExpressionDescriptorProvider.cs
@@ -23,7 +23,11 @@ public class ExpressionDescriptorProvider
     /// Gets an expression descriptor by type.
     /// </summary>
     public ExpressionDescriptor? GetByType(string type) => _expressionDescriptors.TryGetValue(type, out var descriptor) ? descriptor : default;
-
+    
+    /// <summary>
+    /// Gets an expression descriptor by editor language.
+    /// </summary>
+    public ExpressionDescriptor? GetByLanguage(string? language) => _expressionDescriptors.Values.FirstOrDefault(descriptor => descriptor.Properties.TryGetValue("MonacoLanguage", out var monacoLanguage) && monacoLanguage == language);
 
     /// <summary>
     /// Adds a range of expression descriptors.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -177,8 +177,8 @@ public partial class InputsTab
 
     private ExpressionDescriptor? GetSyntaxProvider(WrappedInput wrappedInput, InputDescriptor inputDescriptor)
     {
-        return inputDescriptor.UIHint.Equals("code-editor")
-            ? ExpressionDescriptorProvider.GetByLanguage(inputDescriptor.GetCodeEditorOptions().Language)
+        return inputDescriptor.UIHint.Equals("code-editor") && !string.IsNullOrEmpty(inputDescriptor.DefaultSyntax)
+            ? ExpressionDescriptorProvider.GetByType(inputDescriptor.DefaultSyntax)
             : ExpressionDescriptorProvider.GetByType(wrappedInput.Expression.Type);
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -1,15 +1,14 @@
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Elsa.Api.Client.Converters;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptorOptions.Contracts;
-using Elsa.Api.Client.Resources.ActivityDescriptorOptions.Requests;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Models;
+using Elsa.Studio.UIHints.Extensions;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Humanizer;
@@ -85,7 +84,7 @@ public partial class InputsTab
             var inputName = inputDescriptor.Name.Camelize();
             var value = activity.GetProperty(inputName);
             var wrappedInput = inputDescriptor.IsWrapped ? ToWrappedInput(value) : null;
-            var syntaxProvider = wrappedInput != null ? ExpressionDescriptorProvider.GetByType(wrappedInput.Expression.Type) : null;
+            var syntaxProvider = wrappedInput != null ? GetSyntaxProvider(wrappedInput, inputDescriptor) : null;
 
             // Check if refresh is needed.
             if (inputDescriptor.UISpecifications != null
@@ -174,5 +173,12 @@ public partial class InputsTab
 
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);
+    }
+
+    private ExpressionDescriptor? GetSyntaxProvider(WrappedInput wrappedInput, InputDescriptor inputDescriptor)
+    {
+        return inputDescriptor.UIHint.Equals("code-editor")
+            ? ExpressionDescriptorProvider.GetByLanguage(inputDescriptor.GetCodeEditorOptions().Language)
+            : ExpressionDescriptorProvider.GetByType(wrappedInput.Expression.Type);
     }
 }


### PR DESCRIPTION
This PR closes #441 

A new method has been added to the `InputsTab.razor.cs` file called `GetSyntaxProvider()` to return the `ExpressionDescriptor` based on the editors lanaguage.

The limitations in the `JavaScriptMonacoHandler` to not allow it to render in the `Elsa.RunJavaScript` have also been removed.

This implimentation also allows for other Monaco language handlers to work for all editors too.