### PR TITLE
Add activity tab registry for managing activity editor tabs

### DIFF
--- a/src/framework/Elsa.Studio.Core/Contracts/IActivityTab.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IActivityTab.cs
@@ -1,15 +1,29 @@
 ﻿using Microsoft.AspNetCore.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Elsa.Studio.Contracts;
 
+/// <summary>
+/// Represents a contract for defining activity tabs within the application.
+/// </summary>
 public interface IActivityTab
 {
+    /// <summary>
+    /// Gets the title of the activity tab. This property represents a user-facing label or name
+    /// for the tab within the user interface, displayed as the tab header text.
+    /// </summary>
     string Title { get; }
 
+    /// <summary>
+    /// Gets the order of the tab in relation to other tabs.
+    /// This property determines the relative position of the tab when displayed, allowing tabs to
+    /// be sorted or organized based on their numerical order value.
+    /// </summary>
+    double Order { get; }
+
+    /// <summary>
+    /// Defines a rendering function for an activity tab. This function takes a dictionary of attributes
+    /// as its input and returns a <see cref="RenderFragment"/> that describes the content to be rendered
+    /// within the tab.
+    /// </summary>
     Func<IDictionary<string, object?>, RenderFragment> Render { get; }
 }

--- a/src/framework/Elsa.Studio.Core/Contracts/IActivityTabRegistry.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IActivityTabRegistry.cs
@@ -1,0 +1,19 @@
+namespace Elsa.Studio.Contracts;
+
+/// <summary>
+/// Provides functionality for managing activity editor tabs in the system.
+/// </summary>
+public interface IActivityTabRegistry
+{
+    /// <summary>
+    /// Adds a new activity tab to the registry.
+    /// </summary>
+    /// <param name="tab">The activity tab to be added. The <see cref="IActivityTab"/> represents a tab with a title and render logic for the editor.</param>
+    void Add(IActivityTab tab);
+
+    /// <summary>
+    /// Retrieves all activity tabs that have been added to the registry.
+    /// </summary>
+    /// <returns>An enumerable collection of <see cref="IActivityTab"/> instances currently registered.</returns>
+    IEnumerable<IActivityTab> List();
+}

--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IServerInformationProvider, EmptyServerInformationProvider>()
             .AddScoped<IClientInformationProvider, AssemblyClientInformationProvider>()
             .AddScoped<IWidgetRegistry, DefaultWidgetRegistry>()
+            .AddScoped<IActivityTabRegistry, DefaultActivityTabRegistry>()
             ;
         
         // Mediator.

--- a/src/framework/Elsa.Studio.Core/Services/DefaultActivityTabRegistry.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultActivityTabRegistry.cs
@@ -8,7 +8,7 @@ public class DefaultActivityTabRegistry : IActivityTabRegistry
     private HashSet<IActivityTab> ActivityTabs { get; set; } = new();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DefaultWidgetRegistry"/> class.
