### PR TITLE
Add hotkey support for saving workflows with Ctrl+S/Cmd+S

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -61,6 +61,7 @@
 
 <script>
     window.editorHotkeys = {
+        _hotkeyHandler: null,
         register: function (dotNetRef) {
             function handler(e) {
                 // Ctrl+S (Windows/Linux) and Cmd+S (Mac)
@@ -75,12 +76,12 @@
                 }
             }
             window.addEventListener('keydown', handler);
-            dotNetRef._hotkeyHandler = handler;
+            this._hotkeyHandler = handler;
         },
         dispose: function (dotNetRef) {
-            if (dotNetRef._hotkeyHandler) {
-                window.removeEventListener('keydown', dotNetRef._hotkeyHandler);
-                dotNetRef._hotkeyHandler = null;
+            if (this._hotkeyHandler) {
+                window.removeEventListener('keydown', this._hotkeyHandler);
+                this._hotkeyHandler = null;
             }
         }
     };

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -64,9 +64,14 @@
         register: function (dotNetRef) {
             function handler(e) {
                 // Ctrl+S (Windows/Linux) and Cmd+S (Mac)
-                if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+                if ((e.ctrlKey || e.metaKey) && e.key === 's' && !e.shiftKey) {
                     e.preventDefault();
                     dotNetRef.invokeMethodAsync('OnHotKeysCtrlS');
+                }
+                // Ctrl+Shift+S (Windows/Linux) and Cmd+Shift+S (Mac) for Save As
+                if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'S') {
+                    e.preventDefault();
+                    dotNetRef.invokeMethodAsync('OnHotKeysCtrlShiftS');
                 }
             }
             window.addEventListener('keydown', handler);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -58,3 +58,25 @@
         <ActivityPropertiesPanel @ref="ActivityPropertiesPanel" WorkflowDefinition="@_workflowDefinition" Activity="@SelectedActivity" ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="@OnSelectedActivityUpdated" VisiblePaneHeight="@_activityPropertiesPaneHeight"/>
     </RadzenSplitterPane>
 </RadzenSplitter>
+
+<script>
+    window.editorHotkeys = {
+        register: function (dotNetRef) {
+            function handler(e) {
+                // Ctrl+S (Windows/Linux) and Cmd+S (Mac)
+                if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+                    e.preventDefault();
+                    dotNetRef.invokeMethodAsync('OnHotKeysCtrlS');
+                }
+            }
+            window.addEventListener('keydown', handler);
+            dotNetRef._hotkeyHandler = handler;
+        },
+        dispose: function (dotNetRef) {
+            if (dotNetRef._hotkeyHandler) {
+                window.removeEventListener('keydown', dotNetRef._hotkeyHandler);
+                dotNetRef._hotkeyHandler = null;
+            }
+        }
+    };
+</script>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -29,7 +29,7 @@ using Variant = MudBlazor.Variant;
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 
 /// A component that allows the user to edit a workflow definition.
-public partial class WorkflowEditor : IDisposable
+public partial class WorkflowEditor : IAsyncDisposable
 {
     private readonly RateLimitedFunc<bool, Task> _rateLimitedSaveChangesAsync;
     private bool _autoSave = true;
@@ -79,6 +79,12 @@ public partial class WorkflowEditor : IDisposable
     /// Invoked when the "Ctrl+S" hotkeys are pressed, triggering the save operation.
     /// </summary>
     [JSInvokable] public async Task OnHotKeysCtrlS() => await OnSaveClick();
+
+
+    /// <summary>
+    /// Invoked when the "Ctrl+Shift+S" hotkeys are pressed, triggering the save as operation.
+    /// </summary>
+    [JSInvokable] public async Task OnHotKeysCtrlShiftS() => await OnSaveAsClick();
 
     private JsonObject? Activity => _workflowDefinition?.Root;
     private JsonObject? SelectedActivity { get; set; }
@@ -484,11 +490,11 @@ public partial class WorkflowEditor : IDisposable
     }
 
     /// <inheritdoc/>
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (_dotNetRef != null)
         {
-            JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);
+            await JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);
             _dotNetRef.Dispose();
             _dotNetRef = null;
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -80,7 +80,6 @@ public partial class WorkflowEditor : IAsyncDisposable
     /// </summary>
     [JSInvokable] public async Task OnHotKeysCtrlS() => await OnSaveClick();
 
