### PR TITLE
Add OpenIdConnect Support

### DIFF
--- a/src/framework/Elsa.Studio.Core/TokenNames.cs
+++ b/src/framework/Elsa.Studio.Core/TokenNames.cs
@@ -3,5 +3,6 @@ namespace Elsa.Studio;
 public static class TokenNames
 {
     public const string AccessToken = "accessToken";
+    public const string IdToken = "idToken";
     public const string RefreshToken = "refreshToken";
 }

--- a/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
@@ -12,10 +12,11 @@ namespace Elsa.Studio.Login.BlazorWasm.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds core services with Blazor Server implementations.
+    /// Adds login services with Blazor Server implementations.
     /// </summary>
     public static IServiceCollection AddLoginModule(this IServiceCollection services)
     {
+        // Add the login module.
         services.AddLoginModuleCore();
         
         // Register Blazored LocalStorage.

--- a/src/modules/Elsa.Studio.Login/Components/LoginState.razor
+++ b/src/modules/Elsa.Studio.Login/Components/LoginState.razor
@@ -1,0 +1,42 @@
+@using Elsa.Studio.Login.Contracts
+@using Microsoft.AspNetCore.Components.Authorization
+@inherits StudioComponentBase
+@implements IDisposable
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IEndSessionService EndSessionService
+
+@if (@CurrentState?.User.Identity?.IsAuthenticated is true)
+{
+    <MudMenu Label="@CurrentState.User.Identity.Name"
+             Variant="Variant.Text"
+             EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
+             IconColor="Color.Secondary"
+             AnchorOrigin="Origin.BottomRight"
+             TransformOrigin="Origin.BottomRight"
+             Color="Color.Inherit"
+             Dense="true">
+        <MudMenuItem OnClick="@EndSessionService.LogoutAsync">Logout</MudMenuItem>
+    </MudMenu>
+}
+
+@code
+{
+    private AuthenticationState? CurrentState;
+
+    protected override async Task OnInitializedAsync()
+    {
+        CurrentState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        AuthenticationStateProvider.AuthenticationStateChanged += OnCurrentEnvironmentChanged;
+    }
+
+    public void Dispose()
+    {
+        AuthenticationStateProvider.AuthenticationStateChanged -= OnCurrentEnvironmentChanged;
+    }
+
+    private async void OnCurrentEnvironmentChanged(Task<AuthenticationState> state)
+    {
+        CurrentState = await state;
+        StateHasChanged();
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
+++ b/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
@@ -1,0 +1,30 @@
+﻿using Elsa.Studio.Components;
+using Elsa.Studio.Login.Contracts;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Login.Components;
+
+/// <summary>
+/// Receives the OIDC authorization code and trades it for access_token
+/// </summary>
+[Route("/signin-oidc")]
+public sealed class ReceiveAuthorizationCode : StudioComponentBase
+{
+    /// <summary>
+    /// Gets or sets the <see cref="NavigationManager"/>.
+    /// </summary>
+    [Inject] private IAuthorizationService AuthorizationService { get; set; } = default!;
+
+    [SupplyParameterFromQuery(Name = "code")] private string? AuthorizationCode { get; set; }
+
+    [SupplyParameterFromQuery(Name = "state")] private string? State { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (AuthorizationCode != null)
+        {
+            await AuthorizationService.ReceiveAuthorizationCode(AuthorizationCode, State, default);
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
+++ b/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using Elsa.Studio.Login.Contracts;
+using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Login.Components;
 
@@ -8,23 +9,13 @@ namespace Elsa.Studio.Login.Components;
 public class RedirectToLogin : ComponentBase
 {
     /// <summary>
-    /// Gets or sets the <see cref="NavigationManager"/>.
+    /// Gets or sets the <see cref="AuthorizationService"/>.
     /// </summary>
-    [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
+    [Inject] protected IAuthorizationService AuthorizationService { get; set; } = default!;
 
     /// <inheritdoc />
     protected override Task OnAfterRenderAsync(bool firstRender)
-    { 
-        var returnUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
-        if (string.IsNullOrWhiteSpace(returnUrl))
-        {
-            NavigationManager.NavigateTo("login", true);
-        }
-        else
-        {
-            NavigationManager.NavigateTo($"login?returnUrl={returnUrl}", true);
-        }
-        
-        return Task.CompletedTask;
+    {
+        return AuthorizationService.RedirectToAuthorizationServer();
     }
 }

--- a/src/modules/Elsa.Studio.Login/Contracts/IAuthorizationService.cs
+++ b/src/modules/Elsa.Studio.Login/Contracts/IAuthorizationService.cs
@@ -1,0 +1,17 @@
+﻿namespace Elsa.Studio.Login.Contracts;
+
+/// <summary>
+/// Provides a service to acquire an access_token from an authorization server
+/// </summary>
+public interface IAuthorizationService
+{
+    /// <summary>
+    /// Redirects the user agent to the authorization server for authentication
+    /// </summary>
+    Task RedirectToAuthorizationServer();
+
+    /// <summary>
+    /// Trades a authorization code received from the authorization server for an access_token
+    /// </summary>
+    Task ReceiveAuthorizationCode(string code, string? state, CancellationToken cancellationToken);
+}

--- a/src/modules/Elsa.Studio.Login/Contracts/IEndSessionService.cs
+++ b/src/modules/Elsa.Studio.Login/Contracts/IEndSessionService.cs
@@ -1,0 +1,12 @@
+﻿namespace Elsa.Studio.Login.Contracts;
+
+/// <summary>
+/// Provides a service to end the session with an authorization server
+/// </summary>
+public interface IEndSessionService
+{
+    /// <summary>
+    /// Remove authentication state and end the session with the authorization server
+    /// </summary>
+    Task LogoutAsync();
+}

--- a/src/modules/Elsa.Studio.Login/Contracts/IRefreshTokenService.cs
+++ b/src/modules/Elsa.Studio.Login/Contracts/IRefreshTokenService.cs
@@ -1,0 +1,14 @@
+﻿using Elsa.Api.Client.Resources.Identity.Responses;
+
+namespace Elsa.Studio.Login.Contracts;
+
+/// <summary>
+/// Provides a service to refresh an access_token from an authorization server
+/// </summary>
+public interface IRefreshTokenService
+{
+    /// <summary>
+    /// Refreshes the access_token
+    /// </summary>
+    Task<LoginResponse> RefreshTokenAsync(CancellationToken cancellationToken);
+}

--- a/src/modules/Elsa.Studio.Login/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,8 @@ using Elsa.Studio.Contracts;
 using Elsa.Studio.Login.ComponentProviders;
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.HttpMessageHandlers;
+using Elsa.Studio.Login.Models;
 using Elsa.Studio.Login.Services;
-using Elsa.Studio.Services;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,13 +20,39 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddLoginModuleCore(this IServiceCollection services)
     {
         return services
-                .AddScoped<IFeature, Feature>()
+                .AddScoped<IFeature, LoginFeature>()
                 .AddOptions()
                 .AddAuthorizationCore()
                 .AddScoped<AuthenticatingApiHttpMessageHandler>()
                 .AddScoped<AuthenticationStateProvider, AccessTokenAuthenticationStateProvider>()
                 .AddScoped<IUnauthorizedComponentProvider, RedirectToLoginUnauthorizedComponentProvider>()
-                .AddScoped<ICredentialsValidator, DefaultCredentialsValidator>()
+            ;
+    }
+
+    /// <summary>
+    /// Configures the login module to use elsa identity
+    /// </summary>
+    public static IServiceCollection UseElsaIdentity(this IServiceCollection services)
+    {
+        return services
+                .AddScoped<ICredentialsValidator, ElsaIdentityCredentialsValidator>()
+                .AddScoped<IAuthorizationService, ElsaIdentityAuthorizationService>()
+                .AddScoped<IRefreshTokenService, ElsaIdentityRefreshTokenService>()
+                .AddScoped<IEndSessionService, ElsaIdentityEndSessionService>()
+            ;
+    }
+
+    /// <summary>
+    /// Configures the login module to use OpenIdConnect (OIDC)
+    /// </summary>
+    public static IServiceCollection UseOpenIdConnect(this IServiceCollection services, Action<OpenIdConnectConfiguration> configure)
+    {
+        services.Configure(configure);
+
+        return services
+                .AddScoped<IAuthorizationService, OpenIdConnectAuthorizationService>()
+                .AddScoped<IRefreshTokenService, OpenIdConnectRefreshTokenService>()
+                .AddScoped<IEndSessionService, OpenIdConnectEndSessionService>()
             ;
     }
 }

--- a/src/modules/Elsa.Studio.Login/Feature.cs
+++ b/src/modules/Elsa.Studio.Login/Feature.cs
@@ -1,8 +1,0 @@
-using Elsa.Studio.Abstractions;
-
-namespace Elsa.Studio.Login;
-
-public class Feature : FeatureBase
-{
-    
-}

--- a/src/modules/Elsa.Studio.Login/LoginFeature.cs
+++ b/src/modules/Elsa.Studio.Login/LoginFeature.cs
@@ -1,0 +1,16 @@
+using Elsa.Studio.Abstractions;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Login.Components;
+
+namespace Elsa.Studio.Login;
+
+/// <inheritdoc/>
+public class LoginFeature(IAppBarService appBarService) : FeatureBase
+{
+    /// <inheritdoc/>
+    public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        appBarService.AddAppBarItem<LoginState>();
+        return base.InitializeAsync(cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Models/IdentityTokenOptions.cs
+++ b/src/modules/Elsa.Studio.Login/Models/IdentityTokenOptions.cs
@@ -1,0 +1,20 @@
+﻿using Elsa.Studio.Login.Services;
+using System.Security.Claims;
+
+namespace Elsa.Studio.Login.Models;
+
+/// <summary>
+/// Provides options to configure how a ClaimsIdentity is created by <see cref="AccessTokenAuthenticationStateProvider"/>
+/// </summary>
+public class IdentityTokenOptions
+{
+    /// <summary>
+    /// The claim type that is being used to identify the name of the created ClaimsIdentity
+    /// </summary>
+    public string NameClaimType { get; set; } = ClaimsIdentity.DefaultNameClaimType;
+
+    /// <summary>
+    /// The claim type that is being used to identify the role of the created ClaimsIdentity
+    /// </summary>
+    public string RoleClaimType { get; set; } = ClaimsIdentity.DefaultRoleClaimType;
+}

--- a/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
+++ b/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
@@ -1,0 +1,32 @@
+﻿namespace Elsa.Studio.Login.Models;
+
+/// <summary>
+/// Provides configuration necessary for correct OpenIdConnect operation
+/// </summary>
+public class OpenIdConnectConfiguration
+{
+    /// <summary>
+    /// The authorization_endpoint as given by the openid-configuration
+    /// </summary>
+    public required string AuthEndpoint { get; set; }
+
+    /// <summary>
+    /// The token_endpoint as given by the openid-configuration
+    /// </summary>
+    public required string TokenEndpoint { get; set; }
+
+    /// <summary>
+    /// The end_session_endpoint as given by the openid-configuration
+    /// </summary>
+    public required string EndSessionEndpoint { get; set; }
+
+    /// <summary>
+    /// The client_id as which this application is registered with the authorization server
+    /// </summary>
+    public required string ClientId { get; set; }
+
+    /// <summary>
+    /// The scopes to request, defaulting to: openid profile offline_access
+    /// </summary>
+    public string[] Scopes { get; set; } = ["openid", "profile", "offline_access"];
+}

--- a/src/modules/Elsa.Studio.Login/Models/TokenResponse.cs
+++ b/src/modules/Elsa.Studio.Login/Models/TokenResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Elsa.Studio.Login.Models;
+
+sealed class TokenResponse
+{
+    public string? access_token { get; set; }
+    public string? id_token { get; set; }
+    public string? refresh_token { get; set; }
+    public int expires_in { get; set; }
+}

--- a/src/modules/Elsa.Studio.Login/Services/AccessTokenAuthenticationStateProvider.cs
+++ b/src/modules/Elsa.Studio.Login/Services/AccessTokenAuthenticationStateProvider.cs
@@ -1,43 +1,35 @@
-using System.Security.Claims;
 using Elsa.Studio.Extensions;
 using Elsa.Studio.Login.Contracts;
-using Elsa.Studio.Login.Extensions;
+using Elsa.Studio.Login.Models;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 namespace Elsa.Studio.Login.Services;
 
 /// <summary>
 /// Provides the authentication state for the current user based on an access token.
 /// </summary>
-public class AccessTokenAuthenticationStateProvider : AuthenticationStateProvider
+public class AccessTokenAuthenticationStateProvider(IJwtAccessor jwtAccessor, IJwtParser jwtParser, IOptions<IdentityTokenOptions> options) : AuthenticationStateProvider
 {
-    private readonly IJwtAccessor _jwtAccessor;
-    private readonly IJwtParser _jwtParser;
-
-    /// <inheritdoc />
-    public AccessTokenAuthenticationStateProvider(IJwtAccessor jwtAccessor, IJwtParser jwtParser)
-    {
-        _jwtAccessor = jwtAccessor;
-        _jwtParser = jwtParser;
-    }
-
     /// <inheritdoc />
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {
-        var authToken = await _jwtAccessor.ReadTokenAsync(TokenNames.AccessToken);
+        var authToken = await jwtAccessor.ReadTokenAsync(TokenNames.IdToken)
+                     ?? await jwtAccessor.ReadTokenAsync(TokenNames.AccessToken);
 
         if (string.IsNullOrEmpty(authToken))
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
 
-        var claims = _jwtParser.Parse(authToken).ToList();
+        var claims = jwtParser.Parse(authToken).ToList();
         var isExpired = claims.IsExpired();
-        
+
         // If the token has expired, return an empty authentication state.
         if (isExpired)
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
 
         // Otherwise, return the authentication state.
-        var identity = new ClaimsIdentity(claims, "jwt");
+        var identity = new ClaimsIdentity(claims, "jwt", options.Value.NameClaimType, options.Value.RoleClaimType);
         var user = new ClaimsPrincipal(identity);
 
         return new AuthenticationState(user);

--- a/src/modules/Elsa.Studio.Login/Services/ElsaIdentityAuthorizationService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/ElsaIdentityAuthorizationService.cs
@@ -1,0 +1,30 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Login.Services;
+
+/// <inheritdoc/>
+internal class ElsaIdentityAuthorizationService(NavigationManager NavigationManager) : IAuthorizationService
+{
+    /// <inheritdoc/>
+    public Task RedirectToAuthorizationServer()
+    {
+        var returnUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            NavigationManager.NavigateTo("login", true);
+        }
+        else
+        {
+            NavigationManager.NavigateTo($"login?returnUrl={returnUrl}", true);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task ReceiveAuthorizationCode(string code, string? state, CancellationToken cancellationToken)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Services/ElsaIdentityCredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/ElsaIdentityCredentialsValidator.cs
@@ -7,15 +7,15 @@ using Elsa.Studio.Login.Models;
 namespace Elsa.Studio.Login.Services;
 
 /// <summary>
-/// A default implementation of <see cref="ICredentialsValidator"/> that consumes the endpoints from Elsa.Identity.
+/// A implementation of <see cref="ICredentialsValidator"/> that consumes the endpoints from Elsa.Identity.
 /// </summary>
-public class DefaultCredentialsValidator : ICredentialsValidator
+public class ElsaIdentityCredentialsValidator : ICredentialsValidator
 {
     private readonly IBackendApiClientProvider _backendApiClientProvider;
     /// <summary>
-    /// Initializes a new instance of the <see cref="DefaultCredentialsValidator"/> class.
+    /// Initializes a new instance of the <see cref="ElsaIdentityCredentialsValidator"/> class.
     /// </summary>
-    public DefaultCredentialsValidator(IBackendApiClientProvider backendApiClientProvider)
+    public ElsaIdentityCredentialsValidator(IBackendApiClientProvider backendApiClientProvider)
     {
         _backendApiClientProvider = backendApiClientProvider;
     }

--- a/src/modules/Elsa.Studio.Login/Services/ElsaIdentityEndSessionService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/ElsaIdentityEndSessionService.cs
@@ -1,0 +1,16 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Login.Services;
+
+///<inheritdoc/>
+public class ElsaIdentityEndSessionService(IJwtAccessor jwtAccessor, NavigationManager navigationManager) : IEndSessionService
+{
+    ///<inheritdoc/>
+    public async Task LogoutAsync()
+    {
+        await jwtAccessor.WriteTokenAsync(TokenNames.AccessToken, "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.RefreshToken, "");
+        navigationManager.NavigateTo("/", true);
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Services/ElsaIdentityRefreshTokenService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/ElsaIdentityRefreshTokenService.cs
@@ -1,0 +1,40 @@
+﻿using Elsa.Api.Client.Resources.Identity.Responses;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Login.Contracts;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Elsa.Studio.Login.Services;
+
+///<inheritdoc/>
+public class ElsaIdentityRefreshTokenService(IRemoteBackendAccessor remoteBackendAccessor, IJwtAccessor jwtAccessor, HttpClient httpClient) : IRefreshTokenService
+{
+    ///<inheritdoc/>
+    public async Task<LoginResponse> RefreshTokenAsync(CancellationToken cancellationToken)
+    {
+        // Get refresh token.
+        var refreshToken = await jwtAccessor.ReadTokenAsync(TokenNames.RefreshToken);
+
+        // Setup request to get new tokens.
+        var url = remoteBackendAccessor.RemoteBackend.Url + "/identity/refresh-token";
+        var refreshRequestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+        refreshRequestMessage.Headers.Authorization = new("Bearer", refreshToken);
+
+        // Send request.
+        var response = await httpClient.SendAsync(refreshRequestMessage, cancellationToken);
+
+        // If the refresh token is invalid, we can't do anything.
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+            return new(false, null, null);
+
+        // Parse response into tokens.
+        var tokens = (await response.Content.ReadFromJsonAsync<LoginResponse>(cancellationToken: cancellationToken))!;
+
+        // Store tokens.
+        await jwtAccessor.WriteTokenAsync(TokenNames.RefreshToken, tokens.RefreshToken!);
+        await jwtAccessor.WriteTokenAsync(TokenNames.AccessToken, tokens.AccessToken!);
+
+        // Return tokens.
+        return tokens;
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Services/OpenIdConnectAuthorizationService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OpenIdConnectAuthorizationService.cs
@@ -1,0 +1,61 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+
+namespace Elsa.Studio.Login.Services;
+
+/// <inheritdoc/>
+public class OpenIdConnectAuthorizationService(IJwtAccessor jwtAccessor, IOptions<OpenIdConnectConfiguration> configuration, NavigationManager navigationManager, HttpClient httpClient) : IAuthorizationService
+{
+    /// <inheritdoc/>
+    public Task RedirectToAuthorizationServer()
+    {
+        var config = configuration.Value;
+        var redirectUri = new Uri(navigationManager.Uri).GetLeftPart(UriPartial.Authority) + "/signin-oidc";
+        string url = config.AuthEndpoint + $"?client_id={WebUtility.UrlEncode(config.ClientId)}&redirect_uri={WebUtility.UrlEncode(redirectUri)}&response_type=code&scope={WebUtility.UrlEncode(String.Join(' ', config.Scopes))}";
+        if (navigationManager.ToBaseRelativePath(navigationManager.Uri) is { } returnUrl and not "/")
+        {
+            url += "&state=" + WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(returnUrl));
+        }
+
+        navigationManager.NavigateTo(url, true);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async Task ReceiveAuthorizationCode(string code, string? state, CancellationToken cancellationToken)
+    {
+        var config = configuration.Value;
+        var redirectUri = new Uri(navigationManager.Uri).GetLeftPart(UriPartial.Authority) + "/signin-oidc";
+
+        var refreshRequestMessage = new HttpRequestMessage(HttpMethod.Post, config.TokenEndpoint);
+        refreshRequestMessage.Content = new FormUrlEncodedContent(
+        [
+            new KeyValuePair<string, string>("client_id", config.ClientId),
+            new KeyValuePair<string, string>("code", code),
+            new KeyValuePair<string, string>("grant_type", "authorization_code"),
+            new KeyValuePair<string, string>("redirect_uri", redirectUri),
+        ]);
+
+        // Send request.
+        var response = await httpClient.SendAsync(refreshRequestMessage, cancellationToken);
+
+        var tokens = (await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken))!;
+
+        await jwtAccessor.WriteTokenAsync(TokenNames.RefreshToken, tokens.refresh_token ?? "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.AccessToken, tokens.access_token ?? "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.IdToken, tokens.id_token ?? "");
+
+        string returnUrl = "/";
+        if (!String.IsNullOrWhiteSpace(state))
+        {
+            returnUrl = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(state));
+        }
+        navigationManager.NavigateTo(returnUrl, true);
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Services/OpenIdConnectEndSessionService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OpenIdConnectEndSessionService.cs
@@ -1,0 +1,31 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+using System.Net;
+
+namespace Elsa.Studio.Login.Services;
+
+///<inheritdoc/>
+public class OpenIdConnectEndSessionService(IOptions<OpenIdConnectConfiguration> options, IJwtAccessor jwtAccessor, NavigationManager navigationManager) : IEndSessionService
+{
+    ///<inheritdoc/>
+    public async Task LogoutAsync()
+    {
+        await jwtAccessor.WriteTokenAsync(TokenNames.AccessToken, "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.RefreshToken, "");
+
+        string logoutUrl = "/";
+        if (options.Value.EndSessionEndpoint is { } endSessionEndpoint)
+        {
+            logoutUrl = endSessionEndpoint + $"?post_logout_redirect_uri={WebUtility.UrlEncode(new Uri(navigationManager.Uri).GetLeftPart(UriPartial.Authority))}";
+            if (await jwtAccessor.ReadTokenAsync(TokenNames.IdToken) is { } idToken && !String.IsNullOrWhiteSpace(idToken))
+            {
+                logoutUrl += $"&id_token_hint={WebUtility.UrlEncode(idToken)}";
+            }
+        }
+
+        await jwtAccessor.WriteTokenAsync(TokenNames.IdToken, "");
+        navigationManager.NavigateTo(logoutUrl, true);
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Services/OpenIdConnectRefreshTokenService.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OpenIdConnectRefreshTokenService.cs
@@ -1,0 +1,47 @@
+﻿using Elsa.Api.Client.Resources.Identity.Responses;
+using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Models;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+
+namespace Elsa.Studio.Login.Services;
+
+///<inheritdoc/>
+public class OpenIdConnectRefreshTokenService(IOptions<OpenIdConnectConfiguration> options, IJwtAccessor jwtAccessor, HttpClient httpClient) : IRefreshTokenService
+{
+    ///<inheritdoc/>
+    public async Task<LoginResponse> RefreshTokenAsync(CancellationToken cancellationToken)
+    {
+        // Get refresh token.
+        var refreshToken = await jwtAccessor.ReadTokenAsync(TokenNames.RefreshToken);
+        if (refreshToken == null)
+            return new(false, null, null);
+
+        // Setup request to get new tokens.
+        var refreshRequestMessage = new HttpRequestMessage(HttpMethod.Post, options.Value.TokenEndpoint);
+        refreshRequestMessage.Content = new FormUrlEncodedContent(
+        [
+            new KeyValuePair<string, string>("client_id", options.Value.ClientId),
+            new KeyValuePair<string, string>("grant_type", "refresh_token"),
+            new KeyValuePair<string, string>("refresh_token", refreshToken),
+        ]);
+
+        // Send request.
+        var response = await httpClient.SendAsync(refreshRequestMessage, cancellationToken);
+
+        // If the refresh token is invalid, we can't do anything.
+        if (!response.IsSuccessStatusCode)
+            return new(false, null, null);
+
+        // Parse response into tokens.
+        var tokens = (await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: cancellationToken))!;
+
+        // Store tokens.
+        await jwtAccessor.WriteTokenAsync(TokenNames.RefreshToken, tokens.refresh_token ?? "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.AccessToken, tokens.access_token ?? "");
+        await jwtAccessor.WriteTokenAsync(TokenNames.IdToken, tokens.id_token ?? "");
+
+        // Return tokens.
+        return new(tokens.access_token != null, tokens.access_token, tokens.refresh_token);
+    }
+}


### PR DESCRIPTION
This adds support to authenticate Elsa Studio using OpenIdConnect (OIDC) against the backend server, instead of using Elsa.Identity.

- Uses the Authorization Code flow to redirect the user agent to the authorization server who will then display a login form if needed and redirect the user back to studio after authorization
- Studio will then trade the authorization_code for an access_token + refresh_token (and optionally an id_token)
    - An id_token is a readable proof of authentication to be used by the application that requested authentication while an access_token is the delegated permission to access a protected resource (the Elsa API) on behalf of the user.
- Adds a `LoginState` component which will display the currently logged in user with the option to logout for both `OIDC` and `Elsa.Identity`.
- If an EndSession endpoint is specified, will redirect there to also logout at the authorization server
- Fixes the `BlazorWasmJwtParser` to correctly parse claim types that were present multiple times

# Typical use:
## Elsa.Identity as thus far
```csharp
builder.Services.AddLoginModule()
                .UseElsaIdentity();
```
## OIDC (e.g. using Openiddict)
```csharp
builder.Services.AddLoginModule()
                .UseOpenIdConnect(x =>
                {
                    x.AuthEndpoint = host + "connect/auth";
                    x.TokenEndpoint = host + "connect/token";
                    x.EndSessionEndpoint = host + "connect/logout";
                    x.ClientId = "ElsaStudio";
                });
```

Probably fixes #327