### PR TITLE
Added name field to the instances.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
@@ -76,6 +76,7 @@ public partial class WorkflowInstanceDetails
             return new()
             {
                 new DataPanelItem("ID", _workflowInstance.Id),
+                new DataPanelItem(Localizer["Name"], _workflowInstance.Name ?? WorkflowDefinition?.Name),
                 new DataPanelItem(Localizer["Definition ID"], _workflowInstance.DefinitionId, $"/workflows/definitions/{_workflowInstance.DefinitionId}/edit"),
                 new DataPanelItem(Localizer["Definition version"], _workflowInstance.Version.ToString()),
                 new DataPanelItem(Localizer["Definition version ID"], _workflowInstance.DefinitionVersionId),


### PR DESCRIPTION
Sometimes you forget what workflow definition instance are you reviewing. Sure you have the id but that is not friendly, so the name was added to the instance details. 
![image](https://github.com/user-attachments/assets/37bf64fd-8412-4d14-b75d-44945f222075)
