### PR TITLE
Update Elsa version and rename Properties to Metadata

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
         <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
     <PropertyGroup Label="PackageVersions">
-        <ElsaVersion>3.5.0-preview.3021</ElsaVersion>
-        <ElsaExtensionsVersion>3.5.0-preview.32</ElsaExtensionsVersion>
+        <ElsaVersion>3.5.0-preview.3027</ElsaVersion>
+        <ElsaExtensionsVersion>3.5.0-preview.39</ElsaExtensionsVersion>
     </PropertyGroup>
     <ItemGroup Label="Elsa">
         <PackageVersion Include="Elsa.Agents.Models" Version="$(ElsaExtensionsVersion)"/>

--- a/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
+++ b/src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj
@@ -25,9 +25,9 @@
         <PackageReference Include="ThrottleDebounce"/>
     </ItemGroup>
 
-    <!--    <ItemGroup Label="Elsa">-->
-    <!--        <ProjectReference Include="..\..\..\..\..\elsa-core\3.5.0\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
-    <!--    </ItemGroup>-->
+<!--    <ItemGroup Label="Elsa">-->
+<!--        <ProjectReference Include="..\..\..\..\..\elsa-core\3.5.0\src\clients\Elsa.Api.Client\Elsa.Api.Client.csproj"/>-->
+<!--    </ItemGroup>-->
 
     <ItemGroup Label="Elsa">
         <PackageReference Include="Elsa.Api.Client"/>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ActivityStats.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ActivityStats.cs
@@ -31,7 +31,7 @@ public class ActivityStats
     public bool Faulted { get; set; }
 
     /// <summary>
-    /// A collection of custom properties associated with the activity statistics.
+    /// A collection of metadata associated with the activity statistics.
     /// </summary>
-    public IDictionary<string, object>? Properties { get; set; }
+    public IDictionary<string, object>? Metadata { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrapper.razor
@@ -8,8 +8,8 @@
 @{
     const string white = "#ffffff";
     var colorStyle = CanStartWorkflow ? $"color: {white};" : "";
-    var props = Stats?.Properties;
-    var hasRetryAttempts = props != null && props.TryGetValue("HasRetryAttempts", out var hasRetryAttemptsValue) && hasRetryAttemptsValue is JsonElement { ValueKind: JsonValueKind.True }; 
+    var metadata = Stats?.Metadata;
+    var hasRetryAttempts = metadata != null && metadata.TryGetValue("HasRetryAttempts", out var hasRetryAttemptsValue) && hasRetryAttemptsValue is JsonElement { ValueKind: JsonValueKind.True }; 
     var color = Stats == null ? Color.Transparent : Stats.Faulted ? Color.Error :  Stats.Blocked ? Color.Warning : Stats.Uncompleted > Stats.Completed ? Color.Info : Stats.Completed > 0 ? Color.Success : Color.Default;
     var content = Stats == null ? null : Stats.Faulted || Stats.Blocked ? Stats.Started.ToString() : Stats.Completed.ToString();
     var icon = Stats == null ? null : content == null ? Stats.Blocked ? Icons.Material.Outlined.HourglassTop : Stats.Uncompleted > 0 ? Icons.Material.Outlined.PlayArrow : null : null;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor.cs
@@ -21,7 +21,7 @@ public partial class ActivityExecutionsTab : IAsyncDisposable
     public record ActivityExecutionRecordTableRow(int Number, ActivityExecutionRecordSummary ActivityExecutionSummary)
     {
         /// Indicates whether the activity execution record has recorded retries.
-        public bool HasRetries => ActivityExecutionSummary.Properties != null && ActivityExecutionSummary.Properties.TryGetValue("HasRetryAttempts", out var retryAttempts) && retryAttempts is JsonElement { ValueKind: JsonValueKind.True };
+        public bool HasRetries => ActivityExecutionSummary.Metadata != null && ActivityExecutionSummary.Metadata.TryGetValue("HasRetryAttempts", out var retryAttempts) && retryAttempts is JsonElement { ValueKind: JsonValueKind.True };
     }
 
     /// The height of the visible pane.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -347,7 +347,7 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             Completed = source.CompletedCount,
             Started = source.StartedCount,
             Uncompleted = source.UncompletedCount,
-            Properties = source.Properties
+            Metadata = source.Metadata,
         };
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -313,7 +313,7 @@ public partial class DiagramDesignerWrapper
                 Completed = x.CompletedCount,
                 Started = x.StartedCount,
                 Uncompleted = x.UncompletedCount,
-                Properties = x.Properties
+                Metadata = x.Metadata
             });
         }
     }


### PR DESCRIPTION
Upgraded Elsa and ElsaExtensions to newer preview versions in Directory.Packages.props. Refactored codebase to replace "Properties" with "Metadata" for clarity and consistency in representing activity statistics metadata.
