### PR TITLE
[codex] Add Studio secret picker UI hint

### DIFF
--- a/src/modules/Elsa.Studio.Secrets/Components/CreateSecretDialog.razor
+++ b/src/modules/Elsa.Studio.Secrets/Components/CreateSecretDialog.razor
@@ -11,7 +11,7 @@
                 <MudTextField @bind-Value="_model.Description" Label="Description" Lines="3" Variant="Variant.Outlined" />
 
                 <MudSelect T="string" Value="_model.TypeName" ValueChanged="OnTypeChanged" Label="Type" Required="true" Variant="Variant.Outlined">
-                    @foreach (var type in Descriptors.Types)
+                    @foreach (var type in CompatibleTypes)
                     {
                         <MudSelectItem T="string" Value="@type.Name">@type.DisplayName</MudSelectItem>
                     }
@@ -33,7 +33,7 @@
                     <MudTextField @bind-Value="_model.Value" Label="Value" Required="true" InputType="InputType.Password" Variant="Variant.Outlined" />
                 }
 
-                <MudTextField @bind-Value="_model.Scope" Label="Scope" Variant="Variant.Outlined" />
+                <MudTextField @bind-Value="_model.Scope" Label="Scope" Variant="Variant.Outlined" ReadOnly="@HasFixedScope" />
             </MudStack>
         </MudForm>
     </DialogContent>
