### PR TITLE
Add CategoryDisplayResolver to AccordionActivityPicker

### DIFF
--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -77,6 +77,12 @@ builder.Services.AddTranslations();
 // Replace some services with other implementations.
 builder.Services.AddScoped<ITimeZoneProvider, LocalTimeZoneProvider>();
 builder.Services.AddScoped<IActivityPickerComponentProvider, TreeviewActivityPickerComponentProvider>();
+// Uncomment for the Accordion Activity Picker
+//builder.Services.AddScoped<IActivityPickerComponentProvider>(sp => new AccordionActivityPickerComponentProvider
+//{
+//    // Example - Replace the default category resolver with a custom one.
+//    CategoryDisplayResolver = category => category.Split('/').Last().Trim()
+//});
 
 // Uncomment for V1 designer theme (default is V2).
 // builder.Services.Configure<DesignerOptions>(options =>

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/AccordionActivityPickerComponentProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/AccordionActivityPickerComponentProvider.cs
@@ -8,10 +8,17 @@ namespace Elsa.Studio.Workflows.ActivityPickers.Accordion;
 /// </summary>
 public class AccordionActivityPickerComponentProvider : IActivityPickerComponentProvider
 {
+    /// <summary>
+    /// Resolves the display name for a given category string.
+    /// </summary>
+    /// <remarks>The default behavior is to extract the first segment of the category string.</remarks>
+    public Func<string, string> CategoryDisplayResolver = category => category.Split('/').First().Trim();
+
     /// <inheritdoc />
     public RenderFragment GetActivityPickerComponent() => builder =>
     {
         builder.OpenComponent<ActivityPicker>(0);
+        builder.AddAttribute(1, nameof(ActivityPicker.CategoryDisplayResolver), CategoryDisplayResolver);
         builder.CloseComponent();
     };
 }

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor
@@ -31,7 +31,7 @@
                             var activityDescriptors = grouping.OrderBy(x => x.DisplayName ?? x.Name).ToList();
                             var category = grouping.Key;
 
-                            <MudExpansionPanel Text="@Localizer[@category]">
+                            <MudExpansionPanel Text="@Localizer[CategoryDisplayResolver(category)]">
                                 <MudStack>
                                     @foreach (var activityDescriptor in activityDescriptors)
                                     {

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor.cs
@@ -13,6 +13,9 @@ namespace Elsa.Studio.Workflows.ActivityPickers.Accordion;
 /// </summary>
 public partial class ActivityPicker
 {
+    [Parameter]
+    public Func<string, string> CategoryDisplayResolver { get; set; } = null!;
+
     private string _searchText = "";
 
     private IEnumerable<IGrouping<string, ActivityDescriptor>> GroupedActivityDescriptors


### PR DESCRIPTION
Implement a new `CategoryDisplayResolver` in the
`AccordionActivityPickerComponentProvider` for custom category name resolution. Update the `ActivityPicker` component to use this resolver for displaying category names. Include commented-out code for this implementation.