### PR TITLE
[codex] Update Studio OIDC README docs

### DIFF
--- a/src/modules/Elsa.Studio.Authentication.OpenIdConnect.BlazorServer/README.md
+++ b/src/modules/Elsa.Studio.Authentication.OpenIdConnect.BlazorServer/README.md
@@ -8,7 +8,7 @@ This module provides the Blazor Server-specific implementation for OpenID Connec
 
 - **Cookie-based authentication** - Secure server-side session management
 - **Automatic token refresh** - Silent token renewal using refresh tokens via `OnValidatePrincipal`
-- **Token storage in auth properties** - Tokens stored server-side only, never exposed to browser
+- **Token storage in auth properties** - Tokens are stored in the protected authentication ticket and are not exposed to browser JavaScript
 - **Standard ASP.NET Core middleware** - Integrates with authentication and authorization pipeline
 - **Challenge-based login** - Users are redirected to OIDC provider for authentication
 
@@ -68,7 +68,7 @@ builder.Services.AddOpenIdConnectAuth(options =>
     options.SaveTokens = true; // Default: true (required for token access)
     options.CallbackPath = "/signin-oidc"; // Default
     options.SignedOutCallbackPath = "/signout-callback-oidc"; // Default
-    options.GetClaimsFromUserInfoEndpoint = true; // Default: true
+    options.GetClaimsFromUserInfoEndpoint = false; // Default: false
     options.RequireHttpsMetadata = true; // Default: true
     options.MetadataAddress = "https://.../.well-known/openid-configuration"; // Auto-discovered if not set
 });
@@ -111,11 +111,11 @@ Blazor Server uses ASP.NET Core cookie authentication:
 1. User is redirected to OIDC provider for authentication
 2. After successful login, tokens are stored in server-side authentication properties
 3. A secure HTTP-only cookie is issued to the browser
-4. Cookie contains an encrypted reference to the server-side session
-5. Tokens are never sent to or accessible by the browser
+4. The cookie contains an encrypted ASP.NET Core authentication ticket
+5. Tokens are not accessible to browser JavaScript
 
 **Security benefits:**
-- ✅ Tokens stored server-side only
+- ✅ Tokens stored in a protected authentication ticket
 - ✅ HTTP-only, secure cookies
 - ✅ No token exposure to JavaScript (XSS protection)
 - ✅ Tokens not visible in browser storage/network tools
