### PR TITLE
Fix per-input refresh debouncing

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -22,12 +22,11 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// </summary>
 public partial class InputsTab
 {
-    private readonly RateLimitedFunc<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task> _rateLimitedInputPropertyRefreshAsync;
+    private readonly IDictionary<string, RateLimitedFunc<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>> _inputPropertyRefreshRateLimiters = new Dictionary<string, RateLimitedFunc<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>>();
 
     /// <inheritdoc />
     public InputsTab()
     {
-        _rateLimitedInputPropertyRefreshAsync = Debouncer.Debounce<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>(RefreshDescriptor, TimeSpan.FromMilliseconds(100), true);
     }
 
     /// <summary>
@@ -91,7 +90,8 @@ public partial class InputsTab
                 && inputDescriptor.UISpecifications.TryGetValue("Refresh", out var refreshInput)
                 && bool.Parse(refreshInput.ToString()!))
             {
-                var task = _rateLimitedInputPropertyRefreshAsync.Invoke(activity, activityDescriptor, inputDescriptors, inputDescriptor);
+                var rateLimiter = GetRefreshRateLimiter(inputDescriptor);
+                var task = rateLimiter.Invoke(activity, activityDescriptor, inputDescriptors, inputDescriptor);
                 if (task != null)
                     await task;
             }
@@ -117,6 +117,18 @@ public partial class InputsTab
         }
 
         return models;
+    }
+
+    private RateLimitedFunc<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task> GetRefreshRateLimiter(InputDescriptor inputDescriptor)
+    {
+        var key = inputDescriptor.Name;
+        if (!_inputPropertyRefreshRateLimiters.TryGetValue(key, out var rateLimiter))
+        {
+            rateLimiter = Debouncer.Debounce<JsonObject, ActivityDescriptor, IEnumerable<InputDescriptor>, InputDescriptor, Task>(RefreshDescriptor, TimeSpan.FromMilliseconds(100), true);
+            _inputPropertyRefreshRateLimiters[key] = rateLimiter;
+        }
+
+        return rateLimiter;
     }
 
     private async Task RefreshDescriptor(JsonObject activity, ActivityDescriptor activityDescriptor, IEnumerable<InputDescriptor> inputDescriptors, InputDescriptor currentInputDescriptor)


### PR DESCRIPTION
## Summary
- handle refresh rate limiting per input descriptor in `InputsTab`

## Testing
- `dotnet build Elsa.Studio.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*