### PR TITLE
Add Monaco Dialog Code Editor

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -1,0 +1,122 @@
+﻿@using Elsa.Api.Client.Resources.ActivityDescriptors.Models
+@using Elsa.Studio.Localization
+@using Microsoft.JSInterop
+@using Radzen.Blazor
+@inject ILocalizer Localizer
+@inject IDialogService DialogService
+
+<style>
+    .monaco-editor-container {
+        height: 655px !important;
+    }
+</style>
+
+<MudDialog>
+    <TitleContent>
+        <MudToolBar Dense="true" Gutters="false">
+            <MudStack Spacing="0">
+                <MudStack AlignItems=AlignItems.Center Row=true>
+                    <MudText Typo="Typo.h5">@Label</MudText>
+                    <MudText Typo="Typo.body2" Color="@Color.Info">@LanguageLabel</MudText>
+                </MudStack>
+                <MudText Typo="Typo.caption">@HelperText</MudText>
+            </MudStack>
+            <MudSpacer />
+            <MudIconButton Icon="@Icons.Material.Outlined.Save" Size="Size.Medium" OnClick="OnSaveClicked" />
+            <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+        </MudToolBar>
+    </TitleContent>
+    <DialogContent>
+        <MudPaper Height="665px" Width="100%" Elevation="0">
+            <StandaloneCodeEditor @ref="_monacoEditor"
+                                  Id="@_monacoEditorId"
+                                  ConstructionOptions="ConfigureMonacoEditor"
+                                  OnDidInit="OnMonacoInitializedAsync"
+                                  OnDidChangeModelContent="OnMonacoContentChangedAsync"
+                                  CssClass="studio-expression-input-monaco-editor" />
+        </MudPaper>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string Value { get; set; } = null!;
+    [Parameter] public string Label { get; set; } = null!;
+    [Parameter] public string HelperText { get; set; } = null!;
+    [Parameter] public string LanguageLabel { get; set; } = null!;
+    [Parameter] public string MonacoLanguage { get; set; } = null!;
+
+    [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
+
+    private StandaloneCodeEditor? _monacoEditor = null!;
+    private bool _isInternalContentChange;
+    private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
+    private string? _lastMonacoEditorContent;
+    private string _initialValue;
+
+    private StandaloneEditorConstructionOptions ConfigureMonacoEditor(StandaloneCodeEditor editor)
+    {
+        return new()
+        {
+            Language = MonacoLanguage,
+            Value = Value,
+            FontFamily = "Roboto Mono, monospace",
+            RenderLineHighlight = "none",
+            FixedOverflowWidgets = true,
+            Minimap = new()
+            {
+                Enabled = false
+            },
+            AutomaticLayout = true,
+            LineNumbers = "on",
+            Theme = "vs",
+            RoundedSelection = true,
+            ScrollBeyondLastLine = false,
+            OverviewRulerLanes = 0,
+            OverviewRulerBorder = false,
+            LineDecorationsWidth = 0,
+            HideCursorInOverviewRuler = true,
+            GlyphMargin = false,
+            ReadOnly = false,
+            DomReadOnly = false
+        };
+    }
+
+    private async Task OnMonacoInitializedAsync()
+    {
+        _initialValue = Value;
+        _isInternalContentChange = true;
+        var model = await _monacoEditor!.GetModel();
+        _lastMonacoEditorContent = Value;
+        await model.SetValue(Value);
+        _isInternalContentChange = false;
+        await Global.SetModelLanguage(JSRuntime, model, MonacoLanguage);
+    }
+
+    private async Task OnMonacoContentChangedAsync(ModelContentChangedEvent e)
+    {
+        if (_isInternalContentChange)
+            return;
+
+        var value = await _monacoEditor!.GetValue();
+        if (value == _lastMonacoEditorContent)
+            return;
+
+        Value = value;
+    }
+
+    private void OnSaveClicked() => MudDialog.Close(DialogResult.Ok(Value));
+    private async Task OnClosedClicked()
+    {
+        if (Value != _initialValue)
+        {
+            bool? result = await DialogService.ShowMessageBox(
+                "Discard Changes",
+                "Are you sure you want to discard changes?",
+                yesText: "Yes", cancelText: "Cancel");
+            if (result != true) return;
+        }
+        MudDialog.Close();
+    }
+}

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -27,7 +27,7 @@
         </MudToolBar>
     </TitleContent>
     <DialogContent>
