### PR TITLE
Centralize workflow export dialog and fix filenames

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor.cs
@@ -4,13 +4,11 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.DomInterop.Contracts;
-using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+using Elsa.Studio.Workflows.Contracts;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contracts;
-using Humanizer;
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
 using Radzen;
 using Radzen.Blazor;
 
@@ -27,20 +25,18 @@ public partial class WorkflowDefinitionVersionViewer
 
     /// Gets or sets the workflow definition to view.
     [Parameter] public WorkflowDefinition? WorkflowDefinition { get; set; }
-    
 
     /// Gets or sets the event triggered when an activity is selected.
     [Parameter] public Func<JsonObject, Task>? ActivitySelected { get; set; }
 
     /// Gets the ID of the selected activity.
     public string? SelectedActivityId { get; private set; }
-    
+
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = default!;
     [Inject] private IActivityVisitor ActivityVisitor { get; set; } = default!;
     [Inject] private IDiagramDesignerService DiagramDesignerService { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
-    [Inject] private IFiles Files { get; set; } = default!;
-    [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = default!;
 
     private JsonObject? Activity => _workflowDefinition?.Root;
     private JsonObject? SelectedActivity { get; set; }
@@ -76,9 +72,9 @@ public partial class WorkflowDefinitionVersionViewer
     {
         if (WorkflowDefinition == _workflowDefinition)
             return;
-     
+
         _workflowDefinition = WorkflowDefinition;
-        
+
         if (_workflowDefinition?.Root == null)
             return;
 
@@ -94,7 +90,7 @@ public partial class WorkflowDefinitionVersionViewer
         // Otherwise, the Monaco editor will not be updated with a new value. Perhaps we should consider updating the Monaco Editor via its imperative API instead of via binding.
         SelectedActivity = null;
         ActivityDescriptor = null;
-        
+
         // We must await the render cycle to ensure the Monaco editor is fully disposed before creating a new one.
         // Without this, in Blazor WASM there can be a race condition where the new Monaco editor tries to initialize
         // before the old one is fully cleaned up, causing JSException: "Couldn't find the editor with id".
@@ -110,7 +106,7 @@ public partial class WorkflowDefinitionVersionViewer
     private async Task OnActivitySelected(JsonObject activity)
     {
         await SelectActivityAsync(activity);
-        if(ActivitySelected != null)
+        if (ActivitySelected != null)
             await ActivitySelected(activity);
     }
 
@@ -122,38 +118,10 @@ public partial class WorkflowDefinitionVersionViewer
 
     private async Task OnDownloadClicked()
     {
-        var includeConsumingWorkflows = await ShowExportOptionsDialogAsync();
-
-        if (includeConsumingWorkflows == null)
-            return;
-
-        var download = await WorkflowDefinitionService.ExportDefinitionAsync(_workflowDefinition!.DefinitionId, VersionOptions.SpecificVersion(_workflowDefinition.Version), includeConsumingWorkflows.Value);
-        var fileName = $"{_workflowDefinition.Name.Kebaberize()}.json";
-        await Files.DownloadFileFromStreamAsync(fileName, download.Content);
+        await WorkflowExportDialogService.ExportAndDownloadAsync(include =>
+            WorkflowDefinitionService.ExportDefinitionAsync(_workflowDefinition!.DefinitionId, VersionOptions.SpecificVersion(_workflowDefinition.Version), include));
     }
 
-    /// <summary>
-    /// Shows the export options dialog and returns the selected value for includeConsumingWorkflows,
-    /// or null if the user cancelled.
-    /// </summary>
-    private async Task<bool?> ShowExportOptionsDialogAsync()
-    {
-        var options = new MudBlazor.DialogOptions
-        {
-            CloseOnEscapeKey = true,
-            Position = MudBlazor.DialogPosition.Center,
-            MaxWidth = MaxWidth.Small,
-            FullWidth = true
-        };
-
-        var dialogInstance = await DialogService.ShowAsync<ExportWorkflowDialog>(Localizer["Export"], options);
-        var result = await dialogInstance.Result;
-
-        if (result?.Canceled == true)
-            return null;
-
-        return result?.Data is true;
-    }
 
     private async Task OnResize(RadzenSplitterResizeEventArgs arg)
     {

--- a/src/modules/Elsa.Studio.Workflows/Contracts/IWorkflowExportDialogService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Contracts/IWorkflowExportDialogService.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Contracts;
+
+/// <summary>
+/// Provides functionality for showing the export options dialog when exporting workflow definitions.
+/// </summary>
+public interface IWorkflowExportDialogService
+{
+    /// <summary>
+    /// Shows the export options dialog and returns whether consuming workflows should be included.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> to include consuming workflows, <see langword="false"/> to exclude them,
+    /// or <see langword="null"/> if the user cancelled the dialog.
+    /// </returns>
+    Task<bool?> ShowExportOptionsDialogAsync();
+
+    /// <summary>
+    /// Shows the export options dialog and, if not cancelled, invokes <paramref name="exportFactory"/> with the
+    /// selected option and downloads the resulting file.
+    /// </summary>
+    /// <param name="exportFactory">
+    /// A delegate that receives the <c>includeConsumingWorkflows</c> flag and returns a <see cref="FileDownload"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if the export was performed; <see langword="false"/> if the user cancelled.</returns>
+    Task<bool> ExportAndDownloadAsync(Func<bool, Task<FileDownload>> exportFactory);
+}
+

--- a/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IMenuProvider, WorkflowsMenu>()
             .AddScoped<IWorkflowInstanceObserverFactory, WorkflowInstanceObserverFactory>()
             .AddScoped<IWorkflowCloningDialogService, WorkflowCloningDialogService>()
+            .AddScoped<IWorkflowExportDialogService, WorkflowExportDialogService>()
             .AddDefaultUIHintHandlers()
             .AddDefaultActivityPortProviders()
             .AddWorkflowsCore()

--- a/src/modules/Elsa.Studio.Workflows/Services/WorkflowExportDialogService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/WorkflowExportDialogService.cs
@@ -1,0 +1,50 @@
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.Services;
+
+/// <inheritdoc />
+public class WorkflowExportDialogService(IDialogService dialogService, ILocalizer localizer, IFiles files) : IWorkflowExportDialogService
+{
+    /// <inheritdoc />
+    public async Task<bool?> ShowExportOptionsDialogAsync()
+    {
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            Position = DialogPosition.Center,
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true
+        };
+
+        var dialogInstance = await dialogService.ShowAsync<ExportWorkflowDialog>(localizer["Export"], options);
+        var result = await dialogInstance.Result;
+
+        if (result?.Canceled == true)
+            return null;
+
+        return result?.Data is true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ExportAndDownloadAsync(Func<bool, Task<FileDownload>> exportFactory)
+    {
+        var includeConsumingWorkflows = await ShowExportOptionsDialogAsync();
+
+        if (includeConsumingWorkflows == null)
+            return false;
+
+        var download = await exportFactory(includeConsumingWorkflows.Value);
+
+        if (download.Content.CanSeek)
+            download.Content.Seek(0, SeekOrigin.Begin);
+
+        await files.DownloadFileFromStreamAsync(download.FileName, download.Content);
+        return true;
+    }
+}
+


### PR DESCRIPTION
Summary
- Introduce a shared export dialog service to unify workflow export behavior across components and ensure correct, consistent file names.

Why
- Export logic was duplicated across multiple components, leading to maintenance overhead and inconsistencies.
- Exported file names differed between views (e.g., locally generated kebab-case names vs. server-provided names), causing user confusion and a reported bug.
- Centralizing dialog and download logic simplifies code and ensures all exports use the backend-provided file name.

What’s Changed
- Add a reusable service:
  - Add IWorkflowExportDialogService and WorkflowExportDialogService to encapsulate:
    - Showing the export options dialog
    - Executing the export
    - Seeking streams and downloading files using the server-provided file name
- Refactor components to use the service:
  - WorkflowDefinitionVersionViewer: Replace inline export + download with service call
  - WorkflowEditor: Replace inline export + download with service call
  - WorkflowDefinitionList:
    - Replace single export and bulk export flows with service calls
    - Clear selection only when an export actually occurs
- Remove duplicated, private dialog methods from components
- Remove now-unnecessary dependencies (e.g., direct IFiles and IDialogService injections) from components
- Register the new service in DI

User Impact
- Export dialogs behave consistently across all workflow views
- Downloaded files now reliably use backend-provided names
- Bulk export preserves selection when the dialog is canceled

How to Test
1. Single export from list:
   - Open Workflow Definition List
   - Click Export on a definition
   - Cancel the dialog → no download occurs
   - Confirm the dialog → file downloads with backend-provided file name
2. Bulk export:
   - Select multiple definitions
   - Click Bulk Export
   - Cancel → no download; selection remains intact
   - Confirm → file downloads (likely an archive) with backend-provided file name; selection clears
3. Export from editor:
   - Open a workflow in the editor
   - Click Export
   - Confirm → file downloads and uses the server-provided name
4. Export from version viewer:
   - Open a specific workflow version
   - Click Download
   - Confirm → file downloads with server-provided name
5. General:
   - Verify the export options dialog still appears and functions the same
   - Verify no errors in console for stream handling
   - For UI changes, include before/after screenshots or a GIF demonstrating the export dialogs and resulting filenames

Breaking Changes
- None

Review Focus
- Confirm all export paths now use the backend-provided file name
- Verify the new service is correctly registered and injected
- Validate cancel behavior returns false and avoids side-effects (e.g., selection clearing)
- Check for any lingering direct uses of IFiles or IDialogService in export paths
- Ensure stream seeking logic is correct across all export scenarios