+    /// Initializes a new instance of the <see cref="DefaultActivityTabRegistry"/> class.
     /// </summary>
     public DefaultActivityTabRegistry(IEnumerable<IActivityTab> widgets)
     {

--- a/src/framework/Elsa.Studio.Core/Services/DefaultActivityTabRegistry.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultActivityTabRegistry.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Contracts;
+
+namespace Elsa.Studio.Services;
+
+/// <inheritdoc />
+public class DefaultActivityTabRegistry : IActivityTabRegistry
+{
+    private HashSet<IActivityTab> ActivityTabs { get; set; } = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultWidgetRegistry"/> class.
+    /// </summary>
+    public DefaultActivityTabRegistry(IEnumerable<IActivityTab> widgets)
+    {
+        foreach (var widget in widgets) Add(widget);
+    }
+
+    /// <inheritdoc />
+    public void Add(IActivityTab tab)
+    {
+        ActivityTabs.Add(tab);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<IActivityTab> List()
+    {
+        return ActivityTabs.OrderBy(x => x.Order);
+    }
+}

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Elsa.Studio.Branding;
 using Elsa.Studio.Host.Server;
 using Elsa.Studio.Login.Extensions;
+using Elsa.Studio.WorkflowContexts.Extensions;
 
 // Build the host.
 var builder = WebApplication.CreateBuilder(args);
@@ -81,6 +82,7 @@ builder.Services.AddWebhooksModule();
 builder.Services.AddSecretsModule(backendApiConfig);
 builder.Services.AddLocalizationModule(localizationConfig);
 builder.Services.AddTranslations();
+builder.Services.AddWorkflowContextsModule();
 
 // Replace some services with other implementations.
 builder.Services.AddScoped<ITimeZoneProvider, LocalTimeZoneProvider>();

--- a/src/modules/Elsa.Studio.WorkflowContexts/ActivityTabs/WorkflowContextActivityTab.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/ActivityTabs/WorkflowContextActivityTab.cs
@@ -2,27 +2,28 @@
 using Elsa.Studio.Localization;
 using Elsa.Studio.WorkflowContexts.Components;
 using Microsoft.AspNetCore.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Elsa.Studio.WorkflowContexts.ActivityTabs
+namespace Elsa.Studio.WorkflowContexts.ActivityTabs;
+
+/// <summary>
+/// Represents an activity tab that displays the workflow context in the Elsa Studio interface.
+/// </summary>
+public class WorkflowContextActivityTab(ILocalizer localizer) : IActivityTab
 {
-    public class WorkflowContextActivityTab(ILocalizer localizer) : IActivityTab
+    /// <inheritdoc />
+    public string Title => localizer["Workflow Context"];
+
+    /// <inheritdoc />
+    public double Order => 50;
+
+    /// <inheritdoc />
+    public Func<IDictionary<string, object?>, RenderFragment> Render => attributes => builder =>
     {
-        public string Title => localizer["Workflow Context"];
-
-        public Func<IDictionary<string, object?>, RenderFragment> Render => attributes => builder =>
-        {
-            builder.OpenComponent<WorkflowContextActivityTabPanel>(0);
-            builder.AddAttribute(1, nameof(WorkflowContextActivityTabPanel.WorkflowDefinition), attributes["WorkflowDefinition"]);
-            builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.Activity), attributes["Activity"]);
-            builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.ActivityDescriptor), attributes["ActivityDescriptor"]);
-            builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.OnActivityUpdated), attributes["OnActivityUpdated"]);
-            builder.CloseComponent();
-        };
-
-    }
+        builder.OpenComponent<WorkflowContextActivityTabPanel>(0);
+        builder.AddAttribute(1, nameof(WorkflowContextActivityTabPanel.WorkflowDefinition), attributes["WorkflowDefinition"]);
+        builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.Activity), attributes["Activity"]);
+        builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.ActivityDescriptor), attributes["ActivityDescriptor"]);
+        builder.AddAttribute(2, nameof(WorkflowContextActivityTabPanel.OnActivityUpdated), attributes["OnActivityUpdated"]);
+        builder.CloseComponent();
+    };
 }

--- a/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ActivityExtensions.cs
@@ -1,20 +1,31 @@
 ﻿using Elsa.Api.Client.Extensions;
 using Elsa.Studio.WorkflowContexts.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json.Nodes;
-using System.Threading.Tasks;
 
-namespace Elsa.Studio.WorkflowContexts.Extensions
+namespace Elsa.Studio.WorkflowContexts.Extensions;
+
+/// <summary>
+/// Provides extension methods for managing workflow context settings associated with activities.
+/// </summary>
+public static class ActivityExtensions
 {
-    public static class ActivityExtensions
+    /// <summary>
+    /// Sets the workflow context settings for a given activity.
+    /// </summary>
+    /// <param name="activity">The activity to which the workflow context settings will be applied.</param>
+    /// <param name="value">The workflow context settings to associate with the specified activity.</param>
+    public static void SetWorkflowContextSettings(this JsonObject activity, Dictionary<string, ActivityWorkflowContextSettings> value)
     {
-        public static void SetWorkflowContextSettings(this JsonObject activity, Dictionary<string, ActivityWorkflowContextSettings> value) =>
-            activity.SetProperty(JsonValue.Create(value), "customProperties", "ActivityWorkflowContextSettingsKey");
+        activity.SetProperty(JsonValue.Create(value), "customProperties", "ActivityWorkflowContextSettingsKey");
+    }
 
-        public static Dictionary<string, ActivityWorkflowContextSettings> GetWorkflowContextSettings(this JsonObject activity) =>
-            activity.GetProperty<Dictionary<string, ActivityWorkflowContextSettings>>("customProperties", "ActivityWorkflowContextSettingsKey");
+    /// <summary>
+    /// Retrieves the workflow context settings associated with a given activity.
+    /// </summary>
+    /// <param name="activity">The activity from which to retrieve the workflow context settings.</param>
+    /// <returns>A dictionary containing the workflow context settings associated with the specified activity.</returns>
+    public static Dictionary<string, ActivityWorkflowContextSettings> GetWorkflowContextSettings(this JsonObject activity)
+    {
+        return activity.GetProperty<Dictionary<string, ActivityWorkflowContextSettings>>("customProperties", "ActivityWorkflowContextSettingsKey");
     }
 }

