### PR TITLE
Fix Activity Info tab

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InfoTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InfoTab.razor.cs
@@ -22,6 +22,8 @@ public partial class InfoTab
     {
         ActivityDescriptor.ConstructionProperties.TryGetValue("WorkflowDefinitionId", out var link);
 
+        ActivityInfo.Clear();
+
         ActivityInfo.Add(Localizer["Type"], ActivityDescriptor.TypeName, link == null ? null : $"/workflows/definitions/{link}/edit");
         ActivityInfo.Add(Localizer["Description"], ActivityDescriptor.Description);
     }


### PR DESCRIPTION
Currently info tab shows duplicate details whenever the user switches between the activity, this is due to the recent change from dictionary to list

 Solves #452