### PR TITLE
Minor UI improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,62 +1,61 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-    <PropertyGroup Label="PackageVersions">
-        <ElsaVersion>3.6.0-preview.3093</ElsaVersion>
-        <MicrosoftVersion>9.0.6</MicrosoftVersion>
-    </PropertyGroup>
-    <ItemGroup Label="Elsa">
-        <PackageVersion Include="Elsa.Api.Client" Version="$(ElsaVersion)"/>
-        <PackageVersion Include="Elsa.Secrets.Models" Version="$(ElsaVersion)"/>
-    </ItemGroup>
-    <ItemGroup>
-        <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0"/>
-        <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0"/>
-        <PackageVersion Include="BlazorMonaco" Version="3.3.0"/>
-        <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.2.2"/>
-        <PackageVersion Include="FluentValidation" Version="12.0.0"/>
-        <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
-        <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="MudBlazor" Version="8.8.0"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25218.8"/>
-        <PackageVersion Include="MudBlazor.Translations" Version="2.5.0"/>
-        <PackageVersion Include="Radzen.Blazor" Version="7.1.1"/>
-        <PackageVersion Include="ShortGuid" Version="2.0.1"/>
-        <PackageVersion Include="ThrottleDebounce" Version="2.0.1"/>
-        <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
-        <PackageVersion Include="Refit" Version="8.0.0"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.17"/>
-        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.17" />
-        <PackageVersion Include="Microsoft.JSInterop" Version="8.0.17"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftVersion)" PrivateAssets="all"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftVersion)"/>
-        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="$(MicrosoftVersion)" />
-        <PackageVersion Include="Microsoft.JSInterop" Version="$(MicrosoftVersion)"/>
-
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <PropertyGroup Label="PackageVersions">
+    <ElsaVersion>3.6.0-preview.3093</ElsaVersion>
+    <MicrosoftVersion>9.0.6</MicrosoftVersion>
+  </PropertyGroup>
+  <ItemGroup Label="Elsa">
+    <PackageVersion Include="Elsa.Api.Client" Version="$(ElsaVersion)" />
+    <PackageVersion Include="Elsa.Secrets.Models" Version="$(ElsaVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
+    <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageVersion Include="BlazorMonaco" Version="3.3.0" />
+    <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.2.3" />
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="MudBlazor" Version="8.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.12.0-beta1.25218.8" />
+    <PackageVersion Include="MudBlazor.Translations" Version="2.5.0" />
+    <PackageVersion Include="Radzen.Blazor" Version="7.1.2" />
+    <PackageVersion Include="ShortGuid" Version="2.0.1" />
+    <PackageVersion Include="ThrottleDebounce" Version="2.0.1" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+    <PackageVersion Include="Refit" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="8.0.17" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftVersion)" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="$(MicrosoftVersion)" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="$(MicrosoftVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
@@ -13,77 +13,87 @@
     }
 </style>
 