@@ -46,25 +46,52 @@
 @code {
     private MudForm _form = default!;
     private readonly CreateSecretRequest _model = new();
+    private bool _initialized;
 
     [Parameter] public SecretDescriptorsResponse Descriptors { get; set; } = new();
+    [Parameter] public ICollection<string> TypeNames { get; set; } = [];
+    [Parameter] public ICollection<string> StoreNames { get; set; } = [];
+    [Parameter] public string? Scope { get; set; }
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    private bool HasFixedScope => !string.IsNullOrWhiteSpace(Scope);
+
+    private IEnumerable<SecretTypeDescriptor> CompatibleTypes
+    {
+        get
+        {
+            var stores = StoreNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var typeNames = TypeNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            return Descriptors.Types.Where(type =>
+                (typeNames.Count == 0 || typeNames.Contains(type.Name)) &&
+                (stores.Count == 0 || type.SupportedStoreNames.Any(stores.Contains)));
+        }
+    }
 
     private IEnumerable<SecretStoreDescriptor> CompatibleStores
     {
         get
         {
             var type = Descriptors.Types.FirstOrDefault(x => x.Name == _model.TypeName);
-            return type == null
+            var storeNames = StoreNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var stores = type == null
                 ? Descriptors.Stores
                 : Descriptors.Stores.Where(x => type.SupportedStoreNames.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
+
+            return storeNames.Count == 0 ? stores : stores.Where(x => storeNames.Contains(x.Name));
         }
     }
 
     protected override void OnParametersSet()
     {
-        _model.TypeName = Descriptors.Types.FirstOrDefault()?.Name ?? SecretTypeNames.Text;
+        if (_initialized)
+            return;
+
+        _model.TypeName = CompatibleTypes.FirstOrDefault()?.Name ?? SecretTypeNames.Text;
         _model.StoreName = CompatibleStores.FirstOrDefault()?.Name ?? SecretStoreNames.Encrypted;
+        _model.Scope = Scope;
+        _initialized = true;
     }
 
     private void OnTypeChanged(string typeName)
@@ -80,6 +107,9 @@
         await _form.Validate();
         if (!_form.IsValid)
             return;
+
+        if (HasFixedScope)
+            _model.Scope = Scope;
 
         MudDialog.Close(_model);
     }

--- a/src/modules/Elsa.Studio.Secrets/Components/SecretPicker.razor
+++ b/src/modules/Elsa.Studio.Secrets/Components/SecretPicker.razor
@@ -5,13 +5,13 @@
 @inject ISnackbar Snackbar
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-    <MudSelect T="string" Value="Value" ValueChanged="OnValueChanged" Label="@Label" Dense="true" Variant="Variant.Outlined" Clearable="true" Class="flex-grow-1">
+    <MudSelect T="string" Value="Value" ValueChanged="OnValueChanged" Label="@Label" HelperText="@HelperText" Dense="true" Variant="Variant.Outlined" Clearable="@(!Disabled)" Disabled="@Disabled" Class="flex-grow-1">
         @foreach (var secret in _items)
         {
             <MudSelectItem T="string" Value="@secret.Name">@secret.DisplayName (@secret.Name)</MudSelectItem>
         }
     </MudSelect>
-    @if (AllowInlineCreate && _canCreateInline)
+    @if (!Disabled && AllowInlineCreate && _canCreateInline)
     {
         <MudTooltip Text="Create secret">
             <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary" OnClick="CreateInlineAsync" />
@@ -24,14 +24,19 @@
     private SecretDescriptorsResponse _descriptors = new();
     private bool _canCreateInline;
     private string[]? _loadedTypeNames;
+    private string[]? _loadedStoreNames;
     private string? _loadedScope;
 
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public EventCallback<SecretModel?> SelectedSecretChanged { get; set; }
     [Parameter] public string Label { get; set; } = "Secret";
+    [Parameter] public string? HelperText { get; set; }
     [Parameter] public ICollection<string> TypeNames { get; set; } = [];
+    [Parameter] public ICollection<string> StoreNames { get; set; } = [];
     [Parameter] public string? Scope { get; set; }
     [Parameter] public bool AllowInlineCreate { get; set; } = true;
+    [Parameter] public bool Disabled { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -45,10 +50,11 @@
         {
             var api = await ApiClientProvider.GetApiAsync<ISecretsApi>();
             _descriptors = await api.GetDescriptorsAsync();
-            var response = await api.PickAsync(new SecretPickerRequest { TypeNames = TypeNames, Scope = Scope });
+            var response = await api.PickAsync(new SecretPickerRequest { TypeNames = TypeNames, StoreNames = StoreNames, Scope = Scope });
             _items = response.Items;
             _canCreateInline = response.CanCreateInline;
             _loadedTypeNames = TypeNames.ToArray();
+            _loadedStoreNames = StoreNames.ToArray();
             _loadedScope = Scope;
         }
         catch (Exception e)
@@ -61,14 +67,25 @@
 
     private bool ShouldLoad()
     {
-        return _loadedTypeNames == null || !TypeNames.SequenceEqual(_loadedTypeNames) || !string.Equals(Scope, _loadedScope, StringComparison.Ordinal);
+        return _loadedTypeNames == null || _loadedStoreNames == null || !TypeNames.SequenceEqual(_loadedTypeNames) || !StoreNames.SequenceEqual(_loadedStoreNames) || !string.Equals(Scope, _loadedScope, StringComparison.Ordinal);
     }
 
-    private Task OnValueChanged(string? value) => ValueChanged.InvokeAsync(value);
+    private async Task OnValueChanged(string? value)
+    {
+        var selectedSecret = _items.FirstOrDefault(x => string.Equals(x.Name, value, StringComparison.OrdinalIgnoreCase));
+        await SelectedSecretChanged.InvokeAsync(selectedSecret);
+        await ValueChanged.InvokeAsync(value);
+    }
 
     private async Task CreateInlineAsync()
     {
-        var parameters = new DialogParameters<CreateSecretDialog> { { x => x.Descriptors, _descriptors } };
+        var parameters = new DialogParameters<CreateSecretDialog>
+        {
+            { x => x.Descriptors, _descriptors },
+            { x => x.TypeNames, TypeNames },
+            { x => x.StoreNames, StoreNames },
+            { x => x.Scope, Scope }
+        };
         var options = new DialogOptions { CloseOnEscapeKey = true, CloseButton = true, FullWidth = true, MaxWidth = MaxWidth.Small };
         var dialog = await DialogService.ShowAsync<CreateSecretDialog>("Create Secret", parameters, options);
         var result = await dialog.Result;
@@ -80,6 +97,7 @@
             var api = await ApiClientProvider.GetApiAsync<ISecretsApi>();
             var created = await api.CreateAsync(request);
             await LoadAsync();
+            await SelectedSecretChanged.InvokeAsync(created);
             await ValueChanged.InvokeAsync(created.Name);
         }
         catch (Exception e)

--- a/src/modules/Elsa.Studio.Secrets/Components/SecretPickerInput.razor
+++ b/src/modules/Elsa.Studio.Secrets/Components/SecretPickerInput.razor
@@ -1,0 +1,84 @@
+@using System.Text.Json
+@using Elsa.Api.Client.Resources.Scripting.Models
+@using Elsa.Studio.Models
+@using Elsa.Studio.Secrets.Extensions
+
+@{
+    var inputDescriptor = EditorContext.InputDescriptor;
+    var options = inputDescriptor.GetSecretPickerOptions();
+    var reference = GetSelectedReference();
+}
+
+<FieldExtension UIHintComponent="@SecretInputUIHints.SecretPicker" EditorContext="@EditorContext">
+    <ChildContent>
+        <SecretPicker Value="@reference?.Name"
+                      ValueChanged="OnValueChanged"
+                      SelectedSecretChanged="OnSelectedSecretChanged"
+                      Label="@(inputDescriptor.DisplayName ?? inputDescriptor.Name)"
+                      HelperText="@inputDescriptor.Description"
+                      TypeNames="@options.TypeNames"
+                      StoreNames="@options.StoreNames"
+                      Scope="@options.Scope"
+                      AllowInlineCreate="@options.AllowInlineCreate"
+                      Disabled="@EditorContext.IsReadOnly" />
+    </ChildContent>
+</FieldExtension>
+
+@code {
+    private SecretReference? _pendingReference;
+
+    [Parameter] public DisplayInputEditorContext EditorContext { get; set; } = default!;
+
+    private SecretReference? GetSelectedReference()
+    {
+        var expressionValue = EditorContext.GetExpressionValueOrDefault();
+        if (string.IsNullOrWhiteSpace(expressionValue))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize(expressionValue, SecretJsonSerializerContext.Default.SecretReference);
+        }
+        catch (JsonException)
+        {
+            return new SecretReference(expressionValue);
+        }
+    }
+
+    private Task OnSelectedSecretChanged(SecretModel? secret)
+    {
+        _pendingReference = secret == null ? null : new SecretReference(secret.Name, secret.TypeName, secret.Scope);
+        return Task.CompletedTask;
+    }
+
+    private async Task OnValueChanged(string? value)
+    {
+        if (EditorContext.IsReadOnly)
+            return;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            await UpdateAsync(null);
+            return;
+        }
+
+        var reference = _pendingReference is { } pending && string.Equals(pending.Name, value, StringComparison.OrdinalIgnoreCase)
+            ? pending
+            : new SecretReference(value);
+
+        await UpdateAsync(reference);
+    }
+
+    private async Task UpdateAsync(SecretReference? reference)
+    {
+        var value = reference == null ? string.Empty : JsonSerializer.Serialize(reference, SecretJsonSerializerContext.Default.SecretReference);
+
+        if (EditorContext.InputDescriptor.IsWrapped)
+        {
+            await EditorContext.UpdateExpressionAsync(new Expression(SecretExpressionTypes.Secret, value));
+            return;
+        }
+
+        await EditorContext.UpdateValueAsync(reference?.Name);
+    }
+}

--- a/src/modules/Elsa.Studio.Secrets/Extensions/InputDescriptorSecretPickerExtensions.cs
+++ b/src/modules/Elsa.Studio.Secrets/Extensions/InputDescriptorSecretPickerExtensions.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Secrets.Models;
+
+namespace Elsa.Studio.Secrets.Extensions;
+
+public static class InputDescriptorSecretPickerExtensions
+{
+    public static SecretPickerOptions GetSecretPickerOptions(this InputDescriptor descriptor)
+    {
+        var specifications = descriptor.UISpecifications;
+        if (specifications == null)
+            return new SecretPickerOptions();
+
+        var props = specifications.FirstOrDefault(x =>
+            string.Equals(x.Key, SecretInputUIHints.SecretPicker, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(x.Key, nameof(SecretPickerOptions), StringComparison.OrdinalIgnoreCase));
+
+        if (string.IsNullOrWhiteSpace(props.Key))
+            return new SecretPickerOptions();
+
+        return DeserializeOptions(props.Value);
+    }
+
+    private static SecretPickerOptions DeserializeOptions(object? value)
+    {
+        if (value == null)
+            return new SecretPickerOptions();
+
+        if (value is JsonElement { ValueKind: JsonValueKind.Undefined or JsonValueKind.Null })
+            return new SecretPickerOptions();
+
+        if (value is JsonElement element)
+            return element.Deserialize(SecretJsonSerializerContext.Default.SecretPickerOptions) ?? new SecretPickerOptions();
+
+        if (value is string text)
+            return string.IsNullOrWhiteSpace(text) ? new SecretPickerOptions() : JsonSerializer.Deserialize(text, SecretJsonSerializerContext.Default.SecretPickerOptions) ?? new SecretPickerOptions();
+
+        return value as SecretPickerOptions ?? new SecretPickerOptions();
+    }
+}

--- a/src/modules/Elsa.Studio.Secrets/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Secrets/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Elsa.Studio.Contracts;
 using Elsa.Studio.Extensions;
 using Elsa.Studio.Models;
 using Elsa.Studio.Secrets.Client;
+using Elsa.Studio.Secrets.Handlers;
 using Elsa.Studio.Secrets.Menu;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,7 @@ public static class ServiceCollectionExtensions
         return services
             .AddScoped<IFeature, Feature>()
             .AddScoped<IMenuProvider, SecretsMenu>()
+            .AddUIHintHandler<SecretPickerHandler>()
             .AddRemoteApi<ISecretsApi>(backendApiConfig);
     }
 }

