### PR TITLE
Workflows-as-activity instances do not load (neither double click activity nor select journal item)

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
@@ -13,7 +13,7 @@
                 WorkflowDefinitionVersionId="@WorkflowDefinition.Id"
                 Activity="RootActivity"
                 ActivitySelected="OnActivitySelected"
-                IsReadOnly="false"
+                IsReadOnly="true"
                 WorkflowInstanceId="@WorkflowInstance.Id"
                 PathChanged="PathChanged">
                 <CustomToolbarItems>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
@@ -1,6 +1,5 @@
 @using Orientation = Radzen.Orientation
 @using Elsa.Api.Client.Resources.WorkflowInstances.Enums
-@using Elsa.Studio.Workflows.Services
 @inject ILocalizer Localizer
 @inherits StudioComponentBase
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -114,12 +114,19 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         await _designer.SelectActivityByActivityIdAsync(activityId);
     }
 
+    async Task SelectActivityByIdAsync(string activityId, string nodeId)
+    {
+        if (_designer == null) return;
+        await _designer.SelectActivityByActivityIdAsync(activityId, nodeId);
+    }
+
     /// Sets the selected journal entry.
     public async Task SelectWorkflowExecutionLogRecordAsync(JournalEntry entry)
     {
+        var id = entry.Record.Id;
         var nodeId = entry.Record.NodeId;
         SelectedWorkflowExecutionLogRecord = entry;
-        await SelectActivityAsync(nodeId);
+        await SelectActivityByIdAsync(id, nodeId);
         StateHasChanged();
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -114,7 +114,13 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         await _designer.SelectActivityByActivityIdAsync(activityId);
     }
 
-    async Task SelectActivityByIdAsync(string activityId, string nodeId)
+    /// <summary>
+    /// Selects the activity with the specified ID, and if not found in the current container, uses the node ID to navigate to the correct container first.
+    /// </summary>
+    /// <param name="activityId"></param>
+    /// <param name="nodeId"></param>
+    /// <returns></returns>
+    public async Task SelectActivityByIdAsync(string activityId, string nodeId)
     {
         if (_designer == null) return;
         await _designer.SelectActivityByActivityIdAsync(activityId, nodeId);

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -78,11 +78,7 @@ public class FlowchartDiagramDesigner(ILocalizer localizer) : IDiagramDesignerTo
     {
         yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
         yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
-
-        if (!isReadonly)
-        {
-            yield return DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
-        }
+        yield return DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
     }
 
     private RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -40,44 +40,27 @@ public partial class DiagramDesignerWrapper
 
     /// The root activity to display.
     [Parameter]
-    /// <summary>
-    /// Gets or sets the activity.
-    /// </summary>
     public JsonObject Activity { get; set; } = null!;
 
     /// Whether the designer is read-only.
     [Parameter]
-    /// <summary>
-    /// Indicates whether is read only.
-    /// </summary>
     public bool IsReadOnly { get; set; }
 
     /// The workflow instance ID, if any.
     [Parameter]
-    /// <summary>
-    /// Gets or sets the workflow instance id.
-    /// </summary>
     public string? WorkflowInstanceId { get; set; }
 
     /// A custom toolbar to display.
     [Parameter]
-    /// <summary>
-    /// Gets or sets the custom toolbar items.
-    /// </summary>
     public RenderFragment? CustomToolbarItems { get; set; }
 
     /// Whether the designer is progressing.
     [Parameter]
     /// <summary>
-    /// Indicates whether is progressing.
-    /// </summary>
     public bool IsProgressing { get; set; }
 
     /// An event raised when an activity is selected.
     [Parameter]
-    /// <summary>
-    /// Gets or sets the activity selected event callback.
-    /// </summary>
     public EventCallback<JsonObject> ActivitySelected { get; set; }
 
     /// An event raised when an embedded port is selected.
@@ -87,9 +70,6 @@ public partial class DiagramDesignerWrapper
 
     /// An event raised when the path changes.
     [Parameter]
-    /// <summary>
-    /// Gets or sets the path changed event callback.
-    /// </summary>
     public EventCallback<DesignerPathChangedArgs> PathChanged { get; set; }
 
     [Inject]

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -126,13 +126,13 @@ public partial class DiagramDesignerWrapper
 
     /// Selects the activity with the specified ID.
     /// <param name="activityId">The ID of the activity ID select.</param>
-    public async Task SelectActivityByActivityIdAsync(string activityId)
+    public async Task SelectActivityByActivityIdAsync(string activityId, string? nodeId = null)
     {
         var containerActivity = GetCurrentContainerActivity();
         var activities = containerActivity.GetActivities();
         var activityToSelect = activities.FirstOrDefault(x => x.GetId() == activityId);
 
-        await SelectActivityAsync(activityToSelect);
+        await SelectActivityAsync(activityToSelect, nodeId);
     }
 
     /// Selects the activity with the specified node ID.

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -124,8 +124,9 @@ public partial class DiagramDesignerWrapper
 
     private string? _lastSelectedNodeId;
 
-    /// Selects the activity with the specified ID.
-    /// <param name="activityId">The ID of the activity ID select.</param>
+    /// Selects the activity with the specified ID; optionally specifying a node ID to load the selected node path from the backend when activity cannot be found in current container.
+    /// <param name="activityId">The ID of the activity to select.</param>
+    /// <param name="nodeId">The node ID of the activity to select.</param>
     public async Task SelectActivityByActivityIdAsync(string activityId, string? nodeId = null)
     {
         var containerActivity = GetCurrentContainerActivity();


### PR DESCRIPTION
1. When clicking workflow-as-activity instance, it does not navigate to the sub workflow instance anymore. Underlying root cause: IsReadOnly parameter of WorkflowInstanceViewer was set to false during initialization. This used to be true. The ActivityDoubleClicked event handler is only executed when IsReadOnly is set to true. Hence; the double clicked event is no longer invoked right now

2. When clicking a journal item outside the current active container/flowchart, the activity to which the journal points is not opened. AFter some analysis, it became clear that activities in another graph outside the current container/flowchart were not loaded when a journal item is clicked. Hence, the activity to which the journal item points cannot be found, returns null, and consequently nothing happens.

Temporary commit:
- Simplest way to solve problem 1 is to set IsReadOnly back to true upon initialization. However, is this a wise thing to do, or will it have ramifications. I presume it was set to false with reasoning, yet I did not see the reasoning documented nor could I deduce it from the latest PR. I asked @Sipke to help me with the analysis to find the best solution for this problem

- The journal item issue could be easily resolved by calling SelectActivityById(string activityId, string? nodeIdFallback) The node ID is a fallback, in case the activity is not found/null, it can load the graph for the specified node, and then still find the activity. This is tested, and it works.