### PR TITLE
Bugfix: Rendering Activity Property Tabs before ExpressionDescriptorProvider was populated

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ on:
   release:
     types: [ prereleased, published ]
 env:
-  base_version: '3.6.0'
+  base_version: '3.6.1'
   nuget_feed_feedzio: 'https://f.feedz.io/elsa-workflows/elsa-3/nuget/index.json'
   nuget_feed_nuget: 'https://api.nuget.org/v3/index.json'
   npm_feed_feedzio: 'https://f.feedz.io/elsa-workflows/elsa-3/npm/'

--- a/src/framework/Elsa.Studio.Core/Contracts/IActivityTab.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IActivityTab.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace Elsa.Studio.Contracts;
 
@@ -14,11 +15,35 @@ public interface IActivityTab
     string Title { get; }
 
     /// <summary>
+    /// Gets the icon to render for the activity tab.
+    /// </summary>
+    string? Icon => null;
+
+    /// <summary>
     /// Gets the order of the tab in relation to other tabs.
     /// This property determines the relative position of the tab when displayed, allowing tabs to
     /// be sorted or organized based on their numerical order value.
     /// </summary>
     double Order { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the tab content should be wrapped in a <c>ScrollableWell</c> by the caller.
+    /// </summary>
+    bool WrapInScrollableWell => true;
+
+    /// <summary>
+    /// Determines whether the tab should be visible for the provided attributes.
+    /// </summary>
+    /// <param name="attributes">The activity tab attributes.</param>
+    /// <returns><see langword="true"/> if the tab should be rendered; otherwise, <see langword="false"/>.</returns>
+    bool IsVisible(IDictionary<string, object?> attributes) => true;
+
+    /// <summary>
+    /// Gets the icon color for the tab.
+    /// </summary>
+    /// <param name="attributes">The activity tab attributes.</param>
+    /// <returns>The icon color to use, if any.</returns>
+    Color? GetIconColor(IDictionary<string, object?> attributes) => null;
 
     /// <summary>
     /// Defines a rendering function for an activity tab. This function takes a dictionary of attributes

--- a/src/framework/Elsa.Studio.Core/Models/ActivityTab.cs
+++ b/src/framework/Elsa.Studio.Core/Models/ActivityTab.cs
@@ -1,0 +1,55 @@
+using Elsa.Studio.Contracts;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Models;
+
+/// <summary>
+/// Provides a generic implementation of <see cref="IActivityTab"/>.
+/// </summary>
+public class ActivityTab : IActivityTab
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivityTab"/> class.
+    /// </summary>
+    /// <param name="title">The tab title.</param>
+    /// <param name="order">The tab order.</param>
+    /// <param name="render">The render delegate.</param>
+    public ActivityTab(string title, double order, Func<IDictionary<string, object?>, RenderFragment> render)
+    {
+        Title = title;
+        Order = order;
+        Render = render;
+    }
+
+    /// <inheritdoc />
+    public string Title { get; }
+
+    /// <inheritdoc />
+    public string? Icon { get; set; }
+
+    /// <inheritdoc />
+    public double Order { get; }
+
+    /// <inheritdoc />
+    public bool WrapInScrollableWell { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the predicate used to determine tab visibility.
+    /// </summary>
+    public Func<IDictionary<string, object?>, bool>? VisibilityPredicate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon color provider.
+    /// </summary>
+    public Func<IDictionary<string, object?>, Color?>? IconColorProvider { get; set; }
+
+    /// <inheritdoc />
+    public Func<IDictionary<string, object?>, RenderFragment> Render { get; }
+
+    /// <inheritdoc />
+    public bool IsVisible(IDictionary<string, object?> attributes) => VisibilityPredicate?.Invoke(attributes) ?? true;
+
+    /// <inheritdoc />
+    public Color? GetIconColor(IDictionary<string, object?> attributes) => IconColorProvider?.Invoke(attributes);
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -27,24 +27,25 @@
                               Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
                 </Well>
             }
-        </MudTabPanel>
+            </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
-            @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <OutputsTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
-                                ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any output properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
+            <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
+                @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <OutputsTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
+                                    ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                                  Variant="Variant.Text">@Localizer["This activity does not have any output properties."]</MudAlert>
+                    </Well>
+                }
+            </MudTabPanel>
+        }
 
         <MudTabPanel Text="@Localizer["Common"]" Icon="@Icons.Material.Outlined.Notes">
             @if (Activity != null && ActivityDescriptor != null)
