### PR TITLE
Preserve current page during re-renders by updating `initialPage` in WorkflowDefinitionList.

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -93,6 +93,9 @@ public partial class WorkflowDefinitionList
             })
             .ToList();
 
+        // Update initialPage to preserve current page during re-renders
+        initialPage = state.Page;
+
         // Update URL to reflect current table state & filters
         TryUpdateUrlFromState(state);
 


### PR DESCRIPTION
Fixes #734