-        <MudPaper Height="665px" Width="100%" Elevation="0">
+        <MudPaper Height="668px" Width="100%" Elevation="0">
             <StandaloneCodeEditor @ref="_monacoEditor"
                                   Id="@_monacoEditorId"
                                   ConstructionOptions="ConfigureMonacoEditor"

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -22,15 +22,13 @@
                 <MudText Typo="Typo.caption">@HelperText</MudText>
             </MudStack>
             <MudSpacer />
-            @if (canSave)
-            {
-                <MudIconButton Icon="@Icons.Material.Outlined.Save" Size="Size.Medium" OnClick="OnSaveClicked" Color="@Color.Info" />
-            }
-            <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            <MudTooltip Text="Close">
+                <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            </MudTooltip>
         </MudToolBar>
     </TitleContent>
     <DialogContent>
-        <MudPaper Height="668px" Width="100%" Elevation="0">
+        <MudPaper Height="655px" Width="100%" Elevation="0">
             <StandaloneCodeEditor @ref="_monacoEditor"
                                   Id="@_monacoEditorId"
                                   ConstructionOptions="ConfigureMonacoEditor"

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -1,9 +1,5 @@
-﻿@using Elsa.Api.Client.Resources.ActivityDescriptors.Models
-@using Elsa.Studio.Localization
-@using Microsoft.JSInterop
-@using Radzen.Blazor
+﻿@using Elsa.Studio.Localization
 @inject ILocalizer Localizer
