### PR TITLE
Add Markdown Descriptions Support

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
@@ -19,73 +19,73 @@
     {
         <MudSimpleTable Outlined="true" Striped="false" Dense="true" Elevation="0" Bordered="false">
             <tbody>
-            @{
-                var data = HideEmptyValues
+                @{
+                    var data = HideEmptyValues
                     ? Data.Where(x => !string.IsNullOrWhiteSpace(x.Text)).ToList()
                     : Data;
-            }
-            @if (data.Any())
-            {
-                @foreach (var item in data)
+                }
+                @if (data.Any())
                 {
-                    <tr Class="hover-row">
-                        <td style="width: 200px;">@item.Label</td>
-                        <td>
-                            <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
-                                <MudTooltip Text="@Localizer["View"]">
-                                @if (!string.IsNullOrWhiteSpace(item.Text))
-                                {
-                                    <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
-                                }
-                                </MudTooltip>
-                                @if (!string.IsNullOrWhiteSpace(item.Link))
-                                {
-                                    <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
-                                }
-                                else if (item.OnClick != null)
-                                {
-                                    <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
-                                }
-                                else
-                                {
-                                    @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
+                    @foreach (var item in data)
+                    {
+                        <tr Class="hover-row">
+                            <td style="width: 200px;">@item.Label</td>
+                            <td>
+                                <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
+                                    <MudTooltip Text="@Localizer["View"]">
+                                        @if (!string.IsNullOrWhiteSpace(item.Text))
+                                        {
+                                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" Title="@Localizer["View"]" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
+                                        }
+                                    </MudTooltip>
+                                    @if (!string.IsNullOrWhiteSpace(item.Link))
                                     {
-                                        <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
+                                        <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
+                                    }
+                                    else if (item.OnClick != null)
+                                    {
+                                        <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
                                     }
                                     else
                                     {
-                                        @if (item.Text?.Length > truncationLength)
+                                        @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
                                         {
-                                            <div>
-                                                @item.Text.Substring(0, truncationLength)
-                                                <MudTooltip Text="Show all">
-                                                    <MudLink OnClick="@(() => OnViewClicked(item!))" title="Show all"><small>[...]</small></MudLink>
-                                                </MudTooltip>
-                                            </div>
+                                            <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
                                         }
                                         else
                                         {
-                                            <span>@item.Text</span>
+                                            @if (item.Text?.Length > truncationLength)
+                                            {
+                                                <div>
+                                                    @item.Text.Substring(0, truncationLength)
+                                                    <MudTooltip Text="@Localizer["Show all"]">
+                                                        <MudLink OnClick="@(() => OnViewClicked(item!))" title="@Localizer["Show all"]"><small>[...]</small></MudLink>
+                                                    </MudTooltip>
+                                                </div>
+                                            }
+                                            else
+                                            {
+                                                <span>@item.Text</span>
+                                            }
                                         }
                                     }
-                                }
-                            </MudStack>
-                        </td>
-                        <td style="width: 50px;">
-                            <MudTooltip Text="Copy">
-                                <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Size="Size.Small" Title="@Localizer["Copy"]" OnClick="@(x => OnCopyClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" />
-                            </MudTooltip>
-                        </td>
-                    </tr>
+                                </MudStack>
+                            </td>
+                            <td style="width: 50px;">
+                                <MudTooltip Text="Copy">
+                                    <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Size="Size.Small" Title="@Localizer["Copy"]" OnClick="@(x => OnCopyClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" />
+                                </MudTooltip>
+                            </td>
+                        </tr>
+                    }
                 }
-            }
-            else
-            {
-                if (ShowNoDataAlert)
+                else
                 {
-                    <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Text">@NoDataMessage</MudAlert>
+                    if (ShowNoDataAlert)
+                    {
+                        <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Text">@NoDataMessage</MudAlert>
+                    }
                 }
-            }
             </tbody>
         </MudSimpleTable>
     }

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
@@ -1,0 +1,82 @@
+﻿@using Elsa.Studio.Localization
+@using Radzen.Blazor
+@inject ILocalizer Localizer
+@inject IDialogService DialogService
+
+<MudDialog>
+    <TitleContent>
+        <MudToolBar Dense="true" Gutters="false">
+            <MudStack Spacing="0">
+                <MudStack AlignItems=AlignItems.Center Row=true>
+                    <MudText Typo="Typo.h5">@Label</MudText>
+                    <RadzenIcon class="filled-icon" Icon="markdown" IconColor="@Radzen.Colors.Info" title="Markdown supported" />
+                </MudStack>
+                <MudText Typo="Typo.caption">@HelperText</MudText>
+            </MudStack>
+            <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+        </MudToolBar>
+    </TitleContent>
+    <DialogContent>
+        <MudStack>
+            <MudStack>
+                <MudTabs Position="MudBlazor.Position.Left"
+                         MinimumTabWidth="120px"
+                         Rounded="true"
+                         Border="true"
+                         Outlined="true"
+                         KeepPanelsAlive="true"
+                         ApplyEffectsToContainer="true"
+                         PanelClass="pa-4">
+                    <MudPaper Height="100%" Width="100%" Elevation="0">
+                        @if (!IsReadOnly)
+                        {
+                            <MudTabPanel Text="@Localizer["Edit"]">
+                                <MudTextField T="string"
+                                              Label="@Label"
+                                              Value="@Value"
+                                              ValueChanged="@HandleValueChanged"
+                                              For="@(() => Value)"
+                                              Lines="33"
+                                              Margin="Margin.Dense"
+                                              Variant="Variant.Outlined" />
+                            </MudTabPanel>
+                        }
+                        <MudTabPanel Text="@Localizer["Preview"]">
+                            <div style="min-height:660px">
+
+                                @if (string.IsNullOrEmpty(Value))
+                                {
+                                    <MudText>No content to display.</MudText>
+                                }
+                                else
+                                {
+                                    <RadzenMarkdown Text="@Value"/>
+                                }
+                            </div>
+                        </MudTabPanel>
+                    </MudPaper>
+                </MudTabs>
+            </MudStack>
+        </MudStack>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string Value { get; set; } = null!;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter] public string Label { get; set; } = null!;
+    [Parameter] public string HelperText { get; set; } = null!;
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    private void OnClosedClicked() => MudDialog.Close(DialogResult.Ok(Value));
+
+    private async Task HandleValueChanged(string newValue)
+    {
+        if (Value == newValue) return;
+        Value = newValue;
+        await ValueChanged.InvokeAsync(newValue);
+    }
+}

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownTextArea.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownTextArea.razor
@@ -1,0 +1,68 @@
+﻿@using Elsa.Studio.Localization
+@using System.Linq.Expressions
+@inject ILocalizer Localizer
+@inject IDialogService DialogService
+
+<MudStack AlignItems=AlignItems.Start
+          Spacing="4"
+          Row=true>
+    <MudTextField @ref=@textField
+                  T="string"
+                  Label="@Label"
+                  HelperText="@HelperText"
+                  Value="@Value"
+                  ValueChanged="@HandleValueChanged"
+                  For="@For"
+                  Lines="5"
+                  OnBlur="OnBlur"
+                  ReadOnly="IsReadOnly"
+                  Disabled="IsReadOnly"
+                  Margin="Margin.Dense"
+                  Variant="Variant.Outlined"
+                  Immediate="true" />
+    <MudIconButton Icon="@(IsReadOnly ? Icons.Material.Outlined.ManageSearch : Icons.Material.Outlined.EditNote)"
+                   OnClick="@(() => ShowMarkdownEditor(false))"
+                   title="@Localizer[IsReadOnly ? "View" : "Edit"]" />
+</MudStack>
+
+
+@code {
+    [Parameter] public string Value { get; set; } = null!;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public EventCallback<FocusEventArgs> OnBlur { get; set; }
+    [Parameter] public Expression<Func<string>>? For { get; set; }
+
+    [Parameter] public string Label { get; set; } = null!;
+    [Parameter] public string HelperText { get; set; } = null!;
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    private MudTextField<string> textField = null!;
+
+    private async Task ShowMarkdownEditor(bool readOnly)
+    {
+        var param = new DialogParameters<MarkdownEditor>
+        {
+            { x => x.Label, Label },
+            { x => x.HelperText, HelperText },
+            { x => x.Value, Value },
+            { x => x.IsReadOnly, IsReadOnly ? true : readOnly }
+        };
+
+        var options = new DialogOptions { CloseOnEscapeKey = true, Position = DialogPosition.Center, FullWidth = true, MaxWidth = MaxWidth.Large };
+        var dialogRef = await DialogService.ShowAsync<MarkdownEditor>(Label, param, options);
+        var dialogResult = await dialogRef.Result;
+
+        if (dialogResult?.Data is string newValue && Value != newValue)
+        {
+            await textField.FocusAsync(); // Hack to ensure to ensure the auto save gets triggered
+            await HandleValueChanged(newValue);
+        }
+    }
+
+    private async Task HandleValueChanged(string newValue)
+    {
+        if (Value == newValue) return;
+        Value = newValue;
+        await ValueChanged.InvokeAsync(newValue);
+    }
+}

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownTextArea.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownTextArea.razor
@@ -54,7 +54,7 @@
 
         if (dialogResult?.Data is string newValue && Value != newValue)
         {
-            await textField.FocusAsync(); // Hack to ensure to ensure the auto save gets triggered
+            await textField.FocusAsync(); // Hack to ensure the auto save gets triggered
             await HandleValueChanged(newValue);
         }
     }

