### PR TITLE
Add warning alert for fallback mechanism in designer

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesigner.razor
@@ -1,7 +1,7 @@
 @using System.Text.Json.Nodes
 @using Elsa.Api.Client.Extensions
 <MudPaper Width="100%" Class="pa-16">
-    <MudAlert Severity="Severity.Warning">Fallback mechanism active. This may be caused by the absence of an appropriate designer registered for this type, such as in a code-based workflow.</MudAlert>
+    <MudAlert Severity="Severity.Warning">Fallback view active. This activity cannot be rendered because no designer is registered for its type.</MudAlert>
     <MudContainer MaxWidth="MaxWidth.ExtraSmall">
         @if (Activity != null)
         {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Fallback/FallbackDesigner.razor
@@ -1,6 +1,7 @@
 @using System.Text.Json.Nodes
 @using Elsa.Api.Client.Extensions
 <MudPaper Width="100%" Class="pa-16">
+    <MudAlert Severity="Severity.Warning">Fallback mechanism active. This may be caused by the absence of an appropriate designer registered for this type, such as in a code-based workflow.</MudAlert>
     <MudContainer MaxWidth="MaxWidth.ExtraSmall">
         @if (Activity != null)
         {


### PR DESCRIPTION
Add warning alert for fallback mechanism in designer

A warning alert was added to FallbackDesigner.razor to inform users when the fallback mechanism is active, typically due to the absence of a registered designer for the activity type (e.g., in code-based workflows). This helps clarify why the fallback UI is being shown.