@@ -240,13 +240,15 @@ builder.Services.AddOpenIdConnectAuth(
 
 ### Backend API Token Acquisition
 
-When your backend API requires different scopes than the authentication scopes, use `IBackendApiScopeProvider`:
+When your backend API requires different scopes than the authentication scopes, configure `BackendApiScopes`:
 
 ```csharp
-// Configure backend API scopes separately
-builder.Services.Configure<BackendApiScopeOptions>(options =>
+builder.Services.AddOpenIdConnectAuth(options =>
 {
-    options.Scopes = new[] { "api://your-api/elsa-server-api" };
+    options.Authority = "https://your-identity-server.com";
+    options.ClientId = "elsa-studio";
+    options.AuthenticationScopes = new[] { "openid", "profile", "offline_access" };
+    options.BackendApiScopes = new[] { "api://your-api/elsa-server-api" };
 });
 ```
 
@@ -257,15 +259,14 @@ The HTTP message handler automatically requests tokens with backend API scopes w
 ### Complete Setup Example
 
 ```csharp
+using Elsa.Studio.Authentication.OpenIdConnect.HttpMessageHandlers;
 using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions;
+using Elsa.Studio.Core.BlazorServer.Extensions;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Shell.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
-
-// Add Elsa Studio services
-builder.Services.AddElsaStudio(elsa =>
-{
-    elsa.AddBackend(backend => backend.Url = "https://your-elsa-api.com");
-});
 
 // Add OpenID Connect authentication
 builder.Services.AddOpenIdConnectAuth(options =>
@@ -273,8 +274,20 @@ builder.Services.AddOpenIdConnectAuth(options =>
     options.Authority = "https://login.microsoftonline.com/{tenant-id}/v2.0";
     options.ClientId = "{client-id}";
     options.ClientSecret = "{client-secret}";
-    options.AuthenticationScopes = new[] { "openid", "profile", "offline_access", "api://your-api/scope" };
+    options.AuthenticationScopes = new[] { "openid", "profile", "offline_access" };
+    options.BackendApiScopes = new[] { "api://your-api/scope" };
 });
+
+// Configure the Elsa backend HTTP client to use OIDC tokens.
+var backendApiConfig = new BackendApiConfig
+{
+    ConfigureBackendOptions = options => options.Url = new("https://your-elsa-api.com/elsa/api"),
+    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(OidcAuthenticatingApiHttpMessageHandler)
+};
+
+builder.Services.AddCore();
+builder.Services.AddShell();
+builder.Services.AddRemoteBackend(backendApiConfig);
 
 var app = builder.Build();
 
@@ -348,19 +361,14 @@ Azure AD v2.0 only allows one resource per token request. If you need tokens for
 ```csharp
 // Correct: Separate scopes for authentication vs backend API
 options.AuthenticationScopes = new[] { "openid", "profile", "offline_access" };
-
-// Backend API scopes configured separately
-builder.Services.Configure<BackendApiScopeOptions>(options =>
-{
-    options.Scopes = new[] { "api://your-api/elsa-server-api" };
-});
+options.BackendApiScopes = new[] { "api://your-api/elsa-server-api" };
 ```
 
 ## Security Considerations
 
 ### Token Security
 
-✅ **Tokens are secure** - Stored server-side only, never exposed to browser
+✅ **Tokens are protected** - Stored in the encrypted authentication ticket and not exposed to browser JavaScript
 ✅ **HTTP-only cookies** - Not accessible to JavaScript (XSS protection)
 ✅ **Encrypted cookies** - Cookie content is encrypted by ASP.NET Core
 ✅ **Secure transmission** - Cookies sent over HTTPS only

--- a/src/modules/Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm/README.md
+++ b/src/modules/Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm/README.md
@@ -87,9 +87,6 @@ builder.Services.AddOpenIdConnectAuth(options =>
     options.CallbackPath = "/authentication/login-callback"; // Default
     options.SignedOutCallbackPath = "/authentication/logout-callback"; // Default
 
-    // Optional: Absolute redirect URIs (only if AppBaseUrl is set)
-    options.AppBaseUrl = "https://your-app.com"; // Only needed for absolute URIs
-
     // Discovery
     options.MetadataAddress = "https://.../.well-known/openid-configuration"; // Auto-discovered if not set
 });
@@ -119,7 +116,7 @@ builder.Services.AddOpenIdConnectAuth(options =>
 - Use tenant-specific authority (not `/common` for production)
 - Register your app as a "Single Page Application" (SPA) in Azure AD
 - Add redirect URI: `https://your-app.com/authentication/login-callback`
-- Enable "Access tokens" and "ID tokens" under "Implicit grant and hybrid flows"
+- Do not configure a client secret for the SPA client
 - **Only include scopes for ONE resource** - Azure AD limitation (don't mix Graph scopes with custom API scopes)
 - For userinfo endpoint issues, see troubleshooting section below
 
@@ -264,23 +261,34 @@ Or use the `NavigateToLogin` component provided by this module:
 ### Complete Setup Example
 
 ```csharp
+using Elsa.Studio.Authentication.OpenIdConnect.HttpMessageHandlers;
 using Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.Extensions;
+using Elsa.Studio.Core.BlazorWasm.Extensions;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Shell.Extensions;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
-
-// Add Elsa Studio services
-builder.Services.AddElsaStudio(elsa =>
-{
-    elsa.AddBackend(backend => backend.Url = "https://your-elsa-api.com");
-});
 
 // Add OpenID Connect authentication
 builder.Services.AddOpenIdConnectAuth(options =>
 {
     options.Authority = "https://login.microsoftonline.com/{tenant-id}/v2.0";
     options.ClientId = "{client-id}";
-    options.AuthenticationScopes = new[] { "openid", "profile", "offline_access", "api://your-api/scope" };
+    options.AuthenticationScopes = new[] { "openid", "profile", "offline_access" };
+    options.BackendApiScopes = new[] { "api://your-api/scope" };
 });
+
+// Configure the Elsa backend HTTP client to use OIDC tokens.
+var backendApiConfig = new BackendApiConfig
+{
+    ConfigureBackendOptions = options => options.Url = new("https://your-elsa-api.com/elsa/api"),
+    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(OidcAuthenticatingApiHttpMessageHandler)
+};
+
+builder.Services.AddCore();
+builder.Services.AddShell();
+builder.Services.AddRemoteBackend(backendApiConfig);
 
 await builder.Build().RunAsync();
 ```
@@ -327,10 +335,7 @@ If you need both Graph and custom API tokens, configure them separately:
 options.AuthenticationScopes = new[] { "openid", "profile", "offline_access" };
 
 // Backend API scopes (for Elsa API calls)
-builder.Services.Configure<BackendApiScopeOptions>(backendOptions =>
-{
-    backendOptions.Scopes = new[] { "api://your-api/elsa-server-api" };
-});
+options.BackendApiScopes = new[] { "api://your-api/elsa-server-api" };
 ```
 
 ### Azure AD: UserInfo endpoint returns 401
@@ -341,7 +346,7 @@ builder.Services.Configure<BackendApiScopeOptions>(backendOptions =>
 
 **Solution 1 - Disable UserInfo endpoint (recommended):**
 
-The existing README for `Elsa.Studio.Authentication.OpenIdConnect` mentions setting `GetClaimsFromUserInfoEndpoint = false`, but this property doesn't exist in `OidcOptions` for Blazor WebAssembly (it's only available in Blazor Server).
+The shared `OidcOptions` model has `GetClaimsFromUserInfoEndpoint`, but the Blazor WebAssembly module relies on Microsoft's `Microsoft.AspNetCore.Components.WebAssembly.Authentication` pipeline and does not use that server-side OIDC handler option.
 
 For WASM, claims are automatically included in the ID token, so you typically don't need the UserInfo endpoint.
 
@@ -413,10 +418,8 @@ For Azure AD specifically, redirect URIs must be absolute:
 options.CallbackPath = "/authentication/login-callback";
 // Framework will use current origin: https://your-app.com/authentication/login-callback
 
-// Option 2: Set AppBaseUrl explicitly (only if needed)
-options.AppBaseUrl = "https://your-app.com";
-options.CallbackPath = "/authentication/login-callback";
-// Results in: https://your-app.com/authentication/login-callback
+// Register the exact absolute URI in your identity provider:
+// https://your-app.com/authentication/login-callback
 ```
 
 ## Security Considerations

--- a/src/modules/Elsa.Studio.Authentication.OpenIdConnect/README.md
+++ b/src/modules/Elsa.Studio.Authentication.OpenIdConnect/README.md
@@ -1,296 +1,165 @@
 # Elsa Studio Authentication - OpenID Connect
 
-A modern, best-practices OpenID Connect (OIDC) authentication module for Elsa Studio that leverages Microsoft's built-in authentication infrastructure.
+This module provides the shared OpenID Connect (OIDC) services used by Elsa Studio.
+It is not used directly by host applications. Use one of the hosting-specific packages instead:
 
-## Overview
+- `Elsa.Studio.Authentication.OpenIdConnect.BlazorServer`
+- `Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm`
 
-This module provides a clean, decoupled alternative to the OIDC implementation in `Elsa.Studio.Login`. It uses Microsoft's native authentication packages for automatic token management, PKCE support, and proper integration with ASP.NET Core and Blazor frameworks.
+The implementation is based on Microsoft's ASP.NET Core and Blazor authentication stacks. Studio signs users in with the OIDC provider, obtains access tokens, and attaches those tokens to HTTP and SignalR calls to the Elsa backend API.
 
-**Note**: This is one of potentially many authentication providers for Elsa Studio. It extends the shared `Elsa.Studio.Authentication.Abstractions` to provide OIDC-specific functionality.
-
-### Key Benefits
-
-- **Automatic Token Management**: Tokens are automatically refreshed by the framework
-- **Built-in PKCE Support**: Uses Microsoft's built-in Proof Key for Code Exchange implementation
-- **Proper Middleware Integration**: Integrates with ASP.NET Core authentication pipeline
-- **Hosting Model Optimized**: Separate implementations for Blazor Server and WebAssembly
-- **Clean Architecture**: No browser storage manipulation, uses framework-managed authentication state
-- **Security Best Practices**: Cookie-based sessions for Server, secure token provider for WASM
-- **Shared Abstractions**: Uses common patterns from `Elsa.Studio.Authentication.Abstractions`
-
-## Architecture
-
-### Project Structure
-
-```
-Elsa.Studio.Authentication.Abstractions/
-├── Contracts/
-│   └── ITokenAccessor.cs               # Shared token accessor abstraction
-└── Models/
-    └── AuthenticationOptions.cs        # Base authentication options
-
-Elsa.Studio.Authentication.OpenIdConnect/
-├── Contracts/
-│   └── IOidcTokenAccessor.cs           # OIDC-specific token accessor (extends ITokenAccessor)
-├── Models/
-│   └── OidcOptions.cs                  # OIDC configuration (extends AuthenticationOptions)
-└── Services/
-    └── OidcAuthenticationProvider.cs   # IAuthenticationProvider implementation
-
-Elsa.Studio.Authentication.OpenIdConnect.BlazorServer/
-├── Extensions/
-│   └── ServiceCollectionExtensions.cs  # Server DI setup
-└── Services/
-    └── ServerOidcTokenAccessor.cs      # Server-side token accessor
-
-Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm/
-├── Extensions/
-│   └── ServiceCollectionExtensions.cs  # WASM DI setup
-└── Services/
-    └── WasmOidcTokenAccessor.cs        # WASM-side token accessor
-```
-
-### Design Decisions
-
-#### Blazor Server Implementation
-- Uses `Microsoft.AspNetCore.Authentication.OpenIdConnect` middleware
-- Cookie-based authentication with secure session management
-- Tokens stored in authentication properties (server-side only)
-- Retrieved via `HttpContext.GetTokenAsync()` - no client storage
-
-#### Blazor WebAssembly Implementation
-- Uses `Microsoft.AspNetCore.Components.WebAssembly.Authentication`
-- Leverages built-in `IAccessTokenProvider` for automatic token management
-- Framework handles token refresh, expiry, and renewal automatically
-- Tokens never exposed directly to application code (security by design)
-
-## Installation & Usage
+## Hosting Models
 
 ### Blazor Server
 
-1. **Add Package References** (via project references or NuGet):
-   ```xml
-   <PackageReference Include="Elsa.Studio.Authentication.OpenIdConnect.BlazorServer" />
-   ```
+Use `Elsa.Studio.Authentication.OpenIdConnect.BlazorServer` when Elsa Studio runs as a Blazor Server app.
 
-2. **Configure in `Program.cs`**:
-   ```csharp
-   using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions;
+```csharp
+using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions;
 
-   // Configure OIDC authentication
-   builder.Services.AddOidcAuthentication(options =>
-   {
-       options.Authority = "https://your-identity-server.com";
-       options.ClientId = "elsa-studio";
-       options.ClientSecret = "your-client-secret"; // Optional for confidential clients
-       options.Scopes = new[] { "openid", "profile", "elsa_api", "offline_access" };
-       options.UsePkce = true; // Recommended
-   });
-   ```
+builder.Services.AddOpenIdConnectAuth(options =>
+{
+    options.Authority = "https://your-identity-server.com";
+    options.ClientId = "elsa-studio";
+    options.ClientSecret = "your-client-secret"; // Optional. Use only for confidential clients.
+    options.AuthenticationScopes = ["openid", "profile", "offline_access"];
+    options.BackendApiScopes = ["elsa_api"];
+    options.UsePkce = true;
+    options.SaveTokens = true;
+});
 
-3. **Add Authentication Middleware**:
-   ```csharp
-   // Before app.UseRouting()
-   app.UseAuthentication();
-   app.UseAuthorization();
-   ```
+// After UseRouting and before endpoint mapping.
+app.UseAuthentication();
+app.UseAuthorization();
+```
 
-4. **Protect Pages** (optional):
-   ```csharp
-   // In _Imports.razor or individual pages
-   @attribute [Authorize]
-   ```
+Blazor Server uses ASP.NET Core cookie authentication plus the OpenID Connect handler. Tokens are stored in the encrypted authentication ticket and are not exposed to browser JavaScript.
 
 ### Blazor WebAssembly
 
-1. **Add Package References**:
-   ```xml
-   <PackageReference Include="Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm" />
-   ```
+Use `Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm` when Elsa Studio runs as a WebAssembly app.
 
-2. **Configure in `Program.cs`**:
-   ```csharp
-   using Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.Extensions;
+```csharp
+using Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.Extensions;
 
-   // Configure OIDC authentication
-   builder.Services.AddElsaOidcAuthentication(options =>
-   {
-       options.Authority = "https://your-identity-server.com";
-       options.ClientId = "elsa-studio-wasm";
-       options.Scopes = new[] { "openid", "profile", "elsa_api", "offline_access" };
-       options.ResponseType = "code";
-       options.CallbackPath = "/authentication/login-callback";
-       options.SignedOutCallbackPath = "/authentication/logout-callback";
-   });
-   ```
+builder.Services.AddOpenIdConnectAuth(options =>
+{
+    options.Authority = "https://your-identity-server.com";
+    options.ClientId = "elsa-studio-wasm";
+    options.AuthenticationScopes = ["openid", "profile", "offline_access"];
+    options.BackendApiScopes = ["elsa_api"];
+    options.ResponseType = "code";
+});
+```
 
-   > **Note**: Use `AddElsaOidcAuthentication` instead of `AddOidcAuthentication` to avoid ambiguity with Microsoft's extension method.
+Do not configure a client secret for WebAssembly or other browser-hosted clients. These are public clients and should use authorization code flow with PKCE.
 
-3. **Add Authentication Components** in `App.razor`:
-   ```razor
-   <CascadingAuthenticationState>
-       <Router AppAssembly="@typeof(App).Assembly">
-           <Found Context="routeData">
-               <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                   <NotAuthorized>
-                       <RedirectToLogin />
-                   </NotAuthorized>
-               </AuthorizeRouteView>
-           </Found>
-       </Router>
-   </CascadingAuthenticationState>
-   ```
-3. **Authentication Routes**
+The WebAssembly package provides the `/authentication/{action}` routes used by `RemoteAuthenticatorView`, so host projects do not need to add their own `Authentication.razor` page when using the standard Elsa Studio shell.
 
-   This module ships the required `/authentication/{action}` route (hosting `RemoteAuthenticatorView`) as part of the `Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm` assembly.
+## Default Studio Hosts
 
-   That means integrators **do not** need to add an `Authentication.razor` file to their host project, as long as they use Elsa Studio's shell router that includes module assemblies (which the default Elsa Studio hosts do).
+The default Elsa Studio hosts select the authentication provider from configuration:
 
-### Azure AD / Microsoft Entra ID (Blazor WebAssembly)
+```json
+{
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://your-identity-server.com",
+      "ClientId": "elsa-studio",
+      "ClientSecret": "",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["elsa_api"],
+      "SaveTokens": true
+    }
+  },
+  "Backend": {
+    "Url": "https://localhost:5001/elsa/api"
+  }
+}
+```
 
-Azure AD has specific requirements for Blazor WebAssembly applications:
-
-1. **App Registration Setup**:
-   - Register your application in Azure AD (Azure Portal > Microsoft Entra ID > App registrations)
-   - Set "Supported account types" based on your needs (single/multi-tenant)
-   - Add a redirect URI for SPA: `https://your-app.com/authentication/login-callback`
-   - Enable "Access tokens" and "ID tokens" under "Implicit grant and hybrid flows"
-   - Create an API scope for your backend API (e.g., `api://your-api-id/elsa-server-api`)
-
-2. **Scopes Configuration**:
-   ```csharp
-   using Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.Extensions;
-
-   builder.Services.AddElsaOidcAuthentication(options =>
-   {
-       options.Authority = "https://login.microsoftonline.com/{tenant-id}/v2.0";
-       options.ClientId = "{client-id}";
-       
-       // IMPORTANT: Only include API scopes for your backend
-       // Do NOT mix Microsoft Graph scopes with custom API scopes
-       // Azure AD v2.0 only allows one resource per token request
-       options.Scopes = new[] 
-       { 
-           "openid",                                      // Required for OIDC
-           "profile",                                     // User profile claims
-           "offline_access",                              // Refresh tokens
-           "api://{your-api-id}/elsa-server-api"         // Your API scope
-       };
-       
-       options.ResponseType = "code";
-       options.CallbackPath = "/authentication/login-callback";
-       options.SignedOutCallbackPath = "/authentication/logout-callback";
-   });
-   ```
-
-3. **Key Considerations**:
-   - **Single Resource per Token**: Azure AD v2.0 only allows scopes for ONE resource per token. Don't mix Graph API scopes (`https://graph.microsoft.com/.default`) with your custom API scopes.
-   - **Scope Format**: Use the full scope URI format: `api://{application-id}/{scope-name}`
-   - **Standard Scopes**: The framework automatically filters standard OIDC scopes (`openid`, `profile`, `email`, `offline_access`) and only passes resource scopes during token requests.
-   - **UserInfo Endpoint**: If you encounter 401 errors from the userinfo endpoint, set `options.GetClaimsFromUserInfoEndpoint = false` (most Azure AD setups don't require this).
-
-4. **Backend API Configuration**:
-   Your backend API must accept tokens from Azure AD:
-   ```csharp
-   // In your API's Program.cs
-   builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-       .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-   ```
-
-5. **Troubleshooting Azure AD**:
-   - **AADSTS28000** (Multi-resource error): Remove Graph scopes from `options.Scopes`, only include your API scope
-   - **AADSTS28003** (Scope not found): Verify the API scope is exposed in your app registration
-   - **401 from userinfo**: Set `GetClaimsFromUserInfoEndpoint = false` in options
-   - **Login succeeds but redirects to /login-failed**: Ensure your API scope is correctly configured and the token audience matches your API's expected audience
+`ClientSecret` is optional. Configure it only for confidential clients, such as a Blazor Server Studio host that can keep the secret server-side.
 
 ## Configuration Options
 
-### OidcOptions
+| Property | Description | Default |
+| --- | --- | --- |
+| `Authority` | OIDC provider authority URL. | Required |
+| `ClientId` | Client ID registered with the provider. | Required |
+| `ClientSecret` | Optional client secret for confidential clients. Do not use from WebAssembly. | `null` |
+| `AuthenticationScopes` | Scopes requested during sign-in. | `["openid", "profile", "offline_access"]` |
+| `BackendApiScopes` | Scopes requested for tokens sent to the Elsa backend API. | `[]` |
+| `ResponseType` | OAuth/OIDC response type. | `"code"` |
+| `UsePkce` | Enables PKCE in the Blazor Server OIDC handler. | `true` |
+| `SaveTokens` | Saves tokens in server auth properties. Blazor Server only. | `true` |
+| `CallbackPath` | Sign-in callback path. Server default: `/signin-oidc`; WASM default: `/authentication/login-callback`. | Host-specific |
+| `SignedOutCallbackPath` | Sign-out callback path. Server default: `/signout-callback-oidc`; WASM default: `/authentication/logout-callback`. | Host-specific |
+| `RequireHttpsMetadata` | Requires HTTPS metadata endpoints. | `true` |
+| `GetClaimsFromUserInfoEndpoint` | Calls the OIDC UserInfo endpoint after sign-in. | `false` |
+| `MetadataAddress` | Optional metadata endpoint override. | Auto-discovered |
+| `NameClaimType` | Claim type used for the user name. | `"name"` |
+| `RoleClaimType` | Claim type used for roles. | `"role"` |
 
-`OidcOptions` extends `AuthenticationOptions` from `Elsa.Studio.Authentication.Abstractions`.
+## Authentication Scopes vs Backend API Scopes
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `Authority` | `string` | OIDC provider authority URL | Required |
-| `ClientId` | `string` | Client ID registered with provider | Required |
-| `ClientSecret` | `string?` | Client secret (Server only, optional) | `null` |
-| `ResponseType` | `string` | OAuth2 response type | `"code"` |
-| `Scopes` | `string[]` | Requested scopes (inherited) | `["openid", "profile", "offline_access"]` |
-| `UsePkce` | `bool` | Enable PKCE | `true` |
-| `SaveTokens` | `bool` | Save tokens in auth properties (Server) | `true` |
-| `CallbackPath` | `string` | Authentication callback path | `"/signin-oidc"` |
-| `SignedOutCallbackPath` | `string` | Sign-out callback path | `"/signout-callback-oidc"` |
-| `RequireHttpsMetadata` | `bool` | Require HTTPS for metadata (inherited) | `true` |
-| `GetClaimsFromUserInfoEndpoint` | `bool` | Fetch claims from UserInfo | `true` |
-| `MetadataAddress` | `string?` | Custom metadata address | Auto-discovered |
+Use `AuthenticationScopes` for the sign-in flow. These are usually identity scopes such as `openid`, `profile`, `email`, and optionally `offline_access`.
 
-## Token Access
-
-Both implementations provide access to tokens via the standard `IAuthenticationProvider` interface:
-
-```csharp
-@inject IAuthenticationProviderManager AuthProviderManager
-
-var accessToken = await AuthProviderManager.GetAccessTokenAsync();
-```
-
-### Scope-Specific Token Access (OIDC Multi-Audience)
-
-For scenarios where different APIs require different scopes (e.g., Microsoft Graph vs. your backend API), you can request scope-specific tokens directly:
-
-```csharp
-@inject IAuthenticationProvider AuthProvider
-
-// Get token for backend API
-var backendScopes = new[] { "api://my-api/elsa-server-api" };
-var backendToken = await AuthProvider.GetAccessTokenAsync(backendScopes);
-
-// Get token for Microsoft Graph
-var graphScopes = new[] { "https://graph.microsoft.com/User.Read" };
-var graphToken = await AuthProvider.GetAccessTokenAsync(graphScopes);
-```
-
-**Configuration** (appsettings.json):
+Use `BackendApiScopes` for access tokens sent to the Elsa backend API. This is useful when the backend API has its own audience or scope.
 
 ```json
 {
   "Authentication": {
     "OpenIdConnect": {
-      "Scopes": ["openid", "profile", "offline_access", "https://graph.microsoft.com/User.Read"]
-    },
-    "BackendApiScopes": {
-      "Scopes": ["api://my-api/elsa-server-api"]
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["api://your-api-app-id/elsa-server-api"]
     }
   }
 }
 ```
 
-The `BackendApiScopes` are automatically used by the HTTP message handler when calling the Elsa backend API.
+The `OidcAuthenticatingApiHttpMessageHandler` attaches a bearer token to outgoing Elsa backend API requests. SignalR connections are configured by `OidcHttpConnectionOptionsConfigurator`.
 
-### Token Types
+## Client Secrets
 
-- **Access Token** - Access token for API calls (available in both Server and WASM)
-- **ID Token** - ID token with user claims (Server only - via `ITokenAccessor.GetIdTokenAsync()`)
-- **Refresh Token** - Refresh token for silent renewal (Server only - via `ITokenAccessor.GetRefreshTokenAsync()`)
+A client secret authenticates the OAuth client application to the identity provider. It is not the user's password, and Elsa Studio does not send the user's credentials to the identity provider.
 
-> **Note**: In Blazor WASM, only access tokens are directly accessible through the provider. ID and refresh tokens are managed internally by the framework for security and are not exposed to application code.
+Use a client secret only when the Studio host is a confidential client that can protect it, such as Blazor Server. For WebAssembly, SPA, mobile, and other public clients, leave `ClientSecret` unset and rely on authorization code flow with PKCE.
 
-## SignalR Integration
+## Token Refresh
 
-The module works seamlessly with `WorkflowInstanceObserverFactory` for SignalR connections:
+### Blazor Server
 
-```csharp
-// Token is automatically retrieved and applied to SignalR hub connections
-var observer = await observerFactory.CreateAsync(workflowInstanceId);
+Blazor Server uses ASP.NET Core Cookie plus OpenID Connect authentication. When `SaveTokens = true`, the access token, refresh token if issued, and expiration metadata are stored in the authentication ticket.
+
+Access tokens are refreshed by `AuthCookieEvents.OnValidatePrincipal`. On each HTTP request, the cookie handler checks whether the access token is close to expiry and, if needed, calls the provider token endpoint with the refresh token grant.
+
+Refresh prerequisites:
+
+- `SaveTokens = true`
+- `offline_access` requested when the provider requires it for refresh tokens
+- the identity provider issues refresh tokens to this client
+
+### Blazor WebAssembly
+
+WebAssembly uses `Microsoft.AspNetCore.Components.WebAssembly.Authentication`. Token acquisition and refresh are handled by the framework through `IAccessTokenProvider`.
+
+## Microsoft Entra ID Notes
+
+For Microsoft Entra ID, prefer a tenant-specific authority:
+
+```text
+https://login.microsoftonline.com/{tenant-id}/v2.0
 ```
 
-The `IAuthenticationProviderManager` automatically retrieves the access token from the appropriate source (HTTP context for Server, token provider for WASM).
+Entra ID v2.0 allows scopes for one resource per token request. Do not mix Microsoft Graph scopes with custom API scopes in the same backend API token request. If Studio needs a token for the Elsa backend API, place that API scope in `BackendApiScopes`.
 
-## Migration from Elsa.Studio.Login
+If the UserInfo endpoint returns 401, leave `GetClaimsFromUserInfoEndpoint` disabled unless your app registration and scopes explicitly allow calling UserInfo.
 
-If you're currently using the OIDC implementation in `Elsa.Studio.Login`, here's how to migrate:
+## Migration from `Elsa.Studio.Login`
 
-### Before (Blazor Server):
+Legacy OIDC through `Elsa.Studio.Login` configured explicit authorization, token, and end-session endpoints:
+
 ```csharp
 builder.Services.AddLoginModule();
 builder.Services.UseOpenIdConnect(options =>
@@ -300,211 +169,25 @@ builder.Services.UseOpenIdConnect(options =>
     options.EndSessionEndpoint = "https://identity-server.com/connect/endsession";
     options.ClientId = "elsa-studio";
     options.ClientSecret = "secret";
-    options.Scopes = new[] { "openid", "profile", "elsa_api" };
+    options.Scopes = ["openid", "profile", "elsa_api"];
 });
 ```
 
-### After (Blazor Server):
+The current OIDC modules use authority metadata discovery and hosting-specific framework integration:
+
 ```csharp
-builder.Services.AddOidcAuthentication(options =>
+builder.Services.AddOpenIdConnectAuth(options =>
 {
-    options.Authority = "https://identity-server.com"; // Auto-discovers endpoints
+    options.Authority = "https://identity-server.com";
     options.ClientId = "elsa-studio";
-    options.ClientSecret = "secret";
-    options.Scopes = new[] { "openid", "profile", "elsa_api", "offline_access" };
-});
-
-// Add middleware
-app.UseAuthentication();
-app.UseAuthorization();
-```
-
-## Differences from Legacy Implementation
-
-| Feature | Legacy (Elsa.Studio.Login) | New (This Module) |
-|---------|---------------------------|-------------------|
-| Token Storage | Browser LocalStorage/SessionStorage | Server: Auth properties (server-side only)<br>WASM: Framework-managed |
-| Token Refresh | Manual with custom service | Automatic via framework |
-| PKCE | Manual implementation | Built-in framework support |
-| Middleware | Custom authorization redirect | Standard ASP.NET Core auth pipeline |
-| Token Access | Direct storage access | Via `IAuthenticationProvider` abstraction |
-| Security | Tokens exposed in browser storage | Server: Session cookies only<br>WASM: Framework-secured |
-
-## Troubleshooting
-
-### Common Issues
-
-1. **"SaveTokens must be true" error**:
-   - Ensure `SaveTokens = true` in Server configuration
-   - This is required for token retrieval via `HttpContext.GetTokenAsync()`
-
-2. **Tokens not available in WASM**:
-   - Only access tokens are directly accessible in WASM
-   - ID and refresh tokens are managed by the framework for security
-
-3. **SignalR connections fail**:
-   - Ensure the `offline_access` scope is requested for refresh tokens
-   - Verify the identity provider returns tokens with appropriate audience
-
-4. **Pre-rendering issues in Server**:
-   - Tokens are not available during pre-rendering
-   - Use `@attribute [Authorize]` to ensure authentication before render
-
-## Silent access token refresh (Blazor Server)
-
-On Blazor Server, Elsa Studio uses the standard ASP.NET Core Cookie + OpenID Connect handler.
-When you set `SaveTokens = true`, the handler stores `access_token`, `refresh_token` (if issued) and `expires_at` in the authentication cookie properties.
-
-This module **automatically refreshes the access token** using the standard ASP.NET Core pattern:
-`CookieAuthenticationEvents.OnValidatePrincipal`. This event fires on every HTTP request, checks if the token is about to expire, and refreshes it if needed—**no JavaScript required**.
-
-### How it works
-
-1. On each HTTP request, the cookie authentication handler validates the principal
-2. `OidcCookieAuthenticationEvents.OnValidatePrincipal` checks if `expires_at` is within the skew window (default: 2 minutes)
-3. If expiring soon, it calls the OIDC provider's `token_endpoint` with the `refresh_token` grant
-4. The new tokens are stored in the cookie (via `context.ShouldRenew = true`)
-5. The user continues without interruption
-
-### Flip-a-switch configuration
-
-The only thing you need to do to enable silent refresh is to keep refresh tokens enabled and request `offline_access`:
-
-```csharp
-using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions;
-using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Models;
-
-builder.Services.AddOidcAuthentication(options =>
-{
-    options.Authority = "https://login.microsoftonline.com/{tenantId}/v2.0"; // or your provider
-    options.ClientId = "...";
-
-    // Required if you want the handler to store tokens in the auth cookie.
-    options.SaveTokens = true;
-
-    // Required if you want refresh tokens.
-    // Note: some providers/app registrations might not issue a refresh token even if requested.
-    options.Scopes = new[] { "openid", "profile", "offline_access" };
-});
-
-// Optional: control refresh behavior.
-builder.Services.Configure<OidcTokenRefreshOptions>(options =>
-{
-    options.EnableRefreshTokens = true; // default
-    options.RefreshSkew = TimeSpan.FromMinutes(2); // default
+    options.ClientSecret = "secret"; // Blazor Server confidential clients only.
+    options.AuthenticationScopes = ["openid", "profile", "offline_access"];
+    options.BackendApiScopes = ["elsa_api"];
 });
 ```
 
-### Prerequisites and behavior
+## Related Modules
 
-- `SaveTokens` must be `true` (otherwise no tokens are available in the auth cookie).
-- `offline_access` should be requested (otherwise a refresh token is typically not issued).
-- Token refresh happens automatically on every HTTP request via `OnValidatePrincipal`—this is the standard ASP.NET Core pattern used by most OIDC implementations.
-- If no refresh token is available, or refresh fails, the principal is rejected and the user is redirected to re-authenticate.
-
-### Optional: Browser-side ping for idle tabs
-
-For long-lived idle browser tabs (where no HTTP requests occur), you can optionally add the `OidcPersistedRefreshPing` component to your layout. This periodically POSTs to a refresh endpoint to keep the session alive:
-
-```razor
-@* In your MainLayout.razor - OPTIONAL, only if needed for idle tab scenarios *@
-<OidcPersistedRefreshPing />
-```
-
-**Most applications don't need this** because normal user interaction generates HTTP requests that trigger `OnValidatePrincipal`.
-
-### Microsoft Entra ID notes
-
-For Microsoft Entra ID (Azure AD), the authority usually looks like:
-- Tenant-specific: `https://login.microsoftonline.com/{tenantId}/v2.0`
-- Or common endpoint (multi-tenant apps): `https://login.microsoftonline.com/common/v2.0`
-
-Refresh tokens depend on:
-- requesting `offline_access`
-- your app registration configuration / consent
-- Entra token policies (token lifetimes, session policies)
-
-If you don't receive a refresh token, the app will still work, but access-token renewal will require re-authentication.
-
-### Advanced overrides (rarely needed)
-
-By default, the module auto-discovers the `token_endpoint` from OIDC metadata and uses the configured `ClientId`/`ClientSecret` from `AddOidcAuthentication`.
-
-You can override any of these via `OidcTokenRefreshOptions`:
-
-```csharp
-builder.Services.Configure<OidcTokenRefreshOptions>(options =>
-{
-    options.EnableRefreshTokens = true;
-
-    // Override token endpoint discovery.
-    options.TokenEndpoint = "https://issuer.example.com/oauth2/v2.0/token";
-
-    // Override client credentials.
-    options.ClientId = "...";
-    options.ClientSecret = "..."; // optional
-});
-```
-
-### Host configuration example (appsettings.json)
-
-In the Blazor Server host, you can enable persisted silent refresh purely via configuration:
-
-```json
-{
-  "Authentication": {
-    "Provider": "OpenIdConnect",
-    "OpenIdConnect": {
-      "Authority": "https://login.microsoftonline.com/{tenantId}/v2.0",
-      "ClientId": "...",
-      "ClientSecret": "...",
-      "Scopes": ["openid", "profile", "offline_access"],
-      "SaveTokens": true,
-      "TokenRefresh": {
-        "Strategy": "Persisted",
-        "Ping": {
-          "RefreshEndpointPath": "/authentication/refresh",
-          "Interval": "00:01:00"
-        }
-      }
-    }
-  }
-}
-```
-
-> Set `TokenRefresh:Strategy` to `BestEffort` (or omit it) to disable persisted refresh.
-
-### Microsoft Entra ID: `graph.microsoft.com/oidc/userinfo` returns 401
-
-On Blazor WebAssembly, Microsoft's built-in OIDC stack may call the OIDC UserInfo endpoint.
-With Microsoft Entra ID, this endpoint is hosted on Microsoft Graph (e.g. `https://graph.microsoft.com/oidc/userinfo`).
-
-If you see a login failure with a browser console error like:
-
-- `graph.microsoft.com/oidc/userinfo: 401 (Unauthorized)`
-
-add a Microsoft Graph delegated permission scope such as `User.Read`.
-
-#### Example (`appsettings.json`)
-
-```json
-{
-  "Authentication": {
-    "Provider": "OpenIdConnect",
-    "OpenIdConnect": {
-      "Scopes": [
-        "openid",
-        "profile",
-        "offline_access",
-        "https://graph.microsoft.com/User.Read",
-        "api://{your-api-app-id}/elsa-server-api"
-      ]
-    }
-  }
-}
-```
-
-Then, in the Entra app registration:
-
-- Add Microsoft Graph → **Delegated permissions** → `User.Read`
-- Grant admin consent (or ensure user consent is allowed in your tenant)
+- `Elsa.Studio.Authentication.OpenIdConnect.BlazorServer`
+- `Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm`
+- `Elsa.Studio.Authentication.Abstractions`


### PR DESCRIPTION
## Summary
- Rewrites the shared OIDC README around the actual Elsa Studio 3.7 hosting model.
- Corrects Blazor Server and WebAssembly README examples to use `AddOpenIdConnectAuth`, `AuthenticationScopes`, and `BackendApiScopes`.
- Clarifies that client secrets are only for confidential clients and should not be used by WebAssembly/SPAs.

## Why
The README docs had drifted from the 3.7 implementation and mixed outdated APIs with current hosting-specific modules.

## Validation
- Ran `git diff --check` for the touched README files.
- Searched touched README files for stale API names such as `AddOidcAuthentication`, `AddElsaOidcAuthentication`, `BackendApiScopeOptions`, and `AppBaseUrl`.
