### PR TITLE
Displays incident count on workflow instance details

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
@@ -36,7 +36,7 @@
                                 }
                                 else
                                 {
-                                    @item.Label
+                                    @(!string.IsNullOrWhiteSpace(item.Label) ? item.Label : "-")
                                 }
                             </td>
                             <td>

--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor
@@ -21,7 +21,7 @@
             <tbody>
                 @{
                     var data = HideEmptyValues
-                    ? Data.Where(x => !string.IsNullOrWhiteSpace(x.Text)).ToList()
+                    ? Data.Where(x => !string.IsNullOrWhiteSpace(x.Text) || x.LabelComponent != null || x.ValueComponent != null).ToList()
                     : Data;
                 }
                 @if (data.Any())
@@ -29,47 +29,63 @@
                     @foreach (var item in data)
                     {
                         <tr Class="hover-row">
-                            <td style="width: 200px;" title="@item.LabelToolTip">@item.Label</td>
+                            <td style="width: 200px;" title="@item.LabelToolTip">
+                                @if (item.LabelComponent != null)
+                                {
+                                    @item.LabelComponent
+                                }
+                                else
+                                {
+                                    @item.Label
+                                }
+                            </td>
                             <td>
-                                <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
-                                    @if (!string.IsNullOrWhiteSpace(item.Text))
-                                    {
-                                        <MudTooltip Text="@Localizer["View"]" Delay="500">
-                                            <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
-                                        </MudTooltip>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(item.Link))
-                                    {
-                                        <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
-                                    }
-                                    else if (item.OnClick != null)
-                                    {
-                                        <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
-                                    }
-                                    else
-                                    {
-                                        @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
+                                @if (item.ValueComponent != null)
+                                {
+                                    @item.ValueComponent
+                                }
+                                else
+                                {
+                                    <MudStack Row=true Spacing="1" AlignItems="AlignItems.Center">
+                                        @if (!string.IsNullOrWhiteSpace(item.Text))
                                         {
-                                            <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
+                                            <MudTooltip Text="@Localizer["View"]" Delay="500">
+                                                <MudIconButton Icon="@Icons.Material.Outlined.ManageSearch" Size="Size.Small" OnClick="@(() => OnViewClicked(item!))" Disabled="@(string.IsNullOrWhiteSpace(item.Text))" Class="icon-on-hover" />
+                                            </MudTooltip>
+                                        }
+                                        @if (!string.IsNullOrWhiteSpace(item.Link))
+                                        {
+                                            <MudLink Typo="Typo.body2" Href="@item.Link">@item.Text</MudLink>
+                                        }
+                                        else if (item.OnClick != null)
+                                        {
+                                            <MudLink Typo="Typo.body2" OnClick="@item.OnClick">@item.Text</MudLink>
                                         }
                                         else
                                         {
-                                            @if (item.Text?.Length > truncationLength)
+                                            @if (item.Label == "Created" || item.Label == "Updated" || item.Label == "Finished")
                                             {
-                                                <div>
-                                                    @item.Text.Substring(0, truncationLength)
-                                                    <MudTooltip Text="@Localizer["Show all"]" Delay="500">
-                                                        <MudLink OnClick="@(() => OnViewClicked(item!))"><small>[...]</small></MudLink>
-                                                    </MudTooltip>
-                                                </div>
+                                                <span><Timestamp Value="@Convert.ToDateTime(item.Text)"></Timestamp></span>
                                             }
                                             else
                                             {
-                                                <span>@item.Text</span>
+                                                @if (item.Text?.Length > truncationLength)
+                                                {
+                                                    <div>
+                                                        @item.Text.Substring(0, truncationLength)
+                                                        <MudTooltip Text="@Localizer["Show all"]" Delay="500">
+                                                            <MudLink OnClick="@(() => OnViewClicked(item!))"><small>[...]</small></MudLink>
+                                                        </MudTooltip>
+                                                    </div>
+                                                }
+                                                else
+                                                {
+                                                    <span>@item.Text</span>
+                                                }
                                             }
                                         }
-                                    }
-                                </MudStack>
+                                    </MudStack>
+                                }
                             </td>
                             <td style="width: 50px;">
                                 <MudTooltip Text="@Localizer["Copy"]" Delay="500">

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components;
+
 namespace Elsa.Studio.Models;
 
 /// <summary>
@@ -7,5 +9,14 @@ namespace Elsa.Studio.Models;
 /// <param name="Text">The optional text content for the item.</param>
 /// <param name="Link">The optional link URL for the item.</param>
 /// <param name="OnClick">The optional click handler for the item.</param>
-/// <param name="OnClick">The optional click handler for the item.</param>
-public record DataPanelItem(string Label, string? Text = null, string? Link = null, Func<Task>? OnClick = null, string? LabelToolTip = null);
+/// <param name="LabelToolTip">The optional tooltip for the label.</param>
+/// <param name="LabelComponent">The optional custom component to render in the label cell.</param>
+/// <param name="ValueComponent">The optional custom component to render in the value cell.</param>
+public record DataPanelItem(
+    string? Label = null,
+    string? Text = null,
+    string? Link = null,
+    Func<Task>? OnClick = null,
+    string? LabelToolTip = null,
+    RenderFragment? LabelComponent = null,
+    RenderFragment? ValueComponent = null);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/IncidentNavigateButton.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/IncidentNavigateButton.razor
@@ -1,0 +1,10 @@
+@using ButtonType = MudBlazor.ButtonType
+@using Variant = MudBlazor.Variant
+
+<MudTooltip Text="Navigate to activity that caused the incident">
+    <MudButton OnClick="@OnClick" Variant="Variant.Filled" ButtonType="ButtonType.Button" Color="Color.Primary" Size="Size.Small">Navigate</MudButton>
+</MudTooltip>
+
+@code {
+    [Parameter] public EventCallback OnClick { get; set; }
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor
@@ -42,7 +42,7 @@
         </VerticalWell>
         }
     </MudTabPanel>
-    <MudTabPanel Text="@Localizer["Incidents"]">
+    <MudTabPanel Text="@Localizer["Incidents"]" BadgeData="@(Incidents.Count > 0 ? Incidents.Count : null)" BadgeColor="Color.Error">
         <VerticalWell ExtraPadding="50">
             <MudText Typo="Typo.overline" GutterBottom="true" Align="Align.Left">@Localizer["Incidents"]</MudText>
             @if (IncidentsData.Any())

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
@@ -13,8 +13,6 @@ using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
-using Size = Elsa.Api.Client.Shared.Models.Size;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
@@ -179,6 +179,8 @@ public partial class WorkflowInstanceDetails
         }
     }
     
