### PR TITLE
Fix: Prevent extra Flowchart node from appearing by correctly detecting Elsa.Flowchart activities

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -35,7 +35,7 @@ public static class ActivityExtensions
     {
         // 0) If *this* object is already a container, return it.
         // TODO: Think of a more extensible way to do this. Perhaps adding an attribute called "container" to the activity type?"
-        if(activity.GetTypeName() == "Elsa.Flowchart")
+        if (activity.GetTypeName() == "Elsa.Flowchart")
             return activity;
         
         // 1) If *this* object has an "activities" array, it is the container.

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -42,10 +42,10 @@ public static class ActivityExtensions
         if (activity.TryGetPropertyValue("activities", out var maybeArr) && maybeArr is JsonArray)
             return activity;
 
-        // 2) Otherwise, scan every child property...
+        // 2) Otherwise, scan every child property.
         foreach (var kvp in activity)
         {
-            // if its a JsonObject, recurse into it.
+            // if it's a JsonObject, recurse into it.
             if (kvp.Value is JsonObject childObj)
             {
                 var found = childObj.FindActivitiesContainer();
@@ -53,7 +53,7 @@ public static class ActivityExtensions
                     return found;
             }
 
-            // if its a JsonArray, recurse into each item.
+            // if it's a JsonArray, recurse into each item.
             if (kvp.Value is JsonArray childArr)
             {
                 foreach (var node in childArr.OfType<JsonObject>())

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -34,7 +34,7 @@ public static class ActivityExtensions
     public static JsonObject? FindActivitiesContainer(this JsonObject activity)
     {
         // 0) If *this* object is already a container, return it.
-        // TODO: Think of a more extensible way to do this. Perhaps adding an attribute called "container" to the activity type?"
+        // TODO: Think of a more extensible way to do this. Perhaps adding an attribute called "container" to the activity type?
         if (activity.GetTypeName() == "Elsa.Flowchart")
             return activity;
         

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -33,6 +33,11 @@ public static class ActivityExtensions
     /// </summary>
     public static JsonObject? FindActivitiesContainer(this JsonObject activity)
     {
+        // 0) If *this* object is already a container, return it.
+        // TODO: Think of a more extensible way to do this. Perhaps adding an attribute called "container" to the activity type?"
+        if(activity.GetTypeName() == "Elsa.Flowchart")
+            return activity;
+        
         // 1) If *this* object has an "activities" array, it is the container.
         if (activity.TryGetPropertyValue("activities", out var maybeArr) && maybeArr is JsonArray)
             return activity;


### PR DESCRIPTION
This change fixes a bug introduced in `develop/3.6.0` where an extra *Flowchart* activity node appeared on the design surface when adding container activities.

The issue was caused by `LoadFlowchartAsync` treating any activity with an `activities` array as a container. As a result, `Elsa.Flowchart` activities were being loaded as containers and rendered as standalone nodes.

The fix explicitly checks for `"Elsa.Flowchart"` when determining whether an activity is a container, ensuring that only non-flowchart activities are unwrapped.

**Key changes:**

* Updated flowchart detection logic to explicitly check for `"Elsa.Flowchart"` type.
* Restored correct behaviour where embedded flowcharts open as empty canvases instead of visible *Flowchart* nodes.

**Verification:**
Tested by adding a `Container` activity and drilling into its embedded port. The design surface now correctly displays an empty canvas with no visible *Flowchart* node.

<img width="1842" height="1154" alt="image" src="https://github.com/user-attachments/assets/ede75539-4c2c-4ee0-86cf-6b346025e3d5" />

<img width="1658" height="1170" alt="image" src="https://github.com/user-attachments/assets/b99f63a5-b9b5-42d4-bda3-13772d990272" />
