### PR TITLE
[codex] Show structured log storage diagnostics

### DIFF
--- a/specs/004-diagnostics-structured-logs/contracts/signalr-client.md
+++ b/specs/004-diagnostics-structured-logs/contracts/signalr-client.md
@@ -2,10 +2,10 @@
 
 ## Hub URL
 
-Studio connects to the active backend URL plus:
+Studio derives the hub URL from the configured backend API URL by using the same backend origin and replacing the API path with the canonical hub path:
 
 ```text
-/elsa/hubs/diagnostics/structured-logs
+{backend-origin}/elsa/hubs/diagnostics/structured-logs
 ```
 
 The connection must be configured with `IHttpConnectionOptionsConfigurator` before starting.

--- a/specs/004-diagnostics-structured-logs/contracts/signalr-client.md
+++ b/specs/004-diagnostics-structured-logs/contracts/signalr-client.md
@@ -5,7 +5,7 @@
 Studio connects to the active backend URL plus:
 
 ```text
-/hubs/diagnostics/structured-logs
+/elsa/hubs/diagnostics/structured-logs
 ```
 
 The connection must be configured with `IHttpConnectionOptionsConfigurator` before starting.

--- a/specs/004-diagnostics-structured-logs/plan.md
+++ b/specs/004-diagnostics-structured-logs/plan.md
@@ -111,7 +111,7 @@ Resolved decisions:
 - Canonical remote feature name is `Elsa.Diagnostics.StructuredLogs`.
 - Canonical Studio route is `/diagnostics/structured-logs`.
 - Canonical REST base path is `/diagnostics/structured-logs`.
-- Canonical SignalR hub path is `/hubs/diagnostics/structured-logs`.
+- Canonical SignalR hub path is `/elsa/hubs/diagnostics/structured-logs`.
 - Studio should add a Diagnostics menu group because the current menu model only defines General and Settings.
 - `/server-logs` can be retained only as a development bookmark redirect route if the Razor route model allows it without preserving old active identity.
 

--- a/specs/004-diagnostics-structured-logs/quickstart.md
+++ b/specs/004-diagnostics-structured-logs/quickstart.md
@@ -27,7 +27,8 @@ And expose:
 ```text
 POST /diagnostics/structured-logs/recent
 GET  /diagnostics/structured-logs/sources
-HUB  /hubs/diagnostics/structured-logs
+GET  /diagnostics/structured-logs/storage
+HUB  /elsa/hubs/diagnostics/structured-logs
 ```
 
 Core implementation is handled in the paired `elsa-core` worker branch; do not modify it from Studio.

--- a/specs/004-diagnostics-structured-logs/research.md
+++ b/specs/004-diagnostics-structured-logs/research.md
@@ -13,7 +13,7 @@
 
 ## Decision: Use diagnostics structured paths and feature gate
 
-**Decision**: Gate on `Elsa.Diagnostics.StructuredLogs`, call `/diagnostics/structured-logs/recent` and `/diagnostics/structured-logs/sources`, and connect to `/hubs/diagnostics/structured-logs`.
+**Decision**: Gate on `Elsa.Diagnostics.StructuredLogs`, call `/diagnostics/structured-logs/recent` and `/diagnostics/structured-logs/sources`, and connect to `/elsa/hubs/diagnostics/structured-logs`.
 
 **Rationale**: The namespace umbrella should match the backend feature. A canonical diagnostics path also leaves `/diagnostics/console-logs` and OpenTelemetry paths available for future modules.
 