--- a/src/modules/Elsa.Studio.Secrets/Handlers/SecretPickerHandler.cs
+++ b/src/modules/Elsa.Studio.Secrets/Handlers/SecretPickerHandler.cs
@@ -1,0 +1,25 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Models;
+using Elsa.Studio.Secrets.Components;
+using Elsa.Studio.Secrets.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Secrets.Handlers;
+
+public class SecretPickerHandler : IUIHintHandler
+{
+    public bool GetSupportsUIHint(string uiHint) => string.Equals(uiHint, SecretInputUIHints.SecretPicker, StringComparison.OrdinalIgnoreCase);
+
+    public string UISyntax => SecretExpressionTypes.Secret;
+
+    public RenderFragment DisplayInputEditor(DisplayInputEditorContext context)
+    {
+        return builder =>
+        {
+            builder.OpenComponent(0, typeof(SecretPickerInput));
+            builder.AddAttribute(1, nameof(SecretPickerInput.EditorContext), context);
+            builder.CloseComponent();
+        };
+    }
+}
+

--- a/src/modules/Elsa.Studio.Secrets/Models/SecretModels.cs
+++ b/src/modules/Elsa.Studio.Secrets/Models/SecretModels.cs
@@ -1,4 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Elsa.Studio.Secrets.Models;
+
+public static class SecretInputUIHints
+{
+    public const string SecretPicker = "secret-picker";
+}
+
+public static class SecretExpressionTypes
+{
+    public const string Secret = "Secret";
+}
 
 public enum SecretStatus
 {
@@ -50,6 +62,8 @@ public class SecretModel
     public DateTimeOffset? UpdatedAt { get; set; }
     public DateTimeOffset? ExpiresAt { get; set; }
 }
