### PR TITLE
Disable the 'BULK ACTIONS' button in the Workflow Definition and Workflow Instances pages if items are not selected

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -31,10 +31,10 @@
         @bind-SelectedItems="_selectedRows">
         <ToolBarContent>
             <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="@Localizer["Bulk actions"]" Color="Color.Default" Variant="Variant.Filled">
-                <MudMenuItem Disabled="IsReadOnlyMode" OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
-                <MudMenuItem Disabled="IsReadOnlyMode" OnClick="@OnBulkPublishClicked">@Localizer["Publish"]</MudMenuItem>
-                <MudMenuItem Disabled="IsReadOnlyMode" OnClick="@OnBulkRetractClicked">@Localizer["Unpublish"]</MudMenuItem>
-                <MudMenuItem OnClick="@OnBulkExportClicked">@Localizer["Export"]</MudMenuItem>
+                <MudMenuItem Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
+                <MudMenuItem Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkPublishClicked">@Localizer["Publish"]</MudMenuItem>
+                <MudMenuItem Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkRetractClicked">@Localizer["Unpublish"]</MudMenuItem>
+                <MudMenuItem Disabled="!(_selectedRows?.Any() ?? false)" OnClick="@OnBulkExportClicked">@Localizer["Export"]</MudMenuItem>
             </MudMenu>
             <MudSpacer/>
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -220,6 +220,7 @@ public partial class WorkflowDefinitionList
 
         var workflowDefinitionIds = _selectedRows.Select(x => x.DefinitionId).ToList();
         await WorkflowDefinitionService.BulkDeleteAsync(workflowDefinitionIds);
+        _selectedRows.Clear();
         Reload();
     }
 
@@ -269,7 +270,7 @@ public partial class WorkflowDefinitionList
                 : Localizer["{0} workflows are not found", response.NotFound.Count];
             Snackbar.Add(message, Severity.Warning, options => { options.SnackbarVariant = Variant.Filled; });
         }
-
+        _selectedRows.Clear();
         Reload();
     }
 
@@ -307,7 +308,7 @@ public partial class WorkflowDefinitionList
                 : Localizer["{0} workflows are not found", response.NotFound.Count];
             Snackbar.Add(message, Severity.Warning, options => { options.SnackbarVariant = Variant.Filled; });
         }
-
+        _selectedRows.Clear();
         Reload();
     }
 
@@ -317,6 +318,8 @@ public partial class WorkflowDefinitionList
         var download = await WorkflowDefinitionService.BulkExportDefinitionsAsync(workflowVersionIds);
         var fileName = download.FileName;
         await Files.DownloadFileFromStreamAsync(fileName, download.Content);
+        _selectedRows.Clear();
+        Reload();
     }
 
     private Task OnImportClicked()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -38,8 +38,8 @@
 <ToolBarContent>
     <MudPaper Class="gap-3 d-flex" Elevation="0">
         <MudMenu EndIcon="@Icons.Material.Filled.KeyboardArrowDown" Label="@Localizer["Bulk actions"]" Color="Color.Default" Variant="Variant.Filled" AnchorOrigin="Origin.BottomLeft">
-            <MudMenuItem OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
-            <MudMenuItem OnClick="@OnBulkCancelClicked">@Localizer["Cancel"]</MudMenuItem>
+            <MudMenuItem Disabled="!(_selectedRows?.Any() ?? false)" OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
+            <MudMenuItem Disabled="!(_selectedRows?.Any() ?? false)" OnClick="@OnBulkCancelClicked">@Localizer["Cancel"]</MudMenuItem>
             @* <MudMenuItem Disabled="true">@Localizer["Retry"]</MudMenuItem> *@
             @* <MudMenuItem OnClick="@OnBulkExportClicked">Export</MudMenuItem> *@
         </MudMenu>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -275,6 +275,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
 
         var workflowInstanceIds = _selectedRows.Select(x => x.WorkflowInstanceId).ToList();
         await WorkflowInstanceService.BulkDeleteAsync(workflowInstanceIds);
+        _selectedRows.Clear();
         Reload();
     }
 
@@ -291,6 +292,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
             Ids = workflowInstanceIds
         };
         await WorkflowInstanceService.BulkCancelAsync(request);
+        _selectedRows.Clear();
         Reload();
     }
 


### PR DESCRIPTION
This PR is related to the disable the BULK ACTIONS button if no is no items are selected in the Workflow Definition page and Workflow instance page.

To address the following issue: [[Issue Link](https://github.com/elsa-workflows/elsa-studio/issues/443)](https://github.com/elsa-workflows/elsa-studio/issues/443)