--- a/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Extensions/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using Elsa.Studio.WorkflowContexts.Handlers;
 using Elsa.Studio.WorkflowContexts.Services;
 using Elsa.Studio.Extensions;
 using Microsoft.Extensions.DependencyInjection;
-using Elsa.Studio.WorkflowContexts.ActivityTabs;
 
 namespace Elsa.Studio.WorkflowContexts.Extensions;
 
@@ -22,7 +21,6 @@ public static class ServiceCollectionExtensions
                 .AddScoped<IFeature, Feature>()
                 .AddScoped<IWorkflowContextsProvider, RemoteWorkflowContextsProvider>()
                 .AddUIHintHandler<WorkflowContextProviderPickerHandler>()
-                .AddScoped<IActivityTab, WorkflowContextActivityTab>()
             ;
     }
 }

--- a/src/modules/Elsa.Studio.WorkflowContexts/Feature.cs
+++ b/src/modules/Elsa.Studio.WorkflowContexts/Feature.cs
@@ -1,6 +1,8 @@
 using Elsa.Studio.Abstractions;
 using Elsa.Studio.Attributes;
 using Elsa.Studio.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.WorkflowContexts.ActivityTabs;
 using Elsa.Studio.WorkflowContexts.Widgets;
 
 namespace Elsa.Studio.WorkflowContexts;
@@ -9,20 +11,13 @@ namespace Elsa.Studio.WorkflowContexts;
 /// Registers the workflow contexts feature.
 /// </summary>
 [RemoteFeature("Elsa.WorkflowContexts")]
-public class Feature : FeatureBase
+public class Feature(IWidgetRegistry widgetRegistry, IActivityTabRegistry activityTabRegistry, ILocalizer localizer) : FeatureBase
 {
-    private readonly IWidgetRegistry _widgetRegistry;
-
-    /// <inheritdoc />
-    public Feature(IWidgetRegistry widgetRegistry)
-    {
-        _widgetRegistry = widgetRegistry;
-    }
-    
     /// <inheritdoc />
     public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
-        _widgetRegistry.Add(new WorkflowContextsEditorWidget());
+        widgetRegistry.Add(new WorkflowContextsEditorWidget());
+        activityTabRegistry.Add(new WorkflowContextActivityTab(localizer));
         return default;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -45,10 +45,9 @@ public partial class ActivityPropertiesPanel
     public int VisiblePaneHeight { get; set; }
 
     [Inject] private IExpressionService ExpressionService { get; set; } = null!;
-
-    [Inject] private IEnumerable<IActivityTab> PluginTabs { get; set; } = new List<IActivityTab>();
     [Inject] private IRemoteFeatureProvider RemoteFeatureProvider { get; set; } = null!;
-
+    [Inject] private IActivityTabRegistry ActivityTabRegistry { get; set; } = null!;
+    private IEnumerable<IActivityTab> PluginTabs { get; set; } = new List<IActivityTab>();
     private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; } = new();
     private bool IsResilienceEnabled { get; set; }
     private bool IsResilientActivity => ActivityDescriptor?.CustomProperties.TryGetValue("Resilient", out var resilientObj) == true && resilientObj.ConvertTo<bool>();  
@@ -57,9 +56,10 @@ public partial class ActivityPropertiesPanel
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        var descriptors = await ExpressionService.ListDescriptorsAsync();
+        var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
-        ExpressionDescriptorProvider.AddRange(descriptors);
+        ExpressionDescriptorProvider.AddRange(expressionDescriptors);
+        PluginTabs = ActivityTabRegistry.List().ToList();
     }
 
     private bool IsWorkflowAsActivity => ActivityDescriptor != null && ActivityDescriptor.CustomProperties.TryGetValue("RootType", out var value) && value.ConvertTo<string>() == "WorkflowDefinitionActivity";


### PR DESCRIPTION
Introduced `IActivityTabRegistry` and `DefaultActivityTabRegistry` to manage activity editor tabs in a centralized way. Updated relevant implementations to use the registry for better extensibility and organization.

Fixes #581