-<MudSimpleTable Outlined="true" Striped="false" Dense="true" Elevation="0" Bordered="false">
-    <tbody>
-    @{
-        var data = HideEmptyValues
-            ? Data.Where(x => !string.IsNullOrWhiteSpace(x.Text)).ToList()
-            : Data;
-    }
-    @if (data.Any())
+<div>
+    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Title</MudText>
+    @if (Data.Any())
     {
-        @foreach (var item in data)
-        {
-            <tr Class="hover-row">
-                <td style="width: 200px;">@item.Label</td>
-                <td>
-                    <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
-                        <MudTooltip Text="@Localizer["View content"]">
-                        @if (!string.IsNullOrWhiteSpace(item.Text))
-                        {
-                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View content"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
-                        }
-                        </MudTooltip>
-                        @if (!string.IsNullOrWhiteSpace(item.Link))
-                        {
-                            <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
-                        }
-                        else if (item.OnClick != null)
-                        {
-                            <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
-                        }
-                        else
-                        {
-                            @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
-                            {
-                                <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
-                            }
-                            else
-                            {
-                                @if (item.Text?.Length > truncationLength)
+        <MudSimpleTable Outlined="true" Striped="false" Dense="true" Elevation="0" Bordered="false">
+            <tbody>
+            @{
+                var data = HideEmptyValues
+                    ? Data.Where(x => !string.IsNullOrWhiteSpace(x.Text)).ToList()
+                    : Data;
+            }
+            @if (data.Any())
+            {
+                @foreach (var item in data)
+                {
+                    <tr Class="hover-row">
+                        <td style="width: 200px;">@item.Label</td>
+                        <td>
+                            <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
+                                <MudTooltip Text="@Localizer["View content"]">
+                                @if (!string.IsNullOrWhiteSpace(item.Text))
                                 {
-                                    <div>
-                                        @item.Text.Substring(0, truncationLength)
-                                        <MudTooltip Text="Show all">
-                                            <MudLink OnClick="@(() => OnViewClicked(item!))" title="Show all"><small>[...]</small></MudLink>
-                                        </MudTooltip>
-                                    </div>
+                                    <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View content"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
+                                }
+                                </MudTooltip>
+                                @if (!string.IsNullOrWhiteSpace(item.Link))
+                                {
+                                    <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
+                                }
+                                else if (item.OnClick != null)
+                                {
+                                    <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
                                 }
                                 else
                                 {
-                                    <span>@item.Text</span>
+                                    @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
+                                    {
+                                        <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
+                                    }
+                                    else
+                                    {
+                                        @if (item.Text?.Length > truncationLength)
+                                        {
+                                            <div>
+                                                @item.Text.Substring(0, truncationLength)
+                                                <MudTooltip Text="Show all">
+                                                    <MudLink OnClick="@(() => OnViewClicked(item!))" title="Show all"><small>[...]</small></MudLink>
+                                                </MudTooltip>
+                                            </div>
+                                        }
+                                        else
+                                        {
+                                            <span>@item.Text</span>
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                    </MudStack>
-                </td>
-                <td style="width: 50px;">
-                    <MudTooltip Text="Copy">
-                            <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Size="Size.Small" Title="@Localizer["Copy"]" OnClick="@(x => OnCopyClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" />
-                    </MudTooltip>
-                </td>
-            </tr>
-        }
+                            </MudStack>
+                        </td>
+                        <td style="width: 50px;">
+                            <MudTooltip Text="Copy">
+                                <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Size="Size.Small" Title="@Localizer["Copy"]" OnClick="@(x => OnCopyClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" />
+                            </MudTooltip>
+                        </td>
+                    </tr>
+                }
+            }
+            else
+            {
+                if (ShowNoDataAlert)
+                {
+                    <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Text">@NoDataMessage</MudAlert>
+                }
+            }
+            </tbody>
+        </MudSimpleTable>
     }
     else
     {
-        if (ShowNoDataAlert)
-        {
-            <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Text">@NoDataMessage</MudAlert>
-        }
+        <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Text">@(NoDataMessage)</MudAlert>
     }
-    </tbody>
-</MudSimpleTable>
+</div>
 
 @code {
     private int truncationLength = 300;
@@ -92,7 +102,7 @@
     /// The data to display.
     /// </summary>
     [Parameter]
-    public DataPanelModel Data { get; set; } = new ();
+    public DataPanelModel Data { get; set; } = new();
 
     /// <summary>
     /// If true, empty values will be hidden.
@@ -105,6 +115,12 @@
     /// </summary>
     [Parameter]
     public bool ShowNoDataAlert { get; set; }
+
+    /// <summary>
+    /// The title of the data panel
+    /// </summary>
+    [Parameter]
+    public string Title { get; set; } = null!;
 
     /// <summary>
     /// The message to display when there is no data.

--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
@@ -29,7 +29,10 @@
                 <td>
                     <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
                         <MudTooltip Text="@Localizer["View content"]">
-                                <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View content"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
+                        @if (!string.IsNullOrWhiteSpace(item.Text))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View content"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
+                        }
                         </MudTooltip>
                         @if (!string.IsNullOrWhiteSpace(item.Link))
                         {

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -67,13 +67,13 @@ builder.Services.AddShell(options => configuration.GetSection("Shell").Bind(opti
 builder.Services.AddRemoteBackend(backendApiConfig);
 builder.Services.AddLoginModule();
 
-//builder.Services.UseElsaIdentity();
-builder.Services.UseOAuth2(options =>
-{
-    options.ClientId = "ElsaStudio";
-    options.TokenEndpoint = "https://localhost:44335/connect/token";
-    options.Scope = "AbpSolution1 offline_access";
-});
+builder.Services.UseElsaIdentity();
+//builder.Services.UseOAuth2(options =>
+//{
+//    options.ClientId = "ElsaStudio";
+//    options.TokenEndpoint = "https://localhost:44335/connect/token";
+//    options.Scope = "AbpSolution1 offline_access";
+//});
 
 builder.Services.AddDashboardModule();
 builder.Services.AddWorkflowsModule();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -1,3 +1,4 @@
+@using Elsa.Api.Client.Shared.Models
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components
 @using Elsa.Studio.Extensions
@@ -7,9 +8,9 @@
 @inject ILocalizer Localizer
 
 <CascadingValue Value="ExpressionDescriptorProvider">
-    <MudTabs Elevation="0" ApplyEffectsToContainer="true">
+    <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
 
-        <MudTabPanel Text="@Localizer["Input"]">
+        <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
             @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -26,7 +27,7 @@
             }
         </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Output"]">
+        <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
             @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -43,7 +44,7 @@
             }
         </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Common"]">
+        <MudTabPanel Text="@Localizer["Common"]" Icon="@Icons.Material.Outlined.Notes">
             @if (Activity != null && ActivityDescriptor != null)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -60,16 +61,17 @@
             }
         </MudTabPanel>
         
-        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="Color.Success">
+        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor" >
             @if (WorkflowDefinition != null && ActivityDescriptor != null && Activity != null)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor" Activity="Activity"/>
+                    <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor"
+                             Activity="Activity" OnTestResultChanged="OnTestResultChanged" />
                 </ScrollableWell>
             }
         </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Commit Strategy"]">
+        <MudTabPanel Text="@Localizer["Commit Strategy"]" Icon="@Icons.Material.Outlined.Commit">
             @if (Activity != null)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -87,7 +89,7 @@
 
         @if (IsTaskActivity)
         {
-            <MudTabPanel Text="@Localizer["Task"]">
+            <MudTabPanel Text="@Localizer["Task"]" Icon="@Icons.Material.Outlined.HorizontalSplit">
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
                     <TaskTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
                              OnActivityUpdated="OnActivityUpdated"/>
@@ -95,7 +97,7 @@
             </MudTabPanel>
         }
 
-        <MudTabPanel Text="@Localizer["Log"]">
+        <MudTabPanel Text="@Localizer["Log"]" Icon="@Icons.Material.Outlined.Assignment">
             <ScrollableWell MaxHeight="VisiblePaneHeight">
                 <LogPersistenceTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
                                    ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
@@ -103,7 +105,7 @@
         </MudTabPanel>
 
 
-        <MudTabPanel Text="@Localizer["Info"]">
+        <MudTabPanel Text="@Localizer["Info"]" Icon="@Icons.Material.Outlined.Info">
             @if (ActivityDescriptor != null)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -114,7 +116,7 @@
 
         @if (IsWorkflowAsActivity)
         {
-            <MudTabPanel Text="@Localizer["Version"]">
+            <MudTabPanel Text="@Localizer["Version"]" Icon="@Icons.Material.Outlined.Numbers">
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
                     <VersionTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
                                 OnActivityUpdated="OnActivityUpdated"/>
@@ -124,9 +126,10 @@
 
         @if (DisplayResilienceTab)
         {
-            <MudTabPanel Text="@Localizer["Resilience"]">
+            <MudTabPanel Text="@Localizer["Resilience"]" Icon="@Icons.Material.Outlined.RestartAlt">
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <ResilienceTab WorkflowDefinition="WorkflowDefinition" Activity="Activity" ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    <ResilienceTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
+                                   ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
                 </ScrollableWell>
             </MudTabPanel>
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -3,9 +3,11 @@ using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
 
@@ -30,7 +32,18 @@ public partial class ActivityPropertiesPanel
     /// Gets or sets the activity descriptor.
     /// </summary>
     [Parameter]
-    public ActivityDescriptor? ActivityDescriptor { get; set; }
+    public ActivityDescriptor? ActivityDescriptor
+    {
+        get { return activityDescriptor; }
+        set
+        {
+            if (activityDescriptor != value)
+            {
+                TestResultStatus = ActivityStatus.Canceled;
+            }
+            activityDescriptor = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets a callback that is invoked when the activity is updated.
@@ -45,14 +58,29 @@ public partial class ActivityPropertiesPanel
     public int VisiblePaneHeight { get; set; }
 
     [Inject] private IExpressionService ExpressionService { get; set; } = null!;
-
     [Inject] private IEnumerable<IActivityTab> PluginTabs { get; set; } = new List<IActivityTab>();
     [Inject] private IRemoteFeatureProvider RemoteFeatureProvider { get; set; } = null!;
 
+    private ActivityDescriptor? activityDescriptor;
     private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; } = new();
     private bool IsResilienceEnabled { get; set; }
     private bool IsResilientActivity => ActivityDescriptor?.CustomProperties.TryGetValue("Resilient", out var resilientObj) == true && resilientObj.ConvertTo<bool>();  
     private bool DisplayResilienceTab => IsResilienceEnabled && IsResilientActivity;
+    private ActivityStatus TestResultStatus { get; set; } = ActivityStatus.Canceled;
+    private Color TestIconColor
+    {
+        get
+        {
+            return TestResultStatus switch
+            {
+                ActivityStatus.Running => Color.Warning,
+                ActivityStatus.Completed => Color.Success,
+                ActivityStatus.Canceled => Color.Default,
+                ActivityStatus.Faulted => Color.Error,
+                _ => Color.Error,
+            };
+        }
+    }
 
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
@@ -61,6 +89,16 @@ public partial class ActivityPropertiesPanel
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
         ExpressionDescriptorProvider.AddRange(descriptors);
     }
+    /// <summary>
+    /// Updates the test result status when the tests status changes.
+    /// </summary>
+    /// <param name="status">The new activity status to set as the test result status.</param>
+    private void OnTestResultChanged(ActivityStatus status) => TestResultStatus = status;
+    /// <summary>
+    /// Handles changes to the active panel index.
+    /// </summary>
+    /// <param name="newIndex">The new index of the active panel.</param>
+    private void OnActivePanelIndexChanged(int newIndex) => TestResultStatus = ActivityStatus.Canceled;
 
     private bool IsWorkflowAsActivity => ActivityDescriptor != null && ActivityDescriptor.CustomProperties.TryGetValue("RootType", out var value) && value.ConvertTo<string>() == "WorkflowDefinitionActivity";
     private bool IsTaskActivity => ActivityDescriptor?.Kind == ActivityKind.Task;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InfoTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InfoTab.razor
@@ -1,6 +1,3 @@
 @inject ILocalizer Localizer
 
-<div>
-    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Information"]</MudText>
-    <DataPanel Data="ActivityInfo"/>
-</div>
+<DataPanel Title="@Localizer["Information"]" Data="ActivityInfo"/>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/ResilienceTab.razor
@@ -14,6 +14,8 @@
             <MudSelect Label="@Localizer["Resilience Strategy"]"
                        T="string"
                        Variant="@Variant.Outlined"
+                       Margin="Margin.Dense"
+                       Dense="true"
                        Value="@ResilienceStrategyId"
                        ValueChanged="@OnStrategyChanged"
                        ReadOnly="IsReadOnly"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor
@@ -9,7 +9,7 @@
     <div>
         @if (!HasRun)
         {
-            <MudAlert Icon="@Icons.Material.Filled.Info">@Localizer["Select the Start button to run the activity"]</MudAlert>
+            <MudAlert Icon="@Icons.Material.Outlined.Info">@Localizer["Select the Start button to run the activity."]</MudAlert>
         }
         else if (!IsRunning)
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor
@@ -6,24 +6,15 @@
         <MudButton StartIcon="@Icons.Material.Filled.PlayArrow" Variant="Variant.Filled" Color="Color.Success" OnClick="@OnTestRunClick">@Localizer["Start"]</MudButton>
     </div>
     <MudProgressLinear Color="@(IsRunning ? Color.Success : Color.Transparent)" Indeterminate="true"/>
-    <div>
-        @if (!HasRun)
-        {
-            <MudAlert Icon="@Icons.Material.Outlined.Info">@Localizer["Select the Start button to run the activity."]</MudAlert>
-        }
-        else if (!IsRunning)
-        {
-            <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Status"]</MudText>
-            <DataPanel Data="Status" ShowNoDataAlert="true" NoDataMessage="No status was recorded."/>
-
-            <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["State"]</MudText>
-            <DataPanel Data="ActivityState" ShowNoDataAlert="true" NoDataMessage="No state was recorded."/>
-
-            <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outcomes"]</MudText>
-            <DataPanel Data="Outcomes" ShowNoDataAlert="true" NoDataMessage="No outcomes were recorded."/>
-
-            <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Output"]</MudText>
-            <DataPanel Data="Output" ShowNoDataAlert="true" NoDataMessage="No output was recorded."/>
-        }
-    </div>
+    @if (!HasRun)
+    {
+        <MudAlert Icon="@Icons.Material.Outlined.Info">@Localizer["Select the Start button to run the activity."]</MudAlert>
+    }
+    else if (!IsRunning)
+    {
+        <DataPanel Title="@Localizer["Status"]" Data="Status" ShowNoDataAlert="true" NoDataMessage="@Localizer["No status was recorded."]"/>
+        <DataPanel Title="@Localizer["State"]" Data="ActivityState" ShowNoDataAlert="true" NoDataMessage="@Localizer["No state was recorded."]"/>
+        <DataPanel Title="@Localizer["Outcomes"]" Data="Outcomes" ShowNoDataAlert="true" NoDataMessage="@Localizer["No outcomes were recorded."]"/>
+        <DataPanel Title="@Localizer["Output"]" Data="Output" ShowNoDataAlert="true" NoDataMessage="@Localizer["No output was recorded."]"/>
+    }
 </MudStack>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -5,7 +5,7 @@
 @inject ILocalizer Localizer
 
 <RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height) - 50px);" Resize="@OnResize">
-    <RadzenSplitterPane Size="70%" Style="background: var(--mud-palette-surface);">
+    <RadzenSplitterPane Size="70%">
         <DiagramDesignerWrapper 
             @ref="_diagramDesigner" 
             WorkflowDefinitionVersionId="@_workflowDefinition?.Id"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -4,7 +4,7 @@
 @inherits WorkflowEditorComponentBase
 @inject ILocalizer Localizer
 
-<RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height));" Resize="@OnResize">
+<RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height) - 50px);" Resize="@OnResize">
     <RadzenSplitterPane Size="70%" Style="background: var(--mud-palette-surface);">
         <DiagramDesignerWrapper 
             @ref="_diagramDesigner" 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Info/Info.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Info/Info.razor
