### PR TITLE
Fix dynamic inputs not refreshing

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
@@ -1,5 +1,12 @@
+using System;
 using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
 
-public record ActivityInputDisplayModel(int Index, RenderFragment Editor);
+/// <summary>
+/// Model describing a dynamically rendered input editor.
+/// </summary>
+/// <param name="Key">A unique key to force component recreation when the model is rebuilt.</param>
+/// <param name="Index">The position of the input in the list.</param>
+/// <param name="Editor">The editor fragment to render.</param>
+public record ActivityInputDisplayModel(Guid Key, int Index, RenderFragment Editor);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
@@ -4,7 +4,7 @@
     <MudStack Spacing="5">
         @foreach (var inputModel in InputDisplayModels)
         {
-            <div @key="@inputModel.Index">
+            <div @key="@inputModel.Key">
                 @inputModel.Editor
             </div>
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -115,7 +115,8 @@ public partial class InputsTab
 
             context.OnValueChanged = async v => await HandleValueChangedAsync(context, v);
             var editor = uiHintHandler.DisplayInputEditor(context);
-            models.Add(new(index++, editor));
+            // Use a unique key for each editor instance to ensure the component is re-created when models are rebuilt.
+            models.Add(new(Guid.NewGuid(), index++, editor));
         }
 
         return models;


### PR DESCRIPTION
## Summary
- ensure InputsTab re-creates editor components when descriptors change

## Testing
- `dotnet build Elsa.Studio-Core.sln -c Release` *(fails: project files not found)*