### PR TITLE
Fix resilience dropdown item text

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor.cs
@@ -49,7 +49,14 @@ public partial class ResilienceTab
         if (Activity == null || ActivityDescriptor == null)
             return;
 
+        var previousCategory = ResilienceCategory;
         SetProperties();
+
+        if (previousCategory != ResilienceCategory || ResilienceStrategies.Count == 0)
+        {
+            var strategies = await ResilienceStrategyCatalog.ListAsync(ResilienceCategory);
+            ResilienceStrategies = strategies.ToList();
+        }
 
         if (!_isInitialized)
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor.cs
@@ -48,15 +48,8 @@ public partial class ResilienceTab
     {
         if (Activity == null || ActivityDescriptor == null)
             return;
-
-        var previousCategory = ResilienceCategory;
-        SetProperties();
-
-        if (previousCategory != ResilienceCategory || ResilienceStrategies.Count == 0)
-        {
-            var strategies = await ResilienceStrategyCatalog.ListAsync(ResilienceCategory);
-            ResilienceStrategies = strategies.ToList();
-        }
+        
+        await SetPropertiesAsync();
 
         if (!_isInitialized)
         {
@@ -103,16 +96,23 @@ public partial class ResilienceTab
         await RaiseActivityUpdatedAsync();
     }
 
-    private void SetProperties()
+    private async Task SetPropertiesAsync()
     {
         if (Activity == null || ActivityDescriptor == null)
             return;
 
         var config = Activity.GetResilienceStrategy();
+        var previousCategory = ResilienceCategory;
         ResilienceCategory = ActivityDescriptor.CustomProperties.TryGetValue("ResilienceCategory", out var category) ? category.ToString() ?? DefaultCategory : DefaultCategory;
         ResilienceStrategyConfig = config;
         Expression = config?.Expression;
         ResilienceStrategyId = config?.StrategyId;
+        
+        if (previousCategory != ResilienceCategory || ResilienceStrategies.Count == 0)
+        {
+            var strategies = await ResilienceStrategyCatalog.ListAsync(ResilienceCategory);
+            ResilienceStrategies = strategies.ToList();
+        }
     }
 
     private async Task OnExpressionChangedAsync(Expression? expression)


### PR DESCRIPTION
## Summary
- reload resilience strategy list when category changes

## Testing
- `dotnet test Elsa.Studio.sln --no-build -c Release` *(no tests found)*
- `dotnet build Elsa.Studio.sln -c Release` *(fails: NU1301 No route to host)*