### PR TITLE
Add pkce support for oidc auth flow (#519)

### DIFF
--- a/src/modules/Elsa.Studio.Login.BlazorServer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorServer/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ public static class ServiceCollectionExtensions
         // Register JWT services.
         services.AddSingleton<IJwtParser, BlazorServerJwtParser>();
         services.AddScoped<IJwtAccessor, BlazorServerJwtAccessor>();
+
+        services.AddScoped<IOpenIdConnectPkceStateService, BlazorServerOpenIdConnectPkceStateService>();
         
         return services;
     }

--- a/src/modules/Elsa.Studio.Login.BlazorServer/Services/BlazorServerOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorServer/Services/BlazorServerOpenIdConnectPkceStateService.cs
@@ -1,0 +1,34 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Services;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Elsa.Studio.Login.BlazorServer.Services
+{
+    /// inherit doc
+    public class BlazorServerOpenIdConnectPkceStateService : IOpenIdConnectPkceStateService
+    {
+        private readonly ProtectedSessionStorage _protectedSessionStorage;
+
+        /// inherit doc
+        public BlazorServerOpenIdConnectPkceStateService(ProtectedSessionStorage protectedSessionStorage)
+        {
+            _protectedSessionStorage = protectedSessionStorage;
+        }
+
+        /// inherit doc
+        public async Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge()
+        {
+            var pkce = OpenIdConnectPkceCodeGenerator.GenerateCodeChallengeAndVerifier();
+            await _protectedSessionStorage.SetAsync("pkceCodeVerifier", pkce.CodeVerifier);
+
+            return (pkce.CodeChallenge, pkce.Method);
+        }
+
+        /// inherit doc
+        public async Task<string> GetPkceCodeVerifier()
+        {
+            var verifier = await _protectedSessionStorage.GetAsync<string>("pkceCodeVerifier");
+            return verifier.Success && verifier.Value != null ? verifier.Value : throw new Exception("PKCE code verifier not found in session storage.");
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ public static class ServiceCollectionExtensions
         // Register JWT services.
         services.AddSingleton<IJwtParser, BlazorWasmJwtParser>();
         services.AddScoped<IJwtAccessor, BlazorWasmJwtAccessor>();
+
+        services.AddScoped<IOpenIdConnectPkceStateService, BlazorWasmOpenIdConnectPkceStateService>();
         
         return services;
     }

--- a/src/modules/Elsa.Studio.Login.BlazorWasm/Services/BlazorWasmOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login.BlazorWasm/Services/BlazorWasmOpenIdConnectPkceStateService.cs
@@ -1,0 +1,33 @@
+﻿using Elsa.Studio.Login.Contracts;
+using Elsa.Studio.Login.Services;
+using Microsoft.JSInterop;
+
+namespace Elsa.Studio.Login.BlazorWasm.Services
+{
+    /// inherit doc
+    public class BlazorWasmOpenIdConnectPkceStateService : IOpenIdConnectPkceStateService
+    {
+        private readonly IJSRuntime _js;
+
+        /// inherit doc  
+        public BlazorWasmOpenIdConnectPkceStateService(IJSRuntime js)
+        {
+            _js = js;
+        }
+
+        /// inherit doc
+        public async Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge()
+        {
+            var pkce = OpenIdConnectPkceCodeGenerator.GenerateCodeChallengeAndVerifier();
+            await _js.InvokeVoidAsync("sessionStorage.setItem", "pkceCodeVerifier", pkce.CodeVerifier);
+
+            return (pkce.CodeChallenge, pkce.Method);
+        }
+
+        /// inherit doc
+        public async Task<string> GetPkceCodeVerifier()
+        {
+            return await _js.InvokeAsync<string>("sessionStorage.getItem", "pkceCodeVerifier");
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
+++ b/src/modules/Elsa.Studio.Login/Components/RedirectToLogin.cs
@@ -14,8 +14,8 @@ public class RedirectToLogin : ComponentBase
     [Inject] protected IAuthorizationService AuthorizationService { get; set; } = default!;
 
     /// <inheritdoc />
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        return AuthorizationService.RedirectToAuthorizationServer();
+        await AuthorizationService.RedirectToAuthorizationServer();
     }
 }

--- a/src/modules/Elsa.Studio.Login/Contracts/IOpenIdConnectPkceStateService.cs
+++ b/src/modules/Elsa.Studio.Login/Contracts/IOpenIdConnectPkceStateService.cs
@@ -1,0 +1,18 @@
+﻿namespace Elsa.Studio.Login.Contracts
+{
+    /// <summary>
+    /// Manages PKCE (Proof Key for Code Exchange) state for the authorization code flow.
+    /// </summary>
+    public interface IOpenIdConnectPkceStateService
+    {
+        /// <summary>
+        /// Generates and returns a PKCE code challedge. The associated code verifier is stored in session storage.
+        /// </summary>
+        Task<(string CodeChallenge, string Method)> GeneratePkceCodeChallenge();
+
+        /// <summary>
+        /// Retrieves the code verifier for the current session.
+        /// </summary>
+        Task<string> GetPkceCodeVerifier();
+    }
+}

--- a/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
+++ b/src/modules/Elsa.Studio.Login/Models/OpenIdConnectConfiguration.cs
@@ -29,4 +29,9 @@ public class OpenIdConnectConfiguration
     /// The scopes to request, defaulting to: openid profile offline_access
     /// </summary>
     public string[] Scopes { get; set; } = ["openid", "profile", "offline_access"];
+
+    /// <summary>
+    /// Enables PKCE (Proof Key for Code Exchange) for the authorization code flow.
+    /// </summary>
+    public bool UsePkce { get; set; } = false;
 }

--- a/src/modules/Elsa.Studio.Login/Services/OpenIdConnectPkceCodeGenerator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OpenIdConnectPkceCodeGenerator.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Elsa.Studio.Login.Services
+{
+    /// <summary>
+    /// Used to generate PKCE (Proof Key for Code Exchange) codes for use in the authorization code flow.
+    /// </summary>
+    public static class OpenIdConnectPkceCodeGenerator
+    {
+        /// <summary>
+        /// Generates PKCE (Proof Key for Code Exchange) code challenge and verifier.
+        /// </summary>
+        public static (string CodeChallenge, string CodeVerifier, string Method) GenerateCodeChallengeAndVerifier()
+        {
+            using var rng = RandomNumberGenerator.Create();
+            var randomBytes = new byte[32];
+            rng.GetBytes(randomBytes);
+            var verifier = WebEncoders.Base64UrlEncode(randomBytes);
+            var buffer = Encoding.UTF8.GetBytes(verifier);
+            var hash = SHA256.HashData(buffer);
+            var challenge = WebEncoders.Base64UrlEncode(hash);
+
+            return (CodeChallenge: challenge, CodeVerifier: verifier, Method: "S256");
+        }
+    }
+}


### PR DESCRIPTION
Add pkce support for oidc auth flow (#519)
This Pull Request merge the PKCE support for oidc client settings
it should fix the below oidc provider error when the client is using PKCE support in client settings in oidc provider
sample of the error below from Identity Server 4 

Identity Server Error:  {"DisplayMode":null,"UiLocales":null,"Error":"invalid_request","ErrorDescription":"code challenge required","RequestId":"0HNF6005QIU1B:00000001","RedirectUri":"https://localhost:7052/signin-oidc?error=invalid_request&error_description=code%20challenge%20required#_=_","ResponseMode":"query","ClientId":"ELSA-STUDIO"}

Notes:
- the elsa studio is hosted in blazor web assembly standalone project
- the settings for the elsa studio in app startup should be as below

```Csharp
builder.Services.UseOpenIdConnect(c =>
{
    c.AuthEndpoint = "https://localhost:5001/connect/authorize";
    c.ClientId = "ELSA-STUDIO";
    c.EndSessionEndpoint = "https://localhost:5001/connect/endsession";
    c.TokenEndpoint = "https://localhost:5001/connect/token";
    c.Scopes = ["openid", "profile", "email", "offline_access"];
    c.UsePkce = true; // Add this new line
});