### PR TITLE
Add Studio Platform artifact submission module

### DIFF
--- a/Elsa.Studio.sln
+++ b/Elsa.Studio.sln
@@ -142,6 +142,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Studio.Diagnostics.Ope
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Studio.Diagnostics.OpenTelemetry.Tests", "src\modules\Elsa.Studio.Diagnostics.OpenTelemetry.Tests\Elsa.Studio.Diagnostics.OpenTelemetry.Tests.csproj", "{4F972BCE-BBF9-4FBA-A9EF-A14CA166A6C7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Studio.PlatformIntegration", "src\modules\Elsa.Studio.PlatformIntegration\Elsa.Studio.PlatformIntegration.csproj", "{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Studio.PlatformIntegration.Tests", "src\modules\Elsa.Studio.PlatformIntegration.Tests\Elsa.Studio.PlatformIntegration.Tests.csproj", "{5138EE76-F56E-48D3-8DD8-67EC46DB3528}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -705,6 +709,30 @@ Global
 		{4F972BCE-BBF9-4FBA-A9EF-A14CA166A6C7}.Release|x64.Build.0 = Release|Any CPU
 		{4F972BCE-BBF9-4FBA-A9EF-A14CA166A6C7}.Release|x86.ActiveCfg = Release|Any CPU
 		{4F972BCE-BBF9-4FBA-A9EF-A14CA166A6C7}.Release|x86.Build.0 = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|x64.Build.0 = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Debug|x86.Build.0 = Debug|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|x64.ActiveCfg = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|x64.Build.0 = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|x86.ActiveCfg = Release|Any CPU
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343}.Release|x86.Build.0 = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|x64.Build.0 = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Debug|x86.Build.0 = Debug|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x64.ActiveCfg = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x64.Build.0 = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x86.ActiveCfg = Release|Any CPU
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -767,6 +795,8 @@ Global
 		{250EE233-BF7A-459C-8FC9-B26D81880442} = {D66B9A40-8608-46F3-9868-625C50EACE43}
 		{674AB5E7-20F8-4E25-8419-6D093CDA02F7} = {9496DC7B-D390-44C6-86C7-B49CFEB3DDBF}
 		{4F972BCE-BBF9-4FBA-A9EF-A14CA166A6C7} = {9496DC7B-D390-44C6-86C7-B49CFEB3DDBF}
+		{6DA1401F-C9E2-4C96-91DE-E3898AE1C343} = {D66B9A40-8608-46F3-9868-625C50EACE43}
+		{5138EE76-F56E-48D3-8DD8-67EC46DB3528} = {D66B9A40-8608-46F3-9868-625C50EACE43}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5B8719CC-CF87-45E1-BE1A-13842F951B28}

