### PR TITLE
Fix module URL for `JsInteropBase` in `Elsa.Studio.Workflows.Designer`.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/JsInteropBase.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/JsInteropBase.cs
@@ -20,7 +20,7 @@ public abstract class JsInteropBase : IAsyncDisposable
     public virtual Task<IJSObjectReference> ImportModule(IJSRuntime jsRuntime)
     {
         return jsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", $"./_content/Elsa.Studio.DomInterop/{ModuleName}.entry.js").AsTask();
+            "import", $"./_content/Elsa.Studio.Workflows.Designer/{ModuleName}.entry.js").AsTask();
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
Fixes a bug in #543.

- Incorrect path for `JsInteropBase` in the designer.