### PR TITLE
Prevent rendering of the child element until the ExpressionDescriptorProvider is fully initialized

### DIFF
--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor
@@ -7,141 +7,144 @@
 @inherits StudioComponentBase
 @inject ILocalizer Localizer
 
-<CascadingValue Value="ExpressionDescriptorProvider">
-    <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
+@if (ExpressionDescriptorProvider != null)
+{
+    <CascadingValue Value="ExpressionDescriptorProvider">
+        <MudTabs Elevation="0" ApplyEffectsToContainer="true" ActivePanelIndexChanged="@OnActivePanelIndexChanged">
 
-        <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
-            @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <InputsTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
-                               ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
+            <MudTabPanel Text="@Localizer["Input"]" Icon="@Icons.Material.Outlined.Input">
+                @if (ActivityDescriptor?.Inputs.Any(x => x.IsBrowsable != false) == true)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <InputsTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
+                        ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                        Variant="Variant.Text">@Localizer["This activity does not have any input properties."]</MudAlert>
+                    </Well>
+                }
+            </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
-            @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <OutputsTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
-                                ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any output properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
+            <MudTabPanel Text="@Localizer["Output"]" Icon="@Icons.Material.Outlined.Output">
+                @if (ActivityDescriptor?.Outputs.Any(x => x.IsBrowsable != false) == true)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <OutputsTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
+                        ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                        Variant="Variant.Text">@Localizer["This activity does not have any output properties."]</MudAlert>
+                    </Well>
+                }
+            </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Common"]" Icon="@Icons.Material.Outlined.Notes">
-            @if (Activity != null && ActivityDescriptor != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <CommonTab Activity="@Activity" ActivityDescriptor="@ActivityDescriptor"
-                               OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
-        
-        <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor" >
-            @if (WorkflowDefinition != null && ActivityDescriptor != null && Activity != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor"
-                             Activity="Activity" OnTestResultChanged="OnTestResultChanged" />
-                </ScrollableWell>
-            }
-        </MudTabPanel>
+            <MudTabPanel Text="@Localizer["Common"]" Icon="@Icons.Material.Outlined.Notes">
+                @if (Activity != null && ActivityDescriptor != null)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <CommonTab Activity="@Activity" ActivityDescriptor="@ActivityDescriptor"
+                        OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                        Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
+                    </Well>
+                }
+            </MudTabPanel>
 
-        <MudTabPanel Text="@Localizer["Commit Strategy"]" Icon="@Icons.Material.Outlined.Commit">
-            @if (Activity != null)
-            {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <CommitStrategyTab Activity="@Activity" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            }
-            else
-            {
-                <Well>
-                    <MudAlert Severity="Severity.Normal"
-                              Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
-                </Well>
-            }
-        </MudTabPanel>
+            <MudTabPanel Text="@Localizer["Test"]" Icon="@ElsaStudioIcons.Tabler.Flask" IconColor="@TestIconColor" >
+                @if (WorkflowDefinition != null && ActivityDescriptor != null && Activity != null)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <TestTab WorkflowDefinition="WorkflowDefinition" ActivityDescriptor="@ActivityDescriptor"
+                        Activity="Activity" OnTestResultChanged="OnTestResultChanged" />
+                    </ScrollableWell>
+                }
+            </MudTabPanel>
 
-        @if (IsTaskActivity)
-        {
-            <MudTabPanel Text="@Localizer["Task"]" Icon="@Icons.Material.Outlined.HorizontalSplit">
+            <MudTabPanel Text="@Localizer["Commit Strategy"]" Icon="@Icons.Material.Outlined.Commit">
+                @if (Activity != null)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <CommitStrategyTab Activity="@Activity" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                }
+                else
+                {
+                    <Well>
+                        <MudAlert Severity="Severity.Normal"
+                        Variant="Variant.Text">@Localizer["This activity does not have any common properties."]</MudAlert>
+                    </Well>
+                }
+            </MudTabPanel>
+
+            @if (IsTaskActivity)
+            {
+                <MudTabPanel Text="@Localizer["Task"]" Icon="@Icons.Material.Outlined.HorizontalSplit">
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <TaskTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
+                        OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                </MudTabPanel>
+            }
+
+            <MudTabPanel Text="@Localizer["Log"]" Icon="@Icons.Material.Outlined.Assignment">
                 <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <TaskTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
-                             OnActivityUpdated="OnActivityUpdated"/>
+                    <LogPersistenceTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
+                    ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
                 </ScrollableWell>
             </MudTabPanel>
