### PR TITLE
[codex] Configure Dependabot for Elsa API client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,24 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
+
+registries:
+  elsa-feedz-preview:
+    type: nuget-feed
+    url: https://f.feedz.io/elsa-workflows/elsa-3/nuget/index.json
+    token: ${{secrets.FEEDZ_API_KEY}}
+
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/"
+    target-branch: "main"
+    registries:
+      - elsa-feedz-preview
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    allow:
+      - dependency-name: "Elsa.Api.Client"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary

Configure Dependabot version updates for the `Elsa.Api.Client` NuGet dependency used by Elsa Studio.

## Details

- Adds the Feedz preview NuGet feed as a Dependabot private registry.
- Runs daily checks against `main` at 06:00 Europe/Amsterdam.
- Limits updates to `Elsa.Api.Client` so unrelated NuGet dependencies are not included.
- Limits open Dependabot PRs for this update config to one at a time.

## Validation

- Parsed `.github/dependabot.yml` with Ruby YAML.
- Verified the existing `NuGet.Config` contains the Feedz preview NuGet source.