### PR TITLE
Feature/575 table like dictionary input

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,7 +7,7 @@ on:
       - 'vnext'
       - 'bug/*'
       - 'enh/*'
-      - 'feature/*'
+      - 'feat/*'
       - 'issue/*'
       - 'patch/*'
       - 'rc/*'

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
@@ -1,6 +1,14 @@
 @inherits StudioComponentBase
 @inject ILocalizer Localizer
+
+@{
+    var inputDescriptor = EditorContext.InputDescriptor;
+    var displayName = inputDescriptor.DisplayName;
+    var description = inputDescriptor.Description;
+}
+
 <MudStack>
+    <MudText Typo="Typo.h6">@Localizer[displayName]</MudText>
     <MudTable
         @ref="_table"
         Items="Items"
@@ -53,6 +61,7 @@
             </MudButton>
         </NoRecordsContent>
     </MudTable>
+    <MudText Typo="Typo.h6">@Localizer[description]</MudText>
     @if (Items.Any())
     {
         <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" Class="align-self-start" Disabled="@(DisableAddButton || EditorContext.IsReadOnly)" OnClick="OnAddClicked">

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
@@ -1,0 +1,62 @@
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+<MudStack>
+    <MudTable
+        @ref="_table"
+        Items="Items"
+        Dense="true"
+        Elevation="0"
+        FixedHeader="true"
+        Striped="true"
+        EditTrigger="TableEditTrigger.EditButton"
+        EditButtonPosition="TableEditButtonPosition.Start"
+        ApplyButtonPosition="TableApplyButtonPosition.Start"
+        Outlined="true"
+        CanCancelEdit="true"
+        RowEditPreview="OnRowEditPreview"
+        RowEditCancel="OnRowEditCancel"
+        RowEditCommit="OnRowEditCommitted"
+        ReadOnly="EditorContext.IsReadOnly">
+        <HeaderContent>
+            <MudTh Style="width: 25%">@Localizer["Key"]</MudTh>
+            <MudTh Style="width: 50%;">@Localizer["Value"]</MudTh>
+            <MudTh Style="width: 15%;">@Localizer["Type"]</MudTh>
+            <MudTh Style="width: 40px;"></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Key">@context.Key</MudTd>
+            <MudTd DataLabel="Value">@context.Value</MudTd>
+            <MudTd DataLabel="ExpressionType">@GetExpressionTypeDisplayName(@context.ExpressionType)</MudTd>
+            <MudTd>
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="EditorContext.IsReadOnly"></MudIconButton>
+            </MudTd>
+        </RowTemplate>
+        <RowEditingTemplate>
+            <MudTd DataLabel="Key">
+                <MudTextField @bind-Value="@context.Key" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+            </MudTd>
+            <MudTd DataLabel="Value">
+                <MudTextField @bind-Value="@context.Value" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+            </MudTd>
+            <MudTd DataLabel="ExpressionType">
+                <MudSelect @bind-Value="@context.ExpressionType" Variant="Variant.Outlined" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly">
+                    @foreach (var expressionDescriptor in GetSupportedExpressions())
+                    {
+                        <MudSelectItem Value="@expressionDescriptor.Type">@expressionDescriptor.DisplayName</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudTd>
+        </RowEditingTemplate>
+        <NoRecordsContent>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" OnClick="OnAddClicked" Disabled="EditorContext.IsReadOnly">
+                @Localizer["Add entry"]
+            </MudButton>
+        </NoRecordsContent>
+    </MudTable>
+    @if (Items.Any())
+    {
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" Class="align-self-start" Disabled="@(DisableAddButton || EditorContext.IsReadOnly)" OnClick="OnAddClicked">
+            @Localizer["Add entry"]
+        </MudButton>
+    }
+</MudStack>

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
@@ -8,60 +8,65 @@
 }
 
 <MudStack>
-    <MudText Typo="Typo.h6">@Localizer[displayName]</MudText>
-    <MudTable
-        @ref="_table"
-        Items="Items"
-        Dense="true"
-        Elevation="0"
-        FixedHeader="true"
-        Striped="true"
-        EditTrigger="TableEditTrigger.EditButton"
-        EditButtonPosition="TableEditButtonPosition.Start"
-        ApplyButtonPosition="TableApplyButtonPosition.Start"
-        Outlined="true"
-        CanCancelEdit="true"
-        RowEditPreview="OnRowEditPreview"
-        RowEditCancel="OnRowEditCancel"
-        RowEditCommit="OnRowEditCommitted"
-        ReadOnly="EditorContext.IsReadOnly">
-        <HeaderContent>
-            <MudTh Style="width: 25%">@Localizer["Key"]</MudTh>
-            <MudTh Style="width: 50%;">@Localizer["Value"]</MudTh>
-            <MudTh Style="width: 15%;">@Localizer["Type"]</MudTh>
-            <MudTh Style="width: 40px;"></MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Key">@context.Key</MudTd>
-            <MudTd DataLabel="Value">@context.Value</MudTd>
-            <MudTd DataLabel="ExpressionType">@GetExpressionTypeDisplayName(@context.ExpressionType)</MudTd>
-            <MudTd>
-                <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="EditorContext.IsReadOnly"></MudIconButton>
-            </MudTd>
-        </RowTemplate>
-        <RowEditingTemplate>
-            <MudTd DataLabel="Key">
-                <MudTextField @bind-Value="@context.Key" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
-            </MudTd>
-            <MudTd DataLabel="Value">
-                <MudTextField @bind-Value="@context.Value" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
-            </MudTd>
-            <MudTd DataLabel="ExpressionType">
-                <MudSelect @bind-Value="@context.ExpressionType" Variant="Variant.Outlined" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly">
-                    @foreach (var expressionDescriptor in GetSupportedExpressions())
-                    {
-                        <MudSelectItem Value="@expressionDescriptor.Type">@expressionDescriptor.DisplayName</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudTd>
-        </RowEditingTemplate>
-        <NoRecordsContent>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" OnClick="OnAddClicked" Disabled="EditorContext.IsReadOnly">
-                @Localizer["Add entry"]
-            </MudButton>
-        </NoRecordsContent>
-    </MudTable>
-    <MudText Typo="Typo.h6">@Localizer[description]</MudText>
+    <MudField 
+        Label="@Localizer[displayName]" 
+        HelperText="@Localizer[description]" 
+        Margin="Margin.None" 
+        Underline="true" 
+        Variant="Variant.Text">
+        <MudTable
+            @ref="_table"
+            Items="Items"
+            Dense="true"
+            Elevation="0"
+            FixedHeader="true"
+            Striped="true"
+            EditTrigger="TableEditTrigger.EditButton"
+            EditButtonPosition="TableEditButtonPosition.Start"
+            ApplyButtonPosition="TableApplyButtonPosition.Start"
+            Outlined="true"
+            CanCancelEdit="true"
+            RowEditPreview="OnRowEditPreview"
+            RowEditCancel="OnRowEditCancel"
+            RowEditCommit="OnRowEditCommitted"
+            ReadOnly="EditorContext.IsReadOnly">
+            <HeaderContent>
+                <MudTh Style="width: 25%">@Localizer["Key"]</MudTh>
+                <MudTh Style="width: 50%;">@Localizer["Value"]</MudTh>
+                <MudTh Style="width: 15%;">@Localizer["Type"]</MudTh>
+                <MudTh Style="width: 40px;"></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Key">@context.Key</MudTd>
+                <MudTd DataLabel="Value">@context.Value</MudTd>
+                <MudTd DataLabel="ExpressionType">@GetExpressionTypeDisplayName(@context.ExpressionType)</MudTd>
+                <MudTd>
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="EditorContext.IsReadOnly"></MudIconButton>
+                </MudTd>
+            </RowTemplate>
+            <RowEditingTemplate>
+                <MudTd DataLabel="Key">
+                    <MudTextField @bind-Value="@context.Key" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+                </MudTd>
+                <MudTd DataLabel="Value">
+                    <MudTextField @bind-Value="@context.Value" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+                </MudTd>
+                <MudTd DataLabel="ExpressionType">
+                    <MudSelect @bind-Value="@context.ExpressionType" Variant="Variant.Outlined" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly">
+                        @foreach (var expressionDescriptor in GetSupportedExpressions())
+                        {
+                            <MudSelectItem Value="@expressionDescriptor.Type">@expressionDescriptor.DisplayName</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudTd>
+            </RowEditingTemplate>
+            <NoRecordsContent>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" OnClick="OnAddClicked" Disabled="EditorContext.IsReadOnly">
+                    @Localizer["Add entry"]
+                </MudButton>
+            </NoRecordsContent>
+        </MudTable>
+    </MudField>
     @if (Items.Any())
     {
         <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" Class="align-self-start" Disabled="@(DisableAddButton || EditorContext.IsReadOnly)" OnClick="OnAddClicked">

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -99,7 +99,7 @@ public partial class Dictionary
     private Task SaveChangesAsync()
     {
         var dictionary = Items.ToDictionary(x => x.Key, x => (object)Map(x).Value);
-        return EditorContext.UpdateValueAsync(dictionary);
+        return EditorContext.UpdateValueOrObjectExpressionAsync(dictionary);
     }
 
     private async void OnRowEditCommitted(object data)

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Models;
+using Elsa.Studio.UIHints.Helpers;
+using Elsa.Studio.Workflows.Domain.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.UIHints.Components;
+
+/// <summary>
+/// Renders an editor for a dictionary of key-value pairs.
+/// </summary>
+public partial class Dictionary
+{
+    private readonly string[] _uiSyntaxes = { "Literal", "Object" };
+
+    private DictionaryEntryRecord? _entryBeingEdited;
+    private DictionaryEntryRecord? _entryBeingAdded;
+    private MudTable<DictionaryEntryRecord> _table = default!;
+
+    /// <summary>
+    /// The context for the editor.
+    /// </summary>
+    [Parameter]
+    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+
+    [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
+
+    private ICollection<DictionaryEntryRecord> Items { get; set; } = new List<DictionaryEntryRecord>();
+    private bool DisableAddButton => _entryBeingEdited != null || _entryBeingAdded != null;
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        Items = GetItems();
+    }
+
+    private ICollection<DictionaryEntryRecord> GetItems()
+    {
+        var input = EditorContext.GetObjectValueOrDefault();
+        var dictionary = ParseJson(input);
+        var entryRecords = dictionary.Select(kvp => Map(kvp.Key, kvp.Value)).ToList();
+        return entryRecords;
+    }
+
+    private IDictionary<string, object?> ParseJson(string? json)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        return JsonParser.ParseJson(json, () => new Dictionary<string, object?>(), options);
+    }
+
+    private IEnumerable<ExpressionDescriptor> GetSupportedExpressions()
+    {
+        return ExpressionDescriptorProvider.ListDescriptors().Where(x => !_uiSyntaxes.Contains(x.Type) && x.IsBrowsable).ToList();
+    }
+
+    private string GetDefaultExpressionType()
+    {
+        var defaultExpressionType = GetSupportedExpressions().FirstOrDefault()?.Type ?? "Literal";
+        return defaultExpressionType;
+    }
+
+    private DictionaryEntryRecord Map(string key, object? value)
+    {
+        var defaultExpressionType = GetDefaultExpressionType();
+
+        // Try to extract expression information from the value if it's an Expression object
+        if (value is JsonObject jsonObject && jsonObject.TryGetPropertyValue("type", out var typeNode) && jsonObject.TryGetPropertyValue("expression", out var expressionNode))
+        {
+            return new DictionaryEntryRecord
+            {
+                Key = key,
+                Value = expressionNode?.GetValue<string>() ?? "",
+                ExpressionType = typeNode?.GetValue<string>() ?? defaultExpressionType
+            };
+        }
+
+        return new DictionaryEntryRecord
+        {
+            Key = key,
+            Value = value?.ToString() ?? "",
+            ExpressionType = defaultExpressionType
+        };
+    }
+
+    private KeyValuePair<string, object> Map(DictionaryEntryRecord entry)
+    {
+        var expression = new Expression(entry.ExpressionType, entry.Value);
+        return new KeyValuePair<string, object>(entry.Key, expression);
+    }
+
+    private Task SaveChangesAsync()
+    {
+        var dictionary = Items.ToDictionary(x => x.Key, x => (object)Map(x).Value);
+        return EditorContext.UpdateValueAsync(dictionary);
+    }
+
+    private async void OnRowEditCommitted(object data)
+    {
+        _entryBeingAdded = null;
+        _entryBeingEdited = null;
+        await SaveChangesAsync();
+        StateHasChanged();
+    }
+
+    private void OnRowEditPreview(object obj)
+    {
+        var entry = (DictionaryEntryRecord)obj;
+        _entryBeingEdited = new()
+        {
+            Key = entry.Key,
+            Value = entry.Value,
+            ExpressionType = entry.ExpressionType
+        };
+
+        StateHasChanged();
+    }
+
+    private async void OnRowEditCancel(object obj)
+    {
+        if (_entryBeingAdded != null)
+        {
+            Items.Remove(_entryBeingAdded);
+            await SaveChangesAsync();
+            _entryBeingAdded = null;
+            StateHasChanged();
+            return;
+        }
+
+        var entry = (DictionaryEntryRecord)obj;
+        entry.Key = _entryBeingEdited?.Key ?? "";
+        entry.Value = _entryBeingEdited?.Value ?? "";
+        entry.ExpressionType = _entryBeingEdited?.ExpressionType ?? "";
+        _entryBeingEdited = null;
+        StateHasChanged();
+    }
+
+    private async Task OnDeleteClicked(DictionaryEntryRecord entry)
+    {
+        Items.Remove(entry);
+        await SaveChangesAsync();
+    }
+
+    private void OnAddClicked()
+    {
+        var entry = new DictionaryEntryRecord
+        {
+            Key = $"Key{Items.Count + 1}",
+            Value = "",
+            ExpressionType = GetDefaultExpressionType()
+        };
+
+        Items.Add(entry);
+        _entryBeingAdded = entry;
+
+        // Need to do it this way, otherwise MudTable doesn't show the item in edit mode.
+        _ = Task.Delay(1).ContinueWith(_ =>
+        {
+            InvokeAsync(() =>
+            {
+                _table.SetEditingItem(entry);
+                StateHasChanged();
+            });
+        });
+    }
+
+    private string GetExpressionTypeDisplayName(string expressionType)
+    {
+        var expressionDescriptor = ExpressionDescriptorProvider.GetByType(expressionType) ?? throw new($"Could not find expression descriptor for expression type '{expressionType}'.");
+        return expressionDescriptor.DisplayName;
+    }
+}
+
+/// <summary>
+/// Represents a single key-value entry in a dictionary.
+/// </summary>
+public class DictionaryEntryRecord
+{
+    /// <summary>
+    /// The key of the entry.
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The value of the entry.
+    /// </summary>
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The expression type of the value.
+    /// </summary>
+    public string ExpressionType { get; set; } = "Literal";
+}

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -61,10 +61,10 @@ public partial class Dictionary
         return ExpressionDescriptorProvider.ListDescriptors().Where(x => !_uiSyntaxes.Contains(x.Type) && x.IsBrowsable).ToList();
     }
 
-    private string GetDefaultExpressionType()
+    private static string GetDefaultExpressionType()
     {
-        var defaultExpressionType = GetSupportedExpressions().FirstOrDefault()?.Type ?? "Literal";
-        return defaultExpressionType;
+        // Default to Literal for new entries to avoid unnecessary wrapping
+        return "Literal";
     }
 
     private DictionaryEntryRecord Map(string key, object? value)
@@ -72,12 +72,12 @@ public partial class Dictionary
         var defaultExpressionType = GetDefaultExpressionType();
 
         // Try to extract expression information from the value if it's an Expression object
-        if (value is JsonObject jsonObject && jsonObject.TryGetPropertyValue("type", out var typeNode) && jsonObject.TryGetPropertyValue("expression", out var expressionNode))
+        if (value is JsonObject jsonObject && jsonObject.TryGetPropertyValue("type", out var typeNode) && jsonObject.TryGetPropertyValue("value", out var valueNode))
         {
             return new DictionaryEntryRecord
             {
                 Key = key,
-                Value = expressionNode?.GetValue<string>() ?? "",
+                Value = valueNode?.GetValue<string>() ?? "",
                 ExpressionType = typeNode?.GetValue<string>() ?? defaultExpressionType
             };
         }
@@ -86,12 +86,19 @@ public partial class Dictionary
         {
             Key = key,
             Value = value?.ToString() ?? "",
-            ExpressionType = defaultExpressionType
+            ExpressionType = "Literal" // Default to Literal for raw values
         };
     }
 
     private KeyValuePair<string, object> Map(DictionaryEntryRecord entry)
     {
+        // For literal values, just store the raw string value
+        if (entry.ExpressionType == "Literal")
+        {
+            return new KeyValuePair<string, object>(entry.Key, entry.Value);
+        }
+        
+        // For other expression types, wrap in Expression object
         var expression = new Expression(entry.ExpressionType, entry.Value);
         return new KeyValuePair<string, object>(entry.Key, expression);
     }

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Resources.Scripting.Models;
-using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Models;
 using Elsa.Studio.UIHints.Helpers;
 using Elsa.Studio.Workflows.Domain.Models;
@@ -19,15 +18,15 @@ public partial class Dictionary
 
     private DictionaryEntryRecord? _entryBeingEdited;
     private DictionaryEntryRecord? _entryBeingAdded;
-    private MudTable<DictionaryEntryRecord> _table = default!;
+    private MudTable<DictionaryEntryRecord> _table = null!;
 
     /// <summary>
     /// The context for the editor.
     /// </summary>
     [Parameter]
-    public DisplayInputEditorContext EditorContext { get; set; } = default!;
+    public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
-    [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
+    [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = null!;
 
     private ICollection<DictionaryEntryRecord> Items { get; set; } = new List<DictionaryEntryRecord>();
     private bool DisableAddButton => _entryBeingEdited != null || _entryBeingAdded != null;
@@ -105,7 +104,7 @@ public partial class Dictionary
 
     private Task SaveChangesAsync()
     {
-        var dictionary = Items.ToDictionary(x => x.Key, x => (object)Map(x).Value);
+        var dictionary = Items.ToDictionary(x => x.Key, x => Map(x).Value);
         return EditorContext.UpdateValueOrObjectExpressionAsync(dictionary);
     }
 

--- a/src/modules/Elsa.Studio.UIHints/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.UIHints/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
             .AddUIHintHandler<SingleLineHandler>()
             .AddUIHintHandler<CheckboxHandler>()
             .AddUIHintHandler<CheckListHandler>()
+            .AddUIHintHandler<DictionaryHandler>()
             .AddUIHintHandler<MultiTextHandler>()
             .AddUIHintHandler<MultiLineHandler>()
             .AddUIHintHandler<DropDownHandler>()

--- a/src/modules/Elsa.Studio.UIHints/Handlers/DictionaryHandler.cs
+++ b/src/modules/Elsa.Studio.UIHints/Handlers/DictionaryHandler.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Models;
+using Elsa.Studio.UIHints.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.UIHints.Handlers;
+
+/// <summary>
+/// Provides a handler for the <see cref="InputUIHints.Dictionary"/> UI hint.
+/// </summary>
+public class DictionaryHandler : IUIHintHandler
+{
+    /// <inheritdoc />
+    public bool GetSupportsUIHint(string uiHint) => uiHint is InputUIHints.Dictionary;
+
+    /// <inheritdoc />
+    public string UISyntax => WellKnownSyntaxNames.Object;
+
+    /// <inheritdoc />
+    public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
+    {
+        return builder =>
+        {
+            builder.OpenComponent(0, typeof(Dictionary));
+            builder.AddAttribute(1, nameof(Dictionary.EditorContext), context);
+            builder.CloseComponent();
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.UIHints/InputUIHints.cs
+++ b/src/modules/Elsa.Studio.UIHints/InputUIHints.cs
@@ -9,6 +9,7 @@ public static class InputUIHints
     public const string CheckList = "checklist";
     public const string CodeEditor = "code-editor";
     public const string DateTimePicker = "datetime-picker";
+    public const string Dictionary = "dictionary";
     public const string DropDown = "dropdown";
     public const string DynamicOutcomes = "dynamic-outcomes";
     public const string ExpressionEditor = "expression-editor";


### PR DESCRIPTION
This pull request introduces a new UI hint handler and editor component for managing dictionary-type inputs in Elsa Studio. The main changes include adding the `DictionaryHandler` to the UI hints system, implementing the `Dictionary` editor component with support for key-value pairs and expression types, and updating relevant registration and constant files to support this new feature.

### New Dictionary UI Hint Feature

* Added the `DictionaryHandler` class to handle the new `dictionary` UI hint, enabling dictionary editing capabilities in the UI hints system. (`src/modules/Elsa.Studio.UIHints/Handlers/DictionaryHandler.cs`)
* Defined the new `Dictionary` UI hint constant in `InputUIHints`. (`src/modules/Elsa.Studio.UIHints/InputUIHints.cs`)

### Dictionary Editor Component

* Implemented the `Dictionary` editor component (`Dictionary.razor` and `Dictionary.razor.cs`), providing a UI for viewing, adding, editing, and deleting key-value pairs, each with an associated expression type. The component supports localization and integrates with the expression descriptor system. (`src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor`, `src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs`) [[1]](diffhunk://#diff-cf83ad5f6b07b296a4908537c5cbf259699993d515485b5fb00a5b96c6d2e30cR1-R76) [[2]](diffhunk://#diff-a32d6fce26eb0b9bd3628045516a00a9222054cd9ed544da357f465e43fbfca4R1-R206)