### PR TITLE
Add PKCE support for OIDC auth code flow

### DIFF
--- a/src/modules/Elsa.Studio.Login.BlazorServer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorServer/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ public static class ServiceCollectionExtensions
         // Register JWT services.
         services.AddSingleton<IJwtParser, BlazorServerJwtParser>();
         services.AddScoped<IJwtAccessor, BlazorServerJwtAccessor>();
+
+        services.AddScoped<IOpenIdConnectPkceStateService, BlazorServerOpenIdConnectPkceStateService>();
         
         return services;
     }

--- a/src/modules/Elsa.Studio.Login.BlazorServer/Services/BlazorServerOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorServer/Services/BlazorServerOpenIdConnectPkceStateService.cs
@@ -1,0 +1,34 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Services;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Elsa.Studio.Login.BlazorServer.Services
+{
+    /// inherit doc
+    public class BlazorServerOpenIdConnectPkceStateService : IOpenIdConnectPkceStateService
+    {
+        private readonly ProtectedSessionStorage _protectedSessionStorage;
+
+        /// inherit doc
+        public BlazorServerOpenIdConnectPkceStateService(ProtectedSessionStorage protectedSessionStorage)
+        {
+            _protectedSessionStorage = protectedSessionStorage;
+        }
+
+        /// inherit doc
+        public async Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge()
+        {
+            var pkce = OpenIdConnectPkceCodeGenerator.GenerateCodeChallengeAndVerifier();
+            await _protectedSessionStorage.SetAsync("pkceCodeVerifier", pkce.CodeVerifier);
+
+            return (pkce.CodeChallenge, pkce.Method);
+        }
+
+        /// inherit doc
+        public async Task<string> GetPkceCodeVerifier()
+        {
+            var verifier = await _protectedSessionStorage.GetAsync<string>("pkceCodeVerifier");
+            return verifier.Success && verifier.Value != null ? verifier.Value : throw new Exception("PKCE code verifier not found in session storage.");
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ public static class ServiceCollectionExtensions
         // Register JWT services.
         services.AddSingleton<IJwtParser, BlazorWasmJwtParser>();
         services.AddScoped<IJwtAccessor, BlazorWasmJwtAccessor>();
+
+        services.AddScoped<IOpenIdConnectPkceStateService, BlazorWasmOpenIdConnectPkceStateService>();
         
         return services;
     }

--- a/src/modules/Elsa.Studio.Login.BlazorWasm/Services/BlazorWasmOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorWasm/Services/BlazorWasmOpenIdConnectPkceStateService.cs
@@ -1,0 +1,33 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Services;
+using Microsoft.JSInterop;
+
+namespace Elsa.Studio.Login.BlazorWasm.Services
+{
+    /// inherit doc
+    public class BlazorWasmOpenIdConnectPkceStateService : IOpenIdConnectPkceStateService
+    {
+        private readonly IJSRuntime _js;
+
+        /// inherit doc  
+        public BlazorWasmOpenIdConnectPkceStateService(IJSRuntime js)
+        {
+            _js = js;
+        }
+
+        /// inherit doc
+        public async Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge()
+        {
+            var pkce = OpenIdConnectPkceCodeGenerator.GenerateCodeChallengeAndVerifier();
+            await _js.InvokeVoidAsync("sessionStorage.setItem", "pkceCodeVerifier", pkce.CodeVerifier);
+
+            return (pkce.CodeChallenge, pkce.Method);
+        }
+
+        /// inherit doc
+        public async Task<string> GetPkceCodeVerifier()
+        {
+            return await _js.InvokeAsync<string>("sessionStorage.getItem", "pkceCodeVerifier");
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
+++ b/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
@@ -14,8 +14,8 @@ public class RedirectToLogin : ComponentBase
     [Inject] protected IAuthorizationService AuthorizationService { get; set; } = default!;
 
     /// <inheritdoc />
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        return AuthorizationService.RedirectToAuthorizationServer();
+        await AuthorizationService.RedirectToAuthorizationServer();
     }
 }

--- a/src/modules/Elsa.Studio.Login/Contracts/IOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login/Contracts/IOpenIdConnectPkceStateService.cs
@@ -1,0 +1,18 @@
+﻿namespace Elsa.Studio.Login.Contracts
+{
+    /// <summary>
+    /// Manages PKCE (Proof Key for Code Exchange) state for the authorization code flow.
+    /// </summary>
+    public interface IOpenIdConnectPkceStateService
+    {
+        /// <summary>
+        /// Generates and returns a PKCE code challedge. The associated code verifier is stored in session storage.
+        /// </summary>
+        Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge();
+
+        /// <summary>
+        /// Retrieves the code verifier for the current session.
+        /// </summary>
+        Task<string> GetPkceCodeVerifier();
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
+++ b/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
@@ -29,4 +29,9 @@ public class OpenIdConnectConfiguration
     /// The scopes to request, defaulting to: openid profile offline_access
     /// </summary>
     public string[] Scopes { get; set; } = ["openid", "profile", "offline_access"];
+
+    /// <summary>
+    /// Enables PKCE (Proof Key for Code Exchange) for the authorization code flow.
+    /// </summary>
+    public bool UsePkce { get; set; } = false;
 }

--- a/src/modules/Elsa.Studio.Login/Services/OpenIdConnectPkceCodeGenerator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OpenIdConnectPkceCodeGenerator.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Elsa.Studio.Login.Services
+{
+    /// <summary>
+    /// Used to generate PKCE (Proof Key for Code Exchange) codes for use in the authorization code flow.
+    /// </summary>
+    public static class OpenIdConnectPkceCodeGenerator
+    {
+        /// <summary>
+        /// Generates PKCE (Proof Key for Code Exchange) code challenge and verifier.
+        /// </summary>
+        public static (string CodeChallenge, string CodeVerifier, string Method) GenerateCodeChallengeAndVerifier()
+        {
+            using var rng = RandomNumberGenerator.Create();
+            var randomBytes = new byte[32];
+            rng.GetBytes(randomBytes);
+            var verifier = WebEncoders.Base64UrlEncode(randomBytes);
+            var buffer = Encoding.UTF8.GetBytes(verifier);
+            var hash = SHA256.HashData(buffer);
+            var challenge = WebEncoders.Base64UrlEncode(hash);
+
+            return (CodeChallenge: challenge, CodeVerifier: verifier, Method: "S256");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds PKCE (Proof Key for Code Exchange) support to the Authorization Code Flow that was added to Elsa Studio in this [PR](https://github.com/elsa-workflows/elsa-studio/pull/479). PKCE helps prevent authorization code interception and Cross-Site Request Forgery (CSRF) attacks. PKCE is mandated by a number of IDPs.

- adds utility to generate code challenge and verifier `OpenIdConnectPkceCodeGenerator`
- adds services to store PKCE state for Blazor Wasm and Server `BlazorWasmOpenIdConnectPkceStateService` and `BlazorServerOpenIdConnectPkceStateService`
- adds the UsePkce bool option to the `OpenIdConnectConfiguration` class
- modifies `OpenIdConnectAuthorizationService` to use PKCE when requesting auth from IDP if option UsePkce is set true
- registers new services with the services collection

### Usage
```
builder.Services.AddLoginModule().UseOpenIdConnect(options =>
{
    options.UsePkce = true;
    // other OIDC options, client id etc (see PR linked above)
});
```

Related issue [#327](https://github.com/elsa-workflows/elsa-studio/issues/327)

### Copilot generated summary...

This pull request introduces support for PKCE (Proof Key for Code Exchange) in the authorization code flow for both Blazor Server and Blazor WebAssembly implementations. The changes include adding a new service to manage PKCE state, updating the authorization service to handle PKCE logic, and modifying configuration options to enable PKCE. Below are the most important changes grouped by theme:

### PKCE State Management

* Added a new `IOpenIdConnectPkceStateService` interface to manage PKCE state, including methods to generate a code challenge and retrieve the code verifier. (`src/modules/Elsa.Studio.Login/Contracts/IOpenIdConnectPkceStateService.cs`)
* Implemented `BlazorServerOpenIdConnectPkceStateService` for Blazor Server, using `ProtectedSessionStorage` to store the PKCE code verifier. (`src/modules/Elsa.Studio.Login.BlazorServer/Services/BlazorServerOpenIdConnectPkceStateService.cs`)
* Implemented `BlazorWasmOpenIdConnectPkceStateService` for Blazor WebAssembly, using `sessionStorage` via `IJSRuntime` to store the PKCE code verifier. (`src/modules/Elsa.Studio.Login.BlazorWasm/Services/BlazorWasmOpenIdConnectPkceStateService.cs`)

### Authorization Service Enhancements

* Updated `OpenIdConnectAuthorizationService` to include PKCE logic when redirecting to the authorization server and when exchanging the authorization code for tokens. (`src/modules/Elsa.Studio.Login/Services/OpenIdConnectAuthorizationService.cs`) [[1]](diffhunk://#diff-92dba607f4c40eb5e06c31052e60d79c0c021fa330762aa977047a2eddf3d9e3L13-L27) [[2]](diffhunk://#diff-92dba607f4c40eb5e06c31052e60d79c0c021fa330762aa977047a2eddf3d9e3L36-R56)
* Added `OpenIdConnectPkceCodeGenerator` to generate PKCE code challenges and verifiers using SHA256 hashing. (`src/modules/Elsa.Studio.Login/Services/OpenIdConnectPkceCodeGenerator.cs`)

### Configuration Updates

* Added a `UsePkce` property to `OpenIdConnectConfiguration` to enable or disable PKCE for the authorization code flow. (`src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs`)

### Dependency Injection Changes

* Registered `IOpenIdConnectPkceStateService` implementations in `AddLoginModule` for both Blazor Server and Blazor WebAssembly. (`src/modules/Elsa.Studio.Login.BlazorServer/Extensions/ServiceCollectionExtensions.cs`) [[1]](diffhunk://#diff-83f02de4ce4502d1067b100c1fbbb87ab0c87178700b7384b708a7d22e65eff5R32-R33) (`src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs`) [[2]](diffhunk://#diff-32ba7b4e828bb19c7a323a500f0e4a4fa65ba08721e18060fe7cf6011229d705R29-R30)

### Miscellaneous Fixes

* Fixed an issue in `RedirectToLogin` by making `OnAfterRenderAsync` properly await asynchronous operations. (`src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs`)