--- a/src/framework/Elsa.Studio.Shared/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Shared/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Elsa.Studio.Localization.Time.Providers;
 using Elsa.Studio.Monaco.Handlers;
 using Elsa.Studio.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Radzen;
 
 namespace Elsa.Studio.Extensions;
 
@@ -28,6 +29,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITimeFormatter, DefaultTimeFormatter>();
         services.AddScoped<ITimeZoneProvider, UtcTimeZoneProvider>();
         services.AddScoped<IBrandingProvider, DefaultBrandingProvider>();
+
+        // Required for the Radzen.Blazor.RadzenHtmlEditorLink component to work.
+        services.AddRadzenComponents();
+
         return services;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/CommonTab.razor
@@ -32,17 +32,12 @@
                 ReadOnly="IsReadOnly"
                 Disabled="IsReadOnly"/>
 
-            <MudTextField
-                T="string"
+            <MarkdownTextArea
+                Value="@Activity.GetDescription()"
+                ValueChanged="OnActivityDescriptionChanged"
                 Label="@Localizer["Description"]"
                 HelperText="@Localizer["A description of this activity to be displayed in the designer."]"
-                Value="@Activity.GetDescription()"
-                Variant="Variant.Outlined"
-                Margin="Margin.Dense"
-                Lines="3"
-                ValueChanged="OnActivityDescriptionChanged"
-                ReadOnly="IsReadOnly"
-                Disabled="IsReadOnly"/>
+                IsReadOnly="IsReadOnly" />
 
             <MudField
                 Variant="Variant.Text"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
