### PR TITLE
Prevent autosave on programmatic node resizing

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -382,7 +382,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         // Skip graph update when size was changed programmatically (e.g., from updateActivitySize during initial render).
         // This prevents unwanted auto-saves when the server returns different sizes than what the Studio calculated.
         const binding = graphBindings[graphId];
-        if (binding?.suppressGraphUpdated) {
+        if (binding?.suppressGraphUpdated > 0) {
             return false;
         }
         

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -379,6 +379,13 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
             return false;
         }
         
+        // Skip graph update when size was changed programmatically (e.g., from updateActivitySize during initial render).
+        // This prevents unwanted auto-saves when the server returns different sizes than what the Studio calculated.
+        const binding = graphBindings[graphId];
+        if (binding?.suppressGraphUpdated) {
+            return false;
+        }
+        
         const node = e.node || e.cell;
         if (node) {
             isEnforcingMinSize = true;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
@@ -14,5 +14,6 @@ export interface GraphBinding {
     graphId: string;
     graph: Graph;
     interop: DotNetFlowchartDesigner;
+    suppressGraphUpdated?: boolean;
 }
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
@@ -14,6 +14,6 @@ export interface GraphBinding {
     graphId: string;
     graph: Graph;
     interop: DotNetFlowchartDesigner;
-    suppressGraphUpdated?: boolean;
+    suppressGraphUpdated?: number;
 }
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-size.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-size.ts
@@ -53,11 +53,11 @@ export async function updateActivitySize(elementId: string, activityModel: Activ
         // Suppress graph updated events for programmatic size adjustments (e.g., initial render sizing).
         // This prevents unwanted auto-saves when the calculated size differs from the stored size,
         // which commonly occurs with NotFoundActivity where the server resets sizes on save.
-        graphBinding.suppressGraphUpdated = true;
+        graphBinding.suppressGraphUpdated = (graphBinding.suppressGraphUpdated || 0) + 1;
         try {
             node.size(width, height);
         } finally {
-            graphBinding.suppressGraphUpdated = false;
+            graphBinding.suppressGraphUpdated = Math.max(0, (graphBinding.suppressGraphUpdated || 0) - 1);
         }
     }
 }


### PR DESCRIPTION
Summary
- Suppress graph-updated events during programmatic size adjustments to avoid unintended autosaves on initial render.
- Add a per-graph suppression flag and skip no-op size updates using a small tolerance to reduce redundant events.

Details
- Short-circuit graph update handling when a suppression flag is active, ensuring programmatic size changes (e.g., initial render sizing) do not trigger autosave.
- Only apply size changes when the new size differs by more than 0.5px, minimizing unnecessary event emissions.
- Ensure the suppression flag is reliably reset using a try/finally pattern.

How to Test
1. Open a workflow that recalculates activity sizes on initial render (e.g., activities that commonly differ between server-stored and client-calculated sizes).
2. Verify no autosave is triggered immediately after the initial render when programmatic resizing occurs.
3. Manually resize a node via the UI and confirm an autosave is triggered as expected.
4. Save the workflow, reload it, and confirm there are no repeated or unexpected autosaves on load.
5. Repeat with multiple diagrams in the same session to confirm suppression is scoped per graph and does not leak between graphs.

UI Notes
- If applicable, include before/after screenshots or a GIF showing that the autosave indicator does not appear on initial render but does appear after manual resizing.

Breaking Changes
- None known.

Review Focus
- Verify the suppression flag is correctly set and cleared (no missed legitimate autosaves, no lingering suppression).
- Validate the 0.5px tolerance for change detection is appropriate and does not mask meaningful updates.
- Confirm the suppression applies only to programmatic resizes and not to user-initiated interactions.
- Check for other programmatic operations that might also need similar suppression to avoid unintended autosaves.

Fixes #765