@@ -1,6 +1,4 @@
 @using Elsa.Studio.Workflows.Services
 @inject ILocalizer Localizer
-<div>
-    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Information"]</MudText>
-    <DataPanel Data="_workflowInfo" />
-</div>
+
+<DataPanel Title="@Localizer["Information"]" Data="_workflowInfo" />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor
@@ -14,7 +14,7 @@
     <MudTabPanel Text="@Localizer["Variables"]">
         <VariablesTab WorkflowDefinition="@WorkflowDefinition" WorkflowDefinitionUpdated="WorkflowDefinitionUpdated"/>
     </MudTabPanel>
-    <MudTabPanel Text="@Localizer["Input/output"]">
+    <MudTabPanel Text="@Localizer["Input/Output"]">
         <InputOutputTab WorkflowDefinition="@WorkflowDefinition" WorkflowDefinitionUpdated="WorkflowDefinitionUpdated"/>
     </MudTabPanel>
     <MudTabPanel Text="@Localizer["Version history"]">

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor
@@ -3,49 +3,31 @@
 
 <ScrollableWell MaxHeight="VisiblePaneHeight">
     <MudStack>
-        <div>
-            <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Activity"]</MudText>
-            <DataPanel Data="ActivityInfo" HideEmptyValues="true"/>
-        </div>
+        <DataPanel Title="@Localizer["Activity"]" Data="ActivityInfo" HideEmptyValues="true"/>
 
         @if (ActivityData.Any())
         {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["State"]</MudText>
-                <DataPanel Data="@ActivityData" HideEmptyValues="false"/>
-            </div>
+            <DataPanel Title="@Localizer["State"]" Data="@ActivityData" HideEmptyValues="false"/>
         }
 
         @if (OutcomesData.Any())
         {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outcomes"]</MudText>
-                <DataPanel Data="OutcomesData" HideEmptyValues="true"/>
-            </div>
+            <DataPanel Title="@Localizer["Outcomes"]" Data="OutcomesData" HideEmptyValues="true"/>
         }
 
         @if (OutputData.Any())
         {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Output"]</MudText>
-                <DataPanel Data="OutputData" HideEmptyValues="false"/>
-            </div>
+            <DataPanel Title="@Localizer["Output"]" Data="OutputData" HideEmptyValues="false"/>
         }
 
         @if (ExceptionData.Any())
         {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Fault"]</MudText>
-                <DataPanel Data="ExceptionData" HideEmptyValues="true"/>
-            </div>
+            <DataPanel Title="@Localizer["Fault"]" Data="ExceptionData" HideEmptyValues="true"/>
         }
         
         @if (ResilienceStrategyData.Any())
         {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Resilience Strategy"]</MudText>
-                <DataPanel Data="ResilienceStrategyData" HideEmptyValues="true"/>
-            </div>
+            <DataPanel Title="@Localizer["Resilience Strategy"]" Data="ResilienceStrategyData" HideEmptyValues="true"/>
         }
     </MudStack>
 </ScrollableWell>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionsTab.razor