@@ -1,6 +1,7 @@
 @using Elsa.Studio.Workflows.Services
 @using Variant = MudBlazor.Variant
 @using Microsoft.Extensions.Localization
+@using Elsa.Studio.Components;
 @inject ILocalizer Localizer
 
 <div>
@@ -8,8 +9,8 @@
     <EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit">
         <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator"/>
         <MudStack>
-            <MudTextField T="string" Label="@Localizer["Name"]" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense" HelperText="@Localizer["The name of the workflow."]" @bind-Value="@_model.Name" For="@(() => _model.Name)" OnBlur="ValidateForm" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
-            <MudTextField T="string" Label="@Localizer["Description"]" Variant="Variant.Outlined" Margin="Margin.Dense" HelperText="@Localizer["A brief description of the workflow."]" Lines="4" @bind-Value="@_model.Description" For="@(() => _model.Description)" OnBlur="ValidateForm" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
+            <MudTextField T="string" Label="@Localizer["Name"]" @bind-Value="@_model.Name" For="@(() => _model.Name)" HelperText="@Localizer["The name of the workflow."]" OnBlur="ValidateForm" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
+            <MarkdownTextArea Label="@Localizer["Description"]" @bind-Value="@_model.Description" For="@(() => _model.Description)" HelperText="@Localizer["A brief description of the workflow."]" OnBlur="ValidateForm" IsReadOnly="IsReadOnly" />
         </MudStack>
     </EditForm>
 </div>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CloneWorkflowDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CloneWorkflowDialog.razor
@@ -9,7 +9,7 @@
             <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator" DisableAssemblyScanning="true"/>
             <MudStack>
                 <MudTextField Label="@Localizer["Name"]" @bind-Value="_metadataModel.Name" For="@(() => _metadataModel.Name)" HelperText="@Localizer["The new name of the workflow."]" Variant="Variant.Outlined" Margin="Margin.Dense" />
-                <MudTextField Label="@Localizer["Description"]" @bind-Value="_metadataModel.Description" For="@(() => _metadataModel.Description)" HelperText="@Localizer["A brief description of the workflow."]" Lines="3" Variant="Variant.Outlined" Margin="Margin.Dense" />
+                <MarkdownTextArea Label="@Localizer["Description"]" @bind-Value="_metadataModel.Description" For="@(() => _metadataModel.Description)" HelperText="@Localizer["A brief description of the workflow."]" />
             </MudStack>
         </EditForm>
     </DialogContent>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
@@ -9,7 +9,7 @@
             <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator" DisableAssemblyScanning="true"/>
             <MudStack>
                 <MudTextField Label="@Localizer["Name"]" @bind-Value="_metadataModel.Name" For="@(() => _metadataModel.Name)" HelperText="@Localizer["The name of the new workflow."]" Variant="Variant.Outlined" Margin="Margin.Dense" />
