### PR TITLE
Simplify custom theme instalment

### DIFF
--- a/src/framework/Elsa.Studio.Core/Contracts/IThemeProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IThemeProvider.cs
@@ -1,0 +1,14 @@
+using MudBlazor;
+
+namespace Elsa.Studio.Contracts;
+
+/// <summary>
+/// Provides a theme to the dashboard.
+/// </summary>
+public interface IThemeProvider
+{
+    /// <summary>
+    /// Gets the theme to use in the dashboard.
+    /// </summary>
+    MudTheme GetTheme();
+}

--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IBlazorServiceAccessor, BlazorServiceAccessor>()
             .AddScoped<IMenuService, DefaultMenuService>()
             .AddScoped<IMenuGroupProvider, DefaultMenuGroupProvider>()
+            .AddScoped<IThemeProvider, DefaultThemeProvider>()
             .AddScoped<IThemeService, DefaultThemeService>()
             .AddScoped<IAppBarService, DefaultAppBarService>()
             .AddScoped<IFeatureService, DefaultFeatureService>()

--- a/src/framework/Elsa.Studio.Core/Services/DefaultThemeProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultThemeProvider.cs
@@ -1,0 +1,42 @@
+using Elsa.Studio.Contracts;
+using MudBlazor;
+using MudBlazor.Utilities;
+
+namespace Elsa.Studio.Services;
+
+/// <summary>
+/// Provides the default theme for the dashboard.
+/// </summary>
+public class DefaultThemeProvider : IThemeProvider
+{
+    /// <inheritdoc />
+    public MudTheme GetTheme()
+    {
+        var theme = new MudTheme
+        {
+            LayoutProperties =
+            {
+                DefaultBorderRadius = "4px",
+            },
+            PaletteLight =
+            {
+                Primary = new("0ea5e9"),
+                DrawerBackground = new("#f8fafc"),
+                AppbarBackground = new("#0ea5e9"),
+                AppbarText = new("#ffffff"),
+                Background = new("#ffffff"),
+                Surface = new("#f8fafc")
+            },
+            PaletteDark =
+            {
+                Primary = new("0ea5e9"),
+                AppbarBackground = new("#0f172a"),
+                DrawerBackground = new("#0f172a"),
+                Background = new("#0f172a"),
+                Surface = new("#182234"),
+            }
+        };
+
+        return theme;
+    }
+}

--- a/src/framework/Elsa.Studio.Core/Services/DefaultThemeService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultThemeService.cs
@@ -1,14 +1,23 @@
 using Elsa.Studio.Contracts;
 using MudBlazor;
-using MudBlazor.Utilities;
 
 namespace Elsa.Studio.Services;
 
 /// <inheritdoc />
 public class DefaultThemeService : IThemeService
 {
-    private MudTheme _currentTheme = CreateDefaultTheme();
+    private readonly IThemeProvider _themeProvider;
+    private MudTheme _currentTheme;
     private bool _isDarkMode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultThemeService"/> class.
+    /// </summary>
+    public DefaultThemeService(IThemeProvider themeProvider)
+    {
+        _themeProvider = themeProvider;
+        _currentTheme = themeProvider.GetTheme();
+    }
 
     /// <inheritdoc />
     public event Action? CurrentThemeChanged;
@@ -36,35 +45,5 @@ public class DefaultThemeService : IThemeService
             _isDarkMode = value;
             IsDarkModeChanged?.Invoke();
         }
-    }
-
-    private static MudTheme CreateDefaultTheme()
-    {
-        var theme = new MudTheme
-        {
-            LayoutProperties =
-            {
-                DefaultBorderRadius = "4px",
-            },
-            PaletteLight = 
-            {
-                Primary = new("0ea5e9"),
-                DrawerBackground = new("#f8fafc"),
-                AppbarBackground = new("#0ea5e9"),
-                AppbarText = new("#ffffff"),
-                Background = new("#ffffff"),
-                Surface = new("#f8fafc")
-            },
-            PaletteDark =
-            {
-                Primary = new("0ea5e9"),
-                AppbarBackground = new("#0f172a"),
-                DrawerBackground = new("#0f172a"),
-                Background = new("#0f172a"),
-                Surface = new("#182234"),
-            }
-        };
-
-        return theme;
     }
 }

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Components/WorkflowDefinitionEditorWrapper.razor
@@ -12,19 +12,18 @@
 @code
 {
     private bool _shouldRender;
-    private string _definitionId = default!;
 
     /// The ID of the workflow definition to edit.
     [Parameter] public string DefinitionId
     {
-        get => _definitionId;
+        get;
         set
         {
-            if (_definitionId == value) return;
-            _definitionId = value;
+            if (field == value) return;
+            field = value;
             _shouldRender = true;
         }
-    }
+    } = null!;
 
     /// <summary>An event that is invoked when a workflow definition has been executed.</summary>
     /// <remarks>The ID of the workflow instance is provided as the value to the event callback.</remarks>
@@ -39,7 +38,7 @@
     /// Gets the currently selected activity ID.
     public string? SelectedActivityId => WorkflowDefinitionEditor.SelectedActivityId;
 
-    private WorkflowDefinitionEditor WorkflowDefinitionEditor { get; set; } = default!;
+    private WorkflowDefinitionEditor WorkflowDefinitionEditor { get; set; } = null!;
 
     /// Gets the currently selected workflow definition version.
     public WorkflowDefinition? GetSelectedWorkflowDefinitionVersion() => WorkflowDefinitionEditor.GetSelectedWorkflowDefinitionVersion();


### PR DESCRIPTION
This PR adds `IThemeProvider` which is designed for hosting apps to implement in order to provide a custom MudTheme object, simplifying the method by which one customizes the theme.