### PR TITLE
Component refresh on the editor load to show the latest model from server

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 <PropertyGroup>
-	<ElsaVersion>3.6.0-preview.3239</ElsaVersion>
+	<ElsaVersion>3.6.0-preview.3267</ElsaVersion>
 	<MicrosoftVersion>9.0.8</MicrosoftVersion>
 </PropertyGroup>
   <ItemGroup Label="Elsa">
@@ -16,7 +16,7 @@
     <PackageVersion Include="BlazorMonaco" Version="3.3.0" />
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.2.4" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.AspNetCore.App" Version="2.2.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftVersion)" />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor
@@ -14,7 +14,7 @@
                 T="bool?"
                 Label="@Localizer["Run Asynchronously"]"
                 Dense="@true"
-                Value="@(Activity?.GetRunAsynchronously() == true)"
+                Value="@(Activity?.GetRunAsynchronously())"
                 ValueChanged="OnRunAsynchronouslyChanged"
                 ReadOnly="IsReadOnly" Disabled="IsReadOnly"
                 />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditorComponentBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditorComponentBase.cs
@@ -70,13 +70,23 @@ public abstract class WorkflowEditorComponentBase : StudioComponentBase
         }
     }
 
+    /// <summary>
+    /// Helper method to show progress while executing an async operation (void return)
+    /// </summary>
     protected async Task ProgressAsync(Func<Task> action)
     {
         IsProgressing = true;
         StateHasChanged();
-        await action.Invoke();
-        IsProgressing = false;
-        StateHasChanged();
+ 
+        try
+        {
+            await action.Invoke();
+        }
+        finally
+        {
+            IsProgressing = false;
+            StateHasChanged();
+        }
     }
 
     protected async Task<T> ProgressAsync<T>(Func<Task<T>> action)

--- a/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
+++ b/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
@@ -13,7 +13,8 @@ public class RefreshActivityRegistry : INotificationHandler<WorkflowDefinitionDe
     INotificationHandler<BulkWorkflowDefinitionsDeleted>,
     INotificationHandler<BulkWorkflowDefinitionVersionsDeleted>,
     INotificationHandler<BulkWorkflowDefinitionsPublished>,
-    INotificationHandler<BulkWorkflowDefinitionsRetracted>
+    INotificationHandler<BulkWorkflowDefinitionsRetracted>,
+    INotificationHandler<WorkflowDefinitionSaved>
 {
     private readonly IActivityRegistry _activityRegistry;
 
@@ -26,6 +27,7 @@ public class RefreshActivityRegistry : INotificationHandler<WorkflowDefinitionDe
     }
 
     async Task INotificationHandler<WorkflowDefinitionDeleted>.HandleAsync(WorkflowDefinitionDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
+    async Task INotificationHandler<WorkflowDefinitionSaved>.HandleAsync(WorkflowDefinitionSaved notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
     async Task INotificationHandler<WorkflowDefinitionPublished>.HandleAsync(WorkflowDefinitionPublished notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
     async Task INotificationHandler<WorkflowDefinitionRetracted>.HandleAsync(WorkflowDefinitionRetracted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);
     async Task INotificationHandler<BulkWorkflowDefinitionsDeleted>.HandleAsync(BulkWorkflowDefinitionsDeleted notification, CancellationToken cancellationToken) => await RefreshActivityRegistryAsync(cancellationToken);


### PR DESCRIPTION
This pull request introduces several improvements and fixes across workflow editor components, dependency management, and notification handling. The most significant changes enhance the workflow editor's ability to refresh activity state after saving, improve progress indication during async operations, and update dependencies.

**Workflow Editor Enhancements:**

* Added logic to refresh the selected activity after saving a workflow, ensuring the UI displays the latest state by locating and re-selecting the updated activity in the workflow definition. This includes new methods `RefreshSelectedActivityAsync` and `FindActivityByIdAsync` in `WorkflowEditor.razor.cs`. [[1]](diffhunk://#diff-d20cf58da3a858bc98abd08b4dba527a18ef171d9185546a93e8e218428283b0L198-R213) [[2]](diffhunk://#diff-d20cf58da3a858bc98abd08b4dba527a18ef171d9185546a93e8e218428283b0L246-R294)
* Modified the save workflow logic to invoke the new refresh methods and ensure `onSuccess` callbacks are awaited properly.

**Async Operation Improvements:**

* Added a helper method to show progress while executing async operations that return void, improving UI feedback during long-running tasks in `WorkflowEditorComponentBase.cs`.

**Dependency Updates:**

* Updated the `ElsaVersion` to `3.6.0-preview.3267` and downgraded `JetBrains.Annotations` to `2024.3.0` in `Directory.Packages.props` for improved compatibility and stability. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R7) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L19-R19)

**Notification Handling:**

* Extended the `RefreshActivityRegistry` handler to respond to `WorkflowDefinitionSaved` notifications, ensuring the activity registry stays up-to-date after workflow saves. [[1]](diffhunk://#diff-9640de910f5afb6bbe34fb43ed84a0f299350ad2914539f487e6e50996a1fc59L16-R17) [[2]](diffhunk://#diff-9640de910f5afb6bbe34fb43ed84a0f299350ad2914539f487e6e50996a1fc59R30)

**Minor Fixes:**

* Simplified the value binding for the "Run Asynchronously" property in `TaskTab.razor` to correctly handle nullable values.
* Removed an unused import and added a missing one in `WorkflowEditor.razor.cs` for code cleanliness. [[1]](diffhunk://#diff-d20cf58da3a858bc98abd08b4dba527a18ef171d9185546a93e8e218428283b0L4) [[2]](diffhunk://#diff-d20cf58da3a858bc98abd08b4dba527a18ef171d9185546a93e8e218428283b0R13)