-                <MudTextField Label="@Localizer["Description"]" @bind-Value="_metadataModel.Description" For="@(() => _metadataModel.Description)" HelperText="@Localizer["A brief description of the workflow."]" Lines="3" Variant="Variant.Outlined" Margin="Margin.Dense" />
+                <MarkdownTextArea Label="@Localizer["Description"]" @bind-Value="_metadataModel.Description" For="@(() => _metadataModel.Description)" HelperText="@Localizer["A brief description of the workflow."]" />
             </MudStack>
         </EditForm>
     </DialogContent>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -102,9 +102,19 @@
             <MudTd DataLabel="@Localizer["Published version"]" Style="text-align:left">@(context.PublishedVersion?.ToString() ?? "-")</MudTd>
             <MudTd DataLabel="@Localizer["Description"]">
                 <MudTooltip Text="@context.Description">
-                    <div style="max-width: 400px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;">
-                        @context.Description
-                    </div>
+                    @if (context.Description?.Length > truncationLength)
+                    {
+                        <div>
+                            @context.Description.Substring(0, truncationLength)...
+                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Color=@Color.Info Onclick="@(() => OnViewDescriptionClicked(context.Description!))" title="@Localizer["View description"]" Size="Size.Small" />
+                        </div>
+                    }
+                    else
+                    {
+                        <div style="max-width: 400px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;">
+                            @context.Description
+                        </div>
+                    }
                 </MudTooltip>
             </MudTd>
             <MudTd DataLabel="" Style="text-align:right">

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -106,7 +106,7 @@
                     {
                         <div>
                             @context.Description.Substring(0, truncationLength)...
-                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Color=@Color.Info Onclick="@(() => OnViewDescriptionClicked(context.Description!))" title="@Localizer["View description"]" Size="Size.Small" />
+                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Color=@Color.Info OnClick="@(() => OnViewDescriptionClicked(context.Description!))" title="@Localizer["View description"]" Size="Size.Small" />
                         </div>
                     }
                     else

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -423,7 +423,7 @@ public partial class WorkflowDefinitionList
             FullScreen = false,
             MaxWidth = MaxWidth.Large
         };
-        var result = await DialogService.ShowAsync<MarkdownEditor>("Description", param, options);
+        await DialogService.ShowAsync<MarkdownEditor>("Description", param, options);
     }
 
     private record WorkflowDefinitionRow(

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -2,6 +2,7 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Enums;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
 using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
 using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Components;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Workflows.Contracts;
@@ -20,6 +21,7 @@ public partial class WorkflowDefinitionList
     private MudTable<WorkflowDefinitionRow> _table = null!;
     private HashSet<WorkflowDefinitionRow> _selectedRows = new();
     private long _totalCount;
+    private const int truncationLength = 40;
 
     /// An event that is invoked when a workflow definition is edited.
     [Parameter] public EventCallback<string> EditWorkflowDefinition { get; set; }
@@ -403,6 +405,25 @@ public partial class WorkflowDefinitionList
         await WorkflowDefinitionService.RetractAsync(definitionId);
         UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow retracted"], Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
         Reload();
+    }
+
+    private async Task OnViewDescriptionClicked(string value)
+    {
+        DialogParameters<MarkdownEditor> param = new()
+        {
+            { x => x.Label, "Description" },
+            { x => x.Value, value },
+            { x => x.IsReadOnly, true }
+        };
+        DialogOptions options = new()
+        {
+            CloseOnEscapeKey = true,
+            Position = DialogPosition.Center,
+            FullWidth = true,
+            FullScreen = false,
+            MaxWidth = MaxWidth.Large
+        };
+        var result = await DialogService.ShowAsync<MarkdownEditor>("Description", param, options);
     }
 
     private record WorkflowDefinitionRow(


### PR DESCRIPTION
Updates both Workflow and Activity descriptions to support markdown syntax for better description documentation.

Updated component:
<img width="1056" height="294" alt="image" src="https://github.com/user-attachments/assets/d491eddc-e681-40d5-8d6b-118945650404" />

Editor Example:
<img width="2328" height="1444" alt="image" src="https://github.com/user-attachments/assets/e253c549-f52a-4cee-8973-2c2323f3e05c" />

Notes:
Add MarkdownEditor and MarkdownTextArea components
Introduce reusable MarkdownEditor and MarkdownTextArea components for markdown editing and previewing. These components leverage MudBlazor and Radzen.Blazor libraries and support localization, dynamic labels, helper text, and read-only mode.

Replace MudTextField with MarkdownTextArea in multiple components (e.g., CommonTab, Metadata, CloneWorkflowDialog) to enhance markdown input functionality. Truncate long workflow descriptions in WorkflowDefinitionList with a "view more" option using MarkdownEditor.

Register Radzen components in ServiceCollectionExtensions. Standardize parameters and improve code consistency across components.

Closes #614