### PR TITLE
Enhances HTTP request activity with failure ports

### DIFF
--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IExpressionService, DefaultExpressionService>()
             .AddScoped<IStartupTaskRunner, DefaultStartupTaskRunner>()
             .AddScoped<IServerInformationProvider, EmptyServerInformationProvider>()
-            .AddScoped<IClientInformationProvider, AssemblyClientInformationProvider>()
+            .AddScoped<IClientInformationProvider, StaticClientInformationProvider>()
             .AddScoped<IWidgetRegistry, DefaultWidgetRegistry>()
             .AddScoped<IActivityTabRegistry, DefaultActivityTabRegistry>()
             ;

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
@@ -32,7 +32,7 @@ public class FlowHttpRequestPortProvider : ActivityPortProviderBase
 
         foreach (var statusCode in expectedStatusCodes)
         {
-            yield return new Port
+            yield return new()
             {
                 Name = statusCode.ToString(),
                 Type = PortType.Flow,
@@ -40,28 +40,28 @@ public class FlowHttpRequestPortProvider : ActivityPortProviderBase
             };
         }
         
-        yield return new Port
+        yield return new()
         {
             Name = "Unmatched status code",
             Type = PortType.Flow,
             DisplayName = "Unmatched status code"
         };
         
-        yield return new Port
+        yield return new()
         {
             Name = "Failed to connect",
             Type = PortType.Flow,
             DisplayName = "Failed to connect"
         };
         
-        yield return new Port
+        yield return new()
         {
             Name = "Timeout",
             Type = PortType.Flow,
             DisplayName = "Timeout"
         };
         
-        yield return new Port
+        yield return new()
         {
             Name = "Done",
             Type = PortType.Flow,

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/SendHttpRequestPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/SendHttpRequestPortProvider.cs
@@ -26,7 +26,7 @@ public class SendHttpRequestPortProvider : ActivityPortProviderBase
         {
             var statusCode = GetStatusCode(@case);
 
-            yield return new Port
+            yield return new()
             {
                 Name = statusCode.ToString(),
                 DisplayName = statusCode.ToString(),
@@ -34,11 +34,25 @@ public class SendHttpRequestPortProvider : ActivityPortProviderBase
             };
         }
 
-        yield return new Port
+        yield return new()
         {
             Name = UnmatchedStatusCodePortName,
             DisplayName = "Unmatched status code",
             Type = PortType.Embedded,
+        };
+        
+        yield return new()
+        {
+            Name = "Failed to connect",
+            Type = PortType.Embedded,
+            DisplayName = "Failed to connect"
+        };
+        
+        yield return new()
+        {
+            Name = "Timeout",
+            Type = PortType.Embedded,
+            DisplayName = "Timeout"
         };
     }
 

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -18,13 +18,13 @@ public partial class Login
 {
     private readonly LoginModel _model = new();
     
-    [Inject] private IJwtAccessor JwtAccessor { get; set; } = default!;
-    [Inject] private ICredentialsValidator CredentialsValidator { get; set; } = default!;
-    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
-    [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
-    [Inject] private IClientInformationProvider ClientInformationProvider { get; set; } = default!;
-    [Inject] private IServerInformationProvider ServerInformationProvider { get; set; } = default!;
+    [Inject] private IJwtAccessor JwtAccessor { get; set; } = null!;
+    [Inject] private ICredentialsValidator CredentialsValidator { get; set; } = null!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = null!;
+    [Inject] private ISnackbar Snackbar { get; set; } = null!;
+    [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = null!;
+    [Inject] private IClientInformationProvider ClientInformationProvider { get; set; } = null!;
+    [Inject] private IServerInformationProvider ServerInformationProvider { get; set; } = null!;
     
     private string ClientVersion { get; set; } = "3.0.0";
     private string ServerVersion { get; set; } = "3.0.0";


### PR DESCRIPTION
Adds failure ports to HTTP request activity for improved workflow handling.

Refactors port instantiations and replaces default inject values with `null!` to enforce non-nullable reference types. Updates the `IClientInformationProvider` implementation to `StaticClientInformationProvider`.

<img width="699" height="336" alt="image" src="https://github.com/user-attachments/assets/e49e0236-5e87-4bd4-9d00-92e800c376e5" />
