### PR TITLE
Fix/component losing focus when editing

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -460,4 +460,3 @@ public partial class WorkflowEditor
         }
     }
 }
-

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -270,7 +270,7 @@ public partial class WorkflowEditor
         if (updatedActivity != null)
         {
             // Update the selected activity reference without triggering a disruptive UI refresh.
-            //We avoid calling SelectActivity() which sets the activity to null and calls StateHasChanged() multiple times.
+            // We avoid calling SelectActivity() which sets the activity to null and calls StateHasChanged() multiple times.
             SelectedActivity = updatedActivity;
             SelectedActivityId = updatedActivity.GetId();
             ActivityDescriptor = ActivityRegistry.Find(updatedActivity.GetTypeName(), updatedActivity.GetVersion());

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -269,8 +269,14 @@ public partial class WorkflowEditor
         
         if (updatedActivity != null)
         {
-            // Update the selected activity reference to point to the updated activity
-            SelectActivity(updatedActivity);
+            // Update the selected activity reference without triggering a disruptive UI refresh.
+            //We avoid calling SelectActivity() which sets the activity to null and calls StateHasChanged() multiple times.
+            SelectedActivity = updatedActivity;
+            SelectedActivityId = updatedActivity.GetId();
+            ActivityDescriptor = ActivityRegistry.Find(updatedActivity.GetTypeName(), updatedActivity.GetVersion());
+            
+            // Only call StateHasChanged once to update the UI without disrupting focus
+            StateHasChanged();
         }
     }
 
@@ -454,3 +460,4 @@ public partial class WorkflowEditor
         }
     }
 }
+


### PR DESCRIPTION
This pull request refines the way the selected activity is updated in the workflow editor to minimize unnecessary UI refreshes and disruptions. Instead of calling `SelectActivity()`, which previously caused multiple calls to `StateHasChanged()` and reset the activity to null, the update now directly sets the relevant properties and refreshes the UI only once.

Improvements to UI update logic:

* Changed the activity update process in `RefreshSelectedActivityAsync` to set `SelectedActivity`, `SelectedActivityId`, and `ActivityDescriptor` directly, avoiding multiple disruptive UI refreshes and maintaining focus. (`src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs`)