@@ -143,7 +144,6 @@
                     @tab.Render((new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated }).ToDictionary())
                 </ScrollableWell>
             </MudTabPanel>
-        }
         }        
 
     </MudTabs>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -13,20 +13,20 @@
         @if (isInitialized)
         {
             <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
-            @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <InputsTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
-                               ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
-                </Well>
-            }
+                @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <InputsTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
+                                   ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                                  Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
+                    </Well>
+                }
             </MudTabPanel>
 
             <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
@@ -63,13 +63,13 @@
                 </Well>
             }
         </MudTabPanel>
-        
-        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor" >
+
+        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor">
             @if (WorkflowDefinition != null && ActivityDescriptor != null && Activity != null)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
                     <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor"
-                             Activity="Activity" OnTestResultChanged="OnTestResultChanged" />
+                             Activity="Activity" OnTestResultChanged="OnTestResultChanged"/>
                 </ScrollableWell>
             }
         </MudTabPanel>
@@ -144,7 +144,7 @@
                     @tab.Render((new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated }).ToDictionary())
                 </ScrollableWell>
             </MudTabPanel>
-        }        
+        }
 
     </MudTabs>
 </CascadingValue>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -1,147 +1,23 @@
-@using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs
-@using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components
-@using Elsa.Studio.Extensions
-@using Variant = MudBlazor.Variant
-@using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Tests
 @inherits StudioComponentBase
 @inject ILocalizer Localizer
 
 <CascadingValue Value="ExpressionDescriptorProvider">
     <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
+        @{ var tabAttributes = ActivityTabAttributes; }
 