--- a/specs/004-diagnostics-structured-logs/tasks.md
+++ b/specs/004-diagnostics-structured-logs/tasks.md
@@ -41,7 +41,7 @@
 - [X] T013 Rename `IServerLogsApi` to `IStructuredLogsApi` and update REST paths to `/diagnostics/structured-logs/*` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Client/IStructuredLogsApi.cs`.
 - [X] T014 Rename service contracts to `IStructuredLogService` and `IStructuredLogObserver` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Contracts/`.
 - [X] T015 Rename services to `RemoteStructuredLogService`, `StructuredLogFilterMapper`, and `SignalRStructuredLogObserver` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Services/`.
-- [X] T016 Update SignalR hub URL to `hubs/diagnostics/structured-logs` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Services/SignalRStructuredLogObserver.cs`.
+- [X] T016 Update SignalR hub URL to derive `/elsa/hubs/diagnostics/structured-logs` from the configured backend API URL in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Services/SignalRStructuredLogObserver.cs`.
 - [X] T017 Update `Feature.RemoteFeatureName` to `Elsa.Diagnostics.StructuredLogs` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Feature.cs`.
 - [X] T018 Rename `AddServerLogsModule` to `AddStructuredLogsModule` in `src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
 - [X] T019 Add `MenuItemGroups.Diagnostics` in `src/framework/Elsa.Studio.Core/MenuItemGroups.cs`.

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs.Tests/StructuredLogSerializationTests.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs.Tests/StructuredLogSerializationTests.cs
@@ -59,12 +59,14 @@ public class StructuredLogSerializationTests
     {
         const string json = """
         {
-          "droppedWriteCount": 5
+          "droppedWriteCount": 5,
+          "hasStorageDiagnosticsProvider": true
         }
         """;
 
         var result = JsonSerializer.Deserialize<StructuredLogStorageDiagnostics>(json, Options)!;
 
         Assert.Equal(5, result.DroppedWriteCount);
+        Assert.True(result.HasStorageDiagnosticsProvider);
     }
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs.Tests/StructuredLogSerializationTests.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs.Tests/StructuredLogSerializationTests.cs
@@ -53,4 +53,18 @@ public class StructuredLogSerializationTests
         Assert.Equal("tenant-a", logEvent.Scopes["TenantId"]);
         Assert.Equal("correlation-a", logEvent.Scopes["CorrelationId"]);
     }
+
+    [Fact]
+    public void StructuredLogStorageDiagnostics_DeserializesCoreResponseShape()
+    {
+        const string json = """
+        {
+          "droppedWriteCount": 5
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<StructuredLogStorageDiagnostics>(json, Options)!;
+
+        Assert.Equal(5, result.DroppedWriteCount);
+    }
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Client/IStructuredLogsApi.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Client/IStructuredLogsApi.cs
@@ -19,4 +19,10 @@ public interface IStructuredLogsApi
     /// </summary>
     [Get("/diagnostics/structured-logs/sources")]
     Task<ICollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets storage-level diagnostics.
+    /// </summary>
+    [Get("/diagnostics/structured-logs/storage")]
+    Task<StructuredLogStorageDiagnostics> GetStorageDiagnosticsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Contracts/IStructuredLogService.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Contracts/IStructuredLogService.cs
@@ -16,4 +16,9 @@ public interface IStructuredLogService
     /// Lists structured log sources.
     /// </summary>
     Task<ICollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets storage-level diagnostics.
+    /// </summary>
+    Task<StructuredLogStorageDiagnostics> GetStorageDiagnosticsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
@@ -5,5 +5,9 @@ namespace Elsa.Studio.Diagnostics.StructuredLogs.Models;
 /// </summary>
 public class StructuredLogStorageDiagnostics
 {
+    [System.Text.Json.Serialization.JsonPropertyName("droppedWriteCount")]
     public long DroppedWriteCount { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("hasStorageDiagnosticsProvider")]
+    public bool HasStorageDiagnosticsProvider { get; set; }
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
@@ -1,0 +1,9 @@
+namespace Elsa.Studio.Diagnostics.StructuredLogs.Models;
+
+/// <summary>
+/// Storage-level diagnostics returned by the backend.
+/// </summary>
+public class StructuredLogStorageDiagnostics
+{
+    public long DroppedWriteCount { get; set; }
+}

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/README.md
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/README.md
@@ -27,7 +27,8 @@ And expose:
 ```text
 POST /diagnostics/structured-logs/recent
 GET  /diagnostics/structured-logs/sources
