### PR TITLE
Fix Directory.Packages.props file

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-		<ElsaVersion>3.7.0-preview.3055</ElsaVersion>
+  <PropertyGroup Label="PackageVersions">
+    <ElsaVersion>3.7.0-preview.3055</ElsaVersion>
     <MicrosoftVersion>9.0.6</MicrosoftVersion>
+  </PropertyGroup>
   <ItemGroup Label="Elsa">
     <PackageVersion Include="Elsa.Api.Client" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Secrets.Models" Version="$(ElsaVersion)" />


### PR DESCRIPTION
The merge of `develop-3.6.0` broke the `Directory.Packages.props` file (https://github.com/elsa-workflows/elsa-studio/commit/f53a880270334fa27242e73f50eed27d2f14b6dc#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156)

This PR merges the change with the correct `<PropertyGroup>`.