-        @if (_isInitialized)
+        @foreach (var tab in Tabs.Where(x => x.IsVisible(tabAttributes)))
         {
-            <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
-                @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
+            <MudTabPanel Text="@tab.Title" Icon="@tab.Icon" IconColor="@(tab.GetIconColor(tabAttributes) ?? Color.Default)">
+                @if (tab.WrapInScrollableWell)
                 {
                     <ScrollableWell MaxHeight="VisiblePaneHeight">
-                        <InputsTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
-                                   ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                        @tab.Render(tabAttributes)
                     </ScrollableWell>
                 }
                 else
                 {
-                    <Well>
-                        <MudAlert Severity="Severity.Normal"
-                                  Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
-                    </Well>
+                    @tab.Render(tabAttributes)
                 }
-            </MudTabPanel>
-
-            <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
-                @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
-                {
-                    <ScrollableWell MaxHeight="VisiblePaneHeight">
-                        <OutputsTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
-                                    ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                    </ScrollableWell>
-                }
-                else
-                {
-                    <Well>
-                        <MudAlert Severity="Severity.Normal"
-                                  Variant="Variant.Text">@Localizer["This activity does not have any output properties."]</MudAlert>
-                    </Well>
-                }
-            </MudTabPanel>
-        }
-
-        <MudTabPanel Text="@Localizer["Common"]" Icon="@Icons.Material.Outlined.Notes">
-            @if (Activity != null && ActivityDescriptor != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <CommonTab Activity="@Activity" ActivityDescriptor="@ActivityDescriptor"
-                               OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
-
-        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor">
-            @if (WorkflowDefinition != null && ActivityDescriptor != null && Activity != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor"
-                             Activity="Activity" OnTestResultChanged="OnTestResultChanged"/>
-                </ScrollableWell>
-            }
-        </MudTabPanel>
-
-        <MudTabPanel Text="@Localizer["Commit Strategy"]" Icon="@Icons.Material.Outlined.Commit">
-            @if (Activity != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <CommitStrategyTab Activity="@Activity" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
-
-        @if (IsTaskActivity)
-        {
-            <MudTabPanel Text="@Localizer["Task"]" Icon="@Icons.Material.Outlined.HorizontalSplit">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <TaskTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
-                             OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            </MudTabPanel>
-        }
-
-        <MudTabPanel Text="@Localizer["Log"]" Icon="@Icons.Material.Outlined.Assignment">
-            <ScrollableWell MaxHeight="VisiblePaneHeight">
-                <LogPersistenceTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
-                                   ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-            </ScrollableWell>
-        </MudTabPanel>
-
-
-        <MudTabPanel Text="@Localizer["Info"]" Icon="@Icons.Material.Outlined.Info">
-            @if (ActivityDescriptor != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <InfoTab ActivityDescriptor="@ActivityDescriptor" Activity="Activity"/>
-                </ScrollableWell>
-            }
-        </MudTabPanel>
-
-        @if (IsWorkflowAsActivity)
-        {
-            <MudTabPanel Text="@Localizer["Version"]" Icon="@Icons.Material.Outlined.Numbers">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <VersionTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
-                                OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            </MudTabPanel>
-        }
-
-        @if (DisplayResilienceTab)
-        {
-            <MudTabPanel Text="@Localizer["Resilience"]" Icon="@Icons.Material.Outlined.RestartAlt">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <ResilienceTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
-                                   ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            </MudTabPanel>
-        }
-
-        @foreach (var tab in PluginTabs)
-        {
-            <MudTabPanel Text="@tab.Title">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    @tab.Render((new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated }).ToDictionary())
-                </ScrollableWell>
             </MudTabPanel>
         }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -10,7 +10,9 @@
 <CascadingValue Value="ExpressionDescriptorProvider">
     <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
 
-        <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
+        @if (isInitialized)
+        {
+            <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
             @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
             {
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
@@ -142,6 +144,7 @@
                 </ScrollableWell>
             </MudTabPanel>
         }
+        }        
 
     </MudTabs>
 </CascadingValue>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -1,4 +1,3 @@
-@using Elsa.Api.Client.Extensions
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components
 @using Elsa.Studio.Extensions
@@ -10,7 +9,7 @@
 <CascadingValue Value="ExpressionDescriptorProvider">
     <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
 
-        @if (isInitialized)
+        @if (_isInitialized)
         {
             <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
                 @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -87,12 +87,17 @@ public partial class ActivityPropertiesPanel
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
-        IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
-        ExpressionDescriptorProvider.AddRange(expressionDescriptors);
-        PluginTabs = ActivityTabRegistry.List().ToList();
-
-        isInitialized = true;
+        try
+        {
+            var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
+            IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
+            ExpressionDescriptorProvider.AddRange(expressionDescriptors);
+            PluginTabs = ActivityTabRegistry.List().ToList();
+        }
+        finally
+        {
+            isInitialized = true;
+        }
     }
     /// <summary>
     /// Updates the test result status when the tests status changes.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -4,7 +4,13 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Components;
 using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Tests;
 using Elsa.Studio.Workflows.Domain.Models;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
@@ -16,8 +22,8 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// </summary>
 public partial class ActivityPropertiesPanel
 {
-    private bool _isInitialized = false;
-    
+    private bool _isInitialized;
+
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>
@@ -40,9 +46,8 @@ public partial class ActivityPropertiesPanel
         set
         {
             if (field != value)
-            {
                 TestResultStatus = ActivityStatus.Canceled;
-            }
+
             field = value;
         }
     }
@@ -62,27 +67,22 @@ public partial class ActivityPropertiesPanel
     [Inject] private IExpressionService ExpressionService { get; set; } = null!;
     [Inject] private IRemoteFeatureProvider RemoteFeatureProvider { get; set; } = null!;
     [Inject] private IActivityTabRegistry ActivityTabRegistry { get; set; } = null!;
-    private IEnumerable<IActivityTab> PluginTabs { get; set; } = new List<IActivityTab>();
+    private IEnumerable<IActivityTab> Tabs { get; set; } = Array.Empty<IActivityTab>();
 
+    private IDictionary<string, object?> ActivityTabAttributes => new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated, VisiblePaneHeight }.ToDictionary();
     private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; } = new();
     private bool IsResilienceEnabled { get; set; }
