### PR TITLE
Add per-activity MergeMode selector

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   </ItemGroup>
   
   <PropertyGroup Label="PackageVersions">
-    <ElsaVersion>3.6.0-preview.2906</ElsaVersion>
+    <ElsaVersion>3.6.0-preview.2935</ElsaVersion>
     <ElsaIntegrationsVersion>3.6.0-preview.22</ElsaIntegrationsVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Elsa Workflows Community</Authors>
     <Copyright>2023</Copyright>
@@ -30,7 +30,7 @@
   </ItemGroup>
   
   <PropertyGroup Label="PackageVersions">
-    <ElsaVersion>3.6.0-preview.2899</ElsaVersion>
+    <ElsaVersion>3.6.0-preview.2906</ElsaVersion>
     <ElsaIntegrationsVersion>3.6.0-preview.22</ElsaIntegrationsVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,48 +12,48 @@
         <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0"/>
         <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0"/>
         <PackageVersion Include="BlazorMonaco" Version="3.3.0"/>
-        <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.0.0"/>
+        <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.1.0"/>
         <PackageVersion Include="FluentValidation" Version="11.11.0"/>
         <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
         <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
-        <PackageVersion Include="MudBlazor" Version="8.5.0"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25081.1"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4"/>
+        <PackageVersion Include="MudBlazor" Version="8.6.0"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25155.1"/>
         <PackageVersion Include="MudBlazor.Translations" Version="2.3.0"/>
-        <PackageVersion Include="Radzen.Blazor" Version="6.2.9"/>
+        <PackageVersion Include="Radzen.Blazor" Version="6.6.4"/>
         <PackageVersion Include="ShortGuid" Version="2.0.1"/>
-        <PackageVersion Include="ThrottleDebounce" Version="2.0.0"/>
+        <PackageVersion Include="ThrottleDebounce" Version="2.0.1"/>
         <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
         <PackageVersion Include="Refit" Version="8.0.0"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.14" PrivateAssets="all"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.14"/>
-        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.14" />
-        <PackageVersion Include="Microsoft.JSInterop" Version="8.0.14"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.15" PrivateAssets="all"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15"/>
+        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.15" />
+        <PackageVersion Include="Microsoft.JSInterop" Version="8.0.15"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.2"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.3" />
-        <PackageVersion Include="Microsoft.JSInterop" Version="9.0.3"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.4" PrivateAssets="all"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.JSInterop" Version="9.0.4"/>
 
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup Label="TargetFrameworks">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Files">

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -25,12 +25,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <ItemGroup Label="Elsa">
-        <ProjectReference Include="..\..\..\..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
-    </ItemGroup>
-
 <!--    <ItemGroup Label="Elsa">-->
-<!--        <PackageReference Include="Elsa.Api.Client"/>-->
+<!--        <ProjectReference Include="..\..\..\..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
 <!--    </ItemGroup>-->
+
+    <ItemGroup Label="Elsa">
+        <PackageReference Include="Elsa.Api.Client"/>
+    </ItemGroup>
 
 </Project>

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -25,12 +25,12 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-<!--    <ItemGroup Label="Elsa">-->
-<!--        <ProjectReference Include="..\..\..\..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-<!--    </ItemGroup>-->
-
     <ItemGroup Label="Elsa">
-        <PackageReference Include="Elsa.Api.Client"/>
+        <ProjectReference Include="..\..\..\..\..\elsa-core\main\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>
     </ItemGroup>
+
+<!--    <ItemGroup Label="Elsa">-->
+<!--        <PackageReference Include="Elsa.Api.Client"/>-->
+<!--    </ItemGroup>-->
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -1,6 +1,7 @@
 @using Elsa.Studio.Workflows.Services
 @using Variant = MudBlazor.Variant
 @using Elsa.Api.Client.Extensions
+@using Elsa.Api.Client.Shared.Enums
 @inherits StudioComponentBase
 @using Microsoft.Extensions.Localization
 @inject ILocalizer Localizer
@@ -75,6 +76,23 @@
                         Dense="@true"
                         Value="@(Activity.GetCanStartWorkflow() == true)"
                         ValueChanged="OnCanStartWorkflowChanged"/>