+    private ICollection<ActivityIncident> Incidents => _workflowInstance?.WorkflowState.Incidents ?? new List<ActivityIncident>();
+    
     private IEnumerable<DataPanelModel> IncidentsData
     {
         get

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDetails.razor.cs
@@ -13,6 +13,8 @@ using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Size = Elsa.Api.Client.Shared.Models.Size;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 
@@ -188,12 +190,19 @@ public partial class WorkflowInstanceDetails
                 .Select(i => new DataPanelModel
                 {
                     new DataPanelItem("ActivityId", i.ActivityId),
-                    new DataPanelItem("ActivityNodeId", i.ActivityNodeId, null, () => OnIncidentActivityNodeIdClicked(i.ActivityNodeId)),
+                    new DataPanelItem("ActivityNodeId", i.ActivityNodeId),
                     new DataPanelItem("Message", i.Exception?.Message ?? ""),
-                    new DataPanelItem("InnerException", i.Exception?.InnerException != null
-                        ? i.Exception?.InnerException.Type + ": " + i.Exception?.InnerException.Message
-                        : ""),
-                    new DataPanelItem("StackTrace", i.Exception?.StackTrace ?? "")
+                    new DataPanelItem("InnerException", i.Exception?.InnerException != null ? i.Exception?.InnerException.Type + ": " + i.Exception?.InnerException.Message : ""),
+                    new DataPanelItem("StackTrace", i.Exception?.StackTrace ?? ""),
+                    new DataPanelItem(
+                        LabelComponent: builder =>
+                        {
+                            var activityNodeId = i.ActivityNodeId;
+                            builder.OpenComponent<IncidentNavigateButton>(0);
+                            builder.AddAttribute(1, "OnClick", EventCallback.Factory.Create(this, () => OnIncidentActivityNodeIdClicked(activityNodeId)));
+                            builder.CloseComponent();
+                        }
+                    ),
                 });
         }
     }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -110,8 +110,8 @@ public partial class DiagramDesignerWrapper
     public async Task SelectActivityByActivityIdAsync(string activityId, string? nodeId = null)
     {
         var containerActivity = GetCurrentContainerActivity();
-        var activities = containerActivity.GetActivities();
-        var activityToSelect = activities.FirstOrDefault(x => x.GetId() == activityId);
+        var activities = containerActivity?.GetActivities();
+        var activityToSelect = activities?.FirstOrDefault(x => x.GetId() == activityId);
 
         await SelectActivityAsync(activityToSelect, nodeId);
     }
@@ -120,12 +120,8 @@ public partial class DiagramDesignerWrapper
     /// <param name="nodeId">The ID of the activity node to select.</param>
     public async Task SelectActivityAsync(string nodeId)
     {
-        // Assuming _activityGraph.ActivityNodeLookup is your latest index
-        if (_activityGraph.ActivityNodeLookup.TryGetValue(nodeId, out var node))
-        {
-            var activity = node.Activity;
-            await SelectActivityAsync(activity, nodeId);
-        }
+        var activity = _activityGraph.ActivityNodeLookup.TryGetValue(nodeId, out var node) ? node.Activity : null;
+        await SelectActivityAsync(activity, nodeId);
     }
 
     private async Task SelectActivityAsync(JsonObject? activityToSelect, string? nodeId = null)


### PR DESCRIPTION
Improves the workflow instance details view by displaying a badge indicating the number of incidents.

This change introduces a badge on the "Incidents" tab within the workflow instance details, providing a visual cue when incidents are present. It also defines a property to retrieve the incidents for a given workflow instance.

<img width="2326" height="701" alt="image" src="https://github.com/user-attachments/assets/663dd40f-763e-4817-96ac-5482a17f0519" />


Relates to bug/738