### PR TITLE
Fix “one-interaction-late” UI updates in InputsTab by avoiding debounced rebuilds on value changes

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -21,14 +21,6 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// </summary>
 public partial class InputsTab
 {
-    private readonly RateLimitedFunc<Task<IEnumerable<ActivityInputDisplayModel>>> _rateLimitedBuildInputEditorModelsAsync;
-
-    /// <inheritdoc />
-    public InputsTab()
-    {
-        _rateLimitedBuildInputEditorModelsAsync = Debouncer.Debounce(BuildInputEditorModels, TimeSpan.FromMilliseconds(50), true);
-    }
-
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -57,6 +57,8 @@ public partial class InputsTab
     private ICollection<InputDescriptor> InputDescriptors { get; set; } = new List<InputDescriptor>();
     private ICollection<OutputDescriptor> OutputDescriptors { get; set; } = new List<OutputDescriptor>();
     private ICollection<ActivityInputDisplayModel> InputDisplayModels { get; set; } = new List<ActivityInputDisplayModel>();
+    private string? _lastActivityId;
+    private string? _lastActivityDescriptorTypeName;
 
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
@@ -64,11 +66,21 @@ public partial class InputsTab
         if (Activity == null || ActivityDescriptor == null)
             return;
 
+        // Detect if the activity or descriptor actually changed (not just a value update)
+        var currentActivityId = Activity.GetProperty("id")?.ToString();
+        var currentDescriptorTypeName = ActivityDescriptor.TypeName;
+        var activityOrDescriptorChanged = currentActivityId != _lastActivityId || currentDescriptorTypeName != _lastActivityDescriptorTypeName;
+
         InputDescriptors = ActivityDescriptor.Inputs.ToList();
         OutputDescriptors = ActivityDescriptor.Outputs.ToList();
 
-        var task = _rateLimitedBuildInputEditorModelsAsync.Invoke();
-        if (task != null) InputDisplayModels = (await task).ToList();
+        // Only rebuild display models if the activity/descriptor actually changed
+        if (activityOrDescriptorChanged || InputDisplayModels.Count == 0)
+        {
+            InputDisplayModels = (await BuildInputEditorModels()).ToList();
+            _lastActivityId = currentActivityId;
+            _lastActivityDescriptorTypeName = currentDescriptorTypeName;
+        }
     }
 
     private Task<IEnumerable<ActivityInputDisplayModel>> BuildInputEditorModels()
@@ -204,12 +216,10 @@ public partial class InputsTab
         };
 
         var propName = inputDescriptor.Name.Camelize();
-        activity.SetProperty(value?.SerializeToNode(options), propName);
+        activity.SetProperty(value?.SerializeToNode(options), propName);;
 
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);
-
-        //await InvokeAsync(StateHasChanged);
     }
 
     private ExpressionDescriptor? GetSyntaxProvider(WrappedInput wrappedInput, InputDescriptor inputDescriptor)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/InputsTab.razor.cs
@@ -216,7 +216,7 @@ public partial class InputsTab
         };
 
         var propName = inputDescriptor.Name.Camelize();
-        activity.SetProperty(value?.SerializeToNode(options), propName);;
+        activity.SetProperty(value?.SerializeToNode(options), propName);
 
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);


### PR DESCRIPTION
- Root cause: Debounced rebuilding of InputDisplayModels caused the UI to render with stale models, making updates appear one interaction behind.
- Changes:
  - Stop rebuilding input editor models on every parameter change; rebuild only when the activity or descriptor actually changes.
  - Remove forced StateHasChanged in value change handler so renders don’t occur before a rebuild is needed.
  - Keep full rebuilds for descriptor refresh scenarios (UISpecifications refresh path).
- Result: Immediate, correct UI updates when typing or switching input types, while preserving debounce benefits for expensive rebuilds triggered by actual parameter/descriptor changes.

Video of the symptom (fixed with this PR):
https://github.com/user-attachments/assets/ba3e550b-5d8e-41d4-b29a-3be86312019c