@@ -44,18 +44,9 @@
         @if (SelectedItem != null)
         {
             <div>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["State"]</MudText>
-                    <DataPanel Data="@SelectedActivityState" HideEmptyValues="false" ShowNoDataAlert="true" NoDataMessage="@Localizer["No state associated with this execution."]"/>
-                </div>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outcomes"]</MudText>
-                    <DataPanel Data="@SelectedOutcomesData" HideEmptyValues="true" ShowNoDataAlert="true" NoDataMessage="@Localizer["No outcomes associated with this execution."]"/>
-                </div>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Output"]</MudText>
-                    <DataPanel Data="@SelectedOutputData" HideEmptyValues="false" ShowNoDataAlert="true" NoDataMessage="@Localizer["No output associated with this execution."]"/>
-                </div>
+                <DataPanel Title="@Localizer["State"]" Data="@SelectedActivityState" HideEmptyValues="false" ShowNoDataAlert="true" NoDataMessage="@Localizer["No state associated with this execution."]"/>
+                <DataPanel Title="@Localizer["Outcomes"]" Data="@SelectedOutcomesData" HideEmptyValues="true" ShowNoDataAlert="true" NoDataMessage="@Localizer["No outcomes associated with this execution."]"/>
+                <DataPanel Title="@Localizer["Output"]" Data="@SelectedOutputData" HideEmptyValues="false" ShowNoDataAlert="true" NoDataMessage="@Localizer["No output associated with this execution."]"/>
                 @if (Retries.TotalCount > 0)
                 {
                     <div>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/JournalEntryDetailsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/JournalEntryDetailsTab.razor
@@ -18,10 +18,7 @@
         Merge(eventInfo, payload);
         
         <MudStack>
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Event"]</MudText>
-                <DataPanel Data="eventInfo" HideEmptyValues="true"/>
-            </div>
+            <DataPanel Title="@Localizer["Event"]" Data="eventInfo" HideEmptyValues="true"/>
         </MudStack>
     }
 </ScrollableWell>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/RetriesTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/RetriesTab.razor
@@ -34,12 +34,8 @@
 
     @if (SelectedItem != null)
     {
-        <div>
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Retry Details"]</MudText>
-                <DataPanel Data="@SelectedRetryAttemptData" HideEmptyValues="false" ShowNoDataAlert="true"
-                           NoDataMessage="@Localizer["No information associated with this retry attempt."]"/>
-            </div>
-        </div>
+        <DataPanel Title="@Localizer["Retry Details"]" Data="@SelectedRetryAttemptData" HideEmptyValues="false" ShowNoDataAlert="true"
+                    NoDataMessage="@Localizer["No information associated with this retry attempt."]"/>
+        
     }
 </MudStack>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
@@ -3,24 +3,42 @@
 @using Microsoft.Extensions.Localization
 @inject ILocalizer Localizer
 
+<style>
+    .incidents-custom-spacing .mud-expand-panel-content,
+    .incidents-custom-spacing .mud-expand-panel-content .pa-4
+    {
+        padding: 0 !important;
+    }
+
+    .incidents-custom-spacing .mud-expand-panel-header {
+        padding: 6px 16px !important;
+    }
+
+    .incidents-custom-spacing .truncate-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .incidents-custom-spacing .mud-expand-panel-text {
+        width: 90%;
+    }
+</style>
+
 @if (WorkflowDefinition != null && WorkflowInstance != null)
 {
 <MudTabs Elevation="0" ApplyEffectsToContainer="true">
     <MudTabPanel Text="@Localizer["Details"]">
         <VerticalWell>
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Workflow"]</MudText>
-                <DataPanel Data="WorkflowInstanceData" HideEmptyValues="true"/>
-            </div>
+            <DataPanel Title="@Localizer["Workflow"]" Data="WorkflowInstanceData" HideEmptyValues="true"/>
         </VerticalWell>
 
         @if (WorkflowInstanceSubWorkflowData.Any())
         {
-                <VerticalWell>
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow"]</MudText>
-                <DataPanel Data="WorkflowInstanceSubWorkflowData" HideEmptyValues="true"/>
-            </div>
+        <VerticalWell>
+            <DataPanel Title="@Localizer["Sub-Workflow"]" Data="WorkflowInstanceSubWorkflowData" HideEmptyValues="true"/>
         </VerticalWell>
         }
     </MudTabPanel>
@@ -49,92 +67,32 @@
             }
             else
             {
-                <MudAlert Severity="Severity.Success" Variant="MudBlazor.Variant.Text" Icon="@Icons.Material.Outlined.Check">@Localizer["No incidents"]</MudAlert>
+                <MudAlert Severity="Severity.Success" Dense="true" Variant="MudBlazor.Variant.Text" Icon="@Icons.Material.Outlined.Check">@Localizer["No incidents"]</MudAlert>
             }
         </VerticalWell>
     </MudTabPanel>
     <MudTabPanel Text="@Localizer["Variables"]">
         <VerticalWell ExtraPadding="50">
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Variables"]</MudText>
-                @if (WorkflowVariableData.Any())
-                {
-                <DataPanel Data="WorkflowVariableData" HideEmptyValues="false"/>
-                }
-                else
-                {
-                <MudAlert Severity="Severity.Normal" Variant="MudBlazor.Variant.Text">@Localizer["No variables"]</MudAlert>
-                }
-            </div>
+            <DataPanel Title="@Localizer["Variables"]" Data="WorkflowVariableData" NoDataMessage="@Localizer["No variables"]" HideEmptyValues="false"/>
         </VerticalWell>
     </MudTabPanel>
     <MudTabPanel Text="@Localizer["Input/output"]">
             <VerticalWell>
             <MudStack>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Inputs"]</MudText>
-                    @if (WorkflowInputData.Any())
-                    {
-                    <DataPanel Data="WorkflowInputData" HideEmptyValues="false"/>
-                    }
-                    else
-                    {
-                    <MudAlert Severity="Severity.Normal" Variant="MudBlazor.Variant.Text">@Localizer["No inputs"]</MudAlert>
-                    }
-                </div>
-                <div>
-                    <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Outputs"]</MudText>
-                    @if (WorkflowOutputData.Any())
-                    {
-                    <DataPanel Data="WorkflowOutputData" HideEmptyValues="false"/>
-                    }
-                    else
-                    {
-                    <MudAlert Severity="Severity.Normal" Variant="MudBlazor.Variant.Text">@Localizer["No outputs"]</MudAlert>
-                    }
-                </div>
+                <DataPanel Title="@Localizer["Inputs"]" Data="WorkflowInputData" NoDataMessage="@Localizer["No inputs"]" HideEmptyValues="false"/>
+                <DataPanel Title="@Localizer["Outputs"]" Data="WorkflowOutputData" NoDataMessage="@Localizer["No outputs"]" HideEmptyValues="false"/>
             </MudStack>
         </VerticalWell>
             <VerticalWell>
             @if (SubWorkflowInputData.Any())
             {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Inputs"]</MudText>
-                <DataPanel Data="SubWorkflowInputData" HideEmptyValues="false"/>
-            </div>
+                <DataPanel Title="@Localizer["Sub-Workflow Inputs"]" Data="SubWorkflowInputData" HideEmptyValues="false"/>
             }
             @if (SubWorkflowOutputData.Any())
             {
-            <div>
-                <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Sub-Workflow Outputs"]</MudText>
-                <DataPanel Data="SubWorkflowOutputData" HideEmptyValues="false"/>
-            </div>
+                <DataPanel Title="@Localizer["Sub-Workflow Outputs"]" Data="SubWorkflowOutputData" HideEmptyValues="false"/>
             }
         </VerticalWell>
     </MudTabPanel>
 </MudTabs>
 }
-
-<style>
-    .incidents-custom-spacing .mud-expand-panel-content,
-    .incidents-custom-spacing .mud-expand-panel-content .pa-4
-    {
-        padding: 0 !important;
-    }
-
-    .incidents-custom-spacing .mud-expand-panel-header {
-        padding: 6px 16px !important;
-    }
-
-    .incidents-custom-spacing .truncate-text {
-        display: -webkit-box;
-        -webkit-line-clamp: 1;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-    .incidents-custom-spacing .mud-expand-panel-text {
-        width: 90%;
-    }
-</style>

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor
@@ -1,7 +1,8 @@
 @using Elsa.Studio.Workflows.UI.Contracts
 @inherits StudioComponentBase
+
 <MudPaper Class="ma-2" Elevation="0" Outlined="true">
-    <MudToolBar Dense="true">
+    <MudToolBar Class="mt-1" Dense="true">
         @{
             if (_diagramDesigner is IDiagramDesignerToolboxProvider toolboxProvider)
             {
@@ -14,8 +15,8 @@
         <MudSpacer></MudSpacer>
         @CustomToolbarItems
     </MudToolBar>
+    <MudProgressLinear Color="@(IsProgressing? Color.Primary: Color.Transparent)" Indeterminate="true" />
 </MudPaper>
-<MudProgressLinear Color="@(IsProgressing ? Color.Primary : Color.Transparent)" Indeterminate="true"/>
 <div class="ma-2">
     <MudBreadcrumbs Items="_breadcrumbItems" Style="padding: 6px;">
         <ItemTemplate>

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor
@@ -2,7 +2,7 @@
 @inherits StudioComponentBase
 
 <MudPaper Class="ma-2" Elevation="0" Outlined="true">
-    <MudToolBar Class="mt-1" Dense="true">
+    <MudToolBar Dense="true">
         @{
             if (_diagramDesigner is IDiagramDesignerToolboxProvider toolboxProvider)
             {
@@ -15,7 +15,7 @@
         <MudSpacer></MudSpacer>
         @CustomToolbarItems
     </MudToolBar>
-    <MudProgressLinear Color="@(IsProgressing? Color.Primary: Color.Transparent)" Indeterminate="true" />
+    <MudProgressLinear Style="margin-top: -4px;" Color="@(IsProgressing? Color.Primary: Color.Transparent)" Indeterminate="true" />
 </MudPaper>
 <div class="ma-2">
     <MudBreadcrumbs Items="_breadcrumbItems" Style="padding: 6px;">


### PR DESCRIPTION
This PR add several minor UI improvements.

- Activity test results now changes the Test tab Icon colour.
- Activity tab headers all have icons.
- The view content button remains hidden if there is no value for a property
- Adds dense properties to the Resilience tabs element.
- Adds `Title` property to the `DataPanel` element to remove duplicated code.
- Resolves horizontal splitter divider, within the workflow editor, going off screen when minimised.
- Moves the workflow editors progress bar to within the MudPage for a cleaner UI.
- Other minor UI / Code changes.