### PR TITLE
Fix clipping of Read Only Tooltip in Monaco Editor

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
@@ -1,8 +1,27 @@
 ﻿@using Elsa.Studio.Enums
 
 <style>
-    .monaco-editor-container {
+    /* Override Monaco editor height inside this dialog to fill MudPaper (655px).
+       The global .studio-monaco-editor-large sets 320px; we need the full panel height here. */
+    .mud-dialog .monaco-editor-container.studio-monaco-editor-large {
         height: 655px !important;
+    }
+
+    /* Allow Monaco overlay widgets (read-only tooltip, IntelliSense) to escape
+       clipping containers. The .overflowingContentWidgets div is a direct child
+       of .monaco-editor, which has overflow:hidden. We must also override any
+       ancestor containers that clip. */
+    .mud-dialog .monaco-editor {
+        overflow: visible !important;
+    }
+    .mud-dialog .mud-dialog-content,
+    .mud-dialog .mud-focus-trap-child-container,
+    .mud-dialog .mud-tabs,
+    .mud-dialog .mud-tabs-panels,
+    .mud-dialog .mud-tab-panel,
+    .mud-dialog .mud-paper,
+    .mud-dialog .monaco-editor-container {
+        overflow: visible !important;
     }
 </style>
 

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
@@ -1,31 +1,31 @@
 ﻿@using Elsa.Studio.Enums
 
 <style>
-    /* Override Monaco editor height inside this dialog to fill MudPaper (655px).
+    /* Override Monaco editor height inside this ContentVisualizer dialog to fill MudPaper (655px).
        The global .studio-monaco-editor-large sets 320px; we need the full panel height here. */
-    .mud-dialog .monaco-editor-container.studio-monaco-editor-large {
+    .content-visualizer-dialog .monaco-editor-container.studio-monaco-editor-large {
         height: 655px !important;
     }
 
     /* Allow Monaco overlay widgets (read-only tooltip, IntelliSense) to escape
-       clipping containers. The .overflowingContentWidgets div is a direct child
-       of .monaco-editor, which has overflow:hidden. We must also override any
-       ancestor containers that clip. */
-    .mud-dialog .monaco-editor {
+       clipping containers, but scope this behavior to the ContentVisualizer dialog only.
+       The .overflowingContentWidgets div is a direct child of .monaco-editor, which has
+       overflow:hidden. We must also override any ancestor containers that clip. */
+    .content-visualizer-dialog .monaco-editor {
         overflow: visible !important;
     }
-    .mud-dialog .mud-dialog-content,
-    .mud-dialog .mud-focus-trap-child-container,
-    .mud-dialog .mud-tabs,
-    .mud-dialog .mud-tabs-panels,
-    .mud-dialog .mud-tab-panel,
-    .mud-dialog .mud-paper,
-    .mud-dialog .monaco-editor-container {
+    .content-visualizer-dialog .mud-dialog-content,
+    .content-visualizer-dialog .mud-focus-trap-child-container,
+    .content-visualizer-dialog .mud-tabs,
+    .content-visualizer-dialog .mud-tabs-panels,
+    .content-visualizer-dialog .mud-tab-panel,
+    .content-visualizer-dialog .mud-paper,
+    .content-visualizer-dialog .monaco-editor-container {
         overflow: visible !important;
     }
 </style>
 
-<MudDialog>
+<MudDialog Class="content-visualizer-dialog">
     <TitleContent>
         <MudToolBar Dense="true" Gutters="false">
             <MudText Typo="Typo.h5">@DataPanelItem.Label</MudText>

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor.cs
@@ -1,7 +1,6 @@
 ﻿using BlazorMonaco.Editor;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Contracts;
-using Elsa.Studio.Extensions;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Models;
 using Elsa.Studio.Visualizers;


### PR DESCRIPTION
## Purpose

Enhance Monaco editor styling, improve async operations, and refactor code for better error handling and component lifecycle management.

---

## Scope

Select one primary concern:

- [x] Refactor (no behavior change)

---

## Description

### Problem

The existing Monaco editor styling and operation handling within the application needed improvements for better performance and maintainability.

### Solution

This update includes enhancements to Monaco editor styling, refactoring of asynchronous activity selection mechanisms, and improved error handling by introducing extensions and removing redundancy. Dependency updates for packages like Elsa.Api.Client are also included to align with recent releases.

---

## Verification

<!-- How can reviewers verify this change? -->

Steps:
1. Review the updated styling changes in the editor.
2. Test the async activity selection in the WorkflowEditor component.
3. Verify enhanced error handling mechanisms during runtime.

Expected outcome: Improved styling, error handling, and operation performance without behavioral changes.

---

## Screenshots / Recordings (if applicable)

<img width="1283" height="782" alt="image" src="https://github.com/user-attachments/assets/184dcafd-7e60-42f3-b39e-1df7532b477c" />

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [ ] All tests pass