### PR TITLE
Fix Activity Input Refresh

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
@@ -1,5 +1,12 @@
+using System;
 using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
 
-public record ActivityInputDisplayModel(int Index, RenderFragment Editor);
+/// <summary>
+/// Model describing a dynamically rendered input editor.
+/// </summary>
+/// <param name="Key">A unique key to force component recreation when the model is rebuilt.</param>
+/// <param name="Index">The position of the input in the list.</param>
+/// <param name="Editor">The editor fragment to render.</param>
+public record ActivityInputDisplayModel(Guid Key, int Index, RenderFragment Editor);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
@@ -8,4 +7,4 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// </summary>
 /// <param name="Key">A unique key to force component recreation when the model is rebuilt.</param>
 /// <param name="Editor">The editor fragment to render.</param>
-public record ActivityInputDisplayModelRenderFragment Editor);
+public record ActivityInputDisplayModel(Guid Key, RenderFragment Editor);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
@@ -7,6 +7,5 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// Model describing a dynamically rendered input editor.
 /// </summary>
 /// <param name="Key">A unique key to force component recreation when the model is rebuilt.</param>
-/// <param name="Index">The position of the input in the list.</param>
 /// <param name="Editor">The editor fragment to render.</param>
-public record ActivityInputDisplayModel(Guid Key, int Index, RenderFragment Editor);
+public record ActivityInputDisplayModelRenderFragment Editor);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor
@@ -4,7 +4,7 @@
     <MudStack Spacing="5">
         @foreach (var inputModel in InputDisplayModels)
         {
-            <div @key="@inputModel.Index">
+            <div @key="@inputModel.Key">
                 @inputModel.Editor
             </div>
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -115,7 +115,8 @@ public partial class InputsTab
 
             context.OnValueChanged = async v => await HandleValueChangedAsync(context, v);
             var editor = uiHintHandler.DisplayInputEditor(context);
-            models.Add(new(index++, editor));
+            // Use a unique key for each editor instance to ensure the component is re-created when models are rebuilt.
+            models.Add(new(Guid.NewGuid(), index++, editor));
         }
 
         return models;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -27,7 +27,7 @@ public partial class InputsTab
     /// <inheritdoc />
     public InputsTab()
     {
-        _rateLimitedBuildInputEditorModelsAsync = Debouncer.Debounce(BuildInputEditorModels, TimeSpan.FromMilliseconds(200), true);
+        _rateLimitedBuildInputEditorModelsAsync = Debouncer.Debounce(BuildInputEditorModels, TimeSpan.FromMilliseconds(50), true);
     }
 
     /// <summary>
@@ -81,7 +81,6 @@ public partial class InputsTab
     {
         var models = new List<ActivityInputDisplayModel>();
         var browsableInputDescriptors = inputDescriptors.Where(x => x.IsBrowsable == true).OrderBy(x => x.Order).ToList();
-        var index = 0;
 
         foreach (var inputDescriptor in browsableInputDescriptors)
         {
@@ -116,7 +115,7 @@ public partial class InputsTab
             context.OnValueChanged = async v => await HandleValueChangedAsync(context, v);
             var editor = uiHintHandler.DisplayInputEditor(context);
             // Use a unique key for each editor instance to ensure the component is re-created when models are rebuilt.
-            models.Add(new(Guid.NewGuid(), index++, editor));
+            models.Add(new(Guid.NewGuid(), editor));
         }
 
         return models;
@@ -176,6 +175,8 @@ public partial class InputsTab
 
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);
+
+        //await InvokeAsync(StateHasChanged);
     }
 
     private ExpressionDescriptor? GetSyntaxProvider(WrappedInput wrappedInput, InputDescriptor inputDescriptor)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -8,7 +8,6 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Models;
-using Elsa.Studio.UIHints.Extensions;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Humanizer;


### PR DESCRIPTION
Addresses an issue where activity input editors were not properly refreshed when dependent properties changed.

- Replaces the index-based key with a Guid-based key for ActivityInputDisplayModel to force component re-creation when models are rebuilt.
- Removes rate limiters for refreshing descriptors.
- Reduces the debounce time for rebuilding input editor models.

Fixes #528