-HUB  /hubs/diagnostics/structured-logs
+GET  /diagnostics/structured-logs/storage
+HUB  /elsa/hubs/diagnostics/structured-logs
 ```
 
 ## Route
@@ -59,6 +60,7 @@ Trace/span focused links can use:
 - Clear removes local rows without clearing backend history.
 - Copy selected, copy visible, and details copy actions provide fast handoff for support/debugging.
 - Source selection defaults to all sources and can focus on one backend process, pod, or container.
+- Storage write drops are shown when the backend reports pressure in a durable storage queue.
 
 ## Validation
 

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Services/RemoteStructuredLogService.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Services/RemoteStructuredLogService.cs
@@ -42,4 +42,19 @@ public class RemoteStructuredLogService(IBackendApiClientProvider backendApiClie
             return Array.Empty<StructuredLogSource>();
         }
     }
+
+    /// <inheritdoc />
+    public async Task<StructuredLogStorageDiagnostics> GetStorageDiagnosticsAsync(CancellationToken cancellationToken = default)
+    {
+        var api = await backendApiClientProvider.GetApiAsync<IStructuredLogsApi>(cancellationToken);
+
+        try
+        {
+            return await api.GetStorageDiagnosticsAsync(cancellationToken);
+        }
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return new();
+        }
+    }
 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor
@@ -26,6 +26,11 @@
                 {
                     <span class="structured-logs-dropped">@BackendDroppedCount @Localizer["dropped upstream"]</span>
                 }
+
+                @if (StorageDroppedWriteCount > 0)
+                {
+                    <span class="structured-logs-dropped">@StorageDroppedWriteCount @Localizer["storage writes dropped"]</span>
+                }
             </div>
 
             <div class="structured-logs-actions">

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor
@@ -27,7 +27,7 @@
                     <span class="structured-logs-dropped">@BackendDroppedCount @Localizer["dropped upstream"]</span>
                 }
 
-                @if (StorageDroppedWriteCount > 0)
+                @if (HasStorageDiagnosticsProvider && StorageDroppedWriteCount > 0)
                 {
                     <span class="structured-logs-dropped">@StorageDroppedWriteCount @Localizer["storage writes dropped"]</span>
                 }

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor.cs
@@ -104,6 +104,11 @@ public partial class StructuredLogs : IAsyncDisposable
     /// </summary>
     protected long StorageDroppedWriteCount { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the backend has a storage diagnostics provider.
+    /// </summary>
+    protected bool HasStorageDiagnosticsProvider { get; private set; }
+
     protected string StatusText => ViewState.ConnectionStatus switch
     {
         StructuredLogConnectionStatus.Connecting => "Connecting",
@@ -192,6 +197,8 @@ public partial class StructuredLogs : IAsyncDisposable
         ViewState.SelectedEventId = null;
         ViewState.LocalDroppedRows = 0;
         BackendDroppedCount = 0;
+        StorageDroppedWriteCount = 0;
+        HasStorageDiagnosticsProvider = false;
         return InvokeAsync(StateHasChanged);
     }
 
@@ -449,6 +456,7 @@ public partial class StructuredLogs : IAsyncDisposable
             var storageDiagnostics = await StructuredLogService.GetStorageDiagnosticsAsync(cancellationToken);
             BackendDroppedCount = recent.DroppedEvents;
             StorageDroppedWriteCount = storageDiagnostics.DroppedWriteCount;
+            HasStorageDiagnosticsProvider = storageDiagnostics.HasStorageDiagnosticsProvider;
 
             foreach (var logEvent in recent.Items.OrderBy(x => x.Timestamp))
                 AddRow(logEvent);
@@ -480,11 +488,14 @@ public partial class StructuredLogs : IAsyncDisposable
             ViewState.SelectedEventId = null;
             ViewState.LocalDroppedRows = 0;
             BackendDroppedCount = 0;
+            StorageDroppedWriteCount = 0;
+            HasStorageDiagnosticsProvider = false;
 
             var recent = await StructuredLogService.GetRecentAsync(ViewState.Filter, ViewState.VisibleRowCap, _cancellationTokenSource.Token);
             var storageDiagnostics = await StructuredLogService.GetStorageDiagnosticsAsync(_cancellationTokenSource.Token);
             BackendDroppedCount = recent.DroppedEvents;
             StorageDroppedWriteCount = storageDiagnostics.DroppedWriteCount;
+            HasStorageDiagnosticsProvider = storageDiagnostics.HasStorageDiagnosticsProvider;
 
             foreach (var logEvent in recent.Items.OrderBy(x => x.Timestamp))
                 AddRow(logEvent);

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/UI/Pages/StructuredLogs.razor.cs
@@ -99,6 +99,11 @@ public partial class StructuredLogs : IAsyncDisposable
     /// </summary>
     protected long BackendDroppedCount { get; private set; }
 
+    /// <summary>
+    /// Gets the storage-level dropped write count.
+    /// </summary>
+    protected long StorageDroppedWriteCount { get; private set; }
+
     protected string StatusText => ViewState.ConnectionStatus switch
     {
         StructuredLogConnectionStatus.Connecting => "Connecting",
@@ -441,7 +446,9 @@ public partial class StructuredLogs : IAsyncDisposable
         {
             await LoadSourcesAsync(cancellationToken);
             var recent = await StructuredLogService.GetRecentAsync(ViewState.Filter, ViewState.VisibleRowCap, cancellationToken);
+            var storageDiagnostics = await StructuredLogService.GetStorageDiagnosticsAsync(cancellationToken);
             BackendDroppedCount = recent.DroppedEvents;
+            StorageDroppedWriteCount = storageDiagnostics.DroppedWriteCount;
 
             foreach (var logEvent in recent.Items.OrderBy(x => x.Timestamp))
                 AddRow(logEvent);
@@ -475,7 +482,9 @@ public partial class StructuredLogs : IAsyncDisposable
             BackendDroppedCount = 0;
 
             var recent = await StructuredLogService.GetRecentAsync(ViewState.Filter, ViewState.VisibleRowCap, _cancellationTokenSource.Token);
+            var storageDiagnostics = await StructuredLogService.GetStorageDiagnosticsAsync(_cancellationTokenSource.Token);
             BackendDroppedCount = recent.DroppedEvents;
+            StorageDroppedWriteCount = storageDiagnostics.DroppedWriteCount;
 
             foreach (var logEvent in recent.Items.OrderBy(x => x.Timestamp))
                 AddRow(logEvent);


### PR DESCRIPTION
## Summary

- Fixes structured log documentation to use the canonical `/elsa/hubs/diagnostics/structured-logs` hub path.
- Adds a structured log storage diagnostics client call for `GET /diagnostics/structured-logs/storage`.
- Shows storage dropped-write counts in the Structured Logs toolbar when the backend reports them.
- Keeps compatibility with older backends by treating a missing storage diagnostics endpoint as zero.

## Why

The core SQLite persistence provider can drop newest writes when its bounded durable-write queue is full. Studio already surfaces local and upstream live-stream drops, but it could not surface storage write drops without a small backend diagnostics endpoint.

Depends on elsa-workflows/elsa-core#7446 for non-zero storage diagnostics values.

## Validation

- `dotnet test src/modules/Elsa.Studio.Diagnostics.StructuredLogs.Tests/Elsa.Studio.Diagnostics.StructuredLogs.Tests.csproj`