-    private bool IsResilientActivity => ActivityDescriptor?.CustomProperties.TryGetValue("Resilient", out var resilientObj) == true && resilientObj.ConvertTo<bool>();  
+    private bool IsResilientActivity => ActivityDescriptor?.CustomProperties.TryGetValue("Resilient", out var resilientObj) == true && resilientObj.ConvertTo<bool>();
     private bool DisplayResilienceTab => IsResilienceEnabled && IsResilientActivity;
     private ActivityStatus TestResultStatus { get; set; } = ActivityStatus.Canceled;
-    private Color TestIconColor
+    private Color TestIconColor => TestResultStatus switch
     {
-        get
-        {
-            return TestResultStatus switch
-            {
-                ActivityStatus.Running => Color.Warning,
-                ActivityStatus.Completed => Color.Success,
-                ActivityStatus.Canceled => Color.Default,
-                ActivityStatus.Faulted => Color.Error,
-                _ => Color.Error,
-            };
-        }
-    }
+        ActivityStatus.Running => Color.Warning,
+        ActivityStatus.Completed => Color.Success,
+        ActivityStatus.Canceled => Color.Default,
+        ActivityStatus.Faulted => Color.Error,
+        _ => Color.Error,
+    };
 
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
@@ -90,14 +90,16 @@ public partial class ActivityPropertiesPanel
         var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
         ExpressionDescriptorProvider.AddRange(expressionDescriptors);
-        PluginTabs = ActivityTabRegistry.List().ToList();
+        Tabs = CreateBuiltInTabs().Concat(ActivityTabRegistry.List()).ToList();
         _isInitialized = true;
     }
+
     /// <summary>
     /// Updates the test result status when the tests status changes.
     /// </summary>
     /// <param name="status">The new activity status to set as the test result status.</param>
     private void OnTestResultChanged(ActivityStatus status) => TestResultStatus = status;
+
     /// <summary>
     /// Handles changes to the active panel index.
     /// </summary>
@@ -106,4 +108,174 @@ public partial class ActivityPropertiesPanel
 
     private bool IsWorkflowAsActivity => ActivityDescriptor != null && ActivityDescriptor.CustomProperties.TryGetValue("RootType", out var value) && value.ConvertTo<string>() == "WorkflowDefinitionActivity";
     private bool IsTaskActivity => ActivityDescriptor?.Kind == ActivityKind.Task;
