### PR TITLE
Add unique key to ExpressionEditor for activity updates

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor
@@ -1,4 +1,5 @@
-﻿@using Elsa.Api.Client.Resources.ActivityDescriptors.Models
+﻿@using Elsa.Api.Client.Extensions
+@using Elsa.Api.Client.Resources.ActivityDescriptors.Models
 @using Elsa.Api.Client.Resources.Scripting.Models
 @using Elsa.Api.Client.Shared.Models
 @using Variant = MudBlazor.Variant
@@ -16,8 +17,11 @@
         var expression = logPersistenceConfig?.Expression;
         var strategyType = logPersistenceConfig?.StrategyType;
         var props = GetExpressionEditorProps(propertyDescriptor);
+        var activityId = Activity?.GetNodeId() ?? "default";
+        var key = activityId;
 
         return @<ExpressionEditor
+            @key="@key"
             ExpressionChanged="@(async expr =>
                                {
                                    if (onExpressionChanged.HasDelegate)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
@@ -5,9 +5,7 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using Elsa.Api.Client.Resources.LogPersistenceStrategies;
 using Elsa.Api.Client.Resources.Scripting.Models;
 using Elsa.Api.Client.Shared.Enums;
@@ -59,10 +57,9 @@ public partial class LogPersistenceTab
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        _legacyPersistenceConfiguration = new LegacyPersistenceActivityConfiguration();
-        _persistenceConfiguration = new PersistenceActivityConfiguration();
+        _legacyPersistenceConfiguration = new();
+        _persistenceConfiguration = new();
         _logPersistenceStrategyDescriptors = (await LogPersistenceStrategyService.GetLogPersistenceStrategiesAsync()).ToList();
-        await base.OnInitializedAsync();
     }
 
     /// <inheritdoc />
@@ -79,7 +76,7 @@ public partial class LogPersistenceTab
 
     private async Task OnDefaultStrategyChanged(string? value)
     {
-        _persistenceConfiguration.Default = new LogPersistenceConfiguration
+        _persistenceConfiguration.Default = new()
         {
             EvaluationMode = LogPersistenceEvaluationMode.Strategy,
             StrategyType = value
@@ -89,7 +86,7 @@ public partial class LogPersistenceTab
     
     private async Task OnDefaultExpressionChanged(Expression? expression)
     {
-        _persistenceConfiguration.Default = new LogPersistenceConfiguration
+        _persistenceConfiguration.Default = new()
         {
             EvaluationMode = LogPersistenceEvaluationMode.Expression,
             Expression = expression
@@ -143,7 +140,7 @@ public partial class LogPersistenceTab
         {
             if (newModel.Inputs.ContainsKey(input.Key))
                 continue;
-            newModel.Inputs[input.Key] = new LogPersistenceConfiguration
+            newModel.Inputs[input.Key] = new()
             {
                 EvaluationMode = LogPersistenceEvaluationMode.Strategy,
                 StrategyType = input.Value.ToString()
@@ -154,7 +151,7 @@ public partial class LogPersistenceTab
         {
             if (newModel.Outputs.ContainsKey(output.Key))
                 continue;
-            newModel.Outputs[output.Key] = new LogPersistenceConfiguration
+            newModel.Outputs[output.Key] = new()
             {
                 EvaluationMode = LogPersistenceEvaluationMode.Strategy,
                 StrategyType = output.Value.ToString()


### PR DESCRIPTION
Ensure the ExpressionEditor component updates correctly by using a unique key based on the activity ID. This prevents stale state issues when switching between different activities.

Fixes #488