+                </MudField>
+
+                <MudField
+                    Variant="Variant.Text"
+                    UnderLine="false"
+                    Margin="Margin.None"
+                    HelperText="Controls how this activity joins inbound connections."
+                    Disabled="IsReadOnly">
+                    <MudSelect
+                        T="JoinMode"
+                        Label="Join Kind"
+                        Dense="@true"
+                        Value="@Activity.GetJoinMode()"
+                        ValueChanged="OnJoinKindChanged">
+                        <MudSelectItem T="JoinMode" Value="JoinMode.WaitAll">Wait All</MudSelectItem>
+                        <MudSelectItem T="JoinMode" Value="JoinMode.WaitAny" Text="Wait Any">Wait Any</MudSelectItem>
+                    </MudSelect>
                 </MudField>
 
             </MudStack>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -84,7 +84,7 @@
                         Variant="Variant.Text"
                         UnderLine="false"
                         Margin="Margin.None"
-                        HelperText="Controls how this activity merges inbound connections."
+                        HelperText="Controls how this activity merges inbound connections. Converge will wait for all inbound connections to complete, while Race will allow the first inbound path to continue while cancelling any bookmarks from other inbound paths, and Stream will let all inbound connections pass through as they arrive."
                         Disabled="IsReadOnly">
                         <MudSelect
                             T="MergeMode"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -94,6 +94,24 @@
                         <MudSelectItem T="JoinMode" Value="JoinMode.WaitAny" Text="Wait Any">Wait Any</MudSelectItem>
                     </MudSelect>
                 </MudField>
+                
+                <MudField
+                    Variant="Variant.Text"
+                    UnderLine="false"
+                    Margin="Margin.None"
+                    HelperText="Controls how this activity merges inbound connections."
+                    Disabled="IsReadOnly">
+                    <MudSelect
+                        T="MergeMode"
+                        Label="Merge Mode"
+                        Dense="@true"
+                        Value="@Activity.GetMergeMode()"
+                        ValueChanged="OnMergeModeChanged">
+                        <MudSelectItem T="MergeMode" Value="MergeMode.Converge">Converge</MudSelectItem>
+                        <MudSelectItem T="MergeMode" Value="MergeMode.Race">Race</MudSelectItem>
+                        <MudSelectItem T="MergeMode" Value="MergeMode.Stream">Stream</MudSelectItem>
+                    </MudSelect>
+                </MudField>
 
             </MudStack>
         </MudForm>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -77,23 +77,6 @@
                         Value="@(Activity.GetCanStartWorkflow() == true)"
                         ValueChanged="OnCanStartWorkflowChanged"/>
                 </MudField>
-
-                <MudField
-                    Variant="Variant.Text"
-                    UnderLine="false"
-                    Margin="Margin.None"
-                    HelperText="Controls how this activity joins inbound connections."
-                    Disabled="IsReadOnly">
-                    <MudSelect
-                        T="JoinMode"
-                        Label="Join Kind"
-                        Dense="@true"
-                        Value="@Activity.GetJoinMode()"
-                        ValueChanged="OnJoinKindChanged">
-                        <MudSelectItem T="JoinMode" Value="JoinMode.WaitAll">Wait All</MudSelectItem>
-                        <MudSelectItem T="JoinMode" Value="JoinMode.WaitAny" Text="Wait Any">Wait Any</MudSelectItem>
-                    </MudSelect>
-                </MudField>
                 
                 <MudField
                     Variant="Variant.Text"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -78,23 +78,26 @@
                         ValueChanged="OnCanStartWorkflowChanged"/>
                 </MudField>
                 