-        }
-
-        <MudTabPanel Text="@Localizer["Log"]" Icon="@Icons.Material.Outlined.Assignment">
-            <ScrollableWell MaxHeight="VisiblePaneHeight">
-                <LogPersistenceTab WorkflowDefinition="WorkflowDefinition" Activity="@Activity"
-                                   ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-            </ScrollableWell>
-        </MudTabPanel>
 
 
-        <MudTabPanel Text="@Localizer["Info"]" Icon="@Icons.Material.Outlined.Info">
-            @if (ActivityDescriptor != null)
+            <MudTabPanel Text="@Localizer["Info"]" Icon="@Icons.Material.Outlined.Info">
+                @if (ActivityDescriptor != null)
+                {
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <InfoTab ActivityDescriptor="@ActivityDescriptor" Activity="Activity"/>
+                    </ScrollableWell>
+                }
+            </MudTabPanel>
+
+            @if (IsWorkflowAsActivity)
             {
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <InfoTab ActivityDescriptor="@ActivityDescriptor" Activity="Activity"/>
-                </ScrollableWell>
+                <MudTabPanel Text="@Localizer["Version"]" Icon="@Icons.Material.Outlined.Numbers">
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <VersionTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
+                        OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                </MudTabPanel>
             }
-        </MudTabPanel>
 
-        @if (IsWorkflowAsActivity)
-        {
-            <MudTabPanel Text="@Localizer["Version"]" Icon="@Icons.Material.Outlined.Numbers">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <VersionTab Activity="Activity" ActivityDescriptor="ActivityDescriptor"
-                                OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            </MudTabPanel>
-        }
+            @if (DisplayResilienceTab)
+            {
+                <MudTabPanel Text="@Localizer["Resilience"]" Icon="@Icons.Material.Outlined.RestartAlt">
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        <ResilienceTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
+                        ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
+                    </ScrollableWell>
+                </MudTabPanel>
+            }
 
-        @if (DisplayResilienceTab)
-        {
-            <MudTabPanel Text="@Localizer["Resilience"]" Icon="@Icons.Material.Outlined.RestartAlt">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    <ResilienceTab WorkflowDefinition="WorkflowDefinition" Activity="Activity"
-                                   ActivityDescriptor="ActivityDescriptor" OnActivityUpdated="OnActivityUpdated"/>
-                </ScrollableWell>
-            </MudTabPanel>
-        }
+            @foreach (var tab in PluginTabs)
+            {
+                <MudTabPanel Text="@tab.Title">
+                    <ScrollableWell MaxHeight="VisiblePaneHeight">
+                        @tab.Render((new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated }).ToDictionary())
+                    </ScrollableWell>
+                </MudTabPanel>
+            }
 
-        @foreach (var tab in PluginTabs)
-        {
-            <MudTabPanel Text="@tab.Title">
-                <ScrollableWell MaxHeight="VisiblePaneHeight">
-                    @tab.Render((new { WorkflowDefinition, Activity, ActivityDescriptor, OnActivityUpdated }).ToDictionary())
-                </ScrollableWell>
-            </MudTabPanel>
-        }
-
-    </MudTabs>
-</CascadingValue>
+        </MudTabs>
+    </CascadingValue>
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/ActivityPropertiesPanel.razor.cs
@@ -62,7 +62,7 @@ public partial class ActivityPropertiesPanel
     [Inject] private IActivityTabRegistry ActivityTabRegistry { get; set; } = null!;
     private IEnumerable<IActivityTab> PluginTabs { get; set; } = new List<IActivityTab>();
 
-    private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; } = new();
+    private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
     private bool IsResilienceEnabled { get; set; }
     private bool IsResilientActivity => ActivityDescriptor?.CustomProperties.TryGetValue("Resilient", out var resilientObj) == true && resilientObj.ConvertTo<bool>();  
     private bool DisplayResilienceTab => IsResilienceEnabled && IsResilientActivity;
@@ -87,6 +87,7 @@ public partial class ActivityPropertiesPanel
     {
         var expressionDescriptors = await ExpressionService.ListDescriptorsAsync();
         IsResilienceEnabled = await RemoteFeatureProvider.IsEnabledAsync("Elsa.Resilience");
+        ExpressionDescriptorProvider = new();
         ExpressionDescriptorProvider.AddRange(expressionDescriptors);
         PluginTabs = ActivityTabRegistry.List().ToList();
     }


### PR DESCRIPTION
## Purpose
When opening an action's propertie, i can set the property's value using a different syntax. For example, I can set javascript syntax.
However, when reopening the action's properties, the selected syntax is not restored. Syntax is set to Default (Literal).
This behavior occurs due to a race condition. ActivityPropertiesPanel initializes ExpressionDescriptorProvider later than InputsTab uses it.

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

### Problem
ActivityPropertiesPanel initializes ExpressionDescriptorProvider later than InputsTab uses it.

### Solution
Fix is prevent rendering of the child element until the ExpressionDescriptorProvider is fully initialized.

---

## Verification

Steps:
1. Create new workflow
2. Add "If" activity
3. Set Syntax = Javascript and fill value some code
4. Set focus on the empty space
5. Select "If" activity

Expected outcome:
JavaScript must be specified in the syntax

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass
