### PR TITLE
Refactors query parameter handling

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
@@ -12,21 +12,37 @@ namespace Elsa.Studio.Workflows.Components
     /// </summary>
     public abstract class QueryTableComponentBase : StudioComponentBase
     {
-        protected bool _initializedFromQuery;
+        /// <summary>
+        /// Provides an abstraction for managing navigation functionality, including
+        /// generating and manipulating URIs, navigating between pages, and retrieving
+        /// the current URI in a Blazor environment. Accessible as a dependency via dependency injection.
+        /// </summary>
+        [Inject] protected NavigationManager NavigationManager { get; set; } = null!;
 
-        [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
+        /// <summary>
+        /// Provides a mechanism for logging diagnostic messages and warnings
+        /// within the component. Useful for debugging and tracking application
+        /// behavior related to query parsing and URL navigation.
+        /// Typically injected via dependency injection.
+        /// </summary>
         [Inject] protected ILogger<QueryTableComponentBase>? Logger { get; set; }
 
         /// <summary>
         /// Specifies the initial page index used when starting pagination operations.
         /// </summary>
-        protected int initialPage = 0;
+        protected int InitialPage { get; set; } = 0;
 
         /// <summary>
         /// Specifies the initial number of items to display per page.
         /// </summary>
-        protected int initialPageSize = 10;
+        protected int InitialPageSize { get; set; } = 10;
 
+        /// <summary>
+        /// Indicates whether the component's state has been successfully initialized based
+        /// on query parameters from the current URL. This property helps ensure query parsing
+        /// happens only once unless explicitly forced.
+        /// </summary>
+        private bool InitializedFromQuery { get; set; }
 
         /// <inheritdoc/>
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -44,9 +60,9 @@ namespace Elsa.Studio.Workflows.Components
         /// Parses the current URI's query string and delegates to <see cref="ApplyQueryParameters"/>.
         /// Only runs once unless you clear _initializedFromQuery or call ParseQueryParameters(force: true).
         /// </summary>
-        protected async Task ParseQueryParameters(bool force = false)
+        private async Task ParseQueryParameters(bool force = false)
         {
-            if (_initializedFromQuery && !force) return;
+            if (InitializedFromQuery && !force) return;
 
             try
             {
@@ -65,7 +81,7 @@ namespace Elsa.Studio.Workflows.Components
                     Logger?.LogDebug(ex, "Error while applying query parameters in derived component.");
                 }
 
-                _initializedFromQuery = true;
+                InitializedFromQuery = true;
             }
             catch (Exception ex)
             {
@@ -81,17 +97,13 @@ namespace Elsa.Studio.Workflows.Components
         {
             try
             {
-                if (!_initializedFromQuery)
+                if (!InitializedFromQuery)
                     return;
 
                 var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
                 var baseUri = uri.GetLeftPart(UriPartial.Path);
-
-                var query = BuildQueryFromState(state) ?? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-
-                // Trim empty values
-                var dict = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value!, StringComparer.OrdinalIgnoreCase);
-
+                var query = BuildQueryFromState(state);
+                var dict = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
                 var newUri = QueryHelpers.AddQueryString(baseUri, dict);
 
                 if (!string.Equals(NavigationManager.Uri, newUri, StringComparison.Ordinal))

--- a/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
@@ -58,7 +58,7 @@ namespace Elsa.Studio.Workflows.Components
 
         /// <summary>
         /// Parses the current URI's query string and delegates to <see cref="ApplyQueryParameters"/>.
-        /// Only runs once unless you clear _initializedFromQuery or call ParseQueryParameters(force: true).
+        /// Only runs once unless you reset <see cref="InitializedFromQuery"/> or call ParseQueryParameters(force: true).
         /// </summary>
         private async Task ParseQueryParameters(bool force = false)
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/QueryTableComponentBase.cs
@@ -13,17 +13,12 @@ namespace Elsa.Studio.Workflows.Components
     public abstract class QueryTableComponentBase : StudioComponentBase
     {
         /// <summary>
-        /// Provides an abstraction for managing navigation functionality, including
-        /// generating and manipulating URIs, navigating between pages, and retrieving
-        /// the current URI in a Blazor environment. Accessible as a dependency via dependency injection.
+        /// The injected navigation manager.
         /// </summary>
         [Inject] protected NavigationManager NavigationManager { get; set; } = null!;
 
         /// <summary>
-        /// Provides a mechanism for logging diagnostic messages and warnings
-        /// within the component. Useful for debugging and tracking application
-        /// behavior related to query parsing and URL navigation.
-        /// Typically injected via dependency injection.
+        /// The injected logger.
         /// </summary>
         [Inject] protected ILogger<QueryTableComponentBase> Logger { get; set; } = null!;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -36,7 +36,7 @@
               RowStyle="cursor: pointer;"
               MultiSelection="true"
               SelectOnRowClick="false"
-              CurrentPage="initialPage"
+              CurrentPage="InitialPage"
               Class="definitions-table"
               @bind-SelectedItems="_selectedRows">
         <ToolBarContent>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -94,7 +94,7 @@ public partial class WorkflowDefinitionList
             .ToList();
 
         // Update initialPage to preserve current page during re-renders
-        initialPage = state.Page;
+        InitialPage = state.Page;
 
         // Update URL to reflect current table state & filters
         TryUpdateUrlFromState(state);
@@ -110,7 +110,7 @@ public partial class WorkflowDefinitionList
     protected override async Task ApplyQueryParameters(IDictionary<string, string> query)
     {
         // Paging
-        if (query.TryGetValue("page", out var pageValue) && int.TryParse(pageValue, out var page)) initialPage = page - 1;
+        if (query.TryGetValue("page", out var pageValue) && int.TryParse(pageValue, out var page)) InitialPage = page - 1;
         if (query.TryGetValue("pageSize", out var pageSizeValue) && int.TryParse(pageSizeValue, out var pageSize)) _table.SetRowsPerPage(pageSize);
 
         // Filters

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -93,6 +93,9 @@ public partial class WorkflowDefinitionList
             })
             .ToList();
 
+        // Update initialPage to preserve current page during re-renders
+        initialPage = state.Page;
+
         // Update URL to reflect current table state & filters
         TryUpdateUrlFromState(state);
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor
@@ -30,8 +30,8 @@
                 RowStyle="cursor: pointer;"
                 MultiSelection="true"
                 SelectOnRowClick="false"
-                CurrentPage="initialPage"
-                RowsPerPage="initialPageSize"
+                CurrentPage="InitialPage"
+                RowsPerPage="InitialPageSize"
                 Class="instances-table"
                 @bind-SelectedItems="_selectedRows">
         <ToolBarContent>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -186,8 +186,8 @@ public partial class WorkflowInstanceList : IAsyncDisposable
     protected override async Task ApplyQueryParameters(IDictionary<string, string> query)
     {
         // Paging
-        if (query.TryGetValue("page", out var pageValue) && int.TryParse(pageValue, out var page)) initialPage = page - 1;
-        if (query.TryGetValue("pageSize", out var pageSizeValue) && int.TryParse(pageSizeValue, out var pageSize)) initialPageSize = pageSize;
+        if (query.TryGetValue("page", out var pageValue) && int.TryParse(pageValue, out var page)) InitialPage = page - 1;
+        if (query.TryGetValue("pageSize", out var pageSizeValue) && int.TryParse(pageSizeValue, out var pageSize)) InitialPageSize = pageSize;
 
         // Filters
         if (query.TryGetValue("search", out var searchValues)) SearchTerm = searchValues;


### PR DESCRIPTION
Improves query parameter handling and pagination state management in workflow components.

This change addresses an issue where the current page was not preserved during re-renders. It introduces the following:
- Refactors the query parameter parsing logic in `QueryTableComponentBase` for better maintainability.
- Uses properties instead of fields for initial page and page size.
- Preserves the current page during re-renders by updating `InitialPage` in `WorkflowDefinitionList`.

Fixes bug/734-code-cleanup