-@inject IDialogService DialogService
 
 <style>
     .monaco-editor-container {
@@ -22,7 +18,7 @@
                 <MudText Typo="Typo.caption">@HelperText</MudText>
             </MudStack>
             <MudSpacer />
-            <MudTooltip Text="Close">
+            <MudTooltip Text="@Localizer["Close"]">
                 <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
             </MudTooltip>
         </MudToolBar>

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -22,7 +22,10 @@
                 <MudText Typo="Typo.caption">@HelperText</MudText>
             </MudStack>
             <MudSpacer />
-            <MudIconButton Icon="@Icons.Material.Outlined.Save" Size="Size.Medium" OnClick="OnSaveClicked" />
+            @if (canSave)
+            {
+                <MudIconButton Icon="@Icons.Material.Outlined.Save" Size="Size.Medium" OnClick="OnSaveClicked" Color="@Color.Info" />
+            }
             <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
         </MudToolBar>
     </TitleContent>
@@ -37,86 +40,3 @@
         </MudPaper>
     </DialogContent>
 </MudDialog>
-
-@code {
-    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
-
-    [Parameter] public string Value { get; set; } = null!;
-    [Parameter] public string Label { get; set; } = null!;
-    [Parameter] public string HelperText { get; set; } = null!;
-    [Parameter] public string LanguageLabel { get; set; } = null!;
-    [Parameter] public string MonacoLanguage { get; set; } = null!;
-
-    [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
-
-    private StandaloneCodeEditor? _monacoEditor = null!;
-    private bool _isInternalContentChange;
-    private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
-    private string? _lastMonacoEditorContent;
-    private string _initialValue;
-
-    private StandaloneEditorConstructionOptions ConfigureMonacoEditor(StandaloneCodeEditor editor)
-    {
-        return new()
-        {
-            Language = MonacoLanguage,
-            Value = Value,
-            FontFamily = "Roboto Mono, monospace",
-            RenderLineHighlight = "none",
-            FixedOverflowWidgets = true,
-            Minimap = new()
-            {
-                Enabled = false
-            },
-            AutomaticLayout = true,
-            LineNumbers = "on",
-            Theme = "vs",
-            RoundedSelection = true,
-            ScrollBeyondLastLine = false,
-            OverviewRulerLanes = 0,
-            OverviewRulerBorder = false,
-            LineDecorationsWidth = 0,
-            HideCursorInOverviewRuler = true,
-            GlyphMargin = false,
-            ReadOnly = false,
-            DomReadOnly = false
-        };
-    }
-
-    private async Task OnMonacoInitializedAsync()
-    {
-        _initialValue = Value;
-        _isInternalContentChange = true;
-        var model = await _monacoEditor!.GetModel();
-        _lastMonacoEditorContent = Value;
-        await model.SetValue(Value);
-        _isInternalContentChange = false;
-        await Global.SetModelLanguage(JSRuntime, model, MonacoLanguage);
-    }
-
-    private async Task OnMonacoContentChangedAsync(ModelContentChangedEvent e)
-    {
-        if (_isInternalContentChange)
-            return;
-
-        var value = await _monacoEditor!.GetValue();
-        if (value == _lastMonacoEditorContent)
-            return;
-
-        Value = value;
-    }
-
-    private void OnSaveClicked() => MudDialog.Close(DialogResult.Ok(Value));
-    private async Task OnClosedClicked()
-    {
-        if (Value != _initialValue)
-        {
-            bool? result = await DialogService.ShowMessageBox(
-                "Discard Changes",
-                "Are you sure you want to discard changes?",
-                yesText: "Yes", cancelText: "Cancel");
-            if (result != true) return;
-        }
-        MudDialog.Close();
-    }
-}

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
@@ -12,6 +12,7 @@ namespace Elsa.Studio.Components
         private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
         private string? _lastMonacoEditorContent;
         private string _initialValue;
+
         [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
 
         [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
@@ -21,8 +22,6 @@ namespace Elsa.Studio.Components
         [Parameter] public string HelperText { get; set; } = null!;
         [Parameter] public string LanguageLabel { get; set; } = null!;
         [Parameter] public string MonacoLanguage { get; set; } = null!;
-
-        private bool canSave => _lastMonacoEditorContent != _initialValue;
 
         private async Task OnMonacoInitializedAsync()
         {
@@ -75,18 +74,6 @@ namespace Elsa.Studio.Components
             Value = value;
         }
 
-        private void OnSaveClicked() => MudDialog.Close(DialogResult.Ok(Value));
-        private async Task OnClosedClicked()
-        {
-            if (Value != _initialValue)
-            {
-                bool? result = await DialogService.ShowMessageBox(
-                    "Discard Changes",
-                    "Are you sure you want to discard changes?",
-                    yesText: "Yes", cancelText: "Cancel");
-                if (result != true) return;
-            }
-            MudDialog.Close();
-        }
+        private void OnClosedClicked() => MudDialog.Close(DialogResult.Ok(Value));
     }
 }

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
@@ -7,11 +7,10 @@ namespace Elsa.Studio.Components
 {
     public partial class CodeEditorDialog
     {
+        private readonly string _monacoEditorId = $"monaco-editor-{Guid.NewGuid():N}";
         private StandaloneCodeEditor? _monacoEditor = null!;
         private bool _isInternalContentChange;
-        private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
         private string? _lastMonacoEditorContent;
-        private string _initialValue;
 
         [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
 
@@ -25,7 +24,6 @@ namespace Elsa.Studio.Components
 
         private async Task OnMonacoInitializedAsync()
         {
-            _initialValue = Value;
             _isInternalContentChange = true;
             var model = await _monacoEditor!.GetModel();
             _lastMonacoEditorContent = Value;
@@ -72,6 +70,7 @@ namespace Elsa.Studio.Components
                 return;
 
             Value = value;
+            _lastMonacoEditorContent = value;
         }
 
         private void OnClosedClicked() => MudDialog.Close(DialogResult.Ok(Value));

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
@@ -1,0 +1,92 @@
+﻿using BlazorMonaco.Editor;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using MudBlazor;
+
+namespace Elsa.Studio.Components
+{
+    public partial class CodeEditorDialog
+    {
+        private StandaloneCodeEditor? _monacoEditor = null!;
+        private bool _isInternalContentChange;
+        private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
+        private string? _lastMonacoEditorContent;
+        private string _initialValue;
+        [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
+
+        [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+        [Parameter] public string Value { get; set; } = null!;
+        [Parameter] public string Label { get; set; } = null!;
+        [Parameter] public string HelperText { get; set; } = null!;
+        [Parameter] public string LanguageLabel { get; set; } = null!;
+        [Parameter] public string MonacoLanguage { get; set; } = null!;
+
+        private bool canSave => _lastMonacoEditorContent != _initialValue;
+
+        private async Task OnMonacoInitializedAsync()
+        {
+            _initialValue = Value;
+            _isInternalContentChange = true;
+            var model = await _monacoEditor!.GetModel();
+            _lastMonacoEditorContent = Value;
+            await model.SetValue(Value);
+            _isInternalContentChange = false;
+            await Global.SetModelLanguage(JSRuntime, model, MonacoLanguage);
+        }
+
+        private StandaloneEditorConstructionOptions ConfigureMonacoEditor(StandaloneCodeEditor editor)
+        {
+            return new()
+            {
+                Language = MonacoLanguage,
+                Value = Value,
+                FontFamily = "Roboto Mono, monospace",
+                RenderLineHighlight = "none",
+                FixedOverflowWidgets = true,
+                Minimap = new()
+                {
+                    Enabled = false
+                },
+                AutomaticLayout = true,
+                LineNumbers = "on",
+                Theme = "vs",
+                RoundedSelection = true,
+                ScrollBeyondLastLine = false,
+                OverviewRulerLanes = 0,
+                OverviewRulerBorder = false,
+                LineDecorationsWidth = 0,
+                HideCursorInOverviewRuler = true,
+                GlyphMargin = false,
+                ReadOnly = false,
+                DomReadOnly = false
+            };
+        }
+
+        private async Task OnMonacoContentChangedAsync(ModelContentChangedEvent e)
+        {
+            if (_isInternalContentChange)
+                return;
+
+            var value = await _monacoEditor!.GetValue();
+            if (value == _lastMonacoEditorContent)
+                return;
+
+            Value = value;
+        }
+
+        private void OnSaveClicked() => MudDialog.Close(DialogResult.Ok(Value));
+        private async Task OnClosedClicked()
+        {
+            if (Value != _initialValue)
+            {
+                bool? result = await DialogService.ShowMessageBox(
+                    "Discard Changes",
+                    "Are you sure you want to discard changes?",
+                    yesText: "Yes", cancelText: "Cancel");
+                if (result != true) return;
+            }
+            MudDialog.Close();
+        }
+    }
+}

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
@@ -16,7 +16,7 @@
             <MudSpacer />
             <MudTooltip>
                 <TooltipContent>
-                     @(IsReadOnly? Localizer["Read Only"] : Localizer["Temporary Edit"])
+                    @(IsReadOnly? Localizer["Read Only"] : Localizer["Temporary Edit"])
                 </TooltipContent>
                 <ChildContent>
                     <MudToggleIconButton @bind-Toggled="IsReadOnly"
@@ -39,20 +39,22 @@
                     <MudSelectItem Value="@formatter.Name">@formatter.Name</MudSelectItem>
                 }
             </MudSelect>
-            <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            <MudTooltip Text="Close">
+                <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            </MudTooltip>
         </MudToolBar>
     </TitleContent>
     <DialogContent>
         <MudStack>
             <MudTabs Position="MudBlazor.Position.Left"
-                        @bind-ActivePanelIndex="TabIndex"
-                        MinimumTabWidth="120px"
-                        Rounded="true"
-                        Border="true"
-                        Outlined="true"
-                        KeepPanelsAlive="true"
-                        ApplyEffectsToContainer="true"
-                        PanelClass="pa-4">
+                     @bind-ActivePanelIndex="TabIndex"
+                     MinimumTabWidth="120px"
+                     Rounded="true"
+                     Border="true"
+                     Outlined="true"
+                     KeepPanelsAlive="true"
+                     ApplyEffectsToContainer="true"
+                     PanelClass="pa-4">
                 <MudPaper Height="655px" Width="100%" Elevation="0">
                     <MudTabPanel Text="@Localizer["Pretty"]" Visible="@(Pretty is not null)">
                         <StandaloneCodeEditor @ref="_monacoEditor"
@@ -90,7 +92,7 @@
                                     }
                                 </tbody>
                             }
-                            
+
                         </MudSimpleTable>
                     </MudTabPanel>
                     <MudTabPanel Text="@Localizer["Raw"]">

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
@@ -39,7 +39,7 @@
                     <MudSelectItem Value="@formatter.Name">@formatter.Name</MudSelectItem>
                 }
             </MudSelect>
-            <MudTooltip Text="Close">
+            <MudTooltip Text="@Localizer["Close"]">
                 <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
             </MudTooltip>
         </MudToolBar>

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
@@ -57,15 +57,10 @@ namespace Elsa.Studio.Components
         [Parameter] public DataPanelItem DataPanelItem { get; set; } = null!;
 
         [Inject] private ILocalizer Localizer { get; set; } = null!;
-
         [Inject] private IContentVisualizerProvider VisualizationProvider { get; set; } = null!;
-
         [Inject] private IClipboard Clipboard { get; set; } = null!;
-
         [Inject] private ISnackbar Snackbar { get; set; } = null!;
-
         [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
-
 
         /// <summary>
         /// Performs the on initialized operation.

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor
@@ -58,7 +58,7 @@
                     <div style="display:inline-flex; width:auto;">
                         <MudIconButton Icon="@Icons.Material.Outlined.EditNote"
                                        OnClick="ShowScriptEditor"
-                                       title="@Localizer["Code Editor"]"
+                                       title="@Localizer["Edit"]"
                                        Style="width:auto;" />
                     </div>
                 }

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor
@@ -1,6 +1,8 @@
 @using Elsa.Api.Client.Resources.Scripting.Extensions;
 @using Elsa.Api.Client.Resources.Scripting.Models;
 @using Elsa.Studio.Enums
+@using Elsa.Studio.Localization
+@inject ILocalizer Localizer
 
 <div class="d-flex flex-grow-1 gap-4 align-content-start relative">
     <div class="flex-1">
@@ -24,7 +26,7 @@
         {
             <FieldExtension UIHintComponent=@ComponentType EditorContext="@EditorContext" ChildContent="@ChildContent" />
         }
-        
+
     </div>
     @if (EditorContext.InputDescriptor.IsWrapped)
     {
@@ -33,22 +35,34 @@
                 var isChecked = item.Type == _selectedExpressionType;
                 var iconColor = isChecked ? Color.Secondary : Color.Transparent;
 
-                <MudMenuItem Class="studio-expression-input-menu-item" OnClick="@(() => OnSyntaxSelectedAsync(item.Type))" Icon="@Icons.Material.Filled.Check" IconSize="Size.Small" IconColor="iconColor">@item.DisplayName</MudMenuItem>
-            }</div>;
+                <MudMenuItem Class="studio-expression-input-menu-item" OnClick="@(() => OnSyntaxSelectedAsync(item.Type))" Icon="@Icons.Material.Filled.Check" IconColor="iconColor">@item.DisplayName</MudMenuItem>
+            }
+        </div>;
         <div class="flex-none pt-1">
-            <MudMenu Label="@ButtonLabel" Icon="@ButtonIcon" Variant="@ButtonVariant" Color="@ButtonColor" EndIcon="@ButtonEndIcon" IconColor="@ButtonEndColor" Dense="true" Disabled="EditorContext.IsReadOnly">
-                @DisplayContent(BrowsableExpressionDescriptors.First())
-                <MudDivider />
-                @foreach (var item in BrowsableExpressionDescriptors.Where(i=>!string.IsNullOrEmpty(i.GetMonacoLanguage())))
+            <MudStack>
+                <MudMenu Label="@ButtonLabel" Icon="@ButtonIcon" Variant="@ButtonVariant" Color="@ButtonColor" EndIcon="@ButtonEndIcon" IconColor="@ButtonEndColor" Dense="true" Disabled="EditorContext.IsReadOnly">
+                    @DisplayContent(BrowsableExpressionDescriptors.First())
+                    <MudDivider />
+                    @foreach (var item in BrowsableExpressionDescriptors.Where(i => !string.IsNullOrEmpty(i.GetMonacoLanguage())))
+                    {
+                        @DisplayContent(item);
+                    }
+                    <MudDivider />
+                    @foreach (var item in BrowsableExpressionDescriptors.Skip(1).Where(i => string.IsNullOrEmpty(i.GetMonacoLanguage())))
+                    {
+                        @DisplayContent(item);
+                    }
+                </MudMenu>
+                @if (MonacoSyntaxExist)
                 {
-                    @DisplayContent(item);                   
+                    <div style="display:inline-flex; width:auto;">
+                        <MudIconButton Icon="@Icons.Material.Outlined.EditNote"
+                                       OnClick="ShowScriptEditor"
+                                       title="@Localizer["Code Editor"]"
+                                       Style="width:auto;" />
+                    </div>
                 }
-                <MudDivider />
-                @foreach (var item in BrowsableExpressionDescriptors.Skip(1).Where(i=>string.IsNullOrEmpty(i.GetMonacoLanguage())))
-                {
-                    @DisplayContent(item);                   
-                }
-            </MudMenu>
+            </MudStack>
         </div>
     }
 </div>

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
@@ -30,6 +30,13 @@ public partial class ExpressionInput : IDisposable
     private RateLimitedFunc<WrappedInput, Task> _throttledValueChanged;
     private ICollection<ExpressionDescriptor> _expressionDescriptors = new List<ExpressionDescriptor>();
 
+    [Inject] private TypeDefinitionService TypeDefinitionService { get; set; } = null!;
+    [Inject] private IExpressionService ExpressionService { get; set; } = null!;
+    [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
+    [Inject] private IEnumerable<IMonacoHandler> MonacoHandlers { get; set; } = null!;
+    [Inject] private IUIHintService UIHintService { get; set; } = null!;
+    [Inject] private IDialogService DialogService { get; set; } = null!;
+
     /// <inheritdoc />
     public ExpressionInput()
     {
@@ -51,13 +58,6 @@ public partial class ExpressionInput : IDisposable
     /// </summary>
     [Parameter] public bool IsCodeOnly { get; set; }
 
-    [Inject] private TypeDefinitionService TypeDefinitionService { get; set; } = null!;
-    [Inject] private IExpressionService ExpressionService { get; set; } = null!;
-    [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
-    [Inject] private IEnumerable<IMonacoHandler> MonacoHandlers { get; set; } = null!;
-    [Inject] private IUIHintService UIHintService { get; set; } = null!;
-    [Inject] private IDialogService DialogService { get; set; } = null!;
-
     private IEnumerable<ExpressionDescriptor> BrowsableExpressionDescriptors => _expressionDescriptors.Where(x => x.IsBrowsable);
     private ExpressionDescriptor? SelectedExpressionDescriptor => _expressionDescriptors.FirstOrDefault(x => x.Type == _selectedExpressionType);
     private string MonacoLanguage => SelectedExpressionDescriptor?.GetMonacoLanguage() ?? string.Empty;
@@ -74,7 +74,6 @@ public partial class ExpressionInput : IDisposable
     private string DisplayName => EditorContext.InputDescriptor.DisplayName ?? EditorContext.InputDescriptor.Name;
     private string? Description => EditorContext.InputDescriptor.Description;
     private string InputValue => EditorContext.GetExpressionValueOrDefault();
-
     private string? MonacoSyntax { get; set; }
     private bool MonacoSyntaxExist => !string.IsNullOrEmpty(MonacoLanguage);
 

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
@@ -25,7 +25,7 @@ public partial class ExpressionInput : IDisposable
     private string _selectedExpressionTypeDisplayName = DefaultSyntax;
     private StandaloneCodeEditor? _monacoEditor = null!;
     private bool _isInternalContentChange;
-    private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
+    private string _monacoEditorId = $"monaco-editor-{Guid.NewGuid():N}";
     private string? _lastMonacoEditorContent;
     private RateLimitedFunc<WrappedInput, Task> _throttledValueChanged;
     private ICollection<ExpressionDescriptor> _expressionDescriptors = new List<ExpressionDescriptor>();
@@ -255,7 +255,7 @@ public partial class ExpressionInput : IDisposable
         {
             { x => x.Label, DisplayName },
             { x => x.HelperText, Description },
-            { x => x.Value, _lastMonacoEditorContent },
+            { x => x.Value, _lastMonacoEditorContent ?? InputValue ?? string.Empty },
             { x => x.LanguageLabel, SelectedExpressionDescriptor?.Type ?? ButtonLabel },
             { x => x.MonacoLanguage, MonacoLanguage },
         };

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
@@ -257,7 +257,7 @@ public partial class ExpressionInput : IDisposable
             { x => x.Label, DisplayName },
             { x => x.HelperText, Description },
             { x => x.Value, _lastMonacoEditorContent },
-            { x => x.LanguageLabel, ButtonLabel },
+            { x => x.LanguageLabel, SelectedExpressionDescriptor?.Type ?? ButtonLabel },
             { x => x.MonacoLanguage, MonacoLanguage },
         };
 
@@ -267,10 +267,11 @@ public partial class ExpressionInput : IDisposable
 
         if (dialogResult?.Data is string newValue && InputValue != newValue)
         {
+            _lastMonacoEditorContent = newValue;
             var input = (WrappedInput?)EditorContext.Value ?? new WrappedInput();
             input.Expression = new(_selectedExpressionType, newValue);
-            _lastMonacoEditorContent = newValue;
-            await ThrottleValueChangedCallbackAsync(input);
+            await EditorContext.OnValueChanged(input);
+
             var model = await _monacoEditor!.GetModel();
             await model.SetValue(InputValue);
         }

--- a/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ExpressionInput.razor.cs
@@ -56,6 +56,8 @@ public partial class ExpressionInput : IDisposable
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
     [Inject] private IEnumerable<IMonacoHandler> MonacoHandlers { get; set; } = null!;
     [Inject] private IUIHintService UIHintService { get; set; } = null!;
+    [Inject] private IDialogService DialogService { get; set; } = null!;
+
     private IEnumerable<ExpressionDescriptor> BrowsableExpressionDescriptors => _expressionDescriptors.Where(x => x.IsBrowsable);
     private ExpressionDescriptor? SelectedExpressionDescriptor => _expressionDescriptors.FirstOrDefault(x => x.Type == _selectedExpressionType);
     private string MonacoLanguage => SelectedExpressionDescriptor?.GetMonacoLanguage() ?? string.Empty;
@@ -246,6 +248,32 @@ public partial class ExpressionInput : IDisposable
 
         foreach (var handler in MonacoHandlers)
             await handler.InitializeAsync(context);
+    }
+
+    private async Task ShowScriptEditor()
+    {
+        var param = new DialogParameters<CodeEditorDialog>
+        {
+            { x => x.Label, DisplayName },
+            { x => x.HelperText, Description },
+            { x => x.Value, _lastMonacoEditorContent },
+            { x => x.LanguageLabel, ButtonLabel },
+            { x => x.MonacoLanguage, MonacoLanguage },
+        };
+
+        var options = new DialogOptions { CloseOnEscapeKey = true, Position = DialogPosition.Center, FullWidth = true, MaxWidth = MaxWidth.Large };
+        var dialogRef = await DialogService.ShowAsync<CodeEditorDialog>(DisplayName, param, options);
+        var dialogResult = await dialogRef.Result;
+
+        if (dialogResult?.Data is string newValue && InputValue != newValue)
+        {
+            var input = (WrappedInput?)EditorContext.Value ?? new WrappedInput();
+            input.Expression = new(_selectedExpressionType, newValue);
+            _lastMonacoEditorContent = newValue;
+            await ThrottleValueChangedCallbackAsync(input);
+            var model = await _monacoEditor!.GetModel();
+            await model.SetValue(InputValue);
+        }
     }
 
     /// <inheritdoc />

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
@@ -14,7 +14,9 @@
                 <MudText Typo="Typo.caption">@HelperText</MudText>
             </MudStack>
             <MudSpacer />
-            <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            <MudTooltip Text="Close">
+                <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
+            </MudTooltip>
         </MudToolBar>
     </TitleContent>
     <DialogContent>

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
@@ -14,7 +14,7 @@
                 <MudText Typo="Typo.caption">@HelperText</MudText>
             </MudStack>
             <MudSpacer />
-            <MudTooltip Text="Close">
+            <MudTooltip Text="@Localizer["Close"]">
                 <MudIconButton Icon="@Icons.Material.Outlined.Close" Size="Size.Medium" OnClick="OnClosedClicked" />
             </MudTooltip>
         </MudToolBar>

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor
@@ -4,7 +4,7 @@
 <FieldExtension UIHintComponent="@InputUIHints.CodeEditor" EditorContext="@EditorContext">
     <ChildContent>
         <MudStack AlignItems=AlignItems.Start Spacing="4" Row=true>
-            <MudField Variant="Variant.Outlined" Label="@Localizer[_inputDescriptor.DisplayName]" HelperText="@Localizer[_inputDescriptor.Description]" Margin="Margin.Dense">
+            <MudField Variant="Variant.Outlined" Label="@Localizer[InputDescriptor.DisplayName]" HelperText="@Localizer[InputDescriptor.Description]" Margin="Margin.Dense">
                 <StandaloneCodeEditor @ref="_monacoEditor"
                                       Id="@_monacoEditorId"
                                       ConstructionOptions="ConfigureMonacoEditor"

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor
@@ -1,21 +1,22 @@
 @using BlazorMonaco.Editor
 @inject ILocalizer Localizer
 
-@{
-    var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
-}
-
 <FieldExtension UIHintComponent="@InputUIHints.CodeEditor" EditorContext="@EditorContext">
     <ChildContent>
-        <MudField Variant="Variant.Outlined" Label="@Localizer[displayName]" HelperText="@Localizer[description]" Margin="Margin.Dense">
-            <StandaloneCodeEditor @ref="_monacoEditor"
-                                  Id="@_monacoEditorId"
-                                  ConstructionOptions="ConfigureMonacoEditor"
-                                  OnDidInit="OnMonacoInitializedAsync"
-                                  OnDidChangeModelContent="OnMonacoContentChanged"
-                                  CssClass="studio-expression-input-monaco-editor studio-monaco-editor-large" />
-        </MudField>
+        <MudStack AlignItems=AlignItems.Start Spacing="4" Row=true>
+            <MudField Variant="Variant.Outlined" Label="@Localizer[_inputDescriptor.DisplayName]" HelperText="@Localizer[_inputDescriptor.Description]" Margin="Margin.Dense">
+                <StandaloneCodeEditor @ref="_monacoEditor"
+                                      Id="@_monacoEditorId"
+                                      ConstructionOptions="ConfigureMonacoEditor"
+                                      OnDidInit="OnMonacoInitializedAsync"
+                                      OnDidChangeModelContent="OnMonacoContentChanged"
+                                      CssClass="studio-expression-input-monaco-editor studio-monaco-editor-large" />
+
+            </MudField>
+            <MudIconButton Icon="@Icons.Material.Outlined.EditNote"
+                           OnClick="ShowScriptEditor"
+                           title="@Localizer["Code Editor"]"
+                           Style="width:auto;" />
+        </MudStack>
     </ChildContent>
 </FieldExtension>

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor
@@ -15,7 +15,7 @@
             </MudField>
             <MudIconButton Icon="@Icons.Material.Outlined.EditNote"
                            OnClick="ShowScriptEditor"
-                           title="@Localizer["Code Editor"]"
+                           title="@Localizer["Edit"]"
                            Style="width:auto;" />
         </MudStack>
     </ChildContent>

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor.cs
@@ -19,7 +19,7 @@ namespace Elsa.Studio.UIHints.Components;
 /// </summary>
 public partial class Code : IDisposable
 {
-    private readonly string _monacoEditorId = $"monaco-editor-{Guid.NewGuid()}:N";
+    private readonly string _monacoEditorId = $"monaco-editor-{Guid.NewGuid():N}";
     private StandaloneCodeEditor? _monacoEditor;
     private string _monacoLanguage = "";
     private string? _lastMonacoEditorContent;
@@ -43,7 +43,7 @@ public partial class Code : IDisposable
     [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
 
     private string InputValue => EditorContext.GetLiteralValueOrDefault();
-    private InputDescriptor _inputDescriptor => EditorContext.InputDescriptor;
+    private InputDescriptor InputDescriptor => EditorContext.InputDescriptor;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -134,10 +134,10 @@ public partial class Code : IDisposable
     {
         var param = new DialogParameters<CodeEditorDialog>
         {
-            { x => x.Label, _inputDescriptor.DisplayName },
-            { x => x.HelperText, _inputDescriptor.Description },
-            { x => x.Value, _lastMonacoEditorContent },
-            { x => x.LanguageLabel, _inputDescriptor.DefaultSyntax },
+            { x => x.Label, InputDescriptor.DisplayName },
+            { x => x.HelperText, InputDescriptor.Description },
+            { x => x.Value, _lastMonacoEditorContent ?? InputValue ?? string.Empty },
+            { x => x.LanguageLabel, InputDescriptor.DefaultSyntax },
             { x => x.MonacoLanguage, _monacoLanguage },
         };
 

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor;
 using ThrottleDebounce;
-using static MudBlazor.Colors;
 
 namespace Elsa.Studio.UIHints.Components;
 


### PR DESCRIPTION
TLDR: Adds Dialog popup support for script editing for both ExpressionInput and Code components.

- Introduced a `CodeEditorDialog.razor` component to provide a modal Monaco editor for editing expressions.
- Updated `ExpressionInput` and `Code` to include an edit button that opens the dialog for Monaco-based syntaxes.
- Also cleaned up unused dependency injections in ContentVisualizer.razor.cs for better maintainability.

<img width="1952" height="750" alt="image" src="https://github.com/user-attachments/assets/0e92a735-a847-4b6e-a806-bffce348c25f" />

<img width="2332" height="1380" alt="image" src="https://github.com/user-attachments/assets/11eaaf1b-6243-4bc5-b93e-59f1ba4796f8" />

Closes: #660