+
+    private IEnumerable<IActivityTab> CreateBuiltInTabs() =>
+    [
+        new ActivityTab(Localizer["Input"], 0, _ => RenderInputsTab())
+        {
+            Icon = Icons.Material.Outlined.Input,
+            WrapInScrollableWell = false,
+            VisibilityPredicate = _ => _isInitialized,
+        },
+        new ActivityTab(Localizer["Output"], 1, _ => RenderOutputsTab())
+        {
+            Icon = Icons.Material.Outlined.Output,
+            WrapInScrollableWell = false,
+            VisibilityPredicate = _ => _isInitialized,
+        },
+        new ActivityTab(Localizer["Common"], 2, _ => RenderCommonTab())
+        {
+            Icon = Icons.Material.Outlined.Notes,
+            WrapInScrollableWell = false,
+        },
+        new ActivityTab(Localizer["Test"], 3, _ => RenderTestTab())
+        {
+            Icon = ElsaStudioIcons.Tabler.Flask,
+            WrapInScrollableWell = false,
+            IconColorProvider = _ => TestIconColor,
+        },
+        new ActivityTab(Localizer["Commit Strategy"], 4, _ => RenderCommitStrategyTab())
+        {
+            Icon = Icons.Material.Outlined.Commit,
+            WrapInScrollableWell = false,
+        },
+        new ActivityTab(Localizer["Task"], 5, _ => RenderTaskTab())
+        {
+            Icon = Icons.Material.Outlined.HorizontalSplit,
+            WrapInScrollableWell = false,
+            VisibilityPredicate = _ => IsTaskActivity,
+        },
+        new ActivityTab(Localizer["Log"], 6, _ => RenderLogTab())
+        {
+            Icon = Icons.Material.Outlined.Assignment,
+            WrapInScrollableWell = false,
+        },
+        new ActivityTab(Localizer["Info"], 7, _ => RenderInfoTab())
+        {
+            Icon = Icons.Material.Outlined.Info,
+            WrapInScrollableWell = false,
+        },
+        new ActivityTab(Localizer["Version"], 8, _ => RenderVersionTab())
+        {
+            Icon = Icons.Material.Outlined.Numbers,
+            WrapInScrollableWell = false,
+            VisibilityPredicate = _ => IsWorkflowAsActivity,
+        },
+        new ActivityTab(Localizer["Resilience"], 9, _ => RenderResilienceTab())
+        {
+            Icon = Icons.Material.Outlined.RestartAlt,
+            WrapInScrollableWell = false,
+            VisibilityPredicate = _ => DisplayResilienceTab,
+        },
+    ];
+
+    private RenderFragment RenderInputsTab() => ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true
+        ? RenderScrollableComponent<InputsTab>(
+            (nameof(InputsTab.WorkflowDefinition), WorkflowDefinition),
+            (nameof(InputsTab.Activity), Activity),
+            (nameof(InputsTab.ActivityDescriptor), ActivityDescriptor),
+            (nameof(InputsTab.OnActivityUpdated), OnActivityUpdated))
+        : RenderAlertInWell(Localizer["This activity does not have any input properties."]);
+
+    private RenderFragment RenderOutputsTab() => ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true
+        ? RenderScrollableComponent<OutputsTab>(
+            (nameof(OutputsTab.WorkflowDefinition), WorkflowDefinition),
+            (nameof(OutputsTab.Activity), Activity),
+            (nameof(OutputsTab.ActivityDescriptor), ActivityDescriptor),
+            (nameof(OutputsTab.OnActivityUpdated), OnActivityUpdated))
+        : RenderAlertInWell(Localizer["This activity does not have any output properties."]);
+
+    private RenderFragment RenderCommonTab() => Activity != null && ActivityDescriptor != null
+        ? RenderScrollableComponent<CommonTab>(
+            (nameof(CommonTab.Activity), Activity),
+            (nameof(CommonTab.ActivityDescriptor), ActivityDescriptor),
+            (nameof(CommonTab.OnActivityUpdated), OnActivityUpdated))
+        : RenderAlertInWell(Localizer["This activity does not have any common properties."]);
+
+    private RenderFragment RenderTestTab() => WorkflowDefinition != null && ActivityDescriptor != null && Activity != null
+        ? RenderScrollableComponent<TestTab>(
+            (nameof(TestTab.WorkflowDefinition), WorkflowDefinition),
+            (nameof(TestTab.ActivityDescriptor), ActivityDescriptor),
+            (nameof(TestTab.Activity), Activity),
+            (nameof(TestTab.OnTestResultChanged), EventCallback.Factory.Create<ActivityStatus>(this, OnTestResultChanged)))
+        : EmptyContent();
+
+    private RenderFragment RenderCommitStrategyTab() => Activity != null
+        ? RenderScrollableComponent<CommitStrategyTab>(
+            (nameof(CommitStrategyTab.Activity), Activity),
+            (nameof(CommitStrategyTab.OnActivityUpdated), OnActivityUpdated))
+        : RenderAlertInWell(Localizer["This activity does not have any common properties."]);
+
+    private RenderFragment RenderTaskTab() => RenderScrollableComponent<TaskTab>(
+        (nameof(TaskTab.Activity), Activity),
+        (nameof(TaskTab.ActivityDescriptor), ActivityDescriptor),
+        (nameof(TaskTab.OnActivityUpdated), OnActivityUpdated));
+
+    private RenderFragment RenderLogTab() => RenderScrollableComponent<LogPersistenceTab>(
+        (nameof(LogPersistenceTab.WorkflowDefinition), WorkflowDefinition),
+        (nameof(LogPersistenceTab.Activity), Activity),
+        (nameof(LogPersistenceTab.ActivityDescriptor), ActivityDescriptor),
+        (nameof(LogPersistenceTab.OnActivityUpdated), OnActivityUpdated));
+
+    private RenderFragment RenderInfoTab() => ActivityDescriptor != null
+        ? RenderScrollableComponent<InfoTab>(
+            (nameof(InfoTab.ActivityDescriptor), ActivityDescriptor),
+            (nameof(InfoTab.Activity), Activity))
+        : EmptyContent();
+
+    private RenderFragment RenderVersionTab() => RenderScrollableComponent<VersionTab>(
+        (nameof(VersionTab.Activity), Activity),
+        (nameof(VersionTab.ActivityDescriptor), ActivityDescriptor),
+        (nameof(VersionTab.OnActivityUpdated), OnActivityUpdated));
+
+    private RenderFragment RenderResilienceTab() => RenderScrollableComponent<ResilienceTab>(
+        (nameof(ResilienceTab.WorkflowDefinition), WorkflowDefinition),
+        (nameof(ResilienceTab.Activity), Activity),
+        (nameof(ResilienceTab.ActivityDescriptor), ActivityDescriptor),
+        (nameof(ResilienceTab.OnActivityUpdated), OnActivityUpdated));
+
+    private RenderFragment RenderScrollableComponent<TComponent>(params (string Name, object? Value)[] parameters) where TComponent : IComponent => RenderScrollableWell(RenderComponent<TComponent>(parameters));
+
+    private RenderFragment RenderScrollableWell(RenderFragment childContent) => builder =>
+    {
+        var sequence = 0;
+        builder.OpenComponent<ScrollableWell>(sequence++);
+        builder.AddAttribute(sequence++, nameof(ScrollableWell.MaxHeight), VisiblePaneHeight);
+        builder.AddAttribute(sequence++, nameof(ScrollableWell.ChildContent), childContent);
+        builder.CloseComponent();
+    };
+
+    private RenderFragment RenderWell(RenderFragment childContent) => builder =>
+    {
+        var sequence = 0;
+        builder.OpenComponent<Well>(sequence++);
+        builder.AddAttribute(sequence++, nameof(Well.ChildContent), childContent);
+        builder.CloseComponent();
+    };
+
+    private RenderFragment RenderAlertInWell(string message) => RenderWell(RenderAlert(message));
+
+    private static RenderFragment RenderAlert(string message) => builder =>
+    {
+        var sequence = 0;
+        builder.OpenComponent<MudAlert>(sequence++);
+        builder.AddAttribute(sequence++, nameof(MudAlert.Severity), Severity.Normal);
+        builder.AddAttribute(sequence++, nameof(MudAlert.Variant), MudBlazor.Variant.Text);
+        builder.AddAttribute(sequence++, nameof(MudAlert.ChildContent), (RenderFragment)(contentBuilder => contentBuilder.AddContent(0, message)));
+        builder.CloseComponent();
+    };
+
+    private static RenderFragment EmptyContent() => _ => { };
+
+    private static RenderFragment RenderComponent<TComponent>(params (string Name, object? Value)[] parameters) where TComponent : IComponent => builder =>
+    {
+        var sequence = 0;
+        builder.OpenComponent<TComponent>(sequence++);
+
+        foreach (var (name, value) in parameters)
+            builder.AddAttribute(sequence++, name, value);
+
+        builder.CloseComponent();
+    };
 }
