### PR TITLE
[FEAT] Make resizing configurable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-		<ElsaVersion>3.7.0-preview.3055</ElsaVersion>
+  <PropertyGroup Label="PackageVersions">
+    <ElsaVersion>3.7.0-preview.3055</ElsaVersion>
     <MicrosoftVersion>9.0.6</MicrosoftVersion>
+  </PropertyGroup>
   <ItemGroup Label="Elsa">
     <PackageVersion Include="Elsa.Api.Client" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Secrets.Models" Version="$(ElsaVersion)" />

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -157,8 +157,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         graph.use(
             new Transform({
                 resizing: {
-                    enabled: true,
-
+                    enabled: settings?.resizingEnabled ?? true,
                 }
             })
         );

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GraphSettings.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GraphSettings.cs
@@ -6,4 +6,5 @@ public class X6GraphSettings
     public double MagnetThreshold { get; set; }
     public X6Panning Panning { get; set; } = new();
     public X6Mousewheel Mousewheel { get; set; } = new();
+    public bool ResizingEnabled { get; set; } = true;
 }


### PR DESCRIPTION
For our use case, we needed the option to control if resizing of graph elements is enabled.

In this PR a new setting `DesignerOptions.GraphSettings.ResizingEnabled` has been introduced that allows control over whether or not the elements in the graph can be resized.

This setting can currently be controlled using the `PostConfigure` pattern.