--- a/src/modules/Elsa.Studio.PlatformIntegration.Tests/Elsa.Studio.PlatformIntegration.Tests.csproj
+++ b/src/modules/Elsa.Studio.PlatformIntegration.Tests/Elsa.Studio.PlatformIntegration.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Studio.PlatformIntegration\Elsa.Studio.PlatformIntegration.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformArtifactSubmitClientTests.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformArtifactSubmitClientTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Text.Json;
+using Elsa.Studio.PlatformIntegration.Services;
+using Xunit;
+
+namespace Elsa.Studio.PlatformIntegration.Tests;
+
+public sealed class PlatformArtifactSubmitClientTests
+{
+    private readonly PlatformSubmitOptions _options = new()
+    {
+        PlatformEndpoint = new Uri("https://platform.example.test"),
+        WorkspaceId = Guid.Parse("10000000-0000-0000-0000-000000000001")
+    };
+
+    [Fact]
+    public async Task Posts_artifact_registration_to_workspace_endpoint()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.Created, """
+            {
+              "id": "20000000-0000-0000-0000-000000000001",
+              "artifactId": "elsa.workflow-definition:payment-retry:abc",
+              "contentDigest": { "algorithm": "sha256", "value": "abc" },
+              "registeredAt": "2026-05-29T08:00:00Z"
+            }
+            """);
+        var client = new PlatformArtifactSubmitClient(new HttpClient(handler));
+
+        var result = await client.SubmitAsync(Package(), _options);
+
+        Assert.Equal(PlatformSubmitStatus.Submitted, result.Status);
+        Assert.Equal("elsa.workflow-definition:payment-retry:abc", result.ArtifactId);
+        Assert.Equal("sha256:abc", result.ArtifactDigest);
+        Assert.Equal(new Uri("https://platform.example.test/api/workspaces/10000000-0000-0000-0000-000000000001/artifacts"), handler.RequestUri);
+        Assert.NotNull(handler.RequestBody);
+
+        using var document = JsonDocument.Parse(handler.RequestBody);
+        Assert.Equal("elsa.workflow-definition", document.RootElement.GetProperty("artifactTypeId").GetString());
+        Assert.Equal("Unknown", document.RootElement.GetProperty("format").GetString());
+        Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("manifest").GetProperty("environment").ValueKind);
+        Assert.Equal("producer-managed", document.RootElement.GetProperty("payloadReference").GetProperty("provider").GetString());
+        Assert.DoesNotContain("WorkflowDefinitionJson", handler.RequestBody);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Conflict, PlatformSubmitStatus.Conflict)]
+    [InlineData(HttpStatusCode.BadRequest, PlatformSubmitStatus.ValidationFailed)]
+    [InlineData(HttpStatusCode.Unauthorized, PlatformSubmitStatus.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError, PlatformSubmitStatus.RetryableError)]
+    public async Task Maps_platform_responses_to_safe_submit_states(HttpStatusCode statusCode, PlatformSubmitStatus expectedStatus)
+    {
+        var handler = new RecordingHandler(statusCode, """{"title":"Bearer token rejected"}""");
+        var client = new PlatformArtifactSubmitClient(new HttpClient(handler));
+
+        var result = await client.SubmitAsync(Package(), _options);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.DoesNotContain("Bearer", result.Message);
+        Assert.Contains("[redacted]", result.Message);
+    }
+
+    [Fact]
+    public async Task Treats_duplicate_platform_response_as_success()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.OK, """
+            {
+              "id": "20000000-0000-0000-0000-000000000001",
+              "artifactId": "elsa.workflow-definition:payment-retry:abc",
+              "contentDigest": { "algorithm": "sha256", "value": "abc" },
+              "registeredAt": "2026-05-29T08:00:00Z"
+            }
+            """);
+        var client = new PlatformArtifactSubmitClient(new HttpClient(handler));
+
+        var result = await client.SubmitAsync(Package(), _options);
+
+        Assert.Equal(PlatformSubmitStatus.Duplicate, result.Status);
+        Assert.True(result.Succeeded);
+        Assert.Equal("Artifact already exists in Platform.", result.Message);
+    }
+
+    private static PlatformWorkflowSubmitPackage Package() =>
+        new(
+            new PlatformArtifactEnvelope(
+                "elsa.workflow-definition:payment-retry:abc",
+                PlatformArtifactEnvelopeConstants.EnvelopeVersion,
+                PlatformArtifactEnvelopeConstants.ElsaWorkflowDefinitionArtifactType,
+                PlatformArtifactEnvelopeConstants.DefaultArtifactSchemaVersion,
+                new PlatformArtifactDigest("sha256", new string('a', 64)),
+                null,
+                new PlatformArtifactPayloadReference("producer-managed", "studio://workflows/payment-retry/snapshots/abc"),
+                new PlatformArtifactProducer("studio", "Elsa Studio"),
+                new PlatformArtifactDisplayMetadata("Payment Retry", "42", null, new Dictionary<string, string>(), new Dictionary<string, string>(), "studio://workflows/payment-retry"),
+                [],
+                []),
+            "{}",
+            DateTimeOffset.UtcNow);
+
+    private sealed class RecordingHandler(HttpStatusCode statusCode, string content, string contentType = "application/json") : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+
+        public string? RequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            RequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, System.Text.Encoding.UTF8, contentType)
+            };
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformIntegrationModuleRegistrationTests.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformIntegrationModuleRegistrationTests.cs
@@ -1,0 +1,31 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.PlatformIntegration.Extensions;
+using Elsa.Studio.PlatformIntegration.Widgets;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Elsa.Studio.PlatformIntegration.Tests;
+
+public sealed class PlatformIntegrationModuleRegistrationTests
+{
+    [Fact]
+    public void Registers_platform_submission_widgets()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPlatformIntegrationModule(options =>
+        {
+            options.PlatformEndpoint = new Uri("https://platform.example.test");
+            options.WorkspaceId = Guid.Parse("10000000-0000-0000-0000-000000000001");
+        });
+
+        var widgetTypes = services
+            .Where(x => x.ServiceType == typeof(IWidget))
+            .Select(x => x.ImplementationType)
+            .ToList();
+
+        Assert.Contains(typeof(WorkflowDefinitionEditorSubmitWidget), widgetTypes);
+        Assert.Contains(typeof(WorkflowDefinitionListBulkSubmitWidget), widgetTypes);
+        Assert.Contains(typeof(WorkflowDefinitionListRowSubmitWidget), widgetTypes);
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformWorkflowSnapshotPackagerTests.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration.Tests/PlatformWorkflowSnapshotPackagerTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.PlatformIntegration.Services;
+using Xunit;
+
+namespace Elsa.Studio.PlatformIntegration.Tests;
+
+public sealed class PlatformWorkflowSnapshotPackagerTests
+{
+    private readonly PlatformWorkflowSnapshotPackager _packager = new();
+    private readonly PlatformSubmitOptions _options = new()
+    {
+        PlatformEndpoint = new Uri("https://platform.example.test"),
+        WorkspaceId = Guid.Parse("10000000-0000-0000-0000-000000000001"),
+        ProducerVersion = "4.0.0",
+        RuntimeVersionRange = ">=4.0.0"
+    };
+
+    [Fact]
+    public void Packages_workflow_definition_as_platform_artifact_envelope()
+    {
+        var packagedAt = DateTimeOffset.Parse("2026-05-29T08:00:00Z");
+
+        var package = _packager.Package(WorkflowDefinition(), _options, packagedAt);
+
+        Assert.Equal(packagedAt, package.PackagedAt);
+        Assert.StartsWith("elsa.workflow-definition:payment-retry:", package.Envelope.ArtifactId);
+        Assert.Equal(PlatformArtifactEnvelopeConstants.ElsaWorkflowDefinitionArtifactType, package.Envelope.ArtifactTypeId);
+        Assert.Equal(PlatformArtifactEnvelopeConstants.EnvelopeVersion, package.Envelope.EnvelopeVersion);
+        Assert.Equal(PlatformArtifactEnvelopeConstants.DefaultArtifactSchemaVersion, package.Envelope.ArtifactSchemaVersion);
+        Assert.Equal("sha256", package.Envelope.ContentDigest.Algorithm);
+        Assert.Equal(64, package.Envelope.ContentDigest.Value.Length);
+        Assert.Equal("producer-managed", package.Envelope.PayloadReference.Provider);
+        Assert.StartsWith("studio://workflows/payment-retry/snapshots/", package.Envelope.PayloadReference.Uri);
+        Assert.Equal(package.Envelope.ContentDigest, package.Envelope.PayloadReference.ReferenceDigest);
+        Assert.Equal("studio", package.Envelope.Producer.ProducerType);
+        Assert.Equal("Elsa Studio", package.Envelope.Producer.ProducerName);
+        Assert.Equal("4.0.0", package.Envelope.Producer.ProducerVersion);
+        Assert.Equal("workflow:payment-retry:version:workflow-version-42", package.Envelope.Producer.SourceReference);
+        Assert.Equal("Payment Retry", package.Envelope.DisplayMetadata.Name);
+        Assert.Equal("42", package.Envelope.DisplayMetadata.Version);
+        Assert.Single(package.Envelope.CompatibilityHints);
+        Assert.Contains("workflow-definition.apply", package.Envelope.CompatibilityHints.Single().RequiredCapabilities);
+
+        using var document = JsonDocument.Parse(package.WorkflowDefinitionJson);
+        Assert.Equal("payment-retry", document.RootElement.GetProperty("definitionId").GetString());
+    }
+
+    [Fact]
+    public void Uses_stable_artifact_identity_for_duplicate_snapshot()
+    {
+        var first = _packager.Package(WorkflowDefinition(), _options);
+        var second = _packager.Package(WorkflowDefinition(), _options);
+
+        Assert.Equal(first.Envelope.ArtifactId, second.Envelope.ArtifactId);
+        Assert.Equal(first.Envelope.ContentDigest, second.Envelope.ContentDigest);
+        Assert.Equal(first.Envelope.PayloadReference.Uri, second.Envelope.PayloadReference.Uri);
+    }
+
+    [Fact]
+    public void Rejects_missing_platform_configuration()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _packager.Package(WorkflowDefinition(), _options with { PlatformEndpoint = null }));
+
+        Assert.Equal("Platform endpoint is required before submitting to Platform.", exception.Message);
+    }
+
+    [Fact]
+    public void Rejects_unsafe_metadata()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _packager.Package(WorkflowDefinition(description: "contains password"), _options));
+
+        Assert.Equal("Artifact metadata contains unsafe secret-like content.", exception.Message);
+    }
+
+    private static WorkflowDefinition WorkflowDefinition(string description = "Retries payment collection failures.") =>
+        new()
+        {
+            Id = "workflow-version-42",
+            DefinitionId = "payment-retry",
+            Name = "Payment Retry",
+            Version = 42,
+            Description = description,
+            Root = new JsonObject
+            {
+                ["type"] = "Elsa.Flowchart",
+                ["version"] = 1
+            }
+        };
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration.Tests/SubmitWorkflowDefinitionToPlatformTests.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration.Tests/SubmitWorkflowDefinitionToPlatformTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.PlatformIntegration.Contracts;
+using Elsa.Studio.PlatformIntegration.Handlers;
+using Elsa.Studio.Workflows.Domain.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Elsa.Studio.PlatformIntegration.Tests;
+
+public sealed class SubmitWorkflowDefinitionToPlatformTests
+{
+    [Fact]
+    public async Task Skips_submission_when_platform_options_are_not_configured()
+    {
+        var service = new FakeSubmissionService();
+        var handler = new SubmitWorkflowDefinitionToPlatform(
+            Microsoft.Extensions.Options.Options.Create(new PlatformSubmitOptions()),
+            service,
+            NullLogger<SubmitWorkflowDefinitionToPlatform>.Instance);
+
+        await handler.HandleAsync(new WorkflowDefinitionPublished(WorkflowDefinition()), CancellationToken.None);
+
+        Assert.Equal(0, service.SubmitCount);
+    }
+
+    [Fact]
+    public async Task Submits_workflow_when_publish_notification_is_received()
+    {
+        var service = new FakeSubmissionService();
+        var handler = new SubmitWorkflowDefinitionToPlatform(
+            Microsoft.Extensions.Options.Options.Create(ConfiguredOptions()),
+            service,
+            NullLogger<SubmitWorkflowDefinitionToPlatform>.Instance);
+
+        await handler.HandleAsync(new WorkflowDefinitionPublished(WorkflowDefinition()), CancellationToken.None);
+
+        Assert.Equal(1, service.SubmitCount);
+        Assert.Equal("payment-retry", service.LastWorkflowDefinition?.DefinitionId);
+    }
+
+    [Fact]
+    public async Task Contains_submission_failures_so_publish_remains_complete()
+    {
+        var service = new FakeSubmissionService { Exception = new InvalidOperationException("Platform unavailable") };
+        var handler = new SubmitWorkflowDefinitionToPlatform(
+            Microsoft.Extensions.Options.Options.Create(ConfiguredOptions()),
+            service,
+            NullLogger<SubmitWorkflowDefinitionToPlatform>.Instance);
+
+        await handler.HandleAsync(new WorkflowDefinitionPublished(WorkflowDefinition()), CancellationToken.None);
+
+        Assert.Equal(1, service.SubmitCount);
+    }
+
+    private static PlatformSubmitOptions ConfiguredOptions() =>
+        new()
+        {
+            PlatformEndpoint = new Uri("https://platform.example.test"),
+            WorkspaceId = Guid.Parse("10000000-0000-0000-0000-000000000001")
+        };
+
+    private static WorkflowDefinition WorkflowDefinition() =>
+        new()
+        {
+            Id = "workflow-version-42",
+            DefinitionId = "payment-retry",
+            Name = "Payment Retry",
+            Version = 42,
+            Root = new JsonObject
+            {
+                ["type"] = "Elsa.Flowchart",
+                ["version"] = 1
+            }
+        };
+
+    private sealed class FakeSubmissionService : IPlatformWorkflowSubmissionService
+    {
+        public int SubmitCount { get; private set; }
+
+        public WorkflowDefinition? LastWorkflowDefinition { get; private set; }
+
+        public Exception? Exception { get; init; }
+
+        public Task<PlatformSubmitResult> SubmitAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default)
+        {
+            SubmitCount++;
+            LastWorkflowDefinition = workflowDefinition;
+
+            if (Exception is not null)
+                throw Exception;
+
+            return Task.FromResult(new PlatformSubmitResult(PlatformSubmitStatus.Submitted, "Submitted to Platform.", "artifact-1"));
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Components/SubmitWorkflowDefinitionAction.razor
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Components/SubmitWorkflowDefinitionAction.razor
@@ -1,0 +1,124 @@
+@using Elsa.Api.Client.Resources.WorkflowDefinitions.Models
+@using Elsa.Api.Client.Shared.Models
+@using Elsa.Studio.Contracts
+@using Elsa.Studio.Localization
+@using Elsa.Studio.PlatformIntegration.Contracts
+@using Elsa.Studio.Workflows.Domain.Contracts
+@using Microsoft.AspNetCore.Components
+@using Microsoft.Extensions.Options
+@using MudBlazor
+@inject ILocalizer Localizer
+@inject IUserMessageService UserMessageService
+@inject IWorkflowDefinitionService WorkflowDefinitionService
+@inject IPlatformWorkflowSubmissionService SubmissionService
+@inject IOptions<PlatformSubmitOptions> Options
+
+@if (Options.Value.Enabled)
+{
+    @if (RenderAsMenuItem)
+    {
+        <MudMenuItem Icon="@Icons.Material.Outlined.CloudUpload" Disabled="@IsDisabled" OnClick="@SubmitAsync">@Localizer["Submit to Platform"]</MudMenuItem>
+    }
+    else
+    {
+        <MudTooltip Text="@Localizer["Submit to Platform"]" Delay="500">
+            <MudIconButton Icon="@Icons.Material.Outlined.CloudUpload" Color="Color.Primary" Disabled="@IsDisabled" OnClick="@SubmitAsync" />
+        </MudTooltip>
+    }
+}
+
+@code {
+    /// <summary>
+    /// Provides the current workflow definition snapshot.
+    /// </summary>
+    [Parameter] public Func<Task<WorkflowDefinition?>>? GetWorkflowDefinition { get; set; }
+
+    /// <summary>
+    /// Provides workflow definition IDs to submit.
+    /// </summary>
+    [Parameter] public IReadOnlyCollection<string> DefinitionIds { get; set; } = [];
+
+    /// <summary>
+    /// Whether this action should render as a menu item.
+    /// </summary>
+    [Parameter] public bool RenderAsMenuItem { get; set; }
+
+    /// <summary>
+    /// Whether this action is disabled.
+    /// </summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    private bool _isSubmitting;
+    private bool IsDisabled => Disabled || _isSubmitting || !Options.Value.IsConfigured;
+
+    private async Task SubmitAsync()
+    {
+        if (IsDisabled)
+            return;
+
+        _isSubmitting = true;
+
+        try
+        {
+            var workflowDefinitions = await GetWorkflowDefinitionsAsync();
+            if (workflowDefinitions.Count == 0)
+            {
+                UserMessageService.ShowSnackbarTextMessage(Localizer["No workflow definitions selected"], Severity.Info);
+                return;
+            }
+
+            var results = new List<PlatformSubmitResult>();
+            foreach (var workflowDefinition in workflowDefinitions)
+                results.Add(await SubmissionService.SubmitAsync(workflowDefinition));
+
+            ShowResult(results);
+        }
+        catch (Exception ex)
+        {
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow submission to Platform failed: {0}", ex.Message], Severity.Error);
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private async Task<IReadOnlyList<WorkflowDefinition>> GetWorkflowDefinitionsAsync()
+    {
+        if (GetWorkflowDefinition is not null)
+        {
+            var workflowDefinition = await GetWorkflowDefinition();
+            return workflowDefinition is null ? [] : [workflowDefinition];
+        }
+
+        var workflowDefinitions = new List<WorkflowDefinition>();
+        foreach (var definitionId in DefinitionIds.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal))
+        {
+            var workflowDefinition = await WorkflowDefinitionService.FindByDefinitionIdAsync(definitionId, VersionOptions.Latest);
+            if (workflowDefinition is not null)
+                workflowDefinitions.Add(workflowDefinition);
+        }
+
+        return workflowDefinitions;
+    }
+
+    private void ShowResult(IReadOnlyCollection<PlatformSubmitResult> results)
+    {
+        var succeeded = results.Count(x => x.Succeeded);
+        var failed = results.Count - succeeded;
+
+        if (failed == 0)
+        {
+            var message = succeeded == 1
+                ? Localizer["Workflow submitted to Platform"]
+                : Localizer["{0} workflows submitted to Platform", succeeded];
+            UserMessageService.ShowSnackbarTextMessage(message, Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
+            return;
+        }
+
+        var warning = succeeded == 0
+            ? Localizer["Workflow submission to Platform failed"]
+            : Localizer["{0} workflow submissions failed", failed];
+        UserMessageService.ShowSnackbarTextMessage(warning, Severity.Warning, options => { options.SnackbarVariant = Variant.Filled; });
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformArtifactSubmitClient.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformArtifactSubmitClient.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Studio.PlatformIntegration.Contracts;
+
+/// <summary>
+/// Submits packaged workflow artifacts to Elsa Platform.
+/// </summary>
+public interface IPlatformArtifactSubmitClient
+{
+    /// <summary>
+    /// Submits the specified package.
+    /// </summary>
+    Task<PlatformSubmitResult> SubmitAsync(PlatformWorkflowSubmitPackage package, PlatformSubmitOptions options, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformWorkflowSnapshotPackager.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformWorkflowSnapshotPackager.cs
@@ -1,0 +1,14 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+
+namespace Elsa.Studio.PlatformIntegration.Contracts;
+
+/// <summary>
+/// Packages Studio workflow definitions as Platform artifact envelopes.
+/// </summary>
+public interface IPlatformWorkflowSnapshotPackager
+{
+    /// <summary>
+    /// Packages the specified workflow definition.
+    /// </summary>
+    PlatformWorkflowSubmitPackage Package(WorkflowDefinition workflowDefinition, PlatformSubmitOptions options, DateTimeOffset? packagedAt = null);
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformWorkflowSubmissionService.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Contracts/IPlatformWorkflowSubmissionService.cs
@@ -1,0 +1,14 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+
+namespace Elsa.Studio.PlatformIntegration.Contracts;
+
+/// <summary>
+/// Coordinates workflow submission to Elsa Platform.
+/// </summary>
+public interface IPlatformWorkflowSubmissionService
+{
+    /// <summary>
+    /// Submits the specified published workflow definition.
+    /// </summary>
+    Task<PlatformSubmitResult> SubmitAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Elsa.Studio.PlatformIntegration.csproj
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Elsa.Studio.PlatformIntegration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+    <PropertyGroup>
+        <Description>Adds Elsa Platform workflow artifact submission to Elsa Studio.</Description>
+        <PackageTags>elsa studio module platform workflow-artifacts deployment</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <SupportedPlatform Include="browser" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\framework\Elsa.Studio.Core\Elsa.Studio.Core.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Workflows.Core\Elsa.Studio.Workflows.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Studio.PlatformIntegration/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.PlatformIntegration.Contracts;
+using Elsa.Studio.PlatformIntegration.Handlers;
+using Elsa.Studio.PlatformIntegration.Services;
+using Elsa.Studio.PlatformIntegration.Widgets;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Studio.PlatformIntegration.Extensions;
+
+/// <summary>
+/// Contains extension methods for the Elsa Platform integration module.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the Elsa Platform integration module.
+    /// </summary>
+    public static IServiceCollection AddPlatformIntegrationModule(this IServiceCollection services, Action<PlatformSubmitOptions>? configure = null)
+    {
+        services.Configure(configure ?? (_ => { }));
+        services.AddHttpClient<IPlatformArtifactSubmitClient, PlatformArtifactSubmitClient>();
+
+        return services
+            .AddScoped<IFeature, Feature>()
+            .AddScoped<IWidget, WorkflowDefinitionEditorSubmitWidget>()
+            .AddScoped<IWidget, WorkflowDefinitionListBulkSubmitWidget>()
+            .AddScoped<IWidget, WorkflowDefinitionListRowSubmitWidget>()
+            .AddScoped<IPlatformWorkflowSnapshotPackager, PlatformWorkflowSnapshotPackager>()
+            .AddScoped<IPlatformWorkflowSubmissionService, PlatformWorkflowSubmissionService>()
+            .AddNotificationHandler<SubmitWorkflowDefinitionToPlatform>();
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Feature.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Feature.cs
@@ -1,0 +1,8 @@
+using Elsa.Studio.Abstractions;
+
+namespace Elsa.Studio.PlatformIntegration;
+
+/// <summary>
+/// Represents the Elsa Platform integration feature module.
+/// </summary>
+public class Feature : FeatureBase;

--- a/src/modules/Elsa.Studio.PlatformIntegration/Handlers/SubmitWorkflowDefinitionToPlatform.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Handlers/SubmitWorkflowDefinitionToPlatform.cs
@@ -1,0 +1,55 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.PlatformIntegration.Contracts;
+using Elsa.Studio.Workflows.Domain.Notifications;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Studio.PlatformIntegration.Handlers;
+
+/// <summary>
+/// Submits published workflow definitions to Elsa Platform when the module is configured.
+/// </summary>
+public sealed class SubmitWorkflowDefinitionToPlatform(
+    IOptions<PlatformSubmitOptions> options,
+    IPlatformWorkflowSubmissionService submissionService,
+    ILogger<SubmitWorkflowDefinitionToPlatform> logger) : INotificationHandler<WorkflowDefinitionPublished>
+{
+    /// <inheritdoc />
+    public async Task HandleAsync(WorkflowDefinitionPublished notification, CancellationToken cancellationToken)
+    {
+        var value = options.Value;
+
+        if (!value.Enabled || !value.SubmitOnWorkflowPublished || !value.IsConfigured)
+            return;
+
+        try
+        {
+            var result = await submissionService.SubmitAsync(notification.WorkflowDefinition, cancellationToken);
+
+            if (result.Succeeded)
+            {
+                logger.LogInformation(
+                    "Submitted workflow definition {WorkflowDefinitionId} to Elsa Platform as artifact {ArtifactId}.",
+                    notification.WorkflowDefinition.DefinitionId,
+                    result.ArtifactId);
+                return;
+            }
+
+            logger.LogWarning(
+                "Elsa Platform workflow submission completed with status {Status}: {Message}",
+                result.Status,
+                result.Message);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Elsa Platform workflow submission failed after Studio published workflow definition {WorkflowDefinitionId}.",
+                notification.WorkflowDefinition.DefinitionId);
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Models/ArtifactEnvelopeModels.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Models/ArtifactEnvelopeModels.cs
@@ -1,0 +1,119 @@
+namespace Elsa.Studio.PlatformIntegration;
+
+/// <summary>
+/// Provides Platform artifact envelope constants.
+/// </summary>
+public static class PlatformArtifactEnvelopeConstants
+{
+    /// <summary>
+    /// The supported artifact envelope version.
+    /// </summary>
+    public const string EnvelopeVersion = "platform.elsa.io/artifact-envelope/v1alpha1";
+
+    /// <summary>
+    /// The supported deployment artifact layout version.
+    /// </summary>
+    public const string LayoutVersion = "platform.elsa.io/deployment-artifact/v1alpha1";
+
+    /// <summary>
+    /// The default workflow artifact schema version.
+    /// </summary>
+    public const string DefaultArtifactSchemaVersion = "1.0";
+
+    /// <summary>
+    /// The Elsa workflow definition artifact type.
+    /// </summary>
+    public const string ElsaWorkflowDefinitionArtifactType = "elsa.workflow-definition";
+}
+
+/// <summary>
+/// Represents an artifact envelope.
+/// </summary>
+public sealed record PlatformArtifactEnvelope(
+    string ArtifactId,
+    string EnvelopeVersion,
+    string ArtifactTypeId,
+    string ArtifactSchemaVersion,
+    PlatformArtifactDigest ContentDigest,
+    PlatformArtifactDigest? ManifestDigest,
+    PlatformArtifactPayloadReference PayloadReference,
+    PlatformArtifactProducer Producer,
+    PlatformArtifactDisplayMetadata DisplayMetadata,
+    IReadOnlyList<PlatformArtifactCompatibilityHint> CompatibilityHints,
+    IReadOnlyList<PlatformArtifactEnvelopeDiagnostic> Diagnostics);
+
+/// <summary>
+/// Represents an artifact digest.
+/// </summary>
+public sealed record PlatformArtifactDigest(string Algorithm, string Value);
+
+/// <summary>
+/// Represents an artifact payload reference.
+/// </summary>
+public sealed record PlatformArtifactPayloadReference(
+    string Provider,
+    string Uri,
+    string? MediaType = null,
+    long? SizeBytes = null,
+    PlatformArtifactDigest? ReferenceDigest = null,
+    DateTimeOffset? ExpiresAt = null);
+
+/// <summary>
+/// Represents artifact producer metadata.
+/// </summary>
+public sealed record PlatformArtifactProducer(
+    string ProducerType,
+    string ProducerName,
+    string? ProducerVersion = null,
+    string? SourceReference = null);
+
+/// <summary>
+/// Represents artifact display metadata.
+/// </summary>
+public sealed record PlatformArtifactDisplayMetadata(
+    string? Name,
+    string? Version,
+    string? Description,
+    IReadOnlyDictionary<string, string> Labels,
+    IReadOnlyDictionary<string, string> Annotations,
+    string? Source = null);
+
+/// <summary>
+/// Represents an artifact compatibility hint.
+/// </summary>
+public sealed record PlatformArtifactCompatibilityHint(
+    string RequiredArtifactType,
+    string? RuntimeFamily,
+    string? RuntimeVersionRange,
+    IReadOnlyList<string> RequiredCapabilities,
+    IReadOnlyDictionary<string, string> EnvironmentConstraints);
+
+/// <summary>
+/// Represents an artifact envelope diagnostic.
+/// </summary>
+public sealed record PlatformArtifactEnvelopeDiagnostic(
+    string Code,
+    PlatformArtifactEnvelopeDiagnosticSeverity Severity,
+    string Message,
+    string? Target = null);
+
+/// <summary>
+/// Represents artifact envelope diagnostic severity.
+/// </summary>
+public enum PlatformArtifactEnvelopeDiagnosticSeverity
+{
+    /// <summary>
+    /// Informational diagnostic.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Warning diagnostic.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Error diagnostic.
+    /// </summary>
+    Error
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitOptions.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitOptions.cs
@@ -1,0 +1,72 @@
+namespace Elsa.Studio.PlatformIntegration;
+
+/// <summary>
+/// Configures Elsa Platform artifact submission from Studio.
+/// </summary>
+public sealed record PlatformSubmitOptions
+{
+    /// <summary>
+    /// Whether Platform submission is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Whether workflow publish notifications should submit workflow artifacts.
+    /// </summary>
+    public bool SubmitOnWorkflowPublished { get; set; } = true;
+
+    /// <summary>
+    /// The Elsa Platform endpoint.
+    /// </summary>
+    public Uri? PlatformEndpoint { get; set; }
+
+    /// <summary>
+    /// The Platform workspace receiving submitted artifacts.
+    /// </summary>
+    public Guid? WorkspaceId { get; set; }
+
+    /// <summary>
+    /// Optional request customization for authentication headers.
+    /// </summary>
+    public Func<HttpRequestMessage, CancellationToken, Task>? ConfigureRequestAsync { get; set; }
+
+    /// <summary>
+    /// The Studio producer name to record in Platform artifact metadata.
+    /// </summary>
+    public string ProducerName { get; set; } = "Elsa Studio";
+
+    /// <summary>
+    /// The Studio producer version to record in Platform artifact metadata.
+    /// </summary>
+    public string? ProducerVersion { get; set; }
+
+    /// <summary>
+    /// The provider responsible for serving artifact payloads.
+    /// </summary>
+    public string PayloadProvider { get; set; } = "producer-managed";
+
+    /// <summary>
+    /// The URI scheme used for producer-managed payload references.
+    /// </summary>
+    public string PayloadUriScheme { get; set; } = "studio";
+
+    /// <summary>
+    /// The workflow artifact schema version.
+    /// </summary>
+    public string ArtifactSchemaVersion { get; set; } = PlatformArtifactEnvelopeConstants.DefaultArtifactSchemaVersion;
+
+    /// <summary>
+    /// Optional workflow runtime version range expected by this artifact.
+    /// </summary>
+    public string? RuntimeVersionRange { get; set; }
+
+    /// <summary>
+    /// Required runtime capabilities for this artifact.
+    /// </summary>
+    public IReadOnlyList<string> RequiredCapabilities { get; set; } = ["workflow-definition.apply"];
+
+    /// <summary>
+    /// Whether required Platform submission settings have been provided.
+    /// </summary>
+    public bool IsConfigured => PlatformEndpoint is not null && WorkspaceId is { } workspaceId && workspaceId != Guid.Empty;
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitPackage.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitPackage.cs
@@ -1,0 +1,9 @@
+namespace Elsa.Studio.PlatformIntegration;
+
+/// <summary>
+/// Represents a packaged workflow submission.
+/// </summary>
+public sealed record PlatformWorkflowSubmitPackage(
+    PlatformArtifactEnvelope Envelope,
+    string WorkflowDefinitionJson,
+    DateTimeOffset PackagedAt);

--- a/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitResult.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Models/PlatformSubmitResult.cs
@@ -1,0 +1,53 @@
+namespace Elsa.Studio.PlatformIntegration;
+
+/// <summary>
+/// Represents a Platform submission result.
+/// </summary>
+public sealed record PlatformSubmitResult(
+    PlatformSubmitStatus Status,
+    string Message,
+    string? ArtifactId = null,
+    string? ArtifactDigest = null,
+    DateTimeOffset? RegisteredAt = null)
+{
+    /// <summary>
+    /// Whether the submission succeeded.
+    /// </summary>
+    public bool Succeeded => Status is PlatformSubmitStatus.Submitted or PlatformSubmitStatus.Duplicate;
+}
+
+/// <summary>
+/// Represents Platform submission status.
+/// </summary>
+public enum PlatformSubmitStatus
+{
+    /// <summary>
+    /// Artifact was newly submitted.
+    /// </summary>
+    Submitted,
+
+    /// <summary>
+    /// Artifact already existed in Platform.
+    /// </summary>
+    Duplicate,
+
+    /// <summary>
+    /// Platform rejected the submission because Studio is not authorized.
+    /// </summary>
+    Unauthorized,
+
+    /// <summary>
+    /// Platform rejected the submission because of a state conflict.
+    /// </summary>
+    Conflict,
+
+    /// <summary>
+    /// Platform rejected the submission because the request was invalid.
+    /// </summary>
+    ValidationFailed,
+
+    /// <summary>
+    /// Platform submission failed in a way that can be retried.
+    /// </summary>
+    RetryableError
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Models/WorkspaceArtifactRegistrationModels.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Models/WorkspaceArtifactRegistrationModels.cs
@@ -1,0 +1,35 @@
+namespace Elsa.Studio.PlatformIntegration;
+
+internal sealed record WorkspaceArtifactRegistrationRequest(
+    string ArtifactId,
+    string LayoutVersion,
+    PlatformArtifactDigest ContentDigest,
+    string Format,
+    string ReferenceProvider,
+    string Reference,
+    WorkspaceArtifactManifestSummary Manifest,
+    IReadOnlyList<WorkspaceArtifactResourceSummary> Resources,
+    IReadOnlyList<WorkspaceArtifactDiagnostic> Diagnostics,
+    string? EnvelopeVersion = null,
+    string? ArtifactTypeId = null,
+    string? ArtifactSchemaVersion = null,
+    PlatformArtifactDigest? ManifestDigest = null,
+    PlatformArtifactPayloadReference? PayloadReference = null,
+    PlatformArtifactProducer? Producer = null,
+    PlatformArtifactDisplayMetadata? DisplayMetadata = null,
+    IReadOnlyList<PlatformArtifactCompatibilityHint>? CompatibilityHints = null);
+
+internal sealed record WorkspaceArtifactManifestSummary(string? Name, string? Version, string? Environment);
+
+internal sealed record WorkspaceArtifactResourceSummary(
+    string Type,
+    string LogicalId,
+    string? Scope,
+    string? Version,
+    PlatformArtifactDigest? DesiredStateHash);
+
+internal sealed record WorkspaceArtifactDiagnostic(string Code, string Severity, string Message);
+
+internal sealed record WorkspaceArtifactResponse(Guid Id, string ArtifactId, PlatformArtifactDigest ContentDigest, DateTimeOffset RegisteredAt);
+
+internal sealed record ProblemDetailsResponse(string? Title, string? Detail);

--- a/src/modules/Elsa.Studio.PlatformIntegration/Properties/AssemblyInfo.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Elsa.Studio.PlatformIntegration.Tests")]

--- a/src/modules/Elsa.Studio.PlatformIntegration/Serialization/PlatformIntegrationJsonContext.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Serialization/PlatformIntegrationJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elsa.Studio.PlatformIntegration.Serialization;
+
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(WorkspaceArtifactRegistrationRequest))]
+[JsonSerializable(typeof(WorkspaceArtifactResponse))]
+[JsonSerializable(typeof(ProblemDetailsResponse))]
+internal sealed partial class PlatformIntegrationJsonContext : JsonSerializerContext;

--- a/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformArtifactEnvelopeValidator.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformArtifactEnvelopeValidator.cs
@@ -1,0 +1,121 @@
+using System.Text.RegularExpressions;
+
+namespace Elsa.Studio.PlatformIntegration.Services;
+
+internal sealed partial class PlatformArtifactEnvelopeValidator
+{
+    private static readonly string[] UnsafeTerms =
+    [
+        "authorization",
+        "bearer",
+        "connectionstring",
+        "connection string",
+        "password",
+        "private key",
+        "secret",
+        "token"
+    ];
+
+    public void Validate(PlatformArtifactEnvelope envelope)
+    {
+        if (string.IsNullOrWhiteSpace(envelope.ArtifactId))
+            throw new InvalidOperationException("Artifact identity is required.");
+        if (!envelope.EnvelopeVersion.Equals(PlatformArtifactEnvelopeConstants.EnvelopeVersion, StringComparison.Ordinal))
+            throw new InvalidOperationException("Artifact envelope version is not supported.");
+        if (!envelope.ArtifactTypeId.Equals(PlatformArtifactEnvelopeConstants.ElsaWorkflowDefinitionArtifactType, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Artifact type is not supported.");
+        if (!envelope.ArtifactSchemaVersion.Equals(PlatformArtifactEnvelopeConstants.DefaultArtifactSchemaVersion, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Artifact schema version is not supported for the artifact type.");
+
+        ValidateDigest(envelope.ContentDigest.Algorithm, envelope.ContentDigest.Value, "Artifact content digest");
+        ValidatePayloadReference(envelope.PayloadReference);
+        ValidateProducer(envelope.Producer);
+        ValidateDisplayMetadata(envelope.DisplayMetadata);
+        ValidateCompatibilityHints(envelope.ArtifactTypeId, envelope.CompatibilityHints);
+    }
+
+    public string SafeMessage(string? value)
+    {
+        var safe = string.IsNullOrWhiteSpace(value) ? "Platform submission failed." : value.Trim();
+        foreach (var term in UnsafeTerms)
+            safe = safe.Replace(term, "[redacted]", StringComparison.OrdinalIgnoreCase);
+        return safe.Length <= 512 ? safe : safe[..512];
+    }
+
+    private static void ValidateDigest(string algorithm, string value, string label)
+    {
+        if (!algorithm.Equals("sha256", StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"{label} is required.");
+        if (!DigestValueRegex().IsMatch(value))
+            throw new InvalidOperationException($"{label} has an invalid digest value.");
+    }
+
+    private void ValidatePayloadReference(PlatformArtifactPayloadReference reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference.Provider) || string.IsNullOrWhiteSpace(reference.Uri))
+            throw new InvalidOperationException("Artifact payload reference is required.");
+        ValidateSafeValue(reference.Provider, "Artifact payload reference provider");
+        ValidateSafeValue(reference.Uri, "Artifact payload reference URI");
+        ValidateSafeValue(reference.MediaType, "Artifact payload media type");
+        if (reference.ReferenceDigest is { } digest)
+            ValidateDigest(digest.Algorithm, digest.Value, "Artifact reference digest");
+    }
+
+    private void ValidateProducer(PlatformArtifactProducer producer)
+    {
+        if (string.IsNullOrWhiteSpace(producer.ProducerType) || string.IsNullOrWhiteSpace(producer.ProducerName))
+            throw new InvalidOperationException("Artifact producer metadata is required.");
+        ValidateSafeValue(producer.ProducerType, "Artifact producer type");
+        ValidateSafeValue(producer.ProducerName, "Artifact producer name");
+        ValidateSafeValue(producer.ProducerVersion, "Artifact producer version");
+        ValidateSafeValue(producer.SourceReference, "Artifact producer source reference");
+    }
+
+    private void ValidateDisplayMetadata(PlatformArtifactDisplayMetadata metadata)
+    {
+        ValidateSafeValue(metadata.Name, "Artifact display name");
+        ValidateSafeValue(metadata.Version, "Artifact display version");
+        ValidateSafeValue(metadata.Description, "Artifact display description");
+        ValidateSafeValue(metadata.Source, "Artifact display source");
+        ValidateSafeDictionary(metadata.Labels, "Artifact labels");
+        ValidateSafeDictionary(metadata.Annotations, "Artifact annotations");
+    }
+
+    private void ValidateCompatibilityHints(string artifactTypeId, IReadOnlyList<PlatformArtifactCompatibilityHint> hints)
+    {
+        foreach (var hint in hints)
+        {
+            if (!hint.RequiredArtifactType.Equals(artifactTypeId, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Artifact compatibility hint does not match the artifact type.");
+            ValidateSafeValue(hint.RuntimeFamily, "Artifact runtime family");
+            ValidateSafeValue(hint.RuntimeVersionRange, "Artifact runtime version range");
+            foreach (var capability in hint.RequiredCapabilities)
+                ValidateSafeValue(capability, "Artifact required capability");
+            ValidateSafeDictionary(hint.EnvironmentConstraints, "Artifact environment constraints");
+        }
+    }
+
+    private void ValidateSafeDictionary(IReadOnlyDictionary<string, string> values, string label)
+    {
+        if (values.Count > 50)
+            throw new InvalidOperationException($"{label} contains too many entries.");
+        foreach (var (key, value) in values)
+        {
+            ValidateSafeValue(key, label);
+            ValidateSafeValue(value, label);
+        }
+    }
+
+    private void ValidateSafeValue(string? value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+        if (UnsafeTerms.Any(term => value.Contains(term, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException("Artifact metadata contains unsafe secret-like content.");
+        if (value.Length > 2048)
+            throw new InvalidOperationException($"{label} is too long.");
+    }
+
+    [GeneratedRegex("^[A-Fa-f0-9]{64}$")]
+    private static partial Regex DigestValueRegex();
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformArtifactSubmitClient.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformArtifactSubmitClient.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Elsa.Studio.PlatformIntegration.Contracts;
+using Elsa.Studio.PlatformIntegration.Serialization;
+
+namespace Elsa.Studio.PlatformIntegration.Services;
+
+internal sealed class PlatformArtifactSubmitClient(HttpClient httpClient) : IPlatformArtifactSubmitClient
+{
+    private readonly PlatformArtifactEnvelopeValidator _validator = new();
+
+    public async Task<PlatformSubmitResult> SubmitAsync(PlatformWorkflowSubmitPackage package, PlatformSubmitOptions options, CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildSubmissionUri(options))
+        {
+            Content = JsonContent.Create(ToRegistrationRequest(package.Envelope), PlatformIntegrationJsonContext.Default.WorkspaceArtifactRegistrationRequest)
+        };
+
+        if (options.ConfigureRequestAsync is not null)
+            await options.ConfigureRequestAsync(request, cancellationToken);
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var message = await SafeResponseMessageAsync(response, cancellationToken);
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.Created => await SubmittedAsync(response, PlatformSubmitStatus.Submitted, message, cancellationToken),
+            HttpStatusCode.OK => await SubmittedAsync(response, PlatformSubmitStatus.Duplicate, message, cancellationToken),
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new PlatformSubmitResult(PlatformSubmitStatus.Unauthorized, message),
+            HttpStatusCode.Conflict => new PlatformSubmitResult(PlatformSubmitStatus.Conflict, message),
+            HttpStatusCode.BadRequest => new PlatformSubmitResult(PlatformSubmitStatus.ValidationFailed, message),
+            _ when (int)response.StatusCode >= 500 => new PlatformSubmitResult(PlatformSubmitStatus.RetryableError, message),
+            _ => new PlatformSubmitResult(PlatformSubmitStatus.ValidationFailed, message)
+        };
+    }
+
+    private static Uri BuildSubmissionUri(PlatformSubmitOptions options)
+    {
+        if (options.PlatformEndpoint is null)
+            throw new InvalidOperationException("Platform endpoint is required before submitting to Platform.");
+        if (options.WorkspaceId is null || options.WorkspaceId == Guid.Empty)
+            throw new InvalidOperationException("Platform workspace is required before submitting to Platform.");
+
+        return new Uri($"{options.PlatformEndpoint.AbsoluteUri.TrimEnd('/')}/api/workspaces/{options.WorkspaceId:D}/artifacts");
+    }
+
+    private static WorkspaceArtifactRegistrationRequest ToRegistrationRequest(PlatformArtifactEnvelope envelope) =>
+        new(
+            envelope.ArtifactId,
+            PlatformArtifactEnvelopeConstants.LayoutVersion,
+            envelope.ContentDigest,
+            "Unknown",
+            envelope.PayloadReference.Provider,
+            envelope.PayloadReference.Uri,
+            new WorkspaceArtifactManifestSummary(
+                envelope.DisplayMetadata.Name,
+                envelope.DisplayMetadata.Version,
+                null),
+            [],
+            envelope.Diagnostics
+                .Select(x => new WorkspaceArtifactDiagnostic(x.Code, ToWorkspaceSeverity(x.Severity), x.Message))
+                .ToList(),
+            envelope.EnvelopeVersion,
+            envelope.ArtifactTypeId,
+            envelope.ArtifactSchemaVersion,
+            envelope.ManifestDigest,
+            envelope.PayloadReference,
+            envelope.Producer,
+            envelope.DisplayMetadata,
+            envelope.CompatibilityHints);
+
+    private async Task<PlatformSubmitResult> SubmittedAsync(HttpResponseMessage response, PlatformSubmitStatus status, string fallbackMessage, CancellationToken cancellationToken)
+    {
+        WorkspaceArtifactResponse? artifact;
+        try
+        {
+            artifact = await response.Content.ReadFromJsonAsync(PlatformIntegrationJsonContext.Default.WorkspaceArtifactResponse, cancellationToken);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            return new PlatformSubmitResult(PlatformSubmitStatus.RetryableError, "Platform submission response could not be read.");
+        }
+
+        if (artifact is null)
+            return new PlatformSubmitResult(PlatformSubmitStatus.RetryableError, "Platform submission response could not be read.");
+
+        return new PlatformSubmitResult(
+            status,
+            fallbackMessage,
+            artifact.ArtifactId,
+            $"{artifact.ContentDigest.Algorithm}:{artifact.ContentDigest.Value}",
+            artifact.RegisteredAt);
+    }
+
+    private async Task<string> SafeResponseMessageAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return response.StatusCode == HttpStatusCode.Created ? "Submitted to Platform." : "Artifact already exists in Platform.";
+
+        try
+        {
+            var problem = await response.Content.ReadFromJsonAsync(PlatformIntegrationJsonContext.Default.ProblemDetailsResponse, cancellationToken);
+            return _validator.SafeMessage(problem?.Title ?? problem?.Detail ?? response.ReasonPhrase);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            return _validator.SafeMessage(response.ReasonPhrase);
+        }
+    }
+
+    private static string ToWorkspaceSeverity(PlatformArtifactEnvelopeDiagnosticSeverity severity) =>
+        severity switch
+        {
+            PlatformArtifactEnvelopeDiagnosticSeverity.Error => "Error",
+            PlatformArtifactEnvelopeDiagnosticSeverity.Warning => "Warning",
+            _ => "Info"
+        };
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformWorkflowSnapshotPackager.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformWorkflowSnapshotPackager.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.PlatformIntegration.Contracts;
+
+namespace Elsa.Studio.PlatformIntegration.Services;
+
+internal sealed partial class PlatformWorkflowSnapshotPackager(
+    PlatformArtifactEnvelopeValidator? validator = null) : IPlatformWorkflowSnapshotPackager
+{
+    private static readonly JsonSerializerOptions WorkflowJsonOptions = CreateWorkflowJsonOptions();
+    private readonly PlatformArtifactEnvelopeValidator _validator = validator ?? new();
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "WorkflowDefinition is the Studio API client model already serialized dynamically by Studio workflow import/export services.")]
+    public PlatformWorkflowSubmitPackage Package(WorkflowDefinition workflowDefinition, PlatformSubmitOptions options, DateTimeOffset? packagedAt = null)
+    {
+        ValidateWorkflowDefinition(workflowDefinition);
+        ValidateOptions(options);
+
+        var workflowDefinitionJson = JsonSerializer.Serialize(workflowDefinition, WorkflowJsonOptions);
+        var definitionId = workflowDefinition.DefinitionId!.Trim();
+        var displayName = workflowDefinition.Name!.Trim();
+        var contentDigest = ComputeDigest(workflowDefinitionJson);
+        var payloadReference = new PlatformArtifactPayloadReference(
+            options.PayloadProvider.Trim(),
+            BuildPayloadUri(options.PayloadUriScheme, definitionId, contentDigest.Value),
+            "application/vnd.elsa.workflow-definition+json",
+            Encoding.UTF8.GetByteCount(workflowDefinitionJson),
+            contentDigest);
+
+        var envelope = new PlatformArtifactEnvelope(
+            BuildArtifactId(definitionId, contentDigest.Value),
+            PlatformArtifactEnvelopeConstants.EnvelopeVersion,
+            PlatformArtifactEnvelopeConstants.ElsaWorkflowDefinitionArtifactType,
+            options.ArtifactSchemaVersion.Trim(),
+            contentDigest,
+            null,
+            payloadReference,
+            new PlatformArtifactProducer(
+                "studio",
+                options.ProducerName.Trim(),
+                TrimToNull(options.ProducerVersion),
+                BuildSourceReference(definitionId, workflowDefinition.Id)),
+            new PlatformArtifactDisplayMetadata(
+                displayName,
+                workflowDefinition.Version.ToString(CultureInfo.InvariantCulture),
+                TrimToNull(workflowDefinition.Description),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                BuildWorkflowSource(definitionId)),
+            [
+                new PlatformArtifactCompatibilityHint(
+                    PlatformArtifactEnvelopeConstants.ElsaWorkflowDefinitionArtifactType,
+                    "elsa-workflows",
+                    TrimToNull(options.RuntimeVersionRange),
+                    options.RequiredCapabilities
+                        .Select(x => x.Trim())
+                        .Where(x => x.Length > 0)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList(),
+                    new Dictionary<string, string>())
+            ],
+            []);
+
+        _validator.Validate(envelope);
+        return new PlatformWorkflowSubmitPackage(envelope, workflowDefinitionJson, (packagedAt ?? DateTimeOffset.UtcNow).ToUniversalTime());
+    }
+
+    private static void ValidateWorkflowDefinition(WorkflowDefinition workflowDefinition)
+    {
+        if (string.IsNullOrWhiteSpace(workflowDefinition.DefinitionId))
+            throw new InvalidOperationException("Workflow definition identity is required before submitting to Platform.");
+        if (string.IsNullOrWhiteSpace(workflowDefinition.Name))
+            throw new InvalidOperationException("Workflow display name is required before submitting to Platform.");
+        if (workflowDefinition.Root is null)
+            throw new InvalidOperationException("Workflow definition snapshot is required before submitting to Platform.");
+    }
+
+    private static void ValidateOptions(PlatformSubmitOptions options)
+    {
+        if (options.PlatformEndpoint is null)
+            throw new InvalidOperationException("Platform endpoint is required before submitting to Platform.");
+        if (options.WorkspaceId is null || options.WorkspaceId == Guid.Empty)
+            throw new InvalidOperationException("Platform workspace is required before submitting to Platform.");
+        if (string.IsNullOrWhiteSpace(options.ProducerName))
+            throw new InvalidOperationException("Studio producer name is required before submitting to Platform.");
+        if (string.IsNullOrWhiteSpace(options.PayloadProvider))
+            throw new InvalidOperationException("Artifact payload provider is required before submitting to Platform.");
+        if (string.IsNullOrWhiteSpace(options.PayloadUriScheme))
+            throw new InvalidOperationException("Artifact payload URI scheme is required before submitting to Platform.");
+        if (string.IsNullOrWhiteSpace(options.ArtifactSchemaVersion))
+            throw new InvalidOperationException("Workflow artifact schema version is required before submitting to Platform.");
+    }
+
+    private static PlatformArtifactDigest ComputeDigest(string content)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return new PlatformArtifactDigest("sha256", Convert.ToHexString(hash).ToLowerInvariant());
+    }
+
+    private static string BuildArtifactId(string workflowDefinitionId, string digest) =>
+        $"elsa.workflow-definition:{SafeIdentitySegment(workflowDefinitionId)}:{digest}";
+
+    private static string BuildPayloadUri(string scheme, string workflowDefinitionId, string digest) =>
+        $"{scheme.Trim()}://workflows/{Uri.EscapeDataString(workflowDefinitionId.Trim())}/snapshots/{digest}";
+
+    private static string BuildWorkflowSource(string workflowDefinitionId) =>
+        $"studio://workflows/{Uri.EscapeDataString(workflowDefinitionId.Trim())}";
+
+    private static string BuildSourceReference(string workflowDefinitionId, string? workflowDefinitionVersionId)
+    {
+        var workflowId = workflowDefinitionId.Trim();
+        var versionId = TrimToNull(workflowDefinitionVersionId);
+        return versionId is null ? $"workflow:{workflowId}" : $"workflow:{workflowId}:version:{versionId}";
+    }
+
+    private static string SafeIdentitySegment(string value)
+    {
+        var safe = UnsafeIdentityCharacters().Replace(value.Trim(), "-").Trim('-');
+        if (string.IsNullOrWhiteSpace(safe))
+            throw new InvalidOperationException("Workflow definition identity does not contain a safe artifact identity segment.");
+        if (safe.Length <= 96)
+            return safe;
+
+        var identityDigest = ComputeDigest(value.Trim()).Value[..16];
+        return $"{safe[..79]}-{identityDigest}";
+    }
+
+    private static string? TrimToNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static JsonSerializerOptions CreateWorkflowJsonOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        options.Converters.Add(new JsonStringEnumConverter(allowIntegerValues: false));
+        return options;
+    }
+
+    [GeneratedRegex("[^A-Za-z0-9_.-]+")]
+    private static partial Regex UnsafeIdentityCharacters();
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformWorkflowSubmissionService.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Services/PlatformWorkflowSubmissionService.cs
@@ -1,0 +1,18 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.PlatformIntegration.Contracts;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Studio.PlatformIntegration.Services;
+
+internal sealed class PlatformWorkflowSubmissionService(
+    IOptions<PlatformSubmitOptions> options,
+    IPlatformWorkflowSnapshotPackager packager,
+    IPlatformArtifactSubmitClient submitClient) : IPlatformWorkflowSubmissionService
+{
+    public async Task<PlatformSubmitResult> SubmitAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default)
+    {
+        var value = options.Value;
+        var package = packager.Package(workflowDefinition, value);
+        return await submitClient.SubmitAsync(package, value, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionEditorSubmitWidget.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionEditorSubmitWidget.cs
@@ -1,0 +1,35 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.PlatformIntegration.Components;
+using Elsa.Studio.Workflows.Constants;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.PlatformIntegration.Widgets;
+
+/// <summary>
+/// Renders the Submit to Platform action in the workflow definition editor toolbar.
+/// </summary>
+public sealed class WorkflowDefinitionEditorSubmitWidget : IWidget
+{
+    /// <inheritdoc />
+    public string Zone => ZoneNames.WorkflowDefinitionEditorToolbarActions;
+
+    /// <inheritdoc />
+    public double Order => 0;
+
+    /// <inheritdoc />
+    public Func<IDictionary<string, object?>, RenderFragment> Render => attributes => builder =>
+    {
+        var getWorkflowDefinition = GetWorkflowDefinition(attributes);
+        var sequence = 0;
+        builder.OpenComponent<SubmitWorkflowDefinitionAction>(sequence++);
+        builder.AddAttribute(sequence++, nameof(SubmitWorkflowDefinitionAction.GetWorkflowDefinition), getWorkflowDefinition);
+        builder.AddAttribute(sequence++, nameof(SubmitWorkflowDefinitionAction.Disabled), getWorkflowDefinition is null);
+        builder.CloseComponent();
+    };
+
+    private static Func<Task<WorkflowDefinition?>>? GetWorkflowDefinition(IDictionary<string, object?> attributes) =>
+        attributes.TryGetValue("GetWorkflowDefinition", out var value)
+            ? value as Func<Task<WorkflowDefinition?>>
+            : null;
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListBulkSubmitWidget.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListBulkSubmitWidget.cs
@@ -1,0 +1,12 @@
+using Elsa.Studio.Workflows.Constants;
+
+namespace Elsa.Studio.PlatformIntegration.Widgets;
+
+/// <summary>
+/// Renders the Submit to Platform action in the workflow definition list bulk actions menu.
+/// </summary>
+public sealed class WorkflowDefinitionListBulkSubmitWidget : WorkflowDefinitionListSubmitWidgetBase
+{
+    /// <inheritdoc />
+    public override string Zone => ZoneNames.WorkflowDefinitionListBulkActions;
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListRowSubmitWidget.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListRowSubmitWidget.cs
@@ -1,0 +1,12 @@
+using Elsa.Studio.Workflows.Constants;
+
+namespace Elsa.Studio.PlatformIntegration.Widgets;
+
+/// <summary>
+/// Renders the Submit to Platform action in each workflow definition row action menu.
+/// </summary>
+public sealed class WorkflowDefinitionListRowSubmitWidget : WorkflowDefinitionListSubmitWidgetBase
+{
+    /// <inheritdoc />
+    public override string Zone => ZoneNames.WorkflowDefinitionListRowActions;
+}

--- a/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListSubmitWidgetBase.cs
+++ b/src/modules/Elsa.Studio.PlatformIntegration/Widgets/WorkflowDefinitionListSubmitWidgetBase.cs
@@ -1,0 +1,34 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.PlatformIntegration.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.PlatformIntegration.Widgets;
+
+/// <summary>
+/// Renders Submit to Platform menu actions for workflow definition lists.
+/// </summary>
+public abstract class WorkflowDefinitionListSubmitWidgetBase : IWidget
+{
+    /// <inheritdoc />
+    public abstract string Zone { get; }
+
+    /// <inheritdoc />
+    public double Order => 0;
+
+    /// <inheritdoc />
+    public Func<IDictionary<string, object?>, RenderFragment> Render => attributes => builder =>
+    {
+        var sequence = 0;
+        builder.OpenComponent<SubmitWorkflowDefinitionAction>(sequence++);
+        builder.AddAttribute(sequence++, nameof(SubmitWorkflowDefinitionAction.DefinitionIds), GetDefinitionIds(attributes));
+        builder.AddAttribute(sequence++, nameof(SubmitWorkflowDefinitionAction.Disabled), GetDisabled(attributes));
+        builder.AddAttribute(sequence++, nameof(SubmitWorkflowDefinitionAction.RenderAsMenuItem), true);
+        builder.CloseComponent();
+    };
+
+    private static IReadOnlyCollection<string> GetDefinitionIds(IDictionary<string, object?> attributes) =>
+        attributes.TryGetValue("DefinitionIds", out var value) && value is IReadOnlyCollection<string> ids ? ids : [];
+
+    private static bool GetDisabled(IDictionary<string, object?> attributes) =>
+        attributes.TryGetValue("Disabled", out var value) && value is true;
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -31,6 +31,7 @@
                     <MudTooltip Text="@Localizer["Publish workflow"]" Delay="500">
                         <MudIconButton Icon="@Icons.Material.Filled.CloudUpload" Color="Color.Primary" OnClick="@OnPublishClicked" />
                     </MudTooltip>
+                    <Zone Name="@ZoneNames.WorkflowDefinitionEditorToolbarActions" Attributes="@WorkflowDefinitionEditorToolbarActionAttributes" />
                     <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown" Dense="true">
                         <MudTooltip Text="@Localizer["Save As"]" Inline="false" Delay="500">
                             <MudMenuItem Icon="@Icons.Material.Filled.SaveAs" OnClick="@OnSaveAsClick">@Localizer["Save As"]</MudMenuItem>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -97,6 +97,11 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     private JsonObject? SelectedActivity { get; set; }
     private ActivityDescriptor? ActivityDescriptor { get; set; }
     private ActivityPropertiesPanel? ActivityPropertiesPanel { get; set; }
+    private IDictionary<string, object?> WorkflowDefinitionEditorToolbarActionAttributes => new Dictionary<string, object?>
+    {
+        ["WorkflowDefinition"] = _workflowDefinition,
+        ["GetWorkflowDefinition"] = (Func<Task<WorkflowDefinition?>>)GetWorkflowDefinitionSnapshotAsync
+    };
 
     private DotNetObjectReference<WorkflowEditor>? _dotNetRef;
 
@@ -306,6 +311,15 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         _workflowDefinition = WorkflowDefinition = workflowDefinition;
         if (WorkflowDefinitionUpdated != null) await WorkflowDefinitionUpdated();
+    }
+
+    private async Task<WorkflowDefinition?> GetWorkflowDefinitionSnapshotAsync()
+    {
+        if (_workflowDefinition is null)
+            return null;
+
+        _workflowDefinition.Root = await _diagramDesigner.GetActivityAsync();
+        return _workflowDefinition;
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -49,6 +49,7 @@
                 <MudMenuItem Icon="@Icons.Material.Outlined.Delete" Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkDeleteClicked">@Localizer["Delete"]</MudMenuItem>
                 <MudDivider />
                 <MudMenuItem Icon="@Icons.Material.Outlined.CloudUpload" Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkPublishClicked">@Localizer["Publish"]</MudMenuItem>
+                <Zone Name="@ZoneNames.WorkflowDefinitionListBulkActions" Attributes="@WorkflowDefinitionListBulkActionAttributes" />
                 <MudMenuItem Icon="@Icons.Material.Outlined.CloudDownload" Disabled="IsReadOnlyMode || !(_selectedRows?.Any() ?? false)" OnClick="@OnBulkRetractClicked">@Localizer["Unpublish"]</MudMenuItem>
                 <MudDivider />
                 <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" Disabled="!(_selectedRows?.Any() ?? false)" OnClick="@OnBulkExportClicked">@Localizer["Export"]</MudMenuItem>
@@ -140,6 +141,7 @@
                     <MudMenuItem Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => OnDeleteClicked(context))" Disabled="IsReadOnlyMode || context.IsReadOnlyMode">@Localizer["Delete"]</MudMenuItem>
                     <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                     <MudMenuItem Icon="@Icons.Material.Outlined.CloudUpload" OnClick="@(() => OnPublishClicked(context.DefinitionId))" Disabled="IsReadOnlyMode || context.IsReadOnlyMode">@Localizer["Publish"]</MudMenuItem>
+                    <Zone Name="@ZoneNames.WorkflowDefinitionListRowActions" Attributes="@GetWorkflowDefinitionListRowActionAttributes(context)" />
                     <MudMenuItem Icon="@Icons.Material.Outlined.CloudDownload" OnClick="@(() => OnRetractClicked(context.DefinitionId))" Disabled="IsReadOnlyMode || context.IsReadOnlyMode">@Localizer["Unpublish"]</MudMenuItem>
                     <MudDivider DividerType="DividerType.FullWidth"></MudDivider>
                     <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="@(() => OnExportClicked(context))">@Localizer["Export"]</MudMenuItem>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -45,6 +45,17 @@ public partial class WorkflowDefinitionList
     private string SearchTerm { get; set; } = string.Empty;
     private bool IsReadOnlyMode { get; set; }
     private string ReadonlyWorkflowsExcluded => Localizer["The read-only workflows will not be affected."];
+    private IDictionary<string, object?> WorkflowDefinitionListBulkActionAttributes => new Dictionary<string, object?>
+    {
+        ["DefinitionIds"] = _selectedRows.Select(x => x.DefinitionId).ToList(),
+        ["Disabled"] = IsReadOnlyMode || !(_selectedRows?.Any() ?? false)
+    };
+
+    private IDictionary<string, object?> GetWorkflowDefinitionListRowActionAttributes(WorkflowDefinitionRow row) => new Dictionary<string, object?>
+    {
+        ["DefinitionIds"] = new[] { row.DefinitionId },
+        ["Disabled"] = IsReadOnlyMode || row.IsReadOnlyMode
+    };
 
     private async Task<TableData<WorkflowDefinitionRow>> ServerReload(TableState state, CancellationToken cancellationToken)
     {

--- a/src/modules/Elsa.Studio.Workflows/Constants/ZoneNames.cs
+++ b/src/modules/Elsa.Studio.Workflows/Constants/ZoneNames.cs
@@ -11,6 +11,21 @@ public static class ZoneNames
     public const string WorkflowDefinitionProperties = "workflow-definition-properties";
 
     /// <summary>
+    /// The zone for workflow definition editor toolbar actions.
+    /// </summary>
+    public const string WorkflowDefinitionEditorToolbarActions = "workflow-definition-editor-toolbar-actions";
+
+    /// <summary>
+    /// The zone for workflow definition list bulk actions.
+    /// </summary>
+    public const string WorkflowDefinitionListBulkActions = "workflow-definition-list-bulk-actions";
+
+    /// <summary>
+    /// The zone for workflow definition list row actions.
+    /// </summary>
+    public const string WorkflowDefinitionListRowActions = "workflow-definition-list-row-actions";
+
+    /// <summary>
     /// The zone for workflow instance viewer bottom panel tabs.
     /// </summary>
     public const string WorkflowInstanceViewerBottomTabs = "workflow-instance-viewer-bottom-tabs";


### PR DESCRIPTION
## Summary
- Adds an opt-in `Elsa.Studio.PlatformIntegration` module that can submit workflow definitions to Elsa Platform as deployable artifacts.
- Adds neutral Workflows extension zones beside publish actions in the workflow definition editor toolbar, workflow definition list bulk menu, and workflow definition row menu.
- Registers Platform widgets that inject `Submit to Platform` actions into those zones without hard-coding Platform UI into the Workflows module.
- Packages workflow definitions as deterministic `elsa.workflow-definition` artifact envelopes and posts artifact registration requests to the configured Platform workspace.
- Keeps publish-event submission failures contained so Studio publish behavior is not rolled back by Platform submission errors.
- Adds focused tests for packaging, HTTP request mapping, disabled configuration, failure containment, and widget registration.

## Verification
- `dotnet test src/modules/Elsa.Studio.PlatformIntegration.Tests/Elsa.Studio.PlatformIntegration.Tests.csproj --framework net10.0`
- `dotnet build Elsa.Studio.sln --framework net10.0 --no-restore`
- `git diff --check`

Closes #838