### PR TITLE
Fix/dictionary attributes expresions

### DIFF
--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -98,7 +98,7 @@ public class DisplayInputEditorContext
         var wrappedInput = Value as WrappedInput;
         var expression = wrappedInput?.Expression;
 
-        if (expression?.Type is not "Object" and not "JavaScript")
+        if (expression?.Type is not "Object")
             return Serialize(InputDescriptor.DefaultValue);
 
         var value = expression.Value;
@@ -107,7 +107,7 @@ public class DisplayInputEditorContext
 
     /// <summary>
     /// Returns the input expression value if this is a wrapped input (i.e. Input{T}) or naked value otherwise. If either value is null, the default value is returned.
-    /// </summary>  
+    /// </summary>
     public string GetExpressionValueOrDefault()
     {
         if (!InputDescriptor.IsWrapped)

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -98,7 +98,7 @@ public class DisplayInputEditorContext
         var wrappedInput = Value as WrappedInput;
         var expression = wrappedInput?.Expression;
 
-        if (expression?.Type != "Object")
+        if (expression?.Type is not "Object" and not "JavaScript")
             return Serialize(InputDescriptor.DefaultValue);
 
         var value = expression.Value;
@@ -107,7 +107,7 @@ public class DisplayInputEditorContext
 
     /// <summary>
     /// Returns the input expression value if this is a wrapped input (i.e. Input{T}) or naked value otherwise. If either value is null, the default value is returned.
-    /// </summary>
+    /// </summary>  
     public string GetExpressionValueOrDefault()
     {
         if (!InputDescriptor.IsWrapped)

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
@@ -7,70 +7,72 @@
     var description = inputDescriptor.Description;
 }
 
+<ExpressionInput EditorContext="@EditorContext">
 <MudStack>
-    <MudField 
-        Label="@Localizer[displayName]" 
-        HelperText="@Localizer[description]" 
-        Margin="Margin.None" 
-        Underline="true" 
-        Variant="Variant.Text">
-        <MudTable
-            @ref="_table"
-            Items="Items"
-            Dense="true"
-            Elevation="0"
-            FixedHeader="true"
-            Striped="true"
-            EditTrigger="TableEditTrigger.EditButton"
-            EditButtonPosition="TableEditButtonPosition.Start"
-            ApplyButtonPosition="TableApplyButtonPosition.Start"
-            Outlined="true"
-            CanCancelEdit="true"
-            RowEditPreview="OnRowEditPreview"
-            RowEditCancel="OnRowEditCancel"
-            RowEditCommit="OnRowEditCommitted"
-            ReadOnly="EditorContext.IsReadOnly">
-            <HeaderContent>
-                <MudTh Style="width: 25%">@Localizer["Key"]</MudTh>
-                <MudTh Style="width: 50%;">@Localizer["Value"]</MudTh>
-                <MudTh Style="width: 15%;">@Localizer["Type"]</MudTh>
-                <MudTh Style="width: 40px;"></MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd DataLabel="Key">@context.Key</MudTd>
-                <MudTd DataLabel="Value">@context.Value</MudTd>
-                <MudTd DataLabel="ExpressionType">@GetExpressionTypeDisplayName(@context.ExpressionType)</MudTd>
-                <MudTd>
-                    <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="EditorContext.IsReadOnly"></MudIconButton>
-                </MudTd>
-            </RowTemplate>
-            <RowEditingTemplate>
-                <MudTd DataLabel="Key">
-                    <MudTextField @bind-Value="@context.Key" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
-                </MudTd>
-                <MudTd DataLabel="Value">
-                    <MudTextField @bind-Value="@context.Value" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
-                </MudTd>
-                <MudTd DataLabel="ExpressionType">
-                    <MudSelect @bind-Value="@context.ExpressionType" Variant="Variant.Outlined" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly">
-                        @foreach (var expressionDescriptor in GetSupportedExpressions())
-                        {
-                            <MudSelectItem Value="@expressionDescriptor.Type">@expressionDescriptor.DisplayName</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudTd>
-            </RowEditingTemplate>
-            <NoRecordsContent>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" OnClick="OnAddClicked" Disabled="EditorContext.IsReadOnly">
-                    @Localizer["Add entry"]
-                </MudButton>
-            </NoRecordsContent>
-        </MudTable>
-    </MudField>
-    @if (Items.Any())
-    {
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" Class="align-self-start" Disabled="@(DisableAddButton || EditorContext.IsReadOnly)" OnClick="OnAddClicked">
-            @Localizer["Add entry"]
-        </MudButton>
-    }
+        <MudField
+            Label="@Localizer[displayName]"
+            HelperText="@Localizer[description]"
+            Margin="Margin.None"
+            Underline="true"
+            Variant="Variant.Text">
+            <MudTable
+                @ref="_table"
+                Items="Items"
+                Dense="true"
+                Elevation="0"
+                FixedHeader="true"
+                Striped="true"
+                EditTrigger="TableEditTrigger.EditButton"
+                EditButtonPosition="TableEditButtonPosition.Start"
+                ApplyButtonPosition="TableApplyButtonPosition.Start"
+                Outlined="true"
+                CanCancelEdit="true"
+                RowEditPreview="OnRowEditPreview"
+                RowEditCancel="OnRowEditCancel"
+                RowEditCommit="OnRowEditCommitted"
+                ReadOnly="EditorContext.IsReadOnly">
+                <HeaderContent>
+                    <MudTh Style="width: 25%">@Localizer["Key"]</MudTh>
+                    <MudTh Style="width: 50%;">@Localizer["Value"]</MudTh>
+                    <MudTh Style="width: 15%;">@Localizer["Type"]</MudTh>
+                    <MudTh Style="width: 40px;"></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Key">@context.Key</MudTd>
+                    <MudTd DataLabel="Value">@context.Value</MudTd>
+                    <MudTd DataLabel="ExpressionType">@GetExpressionTypeDisplayName(@context.ExpressionType)</MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="EditorContext.IsReadOnly"></MudIconButton>
+                    </MudTd>
+                </RowTemplate>
+                <RowEditingTemplate>
+                    <MudTd DataLabel="Key">
+                        <MudTextField @bind-Value="@context.Key" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+                    </MudTd>
+                    <MudTd DataLabel="Value">
+                        <MudTextField @bind-Value="@context.Value" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly"></MudTextField>
+                    </MudTd>
+                    <MudTd DataLabel="ExpressionType">
+                        <MudSelect @bind-Value="@context.ExpressionType" Variant="Variant.Outlined" ReadOnly="EditorContext.IsReadOnly" Disabled="EditorContext.IsReadOnly">
+                            @foreach (var expressionDescriptor in GetSupportedExpressions())
+                            {
+                                <MudSelectItem Value="@expressionDescriptor.Type">@expressionDescriptor.DisplayName</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudTd>
+                </RowEditingTemplate>
+                <NoRecordsContent>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" OnClick="OnAddClicked" Disabled="EditorContext.IsReadOnly">
+                        @Localizer["Add entry"]
+                    </MudButton>
+                </NoRecordsContent>
+            </MudTable>
+        </MudField>
+        @if (Items.Any())
+        {
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Outlined.Add" Class="align-self-start" Disabled="@(DisableAddButton || EditorContext.IsReadOnly)" OnClick="OnAddClicked">
+                @Localizer["Add entry"]
+            </MudButton>
+        }
 </MudStack>
+</ExpressionInput>

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -47,10 +47,6 @@ public partial class Dictionary
 
     private IDictionary<string, object?> ParseJson(string? json)
     {
-        if (json is not null && json.StartsWith("return "))
-        {
-            json = json["return ".Length..].Trim();
-        }
         var options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -37,7 +37,6 @@ public partial class Dictionary
     private ICollection<DictionaryEntryRecord> GetItems()
     {
         var input = EditorContext.GetObjectValueOrDefault();
-        var aaaaa = EditorContext.GetExpressionValueOrDefault();
         var dictionary = ParseJson(input);
         var entryRecords = dictionary.Select(kvp => Map(kvp.Key, kvp.Value)).ToList();
         return entryRecords;

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -82,7 +82,7 @@ public partial class Dictionary
         }
 
         // Try to extract expression information from the value if it's a JsonObject (legacy handling)
-        if (value is JsonElement { ValueKind: JsonValueKind.Object } jsonElement ) 
+        if (value is JsonElement { ValueKind: JsonValueKind.Object } jsonElement) 
         {
             if (jsonElement.TryGetProperty("type", out var typeNode) && jsonElement.TryGetProperty("value", out var valueNode))
             {

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -47,6 +47,10 @@ public partial class Dictionary
 
     private IDictionary<string, object?> ParseJson(string? json)
     {
+        if (json is not null && json.StartsWith("return "))
+        {
+            json = json["return ".Length..].Trim();
+        }
         var options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase


### PR DESCRIPTION
This pull request introduces several improvements to the handling and rendering of dictionary input editors, particularly around expression support and value parsing. The main changes enhance support for new expression types, improve parsing logic for expressions, and refactor how default expression types are determined and mapped.

**Expression Handling and Parsing Enhancements:**

* Improved expression type support in `GetObjectValueOrDefault()`: Now supports both `"Object"` and `"JavaScript"` types, allowing for broader expression handling.
* Enhanced parsing logic in `ParseJson()`: Strips the `"return "` prefix from JSON strings to correctly parse JavaScript expressions.

**Refactoring and Rendering Improvements:**

* Refactored default expression type determination: `GetDefaultExpressionType()` now dynamically selects the first supported expression type, improving flexibility for new entries.
* Improved mapping of dictionary entry records: The `Map()` method now directly handles `Expression` objects and legacy `JsonObject`/`JsonElement` types, ensuring accurate extraction of expression type and value.
* UI rendering update: Wrapped the dictionary editor UI in an `ExpressionInput` component to improve integration and user experience. [[1]](diffhunk://#diff-cf83ad5f6b07b296a4908537c5cbf259699993d515485b5fb00a5b96c6d2e30cR10) [[2]](diffhunk://#diff-cf83ad5f6b07b296a4908537c5cbf259699993d515485b5fb00a5b96c6d2e30cR78)