+

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -90,7 +90,7 @@ public partial class ActivityPropertiesPanel
         var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
         ExpressionDescriptorProvider.AddRange(expressionDescriptors);
-        Tabs = CreateBuiltInTabs().Concat(ActivityTabRegistry.List()).ToList();
+        Tabs = CreateBuiltInTabs().Concat(ActivityTabRegistry.List()).OrderBy(x => x.Order).ToList();
         _isInitialized = true;
     }
 
@@ -177,7 +177,7 @@ public partial class ActivityPropertiesPanel
             (nameof(InputsTab.OnActivityUpdated), OnActivityUpdated))
         : RenderAlertInWell(Localizer["This activity does not have any input properties."]);
 
-    private RenderFragment RenderOutputsTab() => ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true
+    private RenderFragment RenderOutputsTab() => ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true && WorkflowDefinition != null && Activity != null
         ? RenderScrollableComponent<OutputsTab>(
             (nameof(OutputsTab.WorkflowDefinition), WorkflowDefinition),
             (nameof(OutputsTab.Activity), Activity),
@@ -204,7 +204,7 @@ public partial class ActivityPropertiesPanel
         ? RenderScrollableComponent<CommitStrategyTab>(
             (nameof(CommitStrategyTab.Activity), Activity),
             (nameof(CommitStrategyTab.OnActivityUpdated), OnActivityUpdated))
-        : RenderAlertInWell(Localizer["This activity does not have any common properties."]);
+        : RenderAlertInWell(Localizer["This activity does not have a commit strategy."]);
 
     private RenderFragment RenderTaskTab() => RenderScrollableComponent<TaskTab>(
         (nameof(TaskTab.Activity), Activity),

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -16,6 +16,8 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// </summary>
 public partial class ActivityPropertiesPanel
 {
+    private bool _isInitialized = false;
+    
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>
@@ -34,7 +36,7 @@ public partial class ActivityPropertiesPanel
     [Parameter]
     public ActivityDescriptor? ActivityDescriptor
     {
-        get { return field; }
+        get => field;
         set
         {
             if (field != value)
@@ -82,22 +84,14 @@ public partial class ActivityPropertiesPanel
         }
     }
 
-    private bool isInitialized = false;
-
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        try
-        {
-            var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
-            IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
-            ExpressionDescriptorProvider.AddRange(expressionDescriptors);
-            PluginTabs = ActivityTabRegistry.List().ToList();
-        }
-        finally
-        {
-            isInitialized = true;
-        }
+        var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
+        IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
+        ExpressionDescriptorProvider.AddRange(expressionDescriptors);
+        PluginTabs = ActivityTabRegistry.List().ToList();
+        _isInitialized = true;
     }
     /// <summary>
     /// Updates the test result status when the tests status changes.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -82,6 +82,8 @@ public partial class ActivityPropertiesPanel
         }
     }
 
+    private bool isInitialized = false;
+
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
@@ -89,6 +91,8 @@ public partial class ActivityPropertiesPanel
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
         ExpressionDescriptorProvider.AddRange(expressionDescriptors);
         PluginTabs = ActivityTabRegistry.List().ToList();
+
+        isInitialized = true;
     }
     /// <summary>
     /// Updates the test result status when the tests status changes.


### PR DESCRIPTION
What was going wrong?

1. Cascading Value ExpressionDescriptorProvider is used in some of the tabs (e.g. Input, Output)
2. The .AddRange(ExpressionService.List) to populate the provider, is called from the parent (the panel) method OnInitialized.
3. The child components (tabs) finished rendering before the parent finished the OnInitialized method.
4. Therefore, the ExpressionDescriptorProvider was not fully initialized, and correct initialization of the children tabs requires a populated expression descriptor provider.
5. Before this change, the syntaxProvider always returned null during the first render of the tabs.

Fix:
Only start rendering the tabs when the initialization of cascading values is complete

## Purpose

<!-- What does this PR change? Summarize in 1–2 sentences. -->

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---