-
     /// <summary>
     /// Invoked when the "Ctrl+Shift+S" hotkeys are pressed, triggering the save as operation.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -488,7 +488,7 @@ public partial class WorkflowEditor : IDisposable
     {
         if (_dotNetRef != null)
         {
-            JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);
+            JSRuntime.InvokeVoid("editorHotkeys.dispose", _dotNetRef);
             _dotNetRef.Dispose();
             _dotNetRef = null;
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -488,7 +488,7 @@ public partial class WorkflowEditor : IDisposable
     {
         if (_dotNetRef != null)
         {
-            JSRuntime.InvokeVoid("editorHotkeys.dispose", _dotNetRef);
+            JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);
             _dotNetRef.Dispose();
             _dotNetRef = null;
         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
@@ -19,16 +18,18 @@ using Humanizer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 using MudBlazor;
 using Radzen;
 using Radzen.Blazor;
+using System.Text.Json.Nodes;
 using ThrottleDebounce;
 using Variant = MudBlazor.Variant;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 
 /// A component that allows the user to edit a workflow definition.
-public partial class WorkflowEditor
+public partial class WorkflowEditor : IDisposable
 {
     private readonly RateLimitedFunc<bool, Task> _rateLimitedSaveChangesAsync;
     private bool _autoSave = true;
@@ -64,6 +65,7 @@ public partial class WorkflowEditor
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
     [Inject] private IDiagramDesignerService DiagramDesignerService { get; set; } = null!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = null!;
+    [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
     [Inject] private IFiles Files { get; set; } = null!;
     [Inject] private IMediator Mediator { get; set; } = null!;
     [Inject] private IServiceProvider ServiceProvider { get; set; } = null!;
@@ -73,10 +75,17 @@ public partial class WorkflowEditor
     [Inject] private IDialogService DialogService { get; set; } = null!;
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
 
+    /// <summary>
+    /// Invoked when the "Ctrl+S" hotkeys are pressed, triggering the save operation.
+    /// </summary>
+    [JSInvokable] public async Task OnHotKeysCtrlS() => await OnSaveClick();
+
     private JsonObject? Activity => _workflowDefinition?.Root;
     private JsonObject? SelectedActivity { get; set; }
     private ActivityDescriptor? ActivityDescriptor { get; set; }
     private ActivityPropertiesPanel? ActivityPropertiesPanel { get; set; }
+
+    private DotNetObjectReference<WorkflowEditor>? _dotNetRef;
 
     private RadzenSplitterPane ActivityPropertiesPane
     {
@@ -129,7 +138,11 @@ public partial class WorkflowEditor
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
+        {
             await UpdateActivityPropertiesVisibleHeightAsync();
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JSRuntime.InvokeVoidAsync("editorHotkeys.register", _dotNetRef);
+        }
     }
 
     private async Task HandleChangesAsync(bool readDiagram)
@@ -467,6 +480,17 @@ public partial class WorkflowEditor
             snackbarOptions.SnackbarVariant = Variant.Filled;
             snackbarOptions.CloseAfterNavigation = failedImports.Count > 0;
             snackbarOptions.VisibleStateDuration = failedImports.Count > 0 ? 10000 : 3000;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_dotNetRef != null)
+        {
+            JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);
+            _dotNetRef.Dispose();
+            _dotNetRef = null;
         }
     }
 }


### PR DESCRIPTION
Introduced JavaScript hotkey support in `WorkflowEditor` to allow users to save workflows using "Ctrl+S" (Windows/Linux) or "Cmd+S" (Mac). Added a `<script>` block to define `editorHotkeys` for registering and disposing of the hotkey handler.

Injected `IJSRuntime` into the `WorkflowEditor` class to enable JavaScript interop. Implemented the `[JSInvokable]` method `OnHotKeysCtrlS` to trigger the save operation when the hotkey is pressed.

Registered the hotkey handler during the first render using `DotNetObjectReference` and disposed of it in the `Dispose` method by implementing the `IDisposable` interface.

Close #196 