-                <MudField
-                    Variant="Variant.Text"
-                    UnderLine="false"
-                    Margin="Margin.None"
-                    HelperText="Controls how this activity merges inbound connections."
-                    Disabled="IsReadOnly">
-                    <MudSelect
-                        T="MergeMode"
-                        Label="Merge Mode"
-                        Dense="@true"
-                        Value="@Activity.GetMergeMode()"
-                        ValueChanged="OnMergeModeChanged">
-                        <MudSelectItem T="MergeMode" Value="MergeMode.Converge">Converge</MudSelectItem>
-                        <MudSelectItem T="MergeMode" Value="MergeMode.Race">Race</MudSelectItem>
-                        <MudSelectItem T="MergeMode" Value="MergeMode.Stream">Stream</MudSelectItem>
-                    </MudSelect>
-                </MudField>
+                @if (ActivityDescriptor?.TypeName != "Elsa.FlowJoin")
+                {
+                    <MudField
+                        Variant="Variant.Text"
+                        UnderLine="false"
+                        Margin="Margin.None"
+                        HelperText="Controls how this activity merges inbound connections."
+                        Disabled="IsReadOnly">
+                        <MudSelect
+                            T="MergeMode"
+                            Label="Merge Mode"
+                            Dense="@true"
+                            Value="@Activity.GetMergeMode()"
+                            ValueChanged="OnMergeModeChanged">
+                            <MudSelectItem T="MergeMode" Value="MergeMode.Converge">Converge</MudSelectItem>
+                            <MudSelectItem T="MergeMode" Value="MergeMode.Race">Race</MudSelectItem>
+                            <MudSelectItem T="MergeMode" Value="MergeMode.Stream">Stream</MudSelectItem>
+                        </MudSelect>
+                    </MudField>
+                }
 
             </MudStack>
         </MudForm>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -68,11 +68,11 @@
                     Variant="Variant.Text"
                     UnderLine="@true"
                     Margin="Margin.None"
-                    HelperText="@(IsTrigger ? Localizer["When checked, this activity can trigger this workflow."] : @Localizer["When checked, this activity is the start of this workflow."])"
+                    HelperText="@(IsTrigger ? Localizer["When checked, this activity can trigger this workflow."] : Localizer["When checked, this activity is the start of this workflow."])"
                     Disabled="IsReadOnly">
                     <MudCheckBox
                         T="bool?"
-                        Label="@(IsTrigger ? @Localizer["Trigger workflow"] : @Localizer["Start of workflow"])"
+                        Label="@(IsTrigger ? Localizer["Trigger workflow"] : Localizer["Start of workflow"])"
                         Dense="@true"
                         Value="@(Activity.GetCanStartWorkflow() == true)"
                         ValueChanged="OnCanStartWorkflowChanged"/>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Shared.Enums;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
 
@@ -62,6 +63,12 @@ public partial class CommonTab
     private async Task OnCanStartWorkflowChanged(bool? value)
     {
         Activity!.SetCanStartWorkflow(value == true);
+        await RaiseActivityUpdated();
+    }
+
+    private async Task OnJoinKindChanged(JoinMode value)
+    {
+        Activity!.SetJoinMode(value);
         await RaiseActivityUpdated();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
@@ -65,12 +65,6 @@ public partial class CommonTab
         Activity!.SetCanStartWorkflow(value == true);
         await RaiseActivityUpdated();
     }
-
-    private async Task OnJoinKindChanged(JoinMode value)
-    {
-        Activity!.SetJoinMode(value);
-        await RaiseActivityUpdated();
-    }
     
     private async Task OnMergeModeChanged(MergeMode value)
     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor.cs
@@ -71,4 +71,10 @@ public partial class CommonTab
         Activity!.SetJoinMode(value);
         await RaiseActivityUpdated();
     }
+    
+    private async Task OnMergeModeChanged(MergeMode value)
+    {
+        Activity!.SetMergeMode(value);
+        await RaiseActivityUpdated();
+    }
 }


### PR DESCRIPTION
This PR introduces a small but impactful UI enhancement in Elsa Studio, moving join-mode configuration from a separate FlowJoin activity into each activity’s property panel, and marks the old FlowJoin activity as deprecated.

### ✨ New Feature

* **MergeMode dropdown** on **every** activity’s settings pane

  * Choose join behavior inline:

    * **Converge** (wait for all)
    * **Race** (wait any, first-wins & cancel others)
    * **Stream** (similar to wait all: first-wins but don’t cancel)
  * No need to drag a FlowJoin activity — configure joins right where you need them.

### 🛠️ Deprecation

* **FlowJoin** activity is now **marked “Deprecated”** in the toolbox

  * Remains fully functional for backward compatibility
  * New flows should use the built-in MergeMode setting instead

### 🔄 Backward Compatibility & Migration

* Existing flows that use FlowJoin will continue to work unchanged.
* To migrate, remove FlowJoin nodes and set the target activity’s MergeMode to the desired behavior.

*By making join configuration more discoverable and reducing toolbox clutter, this change streamlines flow design and aligns UI with the new token-centric execution model.*