### PR TITLE
Add XML documentation across public API

### DIFF
--- a/src/framework/Elsa.Studio.Core/Contracts/IAppBarService.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IAppBarService.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Contracts;
 
+/// <summary>
+/// Defines the contract for app bar service.
+/// </summary>
 public interface IAppBarService
 {
     /// <summary>

--- a/src/framework/Elsa.Studio.Core/Contracts/INotification.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/INotification.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Contracts;
 
+/// <summary>
+/// Defines the contract for notification.
+/// </summary>
 public interface INotification
 {
 }

--- a/src/framework/Elsa.Studio.Core/Contracts/IUIHintService.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IUIHintService.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Contracts;
 
+/// <summary>
+/// Defines the contract for uihint service.
+/// </summary>
 public interface IUIHintService
 {
     IUIHintHandler GetHandler(string uiHint);

--- a/src/framework/Elsa.Studio.Core/ElsaStudioIcons.cs
+++ b/src/framework/Elsa.Studio.Core/ElsaStudioIcons.cs
@@ -10,20 +10,65 @@ public static class ElsaStudioIcons
     /// </summary>
     public static class Tabler
     {
+        /// <summary>
+        /// Provides the pencil value.
+        /// </summary>
         public const string Pencil = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M4 20h4l10.5 -10.5a1.5 1.5 0 0 0 -4 -4l-10.5 10.5v4" />  <line x1="13.5" y1="6.5" x2="17.5" y2="10.5" /></svg>""";
+        /// <summary>
+        /// Provides the text value.
+        /// </summary>
         public const string Text = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <line x1="4" y1="6" x2="20" y2="6" />  <line x1="4" y1="18" x2="9" y2="18" />  <path d="M4 12h13a3 3 0 0 1 0 6h-4l2 -2m0 4l-2 -2" /></svg>""";
+        /// <summary>
+        /// Provides the cloud value.
+        /// </summary>
         public const string Cloud = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M7 18a4.6 4.4 0 0 1 0 -9h0a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-12" /></svg>""";
+        /// <summary>
+        /// Provides the switch diagonal value.
+        /// </summary>
         public const string SwitchDiagonal = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <polyline points="15 4 19 4 19 8" />  <line x1="14.75" y1="9.25" x2="19" y2="4" />  <line x1="5" y1="19" x2="9" y2="15" />  <polyline points="15 19 19 19 19 15" />  <line x1="5" y1="5" x2="19" y2="19" /></svg>""";
+        /// <summary>
+        /// Provides the check circle value.
+        /// </summary>
         public const string CheckCircle = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <circle cx="12" cy="12" r="9" />  <path d="M9 12l2 2l4 -4" /></svg>""";
+        /// <summary>
+        /// Provides the check shield value.
+        /// </summary>
         public const string CheckShield = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M9 12l2 2l4 -4" />  <path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" /></svg>""";
+        /// <summary>
+        /// Provides the hexagon value.
+        /// </summary>
         public const string Hexagon = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M12.971 3.54l6 3.333A2 2 0 0120 8.62v6.536a2 2 0 0 1 -1.029 1.748l-6 3.333a2 2 0 0 1 -1.942 0l-6-3.333A2 2 0 014 15.157V8.62a2 2 0 0 1 1.029 -1.748l6-3.333a2 2 0 0 1 1.942 0z" /></svg>""";
+        /// <summary>
+        /// Provides the git merge value.
+        /// </summary>
         public const string GitMerge = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M12.971 3.54l6 3.333A2 2 0 0120 8.62v6.536a2 2 0 0 1 -1.029 1.748l-6 3.333a2 2 0 0 1 -1.942 0l-6-3.333A2 2 0 014 15.157V8.62a2 2 0 0 1 1.029 -1.748l6-3.333a2 2 0 0 1 1.942 0z" /></svg>""";
+        /// <summary>
+        /// Provides the git fork value.
+        /// </summary>
         public const string GitFork = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <circle cx="12" cy="18" r="2" />  <circle cx="7" cy="6" r="2" />  <circle cx="17" cy="6" r="2" />  <path d="M7 8v2a2 2 0 0 0 2 2h6a2 2 0 0 0 2 -2v-2" />  <line x1="12" y1="12" x2="12" y2="16" /></svg>""";
+        /// <summary>
+        /// Provides the world value.
+        /// </summary>
         public const string World = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <circle cx="12" cy="12" r="9" />  <line x1="3.6" y1="9" x2="20.4" y2="9" />  <line x1="3.6" y1="15" x2="20.4" y2="15" />  <path d="M11.5 3a17 17 0 0 0 0 18" />  <path d="M12.5 3a17 17 0 0 1 0 18" /></svg>""";
+        /// <summary>
+        /// Provides the repeat one value.
+        /// </summary>
         public const string RepeatOne = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M4 12v-3a3 3 0 0 1 3 -3h13m-3 -3l3 3l-3 3" />  <path d="M20 12v3a3 3 0 0 1 -3 3h-13m3 3l-3-3l3-3" />  <path d="M11 11l1 -1v4" /></svg>""";
+        /// <summary>
+        /// Provides the back1 value.
+        /// </summary>
         public const string Back1 = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M9 11l-4 4l4 4m-4 -4h11a4 4 0 0 0 0 -8h-1" /></svg>""";
+        /// <summary>
+        /// Provides the italic value.
+        /// </summary>
         public const string Italic = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <circle cx="12" cy="18" r="2" />  <circle cx="7" cy="6" r="2" />  <circle cx="17" cy="6" r="2" />  <path d="M7 8v2a2 2 0 0 0 2 2h6a2 2 0 0 0 2 -2v-2" />  <line x1="12" y1="12" x2="12" y2="16" /></svg>""";
+        /// <summary>
+        /// Provides the rotate clockwise2 value.
+        /// </summary>
         public const string RotateClockwise2 = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <path d="M9 4.55a8 8 0 0 1 6 14.9m0 -4.45v5h5" />  <path d="M11 19.95a8 8 0 0 1 -5.3 -12.8" stroke-dasharray=".001 4.13" /></svg>""";
+        /// <summary>
+        /// Provides the flask value.
+        /// </summary>
         public const string Flask = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <line x1="9" y1="3" x2="15" y2="3" />  <line x1="10" y1="9" x2="14" y2="9" />  <path d="M10 3v6l-4 11a.7 .7 0 0 0 .5 1h11a.7 .7 0 0 0 .5 -1l-4 -11v-6" /></svg>""";
     }
 
@@ -32,11 +77,26 @@ public static class ElsaStudioIcons
     /// </summary>
     public static class Heroicons
     {
+        /// <summary>
+        /// Provides the question value.
+        /// </summary>
         public const string Question = """<svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>""";
+        /// <summary>
+        /// Provides the exclamation value.
+        /// </summary>
         public const string Exclamation = """<svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>""";
+        /// <summary>
+        /// Provides the pencil paper value.
+        /// </summary>
         public const string PencilPaper = """<svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>""";
 
+        /// <summary>
+        /// Provides the outgoing value.
+        /// </summary>
         public const string Outgoing = """<svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg><svg class="h-8 w-8 text-red-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>""";
+        /// <summary>
+        /// Provides the incoming value.
+        /// </summary>
         public const string Incoming = """<svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg><svg class="h-8 w-8 text-red-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>""";
     }
 }

--- a/src/framework/Elsa.Studio.Core/Extensions/MediatorExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/MediatorExtensions.cs
@@ -7,6 +7,9 @@ namespace Elsa.Studio.Extensions;
 /// Contains extension methods for <see cref="IMediator"/>.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Provides extension methods for mediator.
+/// </summary>
 public static class MediatorExtensions
 {
     /// <summary>

--- a/src/framework/Elsa.Studio.Core/Extensions/ObjectExtension.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ObjectExtension.cs
@@ -11,7 +11,7 @@ public static class ObjectExtension
     /// Converts the specified object to a dictionary.
     /// </summary>
     /// <param name="obj"></param>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     public static Dictionary<string, object?> ToDictionary(this object obj)
     {

--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,9 @@ public static class ServiceCollectionExtensions
         return services;
     }
     
+    /// <summary>
+    /// Provides the add remote api.
+    /// </summary>
     public static IServiceCollection AddRemoteApi<TApi>(this IServiceCollection services, BackendApiConfig? config = null) where TApi : class
     {
         services.Configure(config?.ConfigureBackendOptions ?? (_ => { }));

--- a/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizationProvider.cs
@@ -2,6 +2,9 @@
 
 internal class DefaultLocalizationProvider : ILocalizationProvider
 {
+    /// <summary>
+    /// Provides the get translation.
+    /// </summary>
     public string GetTranslation(string key)
     {
         return key;

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
@@ -1,5 +1,8 @@
 ﻿namespace Elsa.Studio.Localization;
 
+/// <summary>
+/// Defines the contract for localization provider.
+/// </summary>
 public interface ILocalizationProvider
 {
     string GetTranslation(string key);

--- a/src/framework/Elsa.Studio.Core/MenuItemGroups.cs
+++ b/src/framework/Elsa.Studio.Core/MenuItemGroups.cs
@@ -2,8 +2,17 @@ using Elsa.Studio.Models;
 
 namespace Elsa.Studio;
 
+/// <summary>
+/// Represents the menu item groups.
+/// </summary>
 public static class MenuItemGroups
 {
+    /// <summary>
+    /// Provides the general.
+    /// </summary>
     public static readonly MenuItemGroup General = new("general", "General", 0f);
+    /// <summary>
+    /// Provides the settings.
+    /// </summary>
     public static readonly MenuItemGroup Settings = new("security", "Settings", 1000f);
 }

--- a/src/framework/Elsa.Studio.Core/Models/BackendApiConfig.cs
+++ b/src/framework/Elsa.Studio.Core/Models/BackendApiConfig.cs
@@ -3,8 +3,17 @@ using Elsa.Studio.Options;
 
 namespace Elsa.Studio.Models;
 
+/// <summary>
+/// Represents the backend api config.
+/// </summary>
 public class BackendApiConfig
 {
+    /// <summary>
+    /// Gets or sets the configure http client builder action.
+    /// </summary>
     public Action<ElsaClientBuilderOptions>? ConfigureHttpClientBuilder { get; set; }
+    /// <summary>
+    /// Gets or sets the configure backend options action.
+    /// </summary>
     public Action<BackendOptions>? ConfigureBackendOptions { get; set; }
 }

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -70,7 +70,7 @@ public class DisplayInputEditorContext
     /// <summary>
     /// Returns the wrapped input literal value.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     public string GetLiteralValueOrDefault()
     {
         if (!InputDescriptor.IsWrapped)
@@ -89,7 +89,7 @@ public class DisplayInputEditorContext
     /// <summary>
     /// Returns the wrapped input object value.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     public string GetObjectValueOrDefault()
     {
         if (!InputDescriptor.IsWrapped)

--- a/src/framework/Elsa.Studio.Core/Models/Result.cs
+++ b/src/framework/Elsa.Studio.Core/Models/Result.cs
@@ -58,7 +58,7 @@ public class Result<TSuccess, TFailure>
     /// <summary>
     /// Invokes the specified handler if the result is successful.
     /// </summary>
-    /// <returns>The success result.</returns>
+    /// <returns>The result of the operation.</returns>
     public TSuccess OnSuccess(Action<TSuccess> handler)
     {
         if (!IsSuccess) return default!;
@@ -80,7 +80,7 @@ public class Result<TSuccess, TFailure>
     /// <summary>
     /// Invokes the specified handler if the result is failed.
     /// </summary>
-    /// <returns>The failed result.</returns>
+    /// <returns>The result of the operation.</returns>
     public TFailure OnFailed(Action<TFailure> handler)
     {
         if (!IsFailed) return default!;

--- a/src/framework/Elsa.Studio.Core/Services/BlazorServiceAccessor.cs
+++ b/src/framework/Elsa.Studio.Core/Services/BlazorServiceAccessor.cs
@@ -30,6 +30,9 @@ public sealed class BlazorServiceAccessor : IBlazorServiceAccessor
 
     private sealed class BlazorServiceHolder
     {
+        /// <summary>
+        /// Gets or sets the services.
+        /// </summary>
         public IServiceProvider? Services { get; set; }
     }
 }

--- a/src/framework/Elsa.Studio.Core/Services/DefaultAppBarService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultAppBarService.cs
@@ -4,14 +4,27 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Services;
 
+/// <summary>
+/// Provides the default implementation of the app bar service.
+/// </summary>
 public class DefaultAppBarService : IAppBarService
 {
     private readonly ICollection<RenderFragment> _appBarItems = new List<RenderFragment>();
     private int _appBarSequence;
     
+    /// <summary>
+    /// Occurs when the set of app bar items has changed.
+    /// </summary>
     public event Action? AppBarItemsChanged;
+    /// <summary>
+    /// Gets the configured app bar items.
+    /// </summary>
     public IEnumerable<RenderFragment> AppBarItems => _appBarItems.ToList();
     
+    /// <summary>
+    /// Adds the specified component to the application bar.
+    /// </summary>
+    /// <typeparam name="T">The type of component to add.</typeparam>
     public void AddAppBarItem<T>() where T : IComponent
     {
         _appBarItems.Add(builder => builder.CreateComponent<T>(ref _appBarSequence));

--- a/src/framework/Elsa.Studio.Core/Services/DefaultMenuGroupProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultMenuGroupProvider.cs
@@ -3,8 +3,14 @@ using Elsa.Studio.Models;
 
 namespace Elsa.Studio.Services;
 
+/// <summary>
+/// Provides default menu group services.
+/// </summary>
 public class DefaultMenuGroupProvider : IMenuGroupProvider
 {
+    /// <summary>
+    /// Provides the get menu groups async.
+    /// </summary>
     public ValueTask<IEnumerable<MenuItemGroup>> GetMenuGroupsAsync(CancellationToken cancellationToken = default)
     {
         var groups = new List<MenuItemGroup>

--- a/src/framework/Elsa.Studio.Core/Services/DefaultUIHintService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultUIHintService.cs
@@ -2,8 +2,16 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Services;
 
+/// <summary>
+/// Provides the default implementation of the UI hint service.
+/// </summary>
 public class DefaultUIHintService(IEnumerable<IUIHintHandler> handlers) : IUIHintService
 {
+    /// <summary>
+    /// Gets the handler.
+    /// </summary>
+    /// <param name="uiHint">The ui hint.</param>
+    /// <returns>The result of the operation.</returns>
     public IUIHintHandler GetHandler(string uiHint)
     {
         var handler = handlers.FirstOrDefault(x => x.GetSupportsUIHint(uiHint));

--- a/src/framework/Elsa.Studio.Core/Services/UnsupportedUIHintHandler.cs
+++ b/src/framework/Elsa.Studio.Core/Services/UnsupportedUIHintHandler.cs
@@ -10,10 +10,21 @@ namespace Elsa.Studio.Services;
 /// </summary>
 public class UnsupportedUIHintHandler : IUIHintHandler
 {
+    /// <summary>
+    /// Provides the get supports uihint.
+    /// </summary>
     public bool GetSupportsUIHint(string uiHint) => false;
 
+    /// <summary>
+    /// Provides the uisyntax.
+    /// </summary>
     public string UISyntax => "Unsupported";
     
+    /// <summary>
+    /// Performs the display input editor operation.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <returns>The result of the operation.</returns>
     public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
     {
         return builder =>

--- a/src/framework/Elsa.Studio.Core/TokenNames.cs
+++ b/src/framework/Elsa.Studio.Core/TokenNames.cs
@@ -1,8 +1,20 @@
 namespace Elsa.Studio;
 
+/// <summary>
+/// Represents the token names.
+/// </summary>
 public static class TokenNames
 {
+    /// <summary>
+    /// Provides the access token value.
+    /// </summary>
     public const string AccessToken = "accessToken";
+    /// <summary>
+    /// Provides the id token value.
+    /// </summary>
     public const string IdToken = "idToken";
+    /// <summary>
+    /// Provides the refresh token value.
+    /// </summary>
     public const string RefreshToken = "refreshToken";
 }

--- a/src/framework/Elsa.Studio.Core/ToolVersion.cs
+++ b/src/framework/Elsa.Studio.Core/ToolVersion.cs
@@ -13,6 +13,6 @@ public static class ToolVersion
     /// <summary>
     /// Gets the display version of the tool.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     public static string GetDisplayVersion() => Version.ToString(2);
 }

--- a/src/framework/Elsa.Studio.DomInterop/Contracts/IClipboard.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Contracts/IClipboard.cs
@@ -1,9 +1,15 @@
 namespace Elsa.Studio.DomInterop.Contracts;
 
 /// <summary>
-/// Provides access to the browser's DOM.
+/// Defines clipboard-related operations that can be invoked from the application.
 /// </summary>
 public interface IClipboard
 {
+    /// <summary>
+    /// Copies the specified text to the system clipboard.
+    /// </summary>
+    /// <param name="text">The text to copy.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>A task that completes when the text has been copied.</returns>
     Task CopyText(string text, CancellationToken cancellationToken = default);
 }

--- a/src/framework/Elsa.Studio.DomInterop/Contracts/IDomAccessor.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Contracts/IDomAccessor.cs
@@ -3,11 +3,31 @@ using Elsa.Studio.DomInterop.Models;
 namespace Elsa.Studio.DomInterop.Contracts;
 
 /// <summary>
-/// Provides access to the browser's DOM.
+/// Describes utility methods that interact with DOM elements through JavaScript interop.
 /// </summary>
 public interface IDomAccessor
 {
+    /// <summary>
+    /// Gets the bounding rectangle of the specified element relative to the viewport.
+    /// </summary>
+    /// <param name="elementRef">The element whose rectangle should be retrieved.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>A task that returns the bounding rectangle.</returns>
     Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculates the visible height of an element within the viewport.
+    /// </summary>
+    /// <param name="elementRef">The element to inspect.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>A task that returns the visible height.</returns>
     Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Triggers a click event on the specified element.
+    /// </summary>
+    /// <param name="elementRef">The element to click.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>A task that completes when the click event has been dispatched.</returns>
     Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default);
 }

--- a/src/framework/Elsa.Studio.DomInterop/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Extensions/ServiceCollectionExtensions.cs
@@ -5,8 +5,16 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Elsa.Studio.DomInterop.Extensions;
 
+/// <summary>
+/// Provides extension methods for registering DOM interop services with the dependency injection container.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers services that facilitate DOM interactions via JavaScript interop.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddDomInterop(this IServiceCollection services)
     {
         services.TryAddScoped<IDomAccessor, DomJsInterop>();
@@ -14,13 +22,23 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers services that expose clipboard functionality via JavaScript interop.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddClipboardInterop(this IServiceCollection services)
     {
         services.TryAddScoped<IClipboard, ClipboardJsInterop>();
 
         return services;
     }
-    
+
+    /// <summary>
+    /// Registers services that allow downloading files from streams using JavaScript interop.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddDownloadInterop(this IServiceCollection services)
     {
         services.TryAddScoped<IFiles, FilesJsInterop>();

--- a/src/framework/Elsa.Studio.DomInterop/Interop/ClipboardJsInterop.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Interop/ClipboardJsInterop.cs
@@ -4,12 +4,19 @@ using Microsoft.JSInterop;
 namespace Elsa.Studio.DomInterop.Interop;
 
 /// <summary>
-/// Provides access to the dom JavaScript module.
+/// Provides clipboard helper operations implemented in JavaScript.
 /// </summary>
 public class ClipboardJsInterop(IJSRuntime jsRuntime) : JsInteropBase(jsRuntime), IClipboard
 {
+    /// <inheritdoc />
     protected override string ModuleName => "clipboard";
 
+    /// <summary>
+    /// Copies the specified text to the clipboard using the browser's clipboard API.
+    /// </summary>
+    /// <param name="text">The text to copy.</param>
+    /// <param name="cancellationToken">A token to cancel the copy request.</param>
+    /// <returns>A task that completes when the text has been copied.</returns>
     public async Task CopyText(string text, CancellationToken cancellationToken = default)
     {
         await InvokeAsync(async module => await module.InvokeVoidAsync("copyText", cancellationToken, text));

--- a/src/framework/Elsa.Studio.DomInterop/Interop/DomJsInterop.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Interop/DomJsInterop.cs
@@ -5,13 +5,34 @@ using Microsoft.JSInterop;
 namespace Elsa.Studio.DomInterop.Interop;
 
 /// <summary>
-/// Provides access to the dom JavaScript module.
+/// Provides DOM convenience operations implemented via JavaScript interop.
 /// </summary>
 public class DomJsInterop(IJSRuntime jsRuntime) : JsInteropBase(jsRuntime), IDomAccessor
 {
+    /// <inheritdoc />
     protected override string ModuleName => "dom";
-    
+
+    /// <summary>
+    /// Gets the bounding client rectangle for the specified element.
+    /// </summary>
+    /// <param name="element">The element whose bounds to retrieve.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>A task that returns the bounding rectangle.</returns>
     public async Task<DomRect> GetBoundingClientRectAsync(ElementRef element, CancellationToken cancellationToken = default) => await InvokeAsync(async module => await module.InvokeAsync<DomRect>("getBoundingClientRect", cancellationToken, element.Match()));
+
+    /// <summary>
+    /// Determines the height of the element that is currently visible within the viewport.
+    /// </summary>
+    /// <param name="elementRef">The element to measure.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>A task that returns the visible height.</returns>
     public async Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => await InvokeAsync(async module => await module.InvokeAsync<double>("getVisibleHeight", cancellationToken, elementRef.Match()));
+
+    /// <summary>
+    /// Dispatches a click event on the specified DOM element.
+    /// </summary>
+    /// <param name="elementRef">The element to click.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>A task that completes after the event has been triggered.</returns>
     public async Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => await InvokeAsync(async module => await module.InvokeVoidAsync("clickElement", cancellationToken, elementRef.Match()));
 }

--- a/src/framework/Elsa.Studio.DomInterop/Interop/JsInteropBase.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Interop/JsInteropBase.cs
@@ -3,20 +3,30 @@ using Microsoft.JSInterop;
 namespace Elsa.Studio.DomInterop.Interop;
 
 /// <summary>
-/// Provides access to the designer JavaScript module.
+/// Provides a base class for JavaScript interop helpers that lazily load and dispose ES modules.
 /// </summary>
 public abstract class JsInteropBase : IAsyncDisposable
 {
     private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
 
+    /// <summary>
+    /// Gets the file name of the JavaScript module to load.
+    /// </summary>
     protected abstract string ModuleName { get; }
-    
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsInteropBase"/> class using the specified runtime.
+    /// </summary>
+    /// <param name="jsRuntime">The JavaScript runtime used to import the module.</param>
     protected JsInteropBase(IJSRuntime jsRuntime)
     {
         _moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
             "import", $"./_content/Elsa.Studio.DomInterop/{ModuleName}.entry.js").AsTask());
     }
-    
+
+    /// <summary>
+    /// Disposes the imported JavaScript module when it has been created.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         if (_moduleTask.IsValueCreated)
@@ -35,12 +45,23 @@ public abstract class JsInteropBase : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Invokes the provided asynchronous delegate with the imported module, creating it if necessary.
+    /// </summary>
+    /// <param name="func">The callback to execute against the module.</param>
+    /// <returns>A task that completes when the invocation finishes.</returns>
     protected async Task InvokeAsync(Func<IJSObjectReference, ValueTask> func)
     {
         var module = await _moduleTask.Value;
         await func(module);
     }
-    
+
+    /// <summary>
+    /// Invokes the provided asynchronous delegate with the imported module and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of value returned by the delegate.</typeparam>
+    /// <param name="func">The callback to execute against the module.</param>
+    /// <returns>The value returned by <paramref name="func"/>.</returns>
     protected async Task<T> InvokeAsync<T>(Func<IJSObjectReference, ValueTask<T>> func)
     {
         var module = await _moduleTask.Value;

--- a/src/framework/Elsa.Studio.DomInterop/Models/DomRect.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Models/DomRect.cs
@@ -1,13 +1,47 @@
 namespace Elsa.Studio.DomInterop.Models;
 
+/// <summary>
+/// Represents the bounding rectangle returned by the DOM <c>getBoundingClientRect</c> API.
+/// </summary>
 public struct DomRect
 {
+    /// <summary>
+    /// Gets or sets the x-coordinate of the rectangle's origin relative to the viewport.
+    /// </summary>
     public double X { get; set; }
+
+    /// <summary>
+    /// Gets or sets the y-coordinate of the rectangle's origin relative to the viewport.
+    /// </summary>
     public double Y { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the rectangle.
+    /// </summary>
     public double Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the rectangle.
+    /// </summary>
     public double Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from the top of the viewport to the rectangle's top edge.
+    /// </summary>
     public double Top { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from the left of the viewport to the rectangle's right edge.
+    /// </summary>
     public double Right { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from the top of the viewport to the rectangle's bottom edge.
+    /// </summary>
     public double Bottom { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from the left of the viewport to the rectangle's left edge.
+    /// </summary>
     public double Left { get; set; }
 }

--- a/src/framework/Elsa.Studio.DomInterop/Models/ElementRef.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Models/ElementRef.cs
@@ -3,10 +3,34 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.DomInterop.Models;
 
+/// <summary>
+/// Represents a reference to a DOM element that can be supplied as either an element identifier or a <see cref="ElementReference"/>.
+/// </summary>
 public class ElementRef : Union<string, ElementReference>
 {
+    /// <summary>
+    /// Creates an <see cref="ElementRef"/> from a string element identifier.
+    /// </summary>
+    /// <param name="value">The DOM element identifier.</param>
     private ElementRef(string value) : base(value) { }
+
+    /// <summary>
+    /// Creates an <see cref="ElementRef"/> from a Blazor <see cref="ElementReference"/>.
+    /// </summary>
+    /// <param name="value">The referenced element.</param>
     private ElementRef(ElementReference value) : base(value) { }
+
+    /// <summary>
+    /// Implicitly converts a string identifier to an <see cref="ElementRef"/>.
+    /// </summary>
+    /// <param name="value">The DOM element identifier.</param>
+    /// <returns>An <see cref="ElementRef"/> referencing the identifier.</returns>
     public static implicit operator ElementRef(string value) => new(value);
+
+    /// <summary>
+    /// Implicitly converts an <see cref="ElementReference"/> to an <see cref="ElementRef"/>.
+    /// </summary>
+    /// <param name="value">The DOM element reference.</param>
+    /// <returns>An <see cref="ElementRef"/> referencing the element.</returns>
     public static implicit operator ElementRef(ElementReference value) => new(value);
 }

--- a/src/framework/Elsa.Studio.DomInterop/Models/Union.cs
+++ b/src/framework/Elsa.Studio.DomInterop/Models/Union.cs
@@ -1,26 +1,57 @@
 namespace Elsa.Studio.Models;
 
+/// <summary>
+/// Represents a discriminated union that can hold a value of either <typeparamref name="T1"/> or <typeparamref name="T2"/>.
+/// </summary>
+/// <typeparam name="T1">The first supported value type.</typeparam>
+/// <typeparam name="T2">The second supported value type.</typeparam>
 public class Union<T1, T2>
 {
     private readonly T1? _value1;
     private readonly T2? _value2;
     private readonly bool _isValue1;
 
+    /// <summary>
+    /// Initializes a new <see cref="Union{T1, T2}"/> instance that stores a value of type <typeparamref name="T1"/>.
+    /// </summary>
+    /// <param name="value">The value to store.</param>
     protected Union(T1 value)
     {
         _value1 = value;
         _isValue1 = true;
     }
 
+    /// <summary>
+    /// Initializes a new <see cref="Union{T1, T2}"/> instance that stores a value of type <typeparamref name="T2"/>.
+    /// </summary>
+    /// <param name="value">The value to store.</param>
     protected Union(T2 value)
     {
         _value2 = value;
         _isValue1 = false;
     }
 
+    /// <summary>
+    /// Implicitly converts a <typeparamref name="T1"/> value into a <see cref="Union{T1, T2}"/>.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <returns>A union containing <paramref name="value"/>.</returns>
     public static implicit operator Union<T1, T2>(T1 value) => new(value);
+
+    /// <summary>
+    /// Implicitly converts a <typeparamref name="T2"/> value into a <see cref="Union{T1, T2}"/>.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <returns>A union containing <paramref name="value"/>.</returns>
     public static implicit operator Union<T1, T2>(T2 value) => new(value);
 
+    /// <summary>
+    /// Executes the matching function corresponding to the stored value type and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of result produced by the matching functions.</typeparam>
+    /// <param name="case1">The function to invoke when the union contains a <typeparamref name="T1"/> value.</param>
+    /// <param name="case2">The function to invoke when the union contains a <typeparamref name="T2"/> value.</param>
+    /// <returns>The result of the executed matching function.</returns>
     public T Match<T>(Func<T1, T> case1, Func<T2, T> case2)
     {
         if (case1 == null) throw new ArgumentNullException(nameof(case1));
@@ -29,5 +60,9 @@ public class Union<T1, T2>
         return _isValue1 ? case1(_value1!) : case2(_value2!);
     }
 
+    /// <summary>
+    /// Returns the raw value stored inside the union without performing any conversion.
+    /// </summary>
+    /// <returns>The result of the operation.</returns>
     public object Match() => _isValue1 ? _value1! : _value2!;
 }

--- a/src/framework/Elsa.Studio.Shared/Branding/DefaultBrandingProvider.cs
+++ b/src/framework/Elsa.Studio.Shared/Branding/DefaultBrandingProvider.cs
@@ -23,6 +23,9 @@ public class DefaultBrandingProvider : IBrandingProvider
         return "_content/Elsa.Studio.Shell/img/icon.png";
     }
     
+    /// <summary>
+    /// Provides the render fragment.
+    /// </summary>
     public virtual RenderFragment Branding =>
         builder =>
         {

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
@@ -10,6 +10,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Components
 {
+    /// <summary>
+    /// Represents the content visualizer.
+    /// </summary>
     public partial class ContentVisualizer : ComponentBase
     {
         private int TabIndex = 0;
@@ -36,6 +39,9 @@ namespace Elsa.Studio.Components
             }
         }
 
+        /// <summary>
+        /// Provides the selected item.
+        /// </summary>
         public string SelectedItem
         {
             get { return selectedItem; }
@@ -61,6 +67,9 @@ namespace Elsa.Studio.Components
         [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
 
 
+        /// <summary>
+        /// Performs the on initialized operation.
+        /// </summary>
         protected override void OnInitialized()
         {
             AvailableVisualizers = VisualizationProvider.GetAll().ToList();

--- a/src/framework/Elsa.Studio.Shared/Components/Error.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/Error.razor.cs
@@ -2,6 +2,9 @@
 
 namespace Elsa.Studio.Components;
 
+/// <summary>
+/// Represents the error.
+/// </summary>
 public partial class Error : ComponentBase
 {
     [Parameter] public Exception Context { get; set; } = null!;

--- a/src/framework/Elsa.Studio.Shared/Components/Zone.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/Zone.razor.cs
@@ -12,12 +12,18 @@ public partial class Zone : IDisposable
     /// Gets or sets the zone name.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
     public string Name { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the attributes that are passed to the widgets.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the attributes.
+    /// </summary>
     public IDictionary<string, object?> Attributes { get; set; } = new Dictionary<string, object?>();
 
     [Inject] private IWidgetRegistry WidgetRegistry { get; set; } = default!;

--- a/src/framework/Elsa.Studio.Shared/Localization/Time/Components/Timestamp.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Localization/Time/Components/Timestamp.razor.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Localization.Time.Components;
 
+/// <summary>
+/// Represents the timestamp.
+/// </summary>
 public partial class Timestamp : ComponentBase
 {
     /// <summary>

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
@@ -1,3 +1,6 @@
 ﻿namespace Elsa.Studio.Models;
 
+/// <summary>
+/// Represents the data panel item record.
+/// </summary>
 public record DataPanelItem(string Label, string? Text = null, string? Link = null, Func<Task>? OnClick = null);

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelModel.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelModel.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Models;
 
+/// <summary>
+/// Represents a data panel model.
+/// </summary>
 public class DataPanelModel : List<DataPanelItem>
 {
     public DataPanelModel()
@@ -10,10 +13,19 @@ public class DataPanelModel : List<DataPanelItem>
     {
     }
     
+    /// <summary>
+    /// Provides the add.
+    /// </summary>
     public void Add(string label, string? text = null, string? link = null) => Add(new DataPanelItem(label, text, link));
 }
 
+/// <summary>
+/// Provides extension methods for data panel model linq.
+/// </summary>
 public static class DataPanelModelLinqExtensions
 {
+    /// <summary>
+    /// Provides the to data panel model.
+    /// </summary>
     public static DataPanelModel ToDataPanelModel(this IEnumerable<DataPanelItem> items) => new(items);
 }

--- a/src/framework/Elsa.Studio.Shared/WellKnownSyntaxNames.cs
+++ b/src/framework/Elsa.Studio.Shared/WellKnownSyntaxNames.cs
@@ -1,7 +1,16 @@
 namespace Elsa.Studio;
 
+/// <summary>
+/// Represents the well known syntax names.
+/// </summary>
 public class WellKnownSyntaxNames
 {
+    /// <summary>
+    /// Provides the literal value.
+    /// </summary>
     public const string Literal = "Literal";
+    /// <summary>
+    /// Provides the object value.
+    /// </summary>
     public const string Object = "Object";
 }

--- a/src/framework/Elsa.Studio.Shell/App.razor.cs
+++ b/src/framework/Elsa.Studio.Shell/App.razor.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Shell;
 
+/// <summary>
+/// Represents the app.
+/// </summary>
 public partial class App
 {
     [Inject] private IEnumerable<IFeature> Modules { get; set; } = null!;

--- a/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
@@ -5,6 +5,11 @@ namespace Elsa.Studio.Translations
 {
     internal class ResxLocalizationProvider : ILocalizationProvider
     {
+        /// <summary>
+        /// Gets the translation.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>The result of the operation.</returns>
         public string? GetTranslation(string key)
         {
             return Elsa.Studio.Translations.Translations.ResourceManager.GetString(key, CultureInfo.CurrentUICulture);

--- a/src/framework/Elsa.Studio.Translations/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Translations/ServiceCollectionExtensions.cs
@@ -3,8 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Translations;
 
+/// <summary>
+/// Provides extension methods for service collection.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the translations.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddTranslations(this IServiceCollection services)
     {
         services.AddSingleton<ILocalizationProvider, ResxLocalizationProvider>();

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendComponentBase.cs
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/BackendComponentBase.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Host.CustomElements.Components;
 
+/// <summary>
+/// Represents the backend component base.
+/// </summary>
 public abstract class BackendComponentBase : StudioComponentBase
 {
     [Parameter] public string? RemoteEndpoint { get; set; }

--- a/src/hosts/Elsa.Studio.Host.HostedWasm/Middleware/WasmAssetsRewritingMiddleware.cs
+++ b/src/hosts/Elsa.Studio.Host.HostedWasm/Middleware/WasmAssetsRewritingMiddleware.cs
@@ -8,6 +8,10 @@ public class WasmAssetsRewritingMiddleware(RequestDelegate next, ILogger<WasmAss
 {
     private static readonly string[] TargetSegments = { "_content", "_framework" };
 
+    /// <summary>
+    /// Invokes the handler asynchronously.
+    /// </summary>
+    /// <param name="context">The context.</param>
     public async Task InvokeAsync(HttpContext context)
     {
         if (context.Request.Path.HasValue && NeedsRewriting(context.Request.Path.Value!))

--- a/src/hosts/Elsa.Studio.Host.Server/StudioBrandingProvider.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/StudioBrandingProvider.cs
@@ -5,6 +5,9 @@ namespace Elsa.Studio.Host.Server
     /// <inheritdoc />
     public class StudioBrandingProvider : DefaultBrandingProvider
     {
+        /// <summary>
+        /// Provides the string.
+        /// </summary>
         public override string AppName => "Elsa Studio 3.6";
     }
 }

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
@@ -17,6 +17,9 @@ namespace Elsa.Studio.ActivityPortProviders.Providers;
 /// Provides ports for the FlowSendHttpRequest & DownloadHttpFile activities based on its supported status codes.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Provides flow http request port services.
+/// </summary>
 public class FlowHttpRequestPortProvider : ActivityPortProviderBase
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
@@ -13,6 +13,9 @@ namespace Elsa.Studio.ActivityPortProviders.Providers;
 /// Provides ports for the FlowSwitch activity based on its cases.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Provides flow switch port services.
+/// </summary>
 public class FlowSwitchPortProvider : ActivityPortProviderBase
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Counter/Menu/CounterMenu.cs
+++ b/src/modules/Elsa.Studio.Counter/Menu/CounterMenu.cs
@@ -4,8 +4,14 @@ using MudBlazor;
 
 namespace Elsa.Studio.Counter.Menu;
 
+/// <summary>
+/// Exposes menu entries for counter.
+/// </summary>
 public class CounterMenu : IMenuProvider
 {
+    /// <summary>
+    /// Provides the get menu items async.
+    /// </summary>
     public ValueTask<IEnumerable<MenuItem>> GetMenuItemsAsync(CancellationToken cancellationToken = default)
     {
         var menuItems = new List<MenuItem>

--- a/src/modules/Elsa.Studio.Counter/Module.cs
+++ b/src/modules/Elsa.Studio.Counter/Module.cs
@@ -2,7 +2,10 @@ using Elsa.Studio.Abstractions;
 
 namespace Elsa.Studio.Counter;
 
+/// <summary>
+/// Declares the counter sample feature for discovery by the host.
+/// </summary>
 public class Feature : FeatureBase
 {
-    
+
 }

--- a/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
@@ -4,8 +4,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Dashboard.Extensions;
 
+/// <summary>
+/// Provides service registration helpers for the dashboard module.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers the dashboard feature and its menu provider.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddDashboardModule(this IServiceCollection services)
     {
         return services

--- a/src/modules/Elsa.Studio.Dashboard/Feature.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Feature.cs
@@ -2,7 +2,10 @@ using Elsa.Studio.Abstractions;
 
 namespace Elsa.Studio.Dashboard;
 
+/// <summary>
+/// Declares the dashboard feature for registration within the studio host.
+/// </summary>
 public class Feature : FeatureBase
 {
-    
+
 }

--- a/src/modules/Elsa.Studio.Environments/Contracts/IEnvironmentsClient.cs
+++ b/src/modules/Elsa.Studio.Environments/Contracts/IEnvironmentsClient.cs
@@ -17,4 +17,7 @@ public interface IEnvironmentsClient
     Task<ListEnvironmentsResponse> ListEnvironmentsAsync(CancellationToken cancellationToken = default);
 }
 
+/// <summary>
+/// Represents a response containing list environments.
+/// </summary>
 public record ListEnvironmentsResponse(ICollection<ServerEnvironment> Environments, string? DefaultEnvironmentName);

--- a/src/modules/Elsa.Studio.Environments/Module.cs
+++ b/src/modules/Elsa.Studio.Environments/Module.cs
@@ -4,12 +4,20 @@ using Elsa.Studio.Environments.Components;
 
 namespace Elsa.Studio.Environments;
 
+/// <summary>
+/// Adds environment selection capabilities to the studio shell.
+/// </summary>
 public class Feature(IAppBarService appBarService) : FeatureBase
 {
+    /// <summary>
+    /// Registers the environment picker in the application bar.
+    /// </summary>
+    /// <param name="cancellationToken">A token used to cancel the initialization.</param>
+    /// <returns>A completed task once the picker has been added.</returns>
     public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
         appBarService.AddAppBarItem<EnvironmentPicker>();
-        
+
         return ValueTask.CompletedTask;
     }
 }

--- a/src/modules/Elsa.Studio.Environments/Services/DefaultEnvironmentService.cs
+++ b/src/modules/Elsa.Studio.Environments/Services/DefaultEnvironmentService.cs
@@ -3,14 +3,32 @@ using Elsa.Studio.Environments.Models;
 
 namespace Elsa.Studio.Environments.Services;
 
+/// <summary>
+/// Provides the default implementation of the environment service.
+/// </summary>
 public class DefaultEnvironmentService : IEnvironmentService
 {
+    /// <summary>
+    /// Occurs when the list of environments changes.
+    /// </summary>
     public event Action? EnvironmentsChanged;
+    /// <summary>
+    /// Occurs when the active environment changes.
+    /// </summary>
     public event Action? CurrentEnvironmentChanged;
 
+    /// <summary>
+    /// Gets the current environment.
+    /// </summary>
     public ServerEnvironment? CurrentEnvironment { get; private set; }
+    /// <summary>
+    /// Gets the collection of available environments.
+    /// </summary>
     public IEnumerable<ServerEnvironment> Environments { get; private set; } = new List<ServerEnvironment>();
 
+    /// <summary>
+    /// Sets the available environments and optionally selects a default environment.
+    /// </summary>
     public void SetEnvironments(IEnumerable<ServerEnvironment> environments, string? defaultEnvironmentName = null)
     {
         var environmentList = environments.ToList();
@@ -24,6 +42,10 @@ public class DefaultEnvironmentService : IEnvironmentService
         EnvironmentsChanged?.Invoke();
     }
 
+    /// <summary>
+    /// Sets the current environment.
+    /// </summary>
+    /// <param name="name">The name.</param>
     public void SetCurrentEnvironment(string name)
     {
         var environments = Environments.ToList();

--- a/src/modules/Elsa.Studio.Environments/Tasks/LoadEnvironmentsStartupTask.cs
+++ b/src/modules/Elsa.Studio.Environments/Tasks/LoadEnvironmentsStartupTask.cs
@@ -3,8 +3,14 @@ using Elsa.Studio.Environments.Contracts;
 
 namespace Elsa.Studio.Environments.Tasks;
 
+/// <summary>
+/// Represents the load environments startup task.
+/// </summary>
 public class LoadEnvironmentsStartupTask(IEnvironmentsClient environmentsClient, IEnvironmentService environmentService) : IStartupTask
 {
+    /// <summary>
+    /// Provides the value task.
+    /// </summary>
     public async ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
     {
         var response = await environmentsClient.ListEnvironmentsAsync(cancellationToken);

--- a/src/modules/Elsa.Studio.Localization.BlazorServer/Controllers/CultureController.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorServer/Controllers/CultureController.cs
@@ -7,6 +7,9 @@ namespace Elsa.Studio.Localization.BlazorServer.Controllers;
 /// Controller for setting the culture.
 /// </summary>
 [Route("[controller]/[action]")]
+/// <summary>
+/// Represents the culture controller.
+/// </summary>
 public class CultureController : Controller
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Localization.BlazorServer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorServer/Extensions/ServiceCollectionExtensions.cs
@@ -6,8 +6,17 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Localization.BlazorServer.Extensions;
 
+/// <summary>
+/// Provides extension methods for service collection.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the localization module.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="localizationConfig">The localization config.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddLocalizationModule(this IServiceCollection services, LocalizationConfig localizationConfig)
     {
         services.AddControllers();

--- a/src/modules/Elsa.Studio.Localization.BlazorServer/Extensions/WebApplicationExtensions.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorServer/Extensions/WebApplicationExtensions.cs
@@ -5,8 +5,16 @@ using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Localization.BlazorServer.Extensions;
 
+/// <summary>
+/// Provides extension methods for web application.
+/// </summary>
 public static class WebApplicationExtensions
 {
+    /// <summary>
+    /// Configures the elsa localization.
+    /// </summary>
+    /// <param name="app">The web application to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static WebApplication UseElsaLocalization(this WebApplication app)
     {
         var localisationOptions = app.Services.GetService<IOptions<LocalizationOptions>>()?.Value;

--- a/src/modules/Elsa.Studio.Localization.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorWasm/Extensions/ServiceCollectionExtensions.cs
@@ -6,8 +6,17 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Localization.BlazorWasm.Extensions
 {
+    /// <summary>
+    /// Provides WebAssembly-specific service registration helpers for localization.
+    /// </summary>
     public static class ServiceCollectionExtensions
     {
+        /// <summary>
+        /// Adds localization services tailored for the Blazor WebAssembly host.
+        /// </summary>
+        /// <param name="services">The service collection to configure.</param>
+        /// <param name="localizationConfig">The configuration to apply to localization services.</param>
+        /// <returns>The result of the operation.</returns>
         public static IServiceCollection AddLocalizationModule(this IServiceCollection services, LocalizationConfig localizationConfig)
         {
             services.AddLocalizationModuleCore(localizationConfig);

--- a/src/modules/Elsa.Studio.Localization.BlazorWasm/Extensions/WebAssemblyHostExtensions.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorWasm/Extensions/WebAssemblyHostExtensions.cs
@@ -10,8 +10,16 @@ using System.Threading.Tasks;
 
 namespace Elsa.Studio.Localization.BlazorWasm.Extensions
 {
+    /// <summary>
+    /// Provides WebAssembly host extensions that configure localization.
+    /// </summary>
     public static class WebAssemblyHostExtensions
     {
+        /// <summary>
+        /// Loads the persisted culture from the browser and applies it to the Blazor host.
+        /// </summary>
+        /// <param name="host">The WebAssembly host to configure.</param>
+        /// <returns>The configured host instance.</returns>
         public static async Task<WebAssemblyHost> UseElsaLocalization(this WebAssemblyHost host) {
 
             const string defaultCulture = "en-US";

--- a/src/modules/Elsa.Studio.Localization/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Localization/Extensions/ServiceCollectionExtensions.cs
@@ -5,8 +5,17 @@ using MudBlazor.Translations;
 
 namespace Elsa.Studio.Localization.Extensions;
 
+/// <summary>
+/// Provides dependency injection helpers for the localization module.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers the services required for localization support in the studio.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="localizationConfig">The localization configuration to apply.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddLocalizationModuleCore(this IServiceCollection services,LocalizationConfig localizationConfig)
     {
         services.AddLocalization();

--- a/src/modules/Elsa.Studio.Localization/LocalizationFeature.cs
+++ b/src/modules/Elsa.Studio.Localization/LocalizationFeature.cs
@@ -3,8 +3,17 @@ using Elsa.Studio.Contracts;
 using Elsa.Studio.Localization.Components;
 
 namespace Elsa.Studio.Localization;
+
+/// <summary>
+/// Registers localization UI elements and services for the studio shell.
+/// </summary>
 public class LocalizationFeature(IAppBarService appBarService) : FeatureBase
 {
+    /// <summary>
+    /// Adds the language picker to the application bar when the feature initializes.
+    /// </summary>
+    /// <param name="cancellationToken">A token used to cancel the initialization.</param>
+    /// <returns>A completed task once the menu item is registered.</returns>
     public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
         appBarService.AddAppBarItem<LanguagePicker>();

--- a/src/modules/Elsa.Studio.Localization/Models/LocalizationConfig.cs
+++ b/src/modules/Elsa.Studio.Localization/Models/LocalizationConfig.cs
@@ -2,7 +2,13 @@
 
 namespace Elsa.Studio.Localization.Models;
 
+/// <summary>
+/// Provides configuration hooks for customizing localization behavior.
+/// </summary>
 public class LocalizationConfig
 {
+    /// <summary>
+    /// Gets or sets a delegate that configures localization options.
+    /// </summary>
     public Action<LocalizationOptions> ConfigureLocalizationOptions { get; set; } = _ => { };
 }

--- a/src/modules/Elsa.Studio.Localization/Options/LocalizationOptions.cs
+++ b/src/modules/Elsa.Studio.Localization/Options/LocalizationOptions.cs
@@ -7,6 +7,9 @@ namespace Elsa.Studio.Localization.Options;
 /// </summary>
 public class LocalizationOptions
 {
+    /// <summary>
+    /// Provides the localization section.
+    /// </summary>
     public static string LocalizationSection = "Localization";
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
+++ b/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
@@ -8,6 +8,9 @@ namespace Elsa.Studio.Login.Components;
 /// Receives the OIDC authorization code and trades it for access_token
 /// </summary>
 [Route("/signin-oidc")]
+/// <summary>
+/// Represents the receive authorization code.
+/// </summary>
 public sealed class ReceiveAuthorizationCode : StudioComponentBase
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Login/Models/TokenResponse.cs
+++ b/src/modules/Elsa.Studio.Login/Models/TokenResponse.cs
@@ -2,6 +2,9 @@
 
 namespace Elsa.Studio.Login.Models;
 
+/// <summary>
+/// Represents a response containing token.
+/// </summary>
 public sealed class TokenResponse
 {
     [JsonPropertyName("access_token")] public string? AccessToken { get; set; }

--- a/src/modules/Elsa.Studio.Login/Models/ValidateCredentialsResult.cs
+++ b/src/modules/Elsa.Studio.Login/Models/ValidateCredentialsResult.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Login.Models;
 
+/// <summary>
+/// Represents the result of validate credentials.
+/// </summary>
 public record ValidateCredentialsResult(bool IsAuthenticated, string? AccessToken, string? RefreshToken);

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -14,6 +14,9 @@ namespace Elsa.Studio.Login.Pages.Login;
 /// The login page.
 /// </summary>
 [AllowAnonymous]
+/// <summary>
+/// Represents the login.
+/// </summary>
 public partial class Login
 {
     private readonly LoginModel _model = new();

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Models/LoginModel.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Models/LoginModel.cs
@@ -2,7 +2,16 @@ namespace Elsa.Studio.Login.Pages.Login.Models;
 
 internal class LoginModel
 {
+    /// <summary>
+    /// Gets or sets the username.
+    /// </summary>
     public string Username { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the password.
+    /// </summary>
     public string Password { get; set; } = default!;
+    /// <summary>
+    /// Indicates whether remember me.
+    /// </summary>
     public bool RememberMe { get; set; }
 }

--- a/src/modules/Elsa.Studio.Security/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Security/Extensions/ServiceCollectionExtensions.cs
@@ -4,8 +4,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Security.Extensions;
 
+/// <summary>
+/// Provides extension methods for service collection.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the security module.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddSecurityModule(this IServiceCollection services)
     {
         return services

--- a/src/modules/Elsa.Studio.Security/Menu/SecurityMenu.cs
+++ b/src/modules/Elsa.Studio.Security/Menu/SecurityMenu.cs
@@ -4,8 +4,14 @@ using MudBlazor;
 
 namespace Elsa.Studio.Security.Menu;
 
+/// <summary>
+/// Exposes menu entries for security.
+/// </summary>
 public class SecurityMenu : IMenuProvider
 {
+    /// <summary>
+    /// Provides the get menu items async.
+    /// </summary>
     public ValueTask<IEnumerable<MenuItem>> GetMenuItemsAsync(CancellationToken cancellationToken = default)
     {
         var menuItems = new List<MenuItem>

--- a/src/modules/Elsa.Studio.Security/Module.cs
+++ b/src/modules/Elsa.Studio.Security/Module.cs
@@ -2,7 +2,10 @@ using Elsa.Studio.Abstractions;
 
 namespace Elsa.Studio.Security;
 
+/// <summary>
+/// Declares the security management feature for the studio host.
+/// </summary>
 public class Feature : FeatureBase
 {
-    
+
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
@@ -26,6 +26,9 @@ public partial class Cases
     /// The context for the editor.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the editor context.
+    /// </summary>
     public DisplayInputEditorContext EditorContext { get; set; } = default!;
 
     [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
@@ -192,6 +195,9 @@ public class SwitchCaseRecord
     public string Condition { get; set; } = string.Empty;
 
     [Obsolete("Use ExpressionType instead.")]
+    /// <summary>
+    /// Provides the syntax.
+    /// </summary>
     public string Syntax
     {
         get => ExpressionType;

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -23,6 +23,9 @@ public partial class Dictionary
     /// The context for the editor.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the editor context.
+    /// </summary>
     public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = null!;
@@ -233,6 +236,6 @@ public class DictionaryEntryRecord
     /// <summary>
     /// Expression representation of the value.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     public Expression ToExpression() => new(ExpressionType, Value);
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor.cs
@@ -7,6 +7,9 @@ using MudExtensions;
 
 namespace Elsa.Studio.UIHints.Components;
 
+/// <summary>
+/// Represents the http status codes.
+/// </summary>
 public partial class HttpStatusCodes
 {
     private List<HttpStatusCodeCase> _items = new();

--- a/src/modules/Elsa.Studio.UIHints/Components/RadioList.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/RadioList.razor.cs
@@ -13,6 +13,9 @@ public partial class RadioList
     private ICollection<RadioListItem> _radioListItems = Array.Empty<RadioListItem>();
     private string? radioItem = string.Empty;
 
+    /// <summary>
+    /// Provides the  radio item.
+    /// </summary>
     public string _radioItem
     {
         get { return radioItem; }
@@ -27,6 +30,9 @@ public partial class RadioList
     /// The editor context.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the editor context.
+    /// </summary>
     public DisplayInputEditorContext EditorContext { get; set; } = default!;
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.UIHints/Handlers/DateTimePickerHandler.cs
+++ b/src/modules/Elsa.Studio.UIHints/Handlers/DateTimePickerHandler.cs
@@ -5,12 +5,26 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.UIHints.Handlers;
 
+/// <summary>
+/// Represents the date time picker handler.
+/// </summary>
 public class DateTimePickerHandler : IUIHintHandler
 {
+    /// <summary>
+    /// Provides the get supports uihint.
+    /// </summary>
     public bool GetSupportsUIHint(string uiHint) => uiHint == InputUIHints.DateTimePicker;
 
+    /// <summary>
+    /// Provides the uisyntax.
+    /// </summary>
     public string UISyntax => WellKnownSyntaxNames.Literal;
 
+    /// <summary>
+    /// Performs the display input editor operation.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <returns>The result of the operation.</returns>
     public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
     {
         return builder =>

--- a/src/modules/Elsa.Studio.UIHints/Handlers/RadioListHandler.cs
+++ b/src/modules/Elsa.Studio.UIHints/Handlers/RadioListHandler.cs
@@ -5,12 +5,26 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.UIHints.Handlers;
 
+/// <summary>
+/// Represents the radio list handler.
+/// </summary>
 public class RadioListHandler : IUIHintHandler
 {
+    /// <summary>
+    /// Provides the get supports uihint.
+    /// </summary>
     public bool GetSupportsUIHint(string uiHint) => uiHint == InputUIHints.RadioList;
 
+    /// <summary>
+    /// Provides the uisyntax.
+    /// </summary>
     public string UISyntax => WellKnownSyntaxNames.Literal;
 
+    /// <summary>
+    /// Performs the display input editor operation.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <returns>The result of the operation.</returns>
     public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
     {
         return builder =>

--- a/src/modules/Elsa.Studio.UIHints/Helpers/JsonParser.cs
+++ b/src/modules/Elsa.Studio.UIHints/Helpers/JsonParser.cs
@@ -2,6 +2,9 @@ using System.Text.Json;
 
 namespace Elsa.Studio.UIHints.Helpers;
 
+/// <summary>
+/// Represents the json parser.
+/// </summary>
 public static class JsonParser
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.UIHints/InputUIHints.cs
+++ b/src/modules/Elsa.Studio.UIHints/InputUIHints.cs
@@ -5,26 +5,113 @@
 /// </summary>
 public static class InputUIHints
 {
+    /// <summary>
+    /// Renders a boolean value using a single checkbox control.
+    /// </summary>
     public const string Checkbox = "checkbox";
+
+    /// <summary>
+    /// Displays a list of items that allow selecting multiple options.
+    /// </summary>
     public const string CheckList = "checklist";
+
+    /// <summary>
+    /// Presents a code editor optimized for editing scripts or expressions.
+    /// </summary>
     public const string CodeEditor = "code-editor";
+
+    /// <summary>
+    /// Allows picking a combined date and time value.
+    /// </summary>
     public const string DateTimePicker = "datetime-picker";
+
+    /// <summary>
+    /// Captures key value pairs using a dictionary editor interface.
+    /// </summary>
     public const string Dictionary = "dictionary";
+
+    /// <summary>
+    /// Renders a dropdown list for selecting a single option.
+    /// </summary>
     public const string DropDown = "dropdown";
+
+    /// <summary>
+    /// Provides a UI for configuring outcomes that are generated at runtime.
+    /// </summary>
     public const string DynamicOutcomes = "dynamic-outcomes";
+
+    /// <summary>
+    /// Hosts an expression editor tailored for workflow expressions.
+    /// </summary>
     public const string ExpressionEditor = "expression-editor";
+
+    /// <summary>
+    /// Offers a curated list of HTTP status codes to select from.
+    /// </summary>
     public const string HttpStatusCodes = "http-status-codes";
+
+    /// <summary>
+    /// Enables editing structured JSON content with validation support.
+    /// </summary>
     public const string JsonEditor = "json-editor";
+
+    /// <summary>
+    /// Provides a multi-line text area for free-form input.
+    /// </summary>
     public const string MultiLine = "multiline";
+
+    /// <summary>
+    /// Displays a list of text inputs for capturing multiple values.
+    /// </summary>
     public const string MultiText = "multitext";
+
+    /// <summary>
+    /// Lets users pick one or more workflow outcomes.
+    /// </summary>
     public const string OutcomePicker = "outcome-picker";
+
+    /// <summary>
+    /// Provides a selection control for choosing workflow outputs.
+    /// </summary>
     public const string OutputPicker = "output-picker";
+
+    /// <summary>
+    /// Renders a radio button list for choosing a single option.
+    /// </summary>
     public const string RadioList = "radiolist";
+
+    /// <summary>
+    /// Displays a single line text box for short input values.
+    /// </summary>
     public const string SingleLine = "singleline";
+
+    /// <summary>
+    /// Visualizes flow switch branches in a dedicated editor.
+    /// </summary>
     public const string FlowSwitchEditor = "flow-switch-editor";
+
+    /// <summary>
+    /// Allows configuring switch activities via a specialized editor.
+    /// </summary>
     public const string SwitchEditor = "switch-editor";
+
+    /// <summary>
+    /// Presents a type picker for selecting .NET types or workflow models.
+    /// </summary>
     public const string TypePicker = "type-picker";
+
+    /// <summary>
+    /// Displays available workflow variables for selection.
+    /// </summary>
     public const string VariablePicker = "variable-picker";
+
+    /// <summary>
+    /// Enables choosing inputs that can be bound to an activity.
+    /// </summary>
     public const string InputPicker = "input-picker";
+
+    /// <summary>
+    /// Provides a picker dialog for selecting workflow definitions.
+    /// </summary>
     public const string WorkflowDefinitionPicker = "workflow-definition-picker";
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityPortService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityPortService.cs
@@ -3,6 +3,9 @@ using Elsa.Studio.Workflows.Domain.Contexts;
 
 namespace Elsa.Studio.Workflows.Domain.Contracts;
 
+/// <summary>
+/// Defines the contract for activity port service.
+/// </summary>
 public interface IActivityPortService
 {
     IActivityPortProvider GetProvider(PortProviderContext context);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowInstanceService.cs
@@ -6,6 +6,9 @@ using Refit;
 
 namespace Elsa.Studio.Workflows.Domain.Contracts;
 
+/// <summary>
+/// Defines the contract for workflow instance service.
+/// </summary>
 public interface IWorkflowInstanceService
 {
     Task<PagedListResponse<WorkflowInstanceSummary>> ListAsync(ListWorkflowInstancesRequest request, CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExecuteWorkflowResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ExecuteWorkflowResult.cs
@@ -1,3 +1,8 @@
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Represents the result of a workflow execution request.
+/// </summary>
+/// <param name="WorkflowInstanceId">The identifier of the workflow instance that was started, if any.</param>
+/// <param name="CannotStart">Indicates whether the workflow could not be started.</param>
 public record ExecuteWorkflowResult(string? WorkflowInstanceId, bool CannotStart);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
@@ -2,10 +2,28 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Represents configuration options that control workflow definition import operations.
+/// </summary>
 public class ImportOptions
 {
+    /// <summary>
+    /// Gets or sets the maximum allowed payload size for imports in bytes.
+    /// </summary>
     public int MaxAllowedSize { get; set; } = 1024 * 1024 * 10; // 10 MB
+
+    /// <summary>
+    /// Gets or sets the target workflow definition identifier for the import.
+    /// </summary>
     public string? DefinitionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback that is invoked after a workflow definition has been imported.
+    /// </summary>
     public Func<WorkflowDefinition, Task>? ImportedCallback { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback that is invoked when an error occurs during import.
+    /// </summary>
     public Func<Exception, Task> ErrorCallback { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowDefinitionVersion.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowDefinitionVersion.cs
@@ -2,18 +2,36 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Represents the workflow definition version record.
+/// </summary>
 public record WorkflowDefinitionVersion(string WorkflowDefinitionId, string WorkflowDefinitionVersionId, int Version)
 {
+    /// <summary>
+    /// Performs the from definition operation.
+    /// </summary>
+    /// <param name="workflowDefinition">The workflow definition.</param>
+    /// <returns>The result of the operation.</returns>
     public static WorkflowDefinitionVersion FromDefinition(WorkflowDefinition workflowDefinition)
     {
         return new(workflowDefinition.DefinitionId, workflowDefinition.Id, workflowDefinition.Version);
     }
     
+    /// <summary>
+    /// Performs the from definition summary operation.
+    /// </summary>
+    /// <param name="workflowDefinitionSummary">The workflow definition summary.</param>
+    /// <returns>The result of the operation.</returns>
     public static WorkflowDefinitionVersion FromDefinitionSummary(WorkflowDefinitionSummary workflowDefinitionSummary)
     {
         return new(workflowDefinitionSummary.DefinitionId, workflowDefinitionSummary.Id, workflowDefinitionSummary.Version);
     }
 
+    /// <summary>
+    /// Performs the from definition model operation.
+    /// </summary>
+    /// <param name="model">The model.</param>
+    /// <returns>The result of the operation.</returns>
     public static WorkflowDefinitionVersion FromDefinitionModel(WorkflowDefinitionModel model)
     {
         return new(model.DefinitionId, model.Id, model.Version);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailure.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailure.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Represents the workflow import failure record.
+/// </summary>
 public record WorkflowImportFailure(string ErrorMessage, WorkflowImportFailureType FailureType);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailureType.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailureType.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Defines the workflow import failure type enumeration.
+/// </summary>
 public enum WorkflowImportFailureType
 {
     Exception,

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
@@ -2,10 +2,25 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Models;
 
+/// <summary>
+/// Represents the result of workflow import.
+/// </summary>
 public class WorkflowImportResult
 {
+    /// <summary>
+    /// Gets or sets the file name.
+    /// </summary>
     public string FileName { get; set; }
+    /// <summary>
+    /// Gets or sets the workflow definition.
+    /// </summary>
     public WorkflowDefinition? WorkflowDefinition { get; set; }
+    /// <summary>
+    /// Gets or sets the failure.
+    /// </summary>
     public WorkflowImportFailure? Failure { get; set; }
+    /// <summary>
+    /// Provides the is success.
+    /// </summary>
     public bool IsSuccess => Failure == null;
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ActivityRegistryRefreshed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ActivityRegistryRefreshed.cs
@@ -3,7 +3,7 @@ using Elsa.Studio.Contracts;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 /// <summary>
-/// Represents a notification published when the activity registry is refreshed.
+/// Represents the notification published when an activity registry is refreshed.
 /// </summary>
 public class ActivityRegistryRefreshed : INotification
 {

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverted.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definition are reverted.
+/// </summary>
 public record BulkWorkflowDefinitionReverted(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionReverting.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definition are reverting.
+/// </summary>
 public record BulkWorkflowDefinitionReverting(ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleted.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definition versions are deleted.
+/// </summary>
 public record BulkWorkflowDefinitionVersionsDeleted(ICollection<WorkflowDefinitionVersion> Versions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionVersionsDeleting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definition versions are deleting.
+/// </summary>
 public record BulkWorkflowDefinitionVersionsDeleting(ICollection<WorkflowDefinitionVersion> Versions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleted.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are deleted.
+/// </summary>
 public record BulkWorkflowDefinitionsDeleted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsDeleting.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are deleting.
+/// </summary>
 public record BulkWorkflowDefinitionsDeleting(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublished.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublished.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are published.
+/// </summary>
 public record BulkWorkflowDefinitionsPublished(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublishing.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsPublishing.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are publishing.
+/// </summary>
 public record BulkWorkflowDefinitionsPublishing(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracted.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are retracted.
+/// </summary>
 public record BulkWorkflowDefinitionsRetracted(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/BulkWorkflowDefinitionsRetracting.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when bulk workflow definitions are retracting.
+/// </summary>
 public record BulkWorkflowDefinitionsRetracting(ICollection<string> WorkflowDefinitionIds) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedFile.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedFile.cs
@@ -5,4 +5,7 @@ using Microsoft.AspNetCore.Components.Forms;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 [UsedImplicitly]
+/// <summary>
+/// Represents the notification published when an imported is file.
+/// </summary>
 public record ImportedFile(IBrowserFile File) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedJson.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedJson.cs
@@ -4,4 +4,7 @@ using JetBrains.Annotations;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 [UsedImplicitly]
+/// <summary>
+/// Represents the notification published when an imported is json.
+/// </summary>
 public record ImportedJson(string Json) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedWorkflowDefinition.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedWorkflowDefinition.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when an imported workflow is definition.
+/// </summary>
 public record ImportedWorkflowDefinition(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingFile.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingFile.cs
@@ -5,4 +5,7 @@ using Microsoft.AspNetCore.Components.Forms;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 [UsedImplicitly]
+/// <summary>
+/// Represents the notification published when an importing is file.
+/// </summary>
 public record ImportingFile(IBrowserFile File) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingJson.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingJson.cs
@@ -5,4 +5,7 @@ using Microsoft.AspNetCore.Components.Forms;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 [UsedImplicitly]
+/// <summary>
+/// Represents the notification published when an importing is json.
+/// </summary>
 public record ImportingJson(string Json) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingWorkflowDefinition.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingWorkflowDefinition.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when an importing workflow is definition.
+/// </summary>
 public record ImportingWorkflowDefinition(WorkflowDefinitionModel WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleted.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is deleted.
+/// </summary>
 public record WorkflowDefinitionDeleted(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionDeleting.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is deleting.
+/// </summary>
 public record WorkflowDefinitionDeleting(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExported.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExported.cs
@@ -4,4 +4,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is exported.
+/// </summary>
 public record WorkflowDefinitionExported(WorkflowDefinition WorkflowDefinition, FileDownload FileDownload) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExporting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionExporting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is exporting.
+/// </summary>
 public record WorkflowDefinitionExporting(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdExported.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdExported.cs
@@ -4,4 +4,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition id is exported.
+/// </summary>
 public record WorkflowDefinitionIdExported(string WorkflowDefinitionId, VersionOptions? VersionOptions, FileDownload FileDownload) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdExporting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdExporting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition id is exporting.
+/// </summary>
 public record WorkflowDefinitionIdExporting(string WorkflowDefinitionId, VersionOptions? VersionOptions) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdPublishing.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdPublishing.cs
@@ -3,6 +3,6 @@ using Elsa.Studio.Contracts;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 /// <summary>
-/// Represents a notification sent when a workflow definition is about to be published by its ID.
+/// Represents the notification published when a workflow definition id is publishing.
 /// </summary>
 public record WorkflowDefinitionIdPublishing(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdRetracting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdRetracting.cs
@@ -2,4 +2,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition id is retracting.
+/// </summary>
 public record WorkflowDefinitionIdRetracting(string WorkflowDefinitionId) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdRetractingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionIdRetractingFailed.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition id retracting is failed.
+/// </summary>
 public record WorkflowDefinitionIdRetractingFailed(string WorkflowDefinitionId, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionPublishingFailed.cs
@@ -5,6 +5,6 @@ using Elsa.Studio.Workflows.Domain.Models;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 /// <summary>
-/// A notification sent when a workflow definition failed to publish.
+/// Represents the notification published when a workflow definition publishing is failed.
 /// </summary>
 public record WorkflowDefinitionPublishingFailed(WorkflowDefinition WorkflowDefinition, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracted.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is retracted.
+/// </summary>
 public record WorkflowDefinitionRetracted(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetracting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is retracting.
+/// </summary>
 public record WorkflowDefinitionRetracting(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetractingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionRetractingFailed.cs
@@ -4,4 +4,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition retracting is failed.
+/// </summary>
 public record WorkflowDefinitionRetractingFailed(WorkflowDefinition WorkflowDefinition, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionReverted.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Contracts;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition is reverted.
+/// </summary>
 public record WorkflowDefinitionReverted(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSavingFailed.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionSavingFailed.cs
@@ -5,6 +5,6 @@ using Elsa.Studio.Workflows.Domain.Models;
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
 /// <summary>
-/// A notification sent when a workflow definition failed to save.
+/// Represents the notification published when a workflow definition saving is failed.
 /// </summary>
 public record WorkflowDefinitionSavingFailed(WorkflowDefinition WorkflowDefinition, ValidationErrors Errors) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleted.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition version is deleted.
+/// </summary>
 public record WorkflowDefinitionVersionDeleted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionDeleting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition version is deleting.
+/// </summary>
 public record WorkflowDefinitionVersionDeleting(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionReverted.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionReverted.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition version is reverted.
+/// </summary>
 public record WorkflowDefinitionVersionReverted(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionReverting.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/WorkflowDefinitionVersionReverting.cs
@@ -3,4 +3,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
+/// <summary>
+/// Represents the notification published when a workflow definition version is reverting.
+/// </summary>
 public record WorkflowDefinitionVersionReverting(WorkflowDefinitionVersion WorkflowDefinitionVersion) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SchemaWorkflowJsonDetector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SchemaWorkflowJsonDetector.cs
@@ -8,6 +8,9 @@ namespace Elsa.Studio.Workflows.Domain.Services;
 /// A service that detects whether a JSON string is a workflow definition using a schema.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Represents the schema workflow json detector.
+/// </summary>
 public class SchemaWorkflowJsonDetector : IWorkflowJsonDetector
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SimpleWorkflowJsonDetector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SimpleWorkflowJsonDetector.cs
@@ -8,6 +8,9 @@ namespace Elsa.Studio.Workflows.Domain.Services;
 /// A service that detects whether a JSON string is a workflow definition using a simple heuristic.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Represents the simple workflow json detector.
+/// </summary>
 public class SimpleWorkflowJsonDetector : IWorkflowJsonDetector
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -12,7 +12,7 @@ public static class ActivityExtensions
     /// Gets the flowchart from the specified activity.
     /// </summary>
     /// <param name="activity"></param>
-    /// <returns></returns>
+    /// <returns>The result of the operation.</returns>
     /// <exception cref="NotSupportedException"></exception>
     public static JsonObject? GetFlowchart(this JsonObject activity)
     {
@@ -40,7 +40,7 @@ public static class ActivityExtensions
         // 2) Otherwise, scan every child property...
         foreach (var kvp in activity)
         {
-            // …if it’s a JsonObject, recurse into it.
+            // if its a JsonObject, recurse into it.
             if (kvp.Value is JsonObject childObj)
             {
                 var found = childObj.FindActivitiesContainer();
@@ -48,7 +48,7 @@ public static class ActivityExtensions
                     return found;
             }
 
-            // …if it’s a JsonArray, recurse into each item.
+            // if its a JsonArray, recurse into each item.
             if (kvp.Value is JsonArray childArr)
             {
                 foreach (var node in childArr.OfType<JsonObject>())

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Models/DefaultActivityColors.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Models/DefaultActivityColors.cs
@@ -5,17 +5,56 @@ namespace Elsa.Studio.Workflows.UI.Models;
 /// </summary>
 public static class DefaultActivityColors
 {
+    /// <summary>
+    /// Gets or sets the default.
+    /// </summary>
     public static string Default { get; set; } = "var(--mud-palette-primary)";
+    /// <summary>
+    /// Gets or sets the not found.
+    /// </summary>
     public static string NotFound { get; set; } = "var(--mud-palette-error)";
+    /// <summary>
+    /// Gets or sets the composition.
+    /// </summary>
     public static string Composition { get; set; } = "#f97316";
+    /// <summary>
+    /// Gets or sets the console.
+    /// </summary>
     public static string Console { get; set; } = "#0369a1";
+    /// <summary>
+    /// Gets or sets the http.
+    /// </summary>
     public static string Http { get; set; } = "#2dd4bf";
+    /// <summary>
+    /// Gets or sets the scripting.
+    /// </summary>
     public static string Scripting { get; set; } = "#22c55e";
+    /// <summary>
+    /// Gets or sets the flowchart.
+    /// </summary>
     public static string Flowchart { get; set; } = "#06b6d4";
+    /// <summary>
+    /// Gets or sets the looping.
+    /// </summary>
     public static string Looping { get; set; } = "#6366f1";
+    /// <summary>
+    /// Gets or sets the primitives.
+    /// </summary>
     public static string Primitives { get; set; } = Default;
+    /// <summary>
+    /// Gets or sets the email.
+    /// </summary>
     public static string Email { get; set; } = "#fcd34d";
+    /// <summary>
+    /// Gets or sets the branching.
+    /// </summary>
     public static string Branching { get; set; } = "#06b6d4";
+    /// <summary>
+    /// Gets or sets the timer.
+    /// </summary>
     public static string Timer { get; set; } = "#d946ef";
+    /// <summary>
+    /// Gets or sets the diagnostics.
+    /// </summary>
     public static string Diagnostics { get; set; } = "#ec407a";
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
@@ -8,6 +8,9 @@ namespace Elsa.Studio.Workflows.UI.Providers;
 
 /// Provides default activity display settings.
 [UsedImplicitly]
+/// <summary>
+/// Provides default activity display settings services.
+/// </summary>
 public class DefaultActivityDisplaySettingsProvider : IActivityDisplaySettingsProvider
 {
     /// <param name="activityDescriptor"></param>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/ActivityWrapperBase.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/ActivityWrapperBase.cs
@@ -56,14 +56,41 @@ public abstract class ActivityWrapperBase : StudioComponentBase
     [Inject] protected IActivityPortService ActivityPortService { get; set; } = null!;
     [Inject] protected IServiceProvider ServiceProvider { get; set; } = null!;
 
+    /// <summary>
+    /// Provides the can start workflow.
+    /// </summary>
     protected bool CanStartWorkflow => Activity.GetCanStartWorkflow() == true;
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
     protected string Label { get; private set; } = null!;
+    /// <summary>
+    /// Gets or sets the type name.
+    /// </summary>
     protected string TypeName { get; private set; } = null!;
+    /// <summary>
+    /// Gets or sets the description.
+    /// </summary>
     protected string Description { get; private set; } = null!;
+    /// <summary>
+    /// Indicates whether show description.
+    /// </summary>
     protected bool ShowDescription { get; private set; }
+    /// <summary>
+    /// Gets or sets the color.
+    /// </summary>
     protected string Color { get; private set; } = null!;
+    /// <summary>
+    /// Gets or sets the icon.
+    /// </summary>
     protected string? Icon { get; private set; }
+    /// <summary>
+    /// Gets or sets the activity descriptor.
+    /// </summary>
     protected ActivityDescriptor? ActivityDescriptor { get; private set; }
+    /// <summary>
+    /// Gets or sets the ports.
+    /// </summary>
     protected ICollection<Port> Ports { get; private set; } = new List<Port>();
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/EmbeddedActivityWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/EmbeddedActivityWrapper.razor.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Designer.Components.ActivityWrappers;
 
+/// <summary>
+/// Represents the embedded activity wrapper base.
+/// </summary>
 public abstract class EmbeddedActivityWrapperBase : StudioComponentBase
 {
     [Parameter] public string? ElementId { get; set; }
@@ -21,12 +24,33 @@ public abstract class EmbeddedActivityWrapperBase : StudioComponentBase
     [Inject] IActivityDisplaySettingsRegistry ActivityDisplaySettingsRegistry { get; set; } = null!;
     [Inject] IServiceProvider ServiceProvider { get; set; } = null!;
 
+    /// <summary>
+    /// Provides the can start workflow.
+    /// </summary>
     protected bool CanStartWorkflow => Activity.GetCanStartWorkflow() == true;
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
     protected string Label { get; private set; } = null!;
+    /// <summary>
+    /// Gets or sets the description.
+    /// </summary>
     protected string Description { get; private set; } = null!;
+    /// <summary>
+    /// Indicates whether show description.
+    /// </summary>
     protected bool ShowDescription { get; private set; }
+    /// <summary>
+    /// Gets or sets the color.
+    /// </summary>
     protected string Color  { get; private set; } = null!;
+    /// <summary>
+    /// Gets or sets the icon.
+    /// </summary>
     protected string? Icon  { get; private set; }
+    /// <summary>
+    /// Gets or sets the activity descriptor.
+    /// </summary>
     protected ActivityDescriptor ActivityDescriptor  { get; private set; } = null!;
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/EmbeddedActivityWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/EmbeddedActivityWrapper.razor.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Designer.Components.ActivityWrappers.V1;
 
+/// <summary>
+/// Represents the embedded activity wrapper.
+/// </summary>
 public partial class EmbeddedActivityWrapper;

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V2/EmbeddedActivityWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V2/EmbeddedActivityWrapper.razor.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Designer.Components.ActivityWrappers.V2;
 
+/// <summary>
+/// Represents the embedded activity wrapper.
+/// </summary>
 public partial class EmbeddedActivityWrapper;

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -86,12 +86,20 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="activity">The selected activity.</param>
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle activity selected operation asynchronously.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
     public async Task HandleActivitySelected(JsonObject activity)
     {
         if (ActivitySelected.HasDelegate)
             await ActivitySelected.InvokeAsync(activity);
     }
 
+    /// <summary>
+    /// Performs the update activity operation asynchronously.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
     public async Task UpdateActivityAsync(JsonObject activity)
     {
         if (ActivityPropsChanged.HasDelegate)
@@ -104,6 +112,11 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     /// <param name="activity">The selected activity.</param>
     /// <param name="portName">The selected port name.</param>
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle activity embedded port selected operation asynchronously.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <param name="portName">The port name.</param>
     public async Task HandleActivityEmbeddedPortSelected(JsonObject activity, string portName)
     {
         if (ActivityEmbeddedPortSelected.HasDelegate)
@@ -118,6 +131,10 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="activity">The clicked activity.</param>
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle activity double click operation asynchronously.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
     public async Task HandleActivityDoubleClick(JsonObject activity)
     {
         if (ActivityDoubleClick.HasDelegate)
@@ -128,6 +145,9 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
 
     /// Invoked from JavaScript when the canvas is selected.
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle canvas selected operation asynchronously.
+    /// </summary>
     public async Task HandleCanvasSelected()
     {
         if (CanvasSelected.HasDelegate)
@@ -136,6 +156,9 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
 
     /// Invoked from JavaScript when the graph is updated.
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle graph updated operation asynchronously.
+    /// </summary>
     public async Task HandleGraphUpdated()
     {
         if (GraphUpdated.HasDelegate)
@@ -144,6 +167,11 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
 
     /// Invoked from JavaScript when the graph is updated.
     [JSInvokable]
+    /// <summary>
+    /// Performs the handle paste cells requested operation asynchronously.
+    /// </summary>
+    /// <param name="activityNodes">The activity nodes.</param>
+    /// <param name="edges">The edges.</param>
     public async Task HandlePasteCellsRequested(X6ActivityNode[] activityNodes, X6Edge[] edges)
     {
         var allActivities = Flowchart.GetActivities().ToList();

--- a/src/modules/Elsa.Studio.Workflows.Designer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Extensions/ServiceCollectionExtensions.cs
@@ -6,8 +6,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Workflows.Designer.Extensions;
 
+/// <summary>
+/// Provides extension methods for service collection.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds the workflows designer.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The result of the operation.</returns>
     public static IServiceCollection AddWorkflowsDesigner(this IServiceCollection services)
     {
         return services

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
@@ -14,6 +14,9 @@ namespace Elsa.Studio.Workflows.Designer.Interop;
 /// </summary>
 public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> options, IServiceProvider serviceProvider) : JsInteropBase(jsRuntime)
 {
+    /// <summary>
+    /// Provides the string.
+    /// </summary>
     protected override string ModuleName => "designer";
 
     /// <summary>
@@ -33,6 +36,9 @@ public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> o
         });
     }
 
+    /// <summary>
+    /// Provides the task.
+    /// </summary>
     public async Task UpdateActivitySizeAsync(string elementId, JsonObject activity, Elsa.Api.Client.Shared.Models.Size? size = null)
     {
         var serializerOptions = GetSerializerOptions();
@@ -40,9 +46,17 @@ public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> o
         await TryInvokeAsync(module => module.InvokeVoidAsync("updateActivitySize", elementId, activityJson, size));
     }
 
+    /// <summary>
+    /// Provides the task.
+    /// </summary>
     public async Task UpdateActivityStatsAsync(string elementId, string activityId, ActivityStats stats) =>
         await TryInvokeAsync(module => module.InvokeVoidAsync("updateActivityStats", elementId, activityId, stats));
 
+    /// <summary>
+    /// Performs the raise activity selected operation asynchronously.
+    /// </summary>
+    /// <param name="elementId">The element id.</param>
+    /// <param name="activity">The activity.</param>
     public async Task RaiseActivitySelectedAsync(string elementId, JsonObject activity)
     {
         var serializerOptions = GetSerializerOptions();
@@ -50,6 +64,12 @@ public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> o
         await TryInvokeAsync(module => module.InvokeVoidAsync("raiseActivitySelected", elementId, activityJson));
     }
 
+    /// <summary>
+    /// Performs the raise activity embedded port selected operation asynchronously.
+    /// </summary>
+    /// <param name="elementId">The element id.</param>
+    /// <param name="activity">The activity.</param>
+    /// <param name="portName">The port name.</param>
     public async Task RaiseActivityEmbeddedPortSelectedAsync(string elementId, JsonObject activity, string portName)
     {
         var serializerOptions = GetSerializerOptions();

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/JsInteropBase.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/JsInteropBase.cs
@@ -9,14 +9,23 @@ public abstract class JsInteropBase : IAsyncDisposable
 {
     private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
 
+    /// <summary>
+    /// Gets the name of the module to import.
+    /// </summary>
     protected abstract string ModuleName { get; }
 
-    /// Initializes a new instance of <see cref="JsInteropBase"/>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsInteropBase"/> class.
+    /// </summary>
+    /// <param name="jsRuntime">The JavaScript runtime used to import the module.</param>
     protected JsInteropBase(IJSRuntime jsRuntime)
     {
         _moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import", $"./_content/Elsa.Studio.Workflows.Designer/{ModuleName}.entry.js").AsTask());
     }
 
+    /// <summary>
+    /// Disposes the imported JavaScript module if it has been created.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         if (_moduleTask.IsValueCreated)
@@ -35,12 +44,20 @@ public abstract class JsInteropBase : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Invokes the specified callback using the imported module instance.
+    /// </summary>
+    /// <param name="func">The callback to execute.</param>
     protected async Task InvokeAsync(Func<IJSObjectReference, ValueTask> func)
     {
         var module = await _moduleTask.Value;
         await func(module);
     }
 
+    /// <summary>
+    /// Safely invokes the specified callback and ignores JavaScript exceptions.
+    /// </summary>
+    /// <param name="func">The callback to execute.</param>
     protected async Task TryInvokeAsync(Func<IJSObjectReference, ValueTask> func)
     {
         try
@@ -54,12 +71,24 @@ public abstract class JsInteropBase : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Invokes the specified callback and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of result returned by the callback.</typeparam>
+    /// <param name="func">The callback to execute.</param>
+    /// <returns>The result produced by <paramref name="func"/>.</returns>
     protected async Task<T> InvokeAsync<T>(Func<IJSObjectReference, ValueTask<T>> func)
     {
         var module = await _moduleTask.Value;
         return await func(module);
     }
 
+    /// <summary>
+    /// Invokes the specified callback and returns its result, ignoring JavaScript exceptions.
+    /// </summary>
+    /// <typeparam name="T">The type of result returned by the callback.</typeparam>
+    /// <param name="func">The callback to execute.</param>
+    /// <returns>The result produced by <paramref name="func"/>, or the default value of <typeparamref name="T"/> when an exception occurs.</returns>
     protected async Task<T> TryInvokeAsync<T>(Func<IJSObjectReference, ValueTask<T>> func)
     {
         try

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6ActivityNode.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6ActivityNode.cs
@@ -4,14 +4,38 @@ using Elsa.Studio.Workflows.UI.Models;
 
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6activity node.
+/// </summary>
 public class X6ActivityNode
 {
+    /// <summary>
+    /// Gets or sets the id.
+    /// </summary>
     public string Id { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the shape.
+    /// </summary>
     public string Shape { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the position.
+    /// </summary>
     public X6Position Position { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the size.
+    /// </summary>
     public X6Size Size { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the data.
+    /// </summary>
     public JsonObject Data { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the ports.
+    /// </summary>
     public X6Ports Ports { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the activity stats.
+    /// </summary>
     public ActivityStats? ActivityStats { get; set; }
     
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Attrs.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Attrs.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6attrs.
+/// </summary>
 public class X6Attrs : Dictionary<string, object>
 {
     

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Edge.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Edge.cs
@@ -1,9 +1,24 @@
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6edge.
+/// </summary>
 public class X6Edge
 {
+    /// <summary>
+    /// Gets or sets the source.
+    /// </summary>
     public X6Endpoint Source { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the target.
+    /// </summary>
     public X6Endpoint Target { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the shape.
+    /// </summary>
     public string? Shape { get; set; }
+    /// <summary>
+    /// Gets or sets the vertices.
+    /// </summary>
     public ICollection<X6Position> Vertices { get; set; } = [];
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Endpoint.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Endpoint.cs
@@ -1,7 +1,16 @@
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6endpoint.
+/// </summary>
 public class X6Endpoint
 {
+    /// <summary>
+    /// Gets or sets the cell.
+    /// </summary>
     public string Cell { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the port.
+    /// </summary>
     public string Port { get; set; } = null!;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Graph.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Graph.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6graph.
+/// </summary>
 public class X6Graph
 {
     [JsonConstructor]
@@ -15,6 +18,12 @@ public class X6Graph
         Edges = edges.ToList();
     }
 
+    /// <summary>
+    /// Gets or sets the nodes.
+    /// </summary>
     public ICollection<X6ActivityNode> Nodes { get; set; } = new List<X6ActivityNode>();
+    /// <summary>
+    /// Gets or sets the edges.
+    /// </summary>
     public ICollection<X6Edge> Edges { get; set; } = new List<X6Edge>();
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Port.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Port.cs
@@ -1,10 +1,28 @@
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6port.
+/// </summary>
 public class X6Port
 {
+    /// <summary>
+    /// Gets or sets the id.
+    /// </summary>
     public string Id { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the group.
+    /// </summary>
     public string Group { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
     public string? Type { get; set; }
+    /// <summary>
+    /// Gets or sets the position.
+    /// </summary>
     public string? Position { get; set; }
+    /// <summary>
+    /// Gets or sets the attrs.
+    /// </summary>
     public IDictionary<string, object>? Attrs { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Ports.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Ports.cs
@@ -1,6 +1,12 @@
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6ports.
+/// </summary>
 public class X6Ports
 {
+    /// <summary>
+    /// Gets or sets the items.
+    /// </summary>
     public ICollection<X6Port> Items { get; set; } = new List<X6Port>();
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Position.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Position.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6position.
+/// </summary>
 public class X6Position
 {
     [JsonConstructor]
@@ -15,6 +18,12 @@ public class X6Position
         Y = y;
     }
 
+    /// <summary>
+    /// Gets or sets the x.
+    /// </summary>
     public double X { get; set; }
+    /// <summary>
+    /// Gets or sets the y.
+    /// </summary>
     public double Y { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Size.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6Size.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace Elsa.Studio.Workflows.Designer.Models;
 
+/// <summary>
+/// Represents the x6size.
+/// </summary>
 public class X6Size
 {
     [JsonConstructor]
@@ -15,6 +18,12 @@ public class X6Size
         Height = height;
     }
 
+    /// <summary>
+    /// Gets or sets the width.
+    /// </summary>
     public double Width { get; set; }
+    /// <summary>
+    /// Gets or sets the height.
+    /// </summary>
     public double Height { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Module.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Module.cs
@@ -2,7 +2,10 @@ using Elsa.Studio.Abstractions;
 
 namespace Elsa.Studio.Workflows.Designer;
 
+/// <summary>
+/// Registers the workflow designer feature with the application shell.
+/// </summary>
 public class Feature : FeatureBase
 {
-    
+
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/DesignerOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/DesignerOptions.cs
@@ -1,7 +1,16 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Represents configuration options for designer.
+/// </summary>
 public class DesignerOptions
 {
+    /// <summary>
+    /// Gets or sets the designer css class.
+    /// </summary>
     public string? DesignerCssClass { get; set; } = "elsa-flowchart-diagram-designer-v2";
+    /// <summary>
+    /// Gets or sets the graph settings.
+    /// </summary>
     public X6GraphSettings GraphSettings { get; set; } = new();
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GraphSettings.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GraphSettings.cs
@@ -1,9 +1,24 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Represents the x6graph settings.
+/// </summary>
 public class X6GraphSettings
 {
+    /// <summary>
+    /// Gets or sets the grid.
+    /// </summary>
     public X6Grid Grid { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the magnet threshold.
+    /// </summary>
     public double MagnetThreshold { get; set; }
+    /// <summary>
+    /// Gets or sets the panning.
+    /// </summary>
     public X6Panning Panning { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the mousewheel.
+    /// </summary>
     public X6Mousewheel Mousewheel { get; set; } = new();
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Grid.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Grid.cs
@@ -1,9 +1,24 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Represents the x6grid.
+/// </summary>
 public class X6Grid
 {
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
     public string Type { get; set; } = "dot";
+    /// <summary>
+    /// Indicates whether visible.
+    /// </summary>
     public bool Visible { get; set; } = true;
+    /// <summary>
+    /// Gets or sets the size.
+    /// </summary>
     public double Size { get; set; } = 20;
+    /// <summary>
+    /// Gets or sets the args.
+    /// </summary>
     public object? Args { get; set; } = new X6GridArgs();
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GridArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GridArgs.cs
@@ -1,7 +1,16 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Provides arguments for x6grid.
+/// </summary>
 public class X6GridArgs
 {
+    /// <summary>
+    /// Gets or sets the color.
+    /// </summary>
     public string Color { get; set; } = "#334154"; //f1f1f1 for V1
+    /// <summary>
+    /// Gets or sets the thickness.
+    /// </summary>
     public double Thickness { get; set; } = 1;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Mousewheel.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Mousewheel.cs
@@ -1,9 +1,24 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Represents the x6mousewheel.
+/// </summary>
 public class X6Mousewheel
 {
+    /// <summary>
+    /// Indicates whether enabled.
+    /// </summary>
     public bool Enabled { get; set; } = true;
+    /// <summary>
+    /// Gets or sets the factor.
+    /// </summary>
     public double factor { get; set; } = 1.05;
+    /// <summary>
+    /// Gets or sets the min scale.
+    /// </summary>
     public double MinScale { get; set; } = 0.4;
+    /// <summary>
+    /// Gets or sets the max scale.
+    /// </summary>
     public double MaxScale { get; set; } = 3;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Panning.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6Panning.cs
@@ -1,6 +1,12 @@
 namespace Elsa.Studio.Workflows.Designer.Options;
 
+/// <summary>
+/// Represents the x6panning.
+/// </summary>
 public class X6Panning
 {
+    /// <summary>
+    /// Indicates whether enabled.
+    /// </summary>
     public bool Enabled { get; set; } = true;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Services/ActivityMapper.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Services/ActivityMapper.cs
@@ -17,6 +17,9 @@ internal class ActivityMapper(
     IActivityDisplaySettingsRegistry activityDisplaySettingsRegistry)
     : IActivityMapper
 {
+    /// <summary>
+    /// Provides the map activity.
+    /// </summary>
     public X6ActivityNode MapActivity(JsonObject activity, ActivityStats? activityStats = null)
     {
         var activityId = activity.GetId();
@@ -47,6 +50,11 @@ internal class ActivityMapper(
         return node;
     }
 
+    /// <summary>
+    /// Gets the ports.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns>The result of the operation.</returns>
     public X6Ports GetPorts(JsonObject activity)
     {
         // Create input ports.
@@ -62,6 +70,11 @@ internal class ActivityMapper(
         };
     }
 
+    /// <summary>
+    /// Gets the out ports.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns>The result of the operation.</returns>
     public IEnumerable<X6Port> GetOutPorts(JsonObject activity)
     {
         var activityType = activity.GetTypeName();
@@ -116,6 +129,11 @@ internal class ActivityMapper(
         return ports;
     }
 
+    /// <summary>
+    /// Gets the in ports.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns>The result of the operation.</returns>
     public IEnumerable<X6Port> GetInPorts(JsonObject activity)
     {
         var displaySettings = activityDisplaySettingsRegistry.GetSettings(activity.GetTypeName());

--- a/src/modules/Elsa.Studio.Workflows.Designer/Services/FlowchartMapper.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Services/FlowchartMapper.cs
@@ -10,6 +10,9 @@ namespace Elsa.Studio.Workflows.Designer.Services;
 
 internal class FlowchartMapper(IActivityMapper activityMapper) : IFlowchartMapper
 {
+    /// <summary>
+    /// Provides the map.
+    /// </summary>
     public X6Graph Map(JsonObject flowchart, IDictionary<string, ActivityStats>? activityStatsMap = null)
     {
         var graph = new X6Graph();
@@ -54,6 +57,11 @@ internal class FlowchartMapper(IActivityMapper activityMapper) : IFlowchartMappe
         return graph;
     }
 
+    /// <summary>
+    /// Performs the map operation.
+    /// </summary>
+    /// <param name="graph">The graph.</param>
+    /// <returns>The result of the operation.</returns>
     public JsonObject Map(X6Graph graph)
     {
         var activities = new List<JsonObject>();

--- a/src/modules/Elsa.Studio.Workflows.Designer/Services/MapperFactory.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Services/MapperFactory.cs
@@ -6,12 +6,18 @@ namespace Elsa.Studio.Workflows.Designer.Services;
 
 internal class MapperFactory(IActivityRegistry activityRegistry, IActivityPortService activityPortService, IActivityDisplaySettingsRegistry activityDisplaySettingsRegistry) : IMapperFactory
 {
+    /// <summary>
+    /// Provides the task.
+    /// </summary>
     public async Task<IFlowchartMapper> CreateFlowchartMapperAsync(CancellationToken cancellationToken = default)
     {
         var activityMapper = await CreateActivityMapperAsync(cancellationToken);
         return new FlowchartMapper(activityMapper);
     }
 
+    /// <summary>
+    /// Provides the task.
+    /// </summary>
     public async Task<IActivityMapper> CreateActivityMapperAsync(CancellationToken cancellationToken = default)
     {
         await activityRegistry.EnsureLoadedAsync(cancellationToken);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -20,12 +20,18 @@ public partial class ActivityPropertiesPanel
     /// Gets or sets the workflow definition.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the workflow definition.
+    /// </summary>
     public WorkflowDefinition? WorkflowDefinition { get; set; }
 
     /// <summary>
     /// Gets or sets the activity.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the activity.
+    /// </summary>
     public JsonObject? Activity { get; set; }
 
     /// <summary>
@@ -49,12 +55,18 @@ public partial class ActivityPropertiesPanel
     /// Gets or sets a callback that is invoked when the activity is updated.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the on activity updated callback.
+    /// </summary>
     public Func<JsonObject, Task>? OnActivityUpdated { get; set; }
 
     /// <summary>
     /// Gets or sets the visible pane height.
     /// </summary>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the visible pane height.
+    /// </summary>
     public int VisiblePaneHeight { get; set; }
 
     [Inject] private IExpressionService ExpressionService { get; set; } = null!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Models.cs
@@ -2,4 +2,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
 
+/// <summary>
+/// Represents a activity input display model.
+/// </summary>
 public record ActivityInputDisplayModel(RenderFragment Editor);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
@@ -268,6 +268,9 @@ public partial class LogPersistenceTab
 /// Defines the Persistence Strategy Configuration for an activity
 /// </summary>
 [Obsolete]
+/// <summary>
+/// Represents the legacy persistence activity configuration.
+/// </summary>
 public class LegacyPersistenceActivityConfiguration
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingKind.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingKind.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models;
 
+/// <summary>
+/// Defines the binding kind enumeration.
+/// </summary>
 public enum BindingKind
 {
     Variable,

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetGroup.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetGroup.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models;
 
+/// <summary>
+/// Represents the binding target group record.
+/// </summary>
 public record BindingTargetGroup(string Text, BindingKind Kind, ICollection<BindingTargetOption> Options);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models;
 
+/// <summary>
+/// Represents the binding target option record.
+/// </summary>
 public record BindingTargetOption(string Text, string Value);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor.cs
@@ -16,6 +16,9 @@ public partial class TaskTab
     
     /// The activity descriptor.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the activity descriptor.
+    /// </summary>
     public ActivityDescriptor ActivityDescriptor { get; set; } = default!;
     
     /// An event raised when the activity is updated.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/VersionTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/VersionTab.razor.cs
@@ -12,6 +12,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs;
 
+/// <summary>
+/// Represents the version tab.
+/// </summary>
 public partial class VersionTab
 {
     [Parameter] public ActivityDescriptor ActivityDescriptor { get; set; } = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
@@ -14,6 +14,9 @@ using Radzen.Blazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 
+/// <summary>
+/// Represents the workflow definition version viewer.
+/// </summary>
 public partial class WorkflowDefinitionVersionViewer
 {
     private RadzenSplitterPane _activityPropertiesPane = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditorComponentBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditorComponentBase.cs
@@ -10,9 +10,18 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 
+/// <summary>
+/// Represents the workflow editor component base.
+/// </summary>
 public abstract class WorkflowEditorComponentBase : StudioComponentBase
 {
+    /// <summary>
+    /// Provides the  workflow definition.
+    /// </summary>
     protected WorkflowDefinition? _workflowDefinition;
+    /// <summary>
+    /// Indicates whether is progressing.
+    /// </summary>
     protected bool IsProgressing { get; set; }
 
     /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
@@ -89,6 +98,12 @@ public abstract class WorkflowEditorComponentBase : StudioComponentBase
         }
     }
 
+    /// <summary>
+    /// Shows progress while executing an asynchronous operation that returns a value.
+    /// </summary>
+    /// <typeparam name="T">The type of result produced by the operation.</typeparam>
+    /// <param name="action">The asynchronous action to execute.</param>
+    /// <returns>The result returned by <paramref name="action"/>.</returns>
     protected async Task<T> ProgressAsync<T>(Func<Task<T>> action)
     {
         IsProgressing = true;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/InputOutputTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/InputOutputTab.razor.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Components;
 
+/// <summary>
+/// Represents the input output tab.
+/// </summary>
 public partial class InputOutputTab
 {
     [Parameter] public WorkflowDefinition WorkflowDefinition { get; set; } = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/EditInputDialog.razor.cs
@@ -13,6 +13,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Components.Inputs;
 
+/// <summary>
+/// Represents the edit input dialog.
+/// </summary>
 public partial class EditInputDialog
 {
     private readonly InputDefinitionModel _model = new();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
@@ -8,6 +8,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Components.Inputs;
 
+/// <summary>
+/// Represents the inputs section.
+/// </summary>
 public partial class InputsSection
 {
     private ICollection<VariableTypeDescriptor> _variableTypes = new List<VariableTypeDescriptor>();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor.cs
@@ -6,6 +6,9 @@ using MudExtensions;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Components.Outcomes;
 
+/// <summary>
+/// Represents the outcomes section.
+/// </summary>
 public partial class OutcomesSection
 {
     private MudChipField<string> _chipField = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
@@ -8,6 +8,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Components.Outputs;
 
+/// <summary>
+/// Represents the outputs section.
+/// </summary>
 public partial class OutputsSection
 {
     private ICollection<VariableTypeDescriptor> _variableTypes = new List<VariableTypeDescriptor>();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/ArgumentDefinitionModel.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/ArgumentDefinitionModel.cs
@@ -2,12 +2,33 @@ using Elsa.Api.Client.Resources.VariableTypes.Models;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Models;
 
+/// <summary>
+/// Represents a argument definition model.
+/// </summary>
 public abstract class ArgumentDefinitionModel
 {
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
     public VariableTypeDescriptor Type { get; set; } = default!;
+    /// <summary>
+    /// Indicates whether is array.
+    /// </summary>
     public bool IsArray { get; set; }
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
     public string Name { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
     public string DisplayName { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the description.
+    /// </summary>
     public string Description { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the category.
+    /// </summary>
     public string Category { get; set; } = default!;
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/InputDefinitionModel.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/InputDefinitionModel.cs
@@ -3,9 +3,18 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Models;
 
+/// <summary>
+/// Represents a input definition model.
+/// </summary>
 public class InputDefinitionModel : ArgumentDefinitionModel
 {
+    /// <summary>
+    /// Gets or sets the uihint.
+    /// </summary>
     public UIHintDescriptor? UIHint { get; set; }
 
+    /// <summary>
+    /// Gets or sets the storage driver.
+    /// </summary>
     public StorageDriverDescriptor StorageDriver { get; set; } = default!;
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/OutputDefinitionModel.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Models/OutputDefinitionModel.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Models;
 
+/// <summary>
+/// Represents a output definition model.
+/// </summary>
 public class OutputDefinitionModel : ArgumentDefinitionModel
 {
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Validators/InputModelValidator.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Validators/InputModelValidator.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Validators;
 
+/// <summary>
+/// Represents the input model validator.
+/// </summary>
 public class InputModelValidator : AbstractValidator<InputDefinitionModel>
 {
     public InputModelValidator(WorkflowDefinition workflowDefinition, ILocalizer localizer)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Validators/OutputModelValidator.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Validators/OutputModelValidator.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.InputOutput.Validators;
 
+/// <summary>
+/// Represents the output model validator.
+/// </summary>
 public class OutputModelValidator : AbstractValidator<OutputDefinitionModel>
 {
     public OutputModelValidator(WorkflowDefinition workflowDefinition, ILocalizer localizer)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Info/Info.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Info/Info.razor.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.Components;
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Properties.
     Sections.Info;
 
+/// <summary>
+/// Represents the info.
+/// </summary>
 public partial class Info
 {
     private DataPanelModel _workflowInfo = new ();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -10,6 +10,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Variables.Components;
 
+/// <summary>
+/// Represents the variables tab.
+/// </summary>
 public partial class VariablesTab
 {
     private ICollection<StorageDriverDescriptor> _storageDriverDescriptors = new List<StorageDriverDescriptor>();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Models/VariableModel.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Models/VariableModel.cs
@@ -3,12 +3,33 @@ using Elsa.Api.Client.Resources.VariableTypes.Models;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Variables.Models;
 
+/// <summary>
+/// Represents a variable model.
+/// </summary>
 public class VariableModel
 {
+    /// <summary>
+    /// Gets or sets the id.
+    /// </summary>
     public string Id { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
     public string Name { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the variable type.
+    /// </summary>
     public VariableTypeDescriptor VariableType { get; set; } = null!;
+    /// <summary>
+    /// Indicates whether is array.
+    /// </summary>
     public bool IsArray { get; set; }
+    /// <summary>
+    /// Gets or sets the default value.
+    /// </summary>
     public string? DefaultValue { get; set; }
+    /// <summary>
+    /// Gets or sets the storage driver.
+    /// </summary>
     public StorageDriverDescriptor StorageDriver { get; set; } = null!;
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Models/VariableTestValueModel.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Models/VariableTestValueModel.cs
@@ -1,7 +1,16 @@
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Variables.Models;
 
+/// <summary>
+/// Represents a variable test value model.
+/// </summary>
 public class VariableTestValueModel
 {
+    /// <summary>
+    /// Gets or sets the variable id.
+    /// </summary>
     public string VariableId { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the test value.
+    /// </summary>
     public string? TestValue { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/WorkflowProperties.razor.cs
@@ -3,6 +3,9 @@ using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties;
 
+/// <summary>
+/// Represents the workflow properties.
+/// </summary>
 public partial class WorkflowProperties
 {
     [Parameter] public WorkflowDefinition WorkflowDefinition { get; set; } = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Components/BulkCancelDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Components/BulkCancelDialog.razor.cs
@@ -3,6 +3,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowInstanceList.Components;
 
+/// <summary>
+/// Represents the bulk cancel dialog.
+/// </summary>
 public partial class BulkCancelDialog : ComponentBase
 {
     private bool ApplyToAllMatches { get; set; }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ElapsedTime.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ElapsedTime.razor.cs
@@ -16,6 +16,9 @@ public partial class ElapsedTime
     /// The default value is set to the current UTC time.
     /// </remarks>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the start time.
+    /// </summary>
     public DateTimeOffset StartTime { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>
@@ -29,6 +32,9 @@ public partial class ElapsedTime
     /// The end time as a <see cref="DateTimeOffset"/> value.
     /// </value>
     [Parameter]
+    /// <summary>
+    /// Gets or sets the end time.
+    /// </summary>
     public DateTimeOffset EndTime { get; set; } = DateTimeOffset.UtcNow;
     
     private TimeSpan Elapsed => EndTime < StartTime ? TimeSpan.Zero : EndTime - StartTime;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceWorkspace.razor.cs
@@ -9,6 +9,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 
+/// <summary>
+/// Represents the workflow instance workspace.
+/// </summary>
 public partial class WorkflowInstanceWorkspace : IWorkspace
 {
     private WorkflowInstanceDetails _workflowInstanceDetails = default!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Models/JournalEntry.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Models/JournalEntry.cs
@@ -4,6 +4,9 @@ using Elsa.Studio.Workflows.UI.Models;
 
 namespace Elsa.Studio.Workflows.Pages.WorkflowInstances.View.Models;
 
+/// <summary>
+/// Represents the journal entry record.
+/// </summary>
 public record JournalEntry(
     WorkflowExecutionLogRecord Record,
     ActivityDescriptor? ActivityDescriptor,

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Models/TimeMetricMode.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Models/TimeMetricMode.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Studio.Workflows.Pages.WorkflowInstances.View.Models;
 
+/// <summary>
+/// Defines the time metric mode enumeration.
+/// </summary>
 public enum TimeMetricMode
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesignerProvider.cs
@@ -4,10 +4,22 @@ using Elsa.Studio.Workflows.UI.Contracts;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.Fallback;
 
+/// <summary>
+/// Provides fallback designer services.
+/// </summary>
 public class FallbackDesignerProvider : IDiagramDesignerProvider
 {
+    /// <summary>
+    /// Provides the priority.
+    /// </summary>
     public double Priority => -1000;
+    /// <summary>
+    /// Provides the get supports activity.
+    /// </summary>
     public bool GetSupportsActivity(JsonObject activity) => true;
 
+    /// <summary>
+    /// Provides the get editor.
+    /// </summary>
     public IDiagramDesigner GetEditor() => new FallbackDiagramDesigner();
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
@@ -11,6 +11,9 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 /// A diagram designer provider for the Flowchart designer.
 /// </summary>
 [UsedImplicitly]
+/// <summary>
+/// Provides flowchart diagram designer services.
+/// </summary>
 public class FlowchartDiagramDesignerProvider(ILocalizer localizer) : IDiagramDesignerProvider
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Extensions/HubConnectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/HubConnectionExtensions.cs
@@ -2,8 +2,18 @@
 
 namespace Elsa.Studio.Workflows.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for hub connection.
+    /// </summary>
     public static class HubConnectionExtensions
     {
+        /// <summary>
+        /// Configures the url.
+        /// </summary>
+        /// <param name="builder">The builder to configure.</param>
+        /// <param name="url">The url.</param>
+        /// <param name="clientFactory">The client factory.</param>
+        /// <returns>The result of the operation.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder builder, string url, IHttpMessageHandlerFactory clientFactory)
         {
             return builder.WithUrl(url, options =>

--- a/src/modules/Elsa.Studio.Workflows/Extensions/WorkflowDefinitionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/WorkflowDefinitionExtensions.cs
@@ -9,7 +9,7 @@ public static class WorkflowDefinitionExtensions
     /// Determines whether the specified workflow definition is read-only.
     /// </summary>
     /// <param name="workflowDefinition">The workflow definition to check.</param>
-    /// <returns><c>true</c> if the workflow definition is read-only; otherwise, <c>false</c>.</returns>
+    /// <returns>The result of the operation.</returns>
     public static bool GetIsReadOnly(this WorkflowDefinition? workflowDefinition)
     {
         return workflowDefinition != null && (workflowDefinition.IsLatest == false || (workflowDefinition.Links?.Count(l => l.Rel == "publish") ?? 0) == 0);

--- a/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
+++ b/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
@@ -7,6 +7,9 @@ namespace Elsa.Studio.Workflows.Handlers;
 
 /// A handler that refreshes the activity registry when a workflow definition is deleted, published or retracted.
 [UsedImplicitly]
+/// <summary>
+/// Represents the refresh activity registry.
+/// </summary>
 public class RefreshActivityRegistry : INotificationHandler<WorkflowDefinitionDeleted>,
     INotificationHandler<WorkflowDefinitionPublished>,
     INotificationHandler<WorkflowDefinitionRetracted>,

--- a/src/modules/Elsa.Studio.Workflows/Menu/WorkflowsMenu.cs
+++ b/src/modules/Elsa.Studio.Workflows/Menu/WorkflowsMenu.cs
@@ -6,8 +6,14 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Menu;
 
+/// <summary>
+/// Exposes menu entries for workflows.
+/// </summary>
 public class WorkflowsMenu(ILocalizer localizer) : IMenuProvider
 {
+    /// <summary>
+    /// Provides the get menu items async.
+    /// </summary>
     public ValueTask<IEnumerable<MenuItem>> GetMenuItemsAsync(CancellationToken cancellationToken = default)
     {
         var menuItems = new List<MenuItem>

--- a/src/modules/Elsa.Studio.Workflows/Models/PagedResult.cs
+++ b/src/modules/Elsa.Studio.Workflows/Models/PagedResult.cs
@@ -1,3 +1,6 @@
 namespace Elsa.Studio.Workflows.Models;
 
+/// <summary>
+/// Represents the result of paged.
+/// </summary>
 public record PagedResult<T>(ICollection<T> Items, long TotalCount);

--- a/src/modules/Elsa.Studio.Workflows/Models/WorkflowInstanceObserverContext.cs
+++ b/src/modules/Elsa.Studio.Workflows/Models/WorkflowInstanceObserverContext.cs
@@ -2,9 +2,21 @@ using System.Text.Json.Nodes;
 
 namespace Elsa.Studio.Workflows.Models;
 
+/// <summary>
+/// Represents the workflow instance observer context.
+/// </summary>
 public class WorkflowInstanceObserverContext
 {
+    /// <summary>
+    /// Gets or sets the workflow instance id.
+    /// </summary>
     public string WorkflowInstanceId { get; set; } = default!;
+    /// <summary>
+    /// Gets or sets the container activity.
+    /// </summary>
     public JsonObject? ContainerActivity { get; set; }
+    /// <summary>
+    /// Gets or sets the cancellation token.
+    /// </summary>
     public CancellationToken CancellationToken { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
@@ -6,6 +6,9 @@ namespace Elsa.Studio.Workflows.Services;
 /// An implementation of <see cref="IWorkflowInstanceObserver"/> that does nothing.
 public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
 {
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
     public string? Name { get; set; }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -33,30 +33,51 @@ public partial class DiagramDesignerWrapper
 
     /// The workflow definition version ID.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the workflow definition version id.
+    /// </summary>
     public string WorkflowDefinitionVersionId { get; set; } = null!;
 
     /// The root activity to display.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the activity.
+    /// </summary>
     public JsonObject Activity { get; set; } = null!;
 
     /// Whether the designer is read-only.
     [Parameter]
+    /// <summary>
+    /// Indicates whether is read only.
+    /// </summary>
     public bool IsReadOnly { get; set; }
 
     /// The workflow instance ID, if any.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the workflow instance id.
+    /// </summary>
     public string? WorkflowInstanceId { get; set; }
 
     /// A custom toolbar to display.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the custom toolbar items.
+    /// </summary>
     public RenderFragment? CustomToolbarItems { get; set; }
 
     /// Whether the designer is progressing.
     [Parameter]
+    /// <summary>
+    /// Indicates whether is progressing.
+    /// </summary>
     public bool IsProgressing { get; set; }
 
     /// An event raised when an activity is selected.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the activity selected event callback.
+    /// </summary>
     public EventCallback<JsonObject> ActivitySelected { get; set; }
 
     /// An event raised when an embedded port is selected.
@@ -66,6 +87,9 @@ public partial class DiagramDesignerWrapper
 
     /// An event raised when the path changes.
     [Parameter]
+    /// <summary>
+    /// Gets or sets the path changed event callback.
+    /// </summary>
     public EventCallback<DesignerPathChangedArgs> PathChanged { get; set; }
 
     [Inject]

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/GraphSegment.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/GraphSegment.cs
@@ -2,4 +2,7 @@ using System.Text.Json.Nodes;
 
 namespace Elsa.Studio.Workflows.Shared.Components;
 
+/// <summary>
+/// Represents the graph segment record.
+/// </summary>
 public record GraphSegment(JsonObject Activity, string PortName, JsonObject? EmbeddedActivity = default);


### PR DESCRIPTION
## Summary
- add XML documentation comments to public types and members throughout the solution to address CS1591 warnings
- improve notification, event, and helper method comments so API consumers understand workflow behaviors

## Testing
- `dotnet build Elsa.Studio.sln` *(fails: Microsoft.Build.Exceptions.InternalLoggerException / ArgumentOutOfRangeException in TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_68d82867e7c08333b2722d73fa3b1e8e