+
+public record SecretReference(string Name, string? TypeName = null, string? Scope = null);
 
 public class CreateSecretRequest
 {
@@ -109,6 +123,14 @@ public class SecretPickerRequest
     public bool ActiveOnly { get; set; } = true;
 }
 
+public class SecretPickerOptions
+{
+    public ICollection<string> TypeNames { get; set; } = [];
+    public ICollection<string> StoreNames { get; set; } = [];
+    public string? Scope { get; set; }
+    public bool AllowInlineCreate { get; set; } = true;
+}
+
 public class SecretPickerResponse
 {
     public ICollection<SecretModel> Items { get; set; } = [];
@@ -120,3 +142,8 @@ public class SecretTestResponse
     public bool Succeeded { get; set; }
     public string? Error { get; set; }
 }
+
+[JsonSerializable(typeof(SecretPickerOptions))]
+[JsonSerializable(typeof(SecretReference))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+internal partial class SecretJsonSerializerContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary
- Add the `secret-picker` UI hint handler in `Elsa.Studio.Secrets` and register it from `AddSecretsModule`.
- Add a `SecretPickerInput` adapter that reuses the existing picker, reads descriptor UI specifications, and stores wrapped selections as `Secret` expressions containing a serialized `SecretReference`.
- Pass `TypeNames`, `StoreNames`, `Scope`, and inline-create options into the picker and constrain inline creation to those filters.

## Validation
- `dotnet build src/modules/Elsa.Studio.Secrets/Elsa.Studio.Secrets.csproj` succeeded with 0 warnings and 0 errors.
- `dotnet build src/hosts/Elsa.Studio.Host.Wasm/Elsa.Studio.Host.Wasm.csproj` succeeded; the host still reports existing warnings outside this S3 slice.
- `git diff --check` passed.

Refs elsa-workflows/elsa-core#7551.
Closes elsa-workflows/elsa-core#7554.
Closes elsa-workflows/elsa-core#7563.
Closes elsa-workflows/elsa-core#7564.
Closes elsa-workflows/elsa-core#7565.
