### PR TITLE
Add operational dashboard UI

### DIFF
--- a/Elsa.Studio.sln
+++ b/Elsa.Studio.sln
@@ -152,6 +152,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "platform", "platform", "{78
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "secrets", "secrets", "{6F1230C3-4315-41EC-9599-2E7EA7F1994B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Studio.Dashboard.Tests", "src\modules\Elsa.Studio.Dashboard.Tests\Elsa.Studio.Dashboard.Tests.csproj", "{72263204-20E5-4EEF-AEA2-72E56929FA04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -739,6 +741,18 @@ Global
 		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x64.Build.0 = Release|Any CPU
 		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x86.ActiveCfg = Release|Any CPU
 		{5138EE76-F56E-48D3-8DD8-67EC46DB3528}.Release|x86.Build.0 = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|x64.Build.0 = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Debug|x86.Build.0 = Debug|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|x64.ActiveCfg = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|x64.Build.0 = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|x86.ActiveCfg = Release|Any CPU
+		{72263204-20E5-4EEF-AEA2-72E56929FA04}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -806,6 +820,7 @@ Global
 		{5138EE76-F56E-48D3-8DD8-67EC46DB3528} = {78D70646-ED98-4220-830B-59B910A964B1}
 		{250EE233-BF7A-459C-8FC9-B26D81880442} = {A610001C-833B-4359-BD59-C65D3133295D}
 		{BC7D8A73-A386-4D89-9CBF-88BDC18CC85C} = {6F1230C3-4315-41EC-9599-2E7EA7F1994B}
+		{72263204-20E5-4EEF-AEA2-72E56929FA04} = {D66B9A40-8608-46F3-9868-625C50EACE43}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5B8719CC-CF87-45E1-BE1A-13842F951B28}

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -117,7 +117,7 @@ builder.Services.AddCore().Replace(new(typeof(IBrandingProvider), typeof(StudioB
 builder.Services.AddShell(options => configuration.GetSection("Shell").Bind(options));
 builder.Services.AddRemoteBackend(backendApiConfig);
 
-builder.Services.AddDashboardModule();
+builder.Services.AddDashboardModule(backendApiConfig);
 builder.Services.AddWorkflowsModule();
 builder.Services.AddAlterationsModule();
 builder.Services.AddOpenTelemetryDiagnosticsModule(backendApiConfig);

--- a/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
@@ -90,7 +90,7 @@ services.AddCore();
 services.AddShell();
 services.AddRemoteBackend(backendApiConfig);
 
-services.AddDashboardModule();
+services.AddDashboardModule(backendApiConfig);
 services.AddWorkflowsModule();
 services.AddAlterationsModule();
 services.AddConsoleLogsModule(backendApiConfig);

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardMetricFormatterTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardMetricFormatterTests.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using Elsa.Studio.Dashboard.Services;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardMetricFormatterTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+
+    public DashboardMetricFormatterTests()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1200, "1,200")]
+    public void Count_FormatsWholeNumbers(long value, string expected)
+    {
+        var result = DashboardMetricFormatter.Count(value);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, "N/A")]
+    [InlineData(500, "500 ms")]
+    [InlineData(1500, "1.5 s")]
+    [InlineData(180000, "3.0 min")]
+    [InlineData(7200000, "2.0 h")]
+    public void Duration_FormatsUsefulUnit(int? milliseconds, string expected)
+    {
+        var duration = milliseconds == null ? (TimeSpan?)null : TimeSpan.FromMilliseconds(milliseconds.Value);
+
+        var result = DashboardMetricFormatter.Duration(duration);
+
+        Assert.Equal(expected, result);
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardNavigationTargetMapperTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardNavigationTargetMapperTests.cs
@@ -1,0 +1,40 @@
+using Elsa.Studio.Dashboard.Services;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardNavigationTargetMapperTests
+{
+    [Theory]
+    [InlineData("running", "workflows/instances?status=Running")]
+    [InlineData("faulted", "workflows/instances?subStatus=Faulted&hasIncidents=true")]
+    [InlineData("suspended", "workflows/instances?subStatus=Suspended")]
+    [InlineData("interrupted", "workflows/instances?subStatus=Interrupted")]
+    [InlineData("incidents", "workflows/instances?hasIncidents=true")]
+    public void ForMetric_ReturnsWorkflowInstanceTarget(string metric, string expected)
+    {
+        var result = DashboardNavigationTargetMapper.ForMetric(metric);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ForWorkflowInstance_EscapesInstanceId()
+    {
+        var result = DashboardNavigationTargetMapper.ForWorkflowInstance("instance/1");
+
+        Assert.Equal("workflows/instances/instance%2F1/view", result);
+    }
+
+    [Theory]
+    [InlineData("WorkflowInstances", "faulted", "workflows/instances?subStatus=Faulted&hasIncidents=true")]
+    [InlineData("StructuredLogs", "errors", "diagnostics/structured-logs?level=Error")]
+    [InlineData("ConsoleLogs", "dropped", "diagnostics/console?stream=stderr")]
+    [InlineData("Runtime", "runtime", null)]
+    public void ForFinding_ReturnsRelevantTarget(string targetKind, string target, string? expected)
+    {
+        var result = DashboardNavigationTargetMapper.ForFinding(targetKind, target);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardRangeMapperTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardRangeMapperTests.cs
@@ -1,0 +1,33 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardRangeMapperTests
+{
+    [Theory]
+    [InlineData("1h", DashboardRangeKeys.OneHour)]
+    [InlineData("24h", DashboardRangeKeys.TwentyFourHours)]
+    [InlineData("7d", DashboardRangeKeys.SevenDays)]
+    [InlineData(null, DashboardRangeKeys.TwentyFourHours)]
+    [InlineData("invalid", DashboardRangeKeys.TwentyFourHours)]
+    public void Normalize_ReturnsSupportedRangeOrDefault(string? range, string expected)
+    {
+        var result = DashboardRangeMapper.Normalize(range);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1h", DashboardTrendGranularity.Minute)]
+    [InlineData("24h", DashboardTrendGranularity.Hour)]
+    [InlineData("7d", DashboardTrendGranularity.Day)]
+    [InlineData("invalid", DashboardTrendGranularity.Hour)]
+    public void GetDefaultGranularity_ReturnsRangeGranularity(string range, string expected)
+    {
+        var result = DashboardRangeMapper.GetDefaultGranularity(range);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardUiMapperTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardUiMapperTests.cs
@@ -1,0 +1,46 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using MudBlazor;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardUiMapperTests
+{
+    [Theory]
+    [InlineData(DashboardRuntimeStatusKeys.AcceptingWork, Color.Success, "Accepting work")]
+    [InlineData(DashboardRuntimeStatusKeys.Paused, Color.Warning, "Paused")]
+    [InlineData(DashboardRuntimeStatusKeys.Draining, Color.Info, "Draining")]
+    [InlineData(DashboardRuntimeStatusKeys.Unavailable, Color.Error, "Unavailable")]
+    public void RuntimeMapping_ReturnsSemanticColorAndLabel(string status, Color expectedColor, string expectedLabel)
+    {
+        Assert.Equal(expectedColor, DashboardUiMapper.RuntimeColor(status));
+        Assert.Equal(expectedLabel, DashboardUiMapper.RuntimeLabel(status));
+    }
+
+    [Theory]
+    [InlineData(DashboardFindingSeverity.Success, Severity.Success, Color.Success)]
+    [InlineData(DashboardFindingSeverity.Warning, Severity.Warning, Color.Warning)]
+    [InlineData(DashboardFindingSeverity.Error, Severity.Error, Color.Error)]
+    [InlineData(DashboardFindingSeverity.Critical, Severity.Error, Color.Error)]
+    [InlineData(DashboardFindingSeverity.Info, Severity.Info, Color.Info)]
+    public void SeverityMapping_ReturnsSemanticSeverityAndColor(string severity, Severity expectedSeverity, Color expectedColor)
+    {
+        Assert.Equal(expectedSeverity, DashboardUiMapper.Severity(severity));
+        Assert.Equal(expectedColor, DashboardUiMapper.SeverityColor(severity));
+        Assert.False(string.IsNullOrWhiteSpace(DashboardUiMapper.SeverityIcon(severity)));
+    }
+
+    [Theory]
+    [InlineData("Available", "Available", Color.Success)]
+    [InlineData("Unauthorized", "No access", Color.Warning)]
+    [InlineData("NotInstalled", "Not installed", Color.Default)]
+    [InlineData("Unavailable", "Unavailable", Color.Error)]
+    public void CapabilityMapping_ReturnsOperatorLabelAndColor(string status, string expectedLabel, Color expectedColor)
+    {
+        var capability = new DashboardCapabilityStatus(status);
+
+        Assert.Equal(expectedLabel, DashboardUiMapper.CapabilityLabel(capability));
+        Assert.Equal(expectedColor, DashboardUiMapper.CapabilityColor(capability));
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Studio.Dashboard\Elsa.Studio.Dashboard.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Studio.Dashboard/Client/IDashboardApi.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Client/IDashboardApi.cs
@@ -1,0 +1,40 @@
+using Elsa.Studio.Dashboard.Models;
+using Refit;
+
+namespace Elsa.Studio.Dashboard.Client;
+
+/// <summary>
+/// Backend API for the operational dashboard.
+/// </summary>
+public interface IDashboardApi
+{
+    [Get("/dashboard/overview")]
+    Task<DashboardOverview> GetOverviewAsync(
+        [AliasAs("range")] string? range = null,
+        [AliasAs("includeSystem")] bool includeSystem = false,
+        CancellationToken cancellationToken = default);
+
+    [Post("/dashboard/workflow-trends")]
+    Task<DashboardTrendResponse> GetWorkflowTrendsAsync(
+        [Body] DashboardTrendRequest request,
+        CancellationToken cancellationToken = default);
+
+    [Get("/dashboard/needs-attention")]
+    Task<DashboardNeedsAttentionResponse> GetNeedsAttentionAsync(
+        [AliasAs("range")] string? range = null,
+        [AliasAs("take")] int take = 8,
+        [AliasAs("includeSystem")] bool includeSystem = false,
+        CancellationToken cancellationToken = default);
+
+    [Get("/dashboard/recent-activity")]
+    Task<DashboardRecentActivityResponse> GetRecentActivityAsync(
+        [AliasAs("range")] string? range = null,
+        [AliasAs("take")] int take = 20,
+        [AliasAs("includeSystem")] bool includeSystem = false,
+        CancellationToken cancellationToken = default);
+
+    [Post("/dashboard/workflow-hotspots")]
+    Task<DashboardWorkflowHotspotsResponse> GetWorkflowHotspotsAsync(
+        [Body] DashboardWorkflowHotspotsRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardDiagnosticsSnapshot.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardDiagnosticsSnapshot.razor
@@ -1,0 +1,46 @@
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header">
+        <MudText Typo="Typo.subtitle1">Diagnostics snapshot</MudText>
+        <MudIcon Icon="@Icons.Material.Outlined.MonitorHeart" Size="Size.Small" />
+    </MudStack>
+
+    <MudGrid Spacing="2">
+        <MudItem xs="12" md="6">
+            <div class="dashboard-diagnostics-block">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudText Typo="Typo.overline">Structured logs</MudText>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DashboardUiMapper.CapabilityColor(Summary.StructuredLogs.Capability)">
+                        @DashboardUiMapper.CapabilityLabel(Summary.StructuredLogs.Capability)
+                    </MudChip>
+                </MudStack>
+                <DashboardDiagnosticsValue Label="Sources" Value="@DashboardMetricFormatter.Count(Summary.StructuredLogs.SourceCount)" />
+                <DashboardDiagnosticsValue Label="Stale" Value="@DashboardMetricFormatter.Count(Summary.StructuredLogs.StaleSourceCount)" Color="@StaleColor(Summary.StructuredLogs.StaleSourceCount)" />
+                <DashboardDiagnosticsValue Label="Errors / critical" Value="@DashboardMetricFormatter.Count(Summary.StructuredLogs.RecentErrorOrCriticalCount)" Color="@ErrorColor(Summary.StructuredLogs.RecentErrorOrCriticalCount)" />
+                <DashboardDiagnosticsValue Label="Dropped writes" Value="@DashboardMetricFormatter.Count(Summary.StructuredLogs.DroppedWriteCount)" Color="@ErrorColor(Summary.StructuredLogs.DroppedWriteCount)" />
+                <MudButton Href="@DashboardNavigationTargetMapper.StructuredLogs" Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Outlined.OpenInNew">Open logs</MudButton>
+            </div>
+        </MudItem>
+        <MudItem xs="12" md="6">
+            <div class="dashboard-diagnostics-block">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudText Typo="Typo.overline">Console</MudText>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DashboardUiMapper.CapabilityColor(Summary.ConsoleLogs.Capability)">
+                        @DashboardUiMapper.CapabilityLabel(Summary.ConsoleLogs.Capability)
+                    </MudChip>
+                </MudStack>
+                <DashboardDiagnosticsValue Label="Sources" Value="@DashboardMetricFormatter.Count(Summary.ConsoleLogs.SourceCount)" />
+                <DashboardDiagnosticsValue Label="Stale" Value="@DashboardMetricFormatter.Count(Summary.ConsoleLogs.StaleSourceCount)" Color="@StaleColor(Summary.ConsoleLogs.StaleSourceCount)" />
+                <DashboardDiagnosticsValue Label="stderr" Value="@DashboardMetricFormatter.Count(Summary.ConsoleLogs.RecentStderrCount)" Color="@ErrorColor(Summary.ConsoleLogs.RecentStderrCount)" />
+                <DashboardDiagnosticsValue Label="Dropped lines" Value="@DashboardMetricFormatter.Count(Summary.ConsoleLogs.DroppedLineCount)" Color="@ErrorColor(Summary.ConsoleLogs.DroppedLineCount)" />
+                <MudButton Href="@DashboardNavigationTargetMapper.Console" Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Outlined.OpenInNew">Open console</MudButton>
+            </div>
+        </MudItem>
+    </MudGrid>
+</MudPaper>
+
+@code {
+    [Parameter] public DashboardDiagnosticsSummary Summary { get; set; } = new();
+
+    private static Color StaleColor(long value) => value > 0 ? Color.Warning : Color.Default;
+    private static Color ErrorColor(long value) => value > 0 ? Color.Error : Color.Default;
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardDiagnosticsValue.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardDiagnosticsValue.razor
@@ -1,0 +1,10 @@
+<MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-diagnostics-value">
+    <MudText Typo="Typo.body2" Class="dashboard-muted">@Label</MudText>
+    <MudText Typo="Typo.body2" Color="@Color">@Value</MudText>
+</MudStack>
+
+@code {
+    [Parameter] public string Label { get; set; } = null!;
+    [Parameter] public string Value { get; set; } = "0";
+    [Parameter] public Color Color { get; set; } = Color.Default;
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardMetricCard.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardMetricCard.razor
@@ -1,0 +1,36 @@
+@if (!string.IsNullOrWhiteSpace(Href))
+{
+    <MudLink Href="@Href" Underline="Underline.None" Class="dashboard-card-link" aria-label="@AriaLabel">
+        @CardContent
+    </MudLink>
+}
+else
+{
+    @CardContent
+}
+
+@code {
+    [Parameter] public string Label { get; set; } = null!;
+    [Parameter] public string Value { get; set; } = "0";
+    [Parameter] public string? Caption { get; set; }
+    [Parameter] public string Icon { get; set; } = Icons.Material.Outlined.Insights;
+    [Parameter] public Color Color { get; set; } = Color.Default;
+    [Parameter] public string? Href { get; set; }
+
+    private string AriaLabel => string.IsNullOrWhiteSpace(Caption)
+        ? $"{Label}: {Value}"
+        : $"{Label}: {Value}. {Caption}";
+
+    private RenderFragment CardContent => @<MudPaper Outlined="true" Elevation="0" Class="@CardClass">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+            <MudText Typo="Typo.overline">@Label</MudText>
+            <MudIcon Icon="@Icon" Size="Size.Small" Color="@Color" />
+        </MudStack>
+        <MudText Typo="Typo.h4" Class="dashboard-metric-value" Color="@Color">@Value</MudText>
+        <MudText Typo="Typo.caption" Class="dashboard-muted">@Caption</MudText>
+    </MudPaper>;
+
+    private string CardClass => !string.IsNullOrWhiteSpace(Href)
+        ? "dashboard-panel dashboard-metric-card dashboard-metric-card-clickable"
+        : "dashboard-panel dashboard-metric-card";
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardNeedsAttention.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardNeedsAttention.razor
@@ -1,0 +1,36 @@
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header">
+        <MudText Typo="Typo.subtitle1">Needs attention</MudText>
+        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@ChipColor">@ChipText</MudChip>
+    </MudStack>
+
+    @if (Items.Count == 0)
+    {
+        <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Text" Icon="@Icons.Material.Outlined.CheckCircle">
+            No active findings in the selected range.
+        </MudAlert>
+    }
+    else
+    {
+        <MudList T="DashboardFinding" Dense="true" Class="dashboard-finding-list">
+            @foreach (var item in Items.OrderBy(x => x.Priority).Take(8))
+            {
+                var href = DashboardNavigationTargetMapper.ForFinding(item.TargetKind, item.Target);
+                <MudListItem T="DashboardFinding" Value="@item" Href="@href" Icon="@DashboardUiMapper.SeverityIcon(item.Severity)" IconColor="@DashboardUiMapper.SeverityColor(item.Severity)">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2" Class="dashboard-finding-row">
+                        <MudText Typo="Typo.body2">@item.Message</MudText>
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="@DashboardUiMapper.SeverityColor(item.Severity)">@item.Severity</MudChip>
+                    </MudStack>
+                </MudListItem>
+            }
+        </MudList>
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public IReadOnlyCollection<DashboardFinding> Items { get; set; } = [];
+    [Parameter] public DashboardCapabilityStatus Capability { get; set; } = DashboardCapabilityStatus.Available;
+
+    private string ChipText => DashboardUiMapper.CapabilityLabel(Capability);
+    private Color ChipColor => DashboardUiMapper.CapabilityColor(Capability);
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardRecentActivityTable.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardRecentActivityTable.razor
@@ -1,0 +1,86 @@
+@inject NavigationManager NavigationManager
+
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header">
+        <MudText Typo="Typo.subtitle1">Recent workflow activity</MudText>
+        <MudText Typo="Typo.caption" Class="dashboard-muted">@Items.Count item(s)</MudText>
+    </MudStack>
+
+    <MudTable T="DashboardRecentActivityItem" Items="@Items" Dense="true" Hover="true" Elevation="0" Breakpoint="Breakpoint.Sm" RowClassFunc="GetRowClass" OnRowClick="OnRowClick">
+        <HeaderContent>
+            <MudTh>Workflow / instance</MudTh>
+            <MudTh>Status</MudTh>
+            <MudTh>Sub-status</MudTh>
+            <MudTh>Incidents</MudTh>
+            <MudTh>Duration</MudTh>
+            <MudTh>Updated</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Workflow / instance">
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.body2">@DisplayName(context)</MudText>
+                    <MudText Typo="Typo.caption" Class="dashboard-muted">@context.InstanceId</MudText>
+                </MudStack>
+            </MudTd>
+            <MudTd DataLabel="Status">
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+            </MudTd>
+            <MudTd DataLabel="Sub-status">
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="@SubStatusColor(context.SubStatus)">@context.SubStatus</MudChip>
+            </MudTd>
+            <MudTd DataLabel="Incidents">@DashboardMetricFormatter.Count(context.IncidentCount)</MudTd>
+            <MudTd DataLabel="Duration">@DashboardMetricFormatter.Duration(context.Duration)</MudTd>
+            <MudTd DataLabel="Updated">@DashboardMetricFormatter.RelativeTimestamp(context.UpdatedAt ?? context.FinishedAt ?? context.CreatedAt)</MudTd>
+            <MudTd>
+                <MudTooltip Text="Open workflow instance">
+                    <MudIconButton Icon="@Icons.Material.Outlined.OpenInNew" Size="Size.Small" Href="@DashboardNavigationTargetMapper.ForWorkflowInstance(context.InstanceId)" aria-label="@($"Open workflow instance {context.InstanceId}")" />
+                </MudTooltip>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text">No workflow instances changed in this range.</MudAlert>
+        </NoRecordsContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    [Parameter] public IReadOnlyCollection<DashboardRecentActivityItem> Items { get; set; } = [];
+
+    private void OnRowClick(TableRowClickEventArgs<DashboardRecentActivityItem> args)
+    {
+        if (args.Item == null)
+            return;
+
+        NavigationManager.NavigateTo(DashboardNavigationTargetMapper.ForWorkflowInstance(args.Item.InstanceId));
+    }
+
+    private static string DisplayName(DashboardRecentActivityItem item) => string.IsNullOrWhiteSpace(item.WorkflowName) ? item.DefinitionId : item.WorkflowName!;
+
+    private static string GetRowClass(DashboardRecentActivityItem item, int rowNumber)
+    {
+        return item.SubStatus is "Faulted" or "Interrupted" || item.IncidentCount > 0 ? "dashboard-row-warning" : string.Empty;
+    }
+
+    private static Color StatusColor(string status)
+    {
+        return status switch
+        {
+            "Running" => Color.Info,
+            "Finished" or "Completed" => Color.Success,
+            "Faulted" => Color.Error,
+            _ => Color.Default
+        };
+    }
+
+    private static Color SubStatusColor(string subStatus)
+    {
+        return subStatus switch
+        {
+            "Faulted" => Color.Error,
+            "Interrupted" or "Suspended" => Color.Warning,
+            "Finished" or "Completed" => Color.Success,
+            _ => Color.Default
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardRuntimeChip.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardRuntimeChip.razor
@@ -1,0 +1,15 @@
+<MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="@DashboardUiMapper.RuntimeColor(Runtime.Status)" Icon="@Icon">
+    @DashboardUiMapper.RuntimeLabel(Runtime.Status)
+</MudChip>
+
+@code {
+    [Parameter] public DashboardRuntimeStatus Runtime { get; set; } = new();
+
+    private string Icon => Runtime.Status switch
+    {
+        DashboardRuntimeStatusKeys.AcceptingWork => Icons.Material.Outlined.CheckCircle,
+        DashboardRuntimeStatusKeys.Paused => Icons.Material.Outlined.PauseCircle,
+        DashboardRuntimeStatusKeys.Draining => Icons.Material.Outlined.WaterDrop,
+        _ => Icons.Material.Outlined.CloudOff
+    };
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor
@@ -1,0 +1,38 @@
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section dashboard-chart-panel">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header">
+        <MudText Typo="Typo.subtitle1">Execution trend</MudText>
+        <MudText Typo="Typo.caption" Class="dashboard-muted">@RangeCaption</MudText>
+    </MudStack>
+
+    @if (Loading)
+    {
+        <MudSkeleton Height="260px" Animation="Animation.Wave" />
+    }
+    else if (Response.Buckets.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text">No workflow activity in this range.</MudAlert>
+    }
+    else
+    {
+        <MudChart T="double" ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@Labels" Width="100%" Height="260px" />
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public DashboardTrendResponse Response { get; set; } = new();
+    [Parameter] public bool Loading { get; set; }
+
+    private string RangeCaption => $"{DashboardMetricFormatter.DateTime(Response.From)} - {DashboardMetricFormatter.DateTime(Response.To)}";
+
+    private string[] Labels => Response.Buckets
+        .Select(x => x.From.ToLocalTime().ToString(Response.Granularity == DashboardTrendGranularity.Day ? "MMM d" : "HH:mm"))
+        .ToArray();
+
+    private List<ChartSeries<double>> Series =>
+    [
+        new() { Name = "Started", Data = Response.Buckets.Select(x => (double)x.CreatedOrStarted).ToArray() },
+        new() { Name = "Finished", Data = Response.Buckets.Select(x => (double)x.Finished).ToArray() },
+        new() { Name = "Faulted", Data = Response.Buckets.Select(x => (double)x.Faulted).ToArray() },
+        new() { Name = "Suspended", Data = Response.Buckets.Select(x => (double)x.Suspended).ToArray() }
+    ];
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardWorkflowHotspotsPanel.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardWorkflowHotspotsPanel.razor
@@ -1,0 +1,40 @@
+@if (Response != null)
+{
+    <MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header">
+            <MudText Typo="Typo.subtitle1">Workflow hotspots</MudText>
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@Response.Metric</MudChip>
+        </MudStack>
+
+        @if (Response.Items.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Variant="Variant.Text">No hotspots in this range.</MudAlert>
+        }
+        else
+        {
+            <MudTable T="DashboardHotspot" Items="@Response.Items" Dense="true" Hover="true" Elevation="0" Breakpoint="Breakpoint.Sm">
+                <HeaderContent>
+                    <MudTh>Workflow</MudTh>
+                    <MudTh>Value</MudTh>
+                    <MudTh>Avg duration</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Workflow">
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.body2">@DisplayName(context)</MudText>
+                            <MudText Typo="Typo.caption" Class="dashboard-muted">@context.DefinitionId</MudText>
+                        </MudStack>
+                    </MudTd>
+                    <MudTd DataLabel="Value">@DashboardMetricFormatter.Count(context.Value)</MudTd>
+                    <MudTd DataLabel="Avg duration">@DashboardMetricFormatter.Duration(context.AverageDuration)</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    </MudPaper>
+}
+
+@code {
+    [Parameter] public DashboardWorkflowHotspotsResponse? Response { get; set; }
+
+    private static string DisplayName(DashboardHotspot item) => string.IsNullOrWhiteSpace(item.WorkflowName) ? item.DefinitionId : item.WorkflowName!;
+}

--- a/src/modules/Elsa.Studio.Dashboard/Elsa.Studio.Dashboard.csproj
+++ b/src/modules/Elsa.Studio.Dashboard/Elsa.Studio.Dashboard.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Description>Adds a dashboard page to the studio.</Description>
         <PackageTags>elsa studio module</PackageTags>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
 using Elsa.Studio.Contracts;
+using Elsa.Studio.Dashboard.Client;
 using Elsa.Studio.Dashboard.Menu;
+using Elsa.Studio.Dashboard.Services;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Dashboard.Extensions;
@@ -18,6 +22,17 @@ public static class ServiceCollectionExtensions
     {
         return services
             .AddScoped<IFeature, Feature>()
-            .AddScoped<IMenuProvider, DashboardMenu>();
+            .AddScoped<IMenuProvider, DashboardMenu>()
+            .AddScoped<IDashboardService, DashboardService>();
+    }
+
+    /// <summary>
+    /// Adds the dashboard module services with remote backend dashboard API support.
+    /// </summary>
+    public static IServiceCollection AddDashboardModule(this IServiceCollection services, BackendApiConfig backendApiConfig)
+    {
+        return services
+            .AddDashboardModule()
+            .AddRemoteApi<IDashboardApi>(backendApiConfig);
     }
 }

--- a/src/modules/Elsa.Studio.Dashboard/Models/DashboardModels.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Models/DashboardModels.cs
@@ -1,0 +1,234 @@
+namespace Elsa.Studio.Dashboard.Models;
+
+public record DashboardOverview
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.Available;
+    public string? BackendName { get; init; }
+    public string? EnvironmentName { get; init; }
+    public DashboardRuntimeStatus Runtime { get; init; } = new();
+    public DashboardWorkflowInstanceMetrics WorkflowInstances { get; init; } = new();
+    public DashboardDiagnosticsSummary Diagnostics { get; init; } = new();
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardCapabilityStatus
+{
+    public static DashboardCapabilityStatus Available { get; } = new("Available");
+    public static DashboardCapabilityStatus NotInstalled { get; } = new("NotInstalled");
+    public static DashboardCapabilityStatus Unauthorized { get; } = new("Unauthorized");
+    public static DashboardCapabilityStatus Unavailable { get; } = new("Unavailable");
+
+    public DashboardCapabilityStatus(string status, string? reason = null)
+    {
+        Status = status;
+        Reason = reason;
+    }
+
+    public string Status { get; init; }
+    public string? Reason { get; init; }
+}
+
+public record DashboardRuntimeStatus
+{
+    public string Status { get; init; } = DashboardRuntimeStatusKeys.Unavailable;
+    public bool IsAcceptingWork { get; init; }
+    public int ActiveExecutionCycleCount { get; init; }
+    public int IngressSourceCount { get; init; }
+    public int FailedIngressSourceCount { get; init; }
+    public DateTimeOffset? PausedAt { get; init; }
+    public DateTimeOffset? DrainStartedAt { get; init; }
+    public string? Reason { get; init; }
+}
+
+public record DashboardWorkflowInstanceMetrics
+{
+    public long Running { get; init; }
+    public long Completed { get; init; }
+    public long Faulted { get; init; }
+    public long Suspended { get; init; }
+    public long Interrupted { get; init; }
+    public long IncidentBearing { get; init; }
+    public TimeSpan? AverageDuration { get; init; }
+}
+
+public record DashboardDiagnosticsSummary
+{
+    public DashboardStructuredLogSummary StructuredLogs { get; init; } = new();
+    public DashboardConsoleLogSummary ConsoleLogs { get; init; } = new();
+}
+
+public record DashboardStructuredLogSummary
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.NotInstalled;
+    public int SourceCount { get; init; }
+    public int StaleSourceCount { get; init; }
+    public int RecentErrorOrCriticalCount { get; init; }
+    public long DroppedWriteCount { get; init; }
+    public long DroppedEventCount { get; init; }
+}
+
+public record DashboardConsoleLogSummary
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.NotInstalled;
+    public int SourceCount { get; init; }
+    public int StaleSourceCount { get; init; }
+    public int RecentStderrCount { get; init; }
+    public long DroppedLineCount { get; init; }
+}
+
+public record DashboardFinding
+{
+    public string Id { get; init; } = null!;
+    public string Severity { get; init; } = DashboardFindingSeverity.Info;
+    public string Message { get; init; } = null!;
+    public string? TargetKind { get; init; }
+    public string? Target { get; init; }
+    public int Priority { get; init; }
+}
+
+public record DashboardNeedsAttentionResponse
+{
+    public IReadOnlyCollection<DashboardFinding> Findings { get; init; } = [];
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.Available;
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+}
+
+public record DashboardTrendRequest
+{
+    public string? Range { get; init; }
+    public string? Granularity { get; init; }
+    public bool IncludeSystem { get; init; }
+}
+
+public record DashboardTrendResponse
+{
+    public IReadOnlyCollection<DashboardTrendBucket> Buckets { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public string Granularity { get; init; } = DashboardTrendGranularity.Hour;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardTrendBucket
+{
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+    public long CreatedOrStarted { get; init; }
+    public long Finished { get; init; }
+    public long Faulted { get; init; }
+    public long Suspended { get; init; }
+    public long IncidentBearing { get; init; }
+}
+
+public record DashboardRecentActivityItem
+{
+    public string InstanceId { get; init; } = null!;
+    public string DefinitionId { get; init; } = null!;
+    public string? WorkflowName { get; init; }
+    public string Status { get; init; } = null!;
+    public string SubStatus { get; init; } = null!;
+    public int IncidentCount { get; init; }
+    public TimeSpan? Duration { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? UpdatedAt { get; init; }
+    public DateTimeOffset? FinishedAt { get; init; }
+}
+
+public record DashboardRecentActivityResponse
+{
+    public IReadOnlyCollection<DashboardRecentActivityItem> Items { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardWorkflowHotspotsRequest
+{
+    public string? Range { get; init; }
+    public string Metric { get; init; } = DashboardHotspotMetric.Faults;
+    public int Take { get; init; } = 10;
+    public bool IncludeSystem { get; init; }
+}
+
+public record DashboardWorkflowHotspotsResponse
+{
+    public IReadOnlyCollection<DashboardHotspot> Items { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public string Metric { get; init; } = DashboardHotspotMetric.Faults;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardHotspot
+{
+    public string DefinitionId { get; init; } = null!;
+    public string? WorkflowName { get; init; }
+    public long Value { get; init; }
+    public TimeSpan? AverageDuration { get; init; }
+}
+
+public record DashboardSnapshot(
+    DashboardOverview Overview,
+    DashboardNeedsAttentionResponse NeedsAttention,
+    DashboardTrendResponse Trend,
+    DashboardRecentActivityResponse RecentActivity,
+    DashboardWorkflowHotspotsResponse? Hotspots);
+
+public record DashboardLoadResult(DashboardLoadStatus Status, DashboardSnapshot? Snapshot = null, string? Message = null)
+{
+    public static DashboardLoadResult Loaded(DashboardSnapshot snapshot) => new(DashboardLoadStatus.Loaded, snapshot);
+    public static DashboardLoadResult Unavailable(string message) => new(DashboardLoadStatus.Unavailable, null, message);
+    public static DashboardLoadResult Unauthorized(string message) => new(DashboardLoadStatus.Unauthorized, null, message);
+    public static DashboardLoadResult BackendDisconnected(string message) => new(DashboardLoadStatus.BackendDisconnected, null, message);
+    public static DashboardLoadResult Failed(string message) => new(DashboardLoadStatus.Failed, null, message);
+}
+
+public enum DashboardLoadStatus
+{
+    Loaded,
+    Unavailable,
+    Unauthorized,
+    BackendDisconnected,
+    Failed
+}
+
+public static class DashboardRangeKeys
+{
+    public const string OneHour = "1h";
+    public const string TwentyFourHours = "24h";
+    public const string SevenDays = "7d";
+}
+
+public static class DashboardRuntimeStatusKeys
+{
+    public const string AcceptingWork = "AcceptingWork";
+    public const string Paused = "Paused";
+    public const string Draining = "Draining";
+    public const string Unavailable = "Unavailable";
+}
+
+public static class DashboardTrendGranularity
+{
+    public const string Minute = "minute";
+    public const string Hour = "hour";
+    public const string Day = "day";
+}
+
+public static class DashboardFindingSeverity
+{
+    public const string Info = "Info";
+    public const string Warning = "Warning";
+    public const string Error = "Error";
+    public const string Critical = "Critical";
+    public const string Success = "Success";
+}
+
+public static class DashboardHotspotMetric
+{
+    public const string Faults = "Faults";
+    public const string Executions = "Executions";
+    public const string Incidents = "Incidents";
+    public const string Duration = "Duration";
+}

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
@@ -1,12 +1,107 @@
-﻿@page "/"
+@page "/"
 @inherits StudioComponentBase
 @inject ILocalizer Localizer
 
-<PageTitle>Index</PageTitle>
+<PageTitle>@Localizer["Dashboard"]</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.False">
-    <PageHeading Text="@Localizer["Dashboard"]"></PageHeading>
-    <MudText Class="mb-8">@Localizer["Manage all the things"]</MudText>
-    <MudAlert Severity="Severity.Normal">@Localizer["You can find documentation and examples here"]: <MudLink Href="https://docs.elsaworkflows.io/" Typo="Typo.body2" Color="Color.Inherit"><b>docs.elsaworkflows.io</b></MudLink></MudAlert>
+<MudContainer MaxWidth="MaxWidth.False" Class="dashboard-shell">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-header" Spacing="3">
+        <MudStack Spacing="1">
+            <MudText Typo="Typo.h4">Dashboard</MudText>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="flex-wrap">
+                <MudText Typo="Typo.body2" Class="dashboard-muted">@BackendLabel</MudText>
+                @if (_snapshot != null)
+                {
+                    <DashboardRuntimeChip Runtime="@_snapshot.Overview.Runtime" />
+                }
+                else
+                {
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="Color.Error" Icon="@Icons.Material.Outlined.CloudOff">@StatusLabel</MudChip>
+                }
+                <MudText Typo="Typo.caption" Class="dashboard-muted">@LastRefreshedLabel</MudText>
+            </MudStack>
+        </MudStack>
 
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.FlexEnd" Spacing="1" Class="flex-wrap">
+            <MudToggleGroup T="string" Value="@_selectedRange" ValueChanged="OnRangeChangedAsync" Color="Color.Primary" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small">
+                @foreach (var option in DashboardRangeMapper.Options)
+                {
+                    <MudToggleItem T="string" Value="@option.Value">@option.Label</MudToggleItem>
+                }
+            </MudToggleGroup>
+            <MudTooltip Text="Refresh dashboard" Delay="400">
+                <MudIconButton Icon="@Icons.Material.Outlined.Refresh" Color="Color.Primary" Disabled="@_loading" OnClick="RefreshAsync" aria-label="Refresh dashboard" />
+            </MudTooltip>
+        </MudStack>
+    </MudStack>
+
+    @if (!string.IsNullOrWhiteSpace(_message))
+    {
+        <MudAlert Severity="@AlertSeverity" Dense="true" Class="mb-4">@_message</MudAlert>
+    }
+
+    @if (_loading && _snapshot == null)
+    {
+        <MudGrid Spacing="2" Class="mb-4">
+            @for (var i = 0; i < 6; i++)
+            {
+                <MudItem xs="12" sm="6" md="4" xl="2">
+                    <MudSkeleton Height="112px" Animation="Animation.Wave" />
+                </MudItem>
+            }
+        </MudGrid>
+        <MudSkeleton Height="360px" Animation="Animation.Wave" />
+    }
+    else if (_snapshot == null)
+    {
+        <MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-empty-state">
+            <MudIcon Icon="@Icons.Material.Outlined.DashboardCustomize" Color="Color.Default" />
+            <MudText Typo="Typo.h6">@StatusLabel</MudText>
+            <MudText Typo="Typo.body2" Class="dashboard-muted">@(_message ?? "Dashboard data is unavailable from the selected backend.")</MudText>
+        </MudPaper>
+    }
+    else
+    {
+        var overview = _snapshot.Overview;
+        var metrics = overview.WorkflowInstances;
+
+        <MudGrid Spacing="2" Class="dashboard-metrics">
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Running" Value="@DashboardMetricFormatter.Count(metrics.Running)" Caption="Current active instances" Icon="@Icons.Material.Outlined.PlayCircle" Color="Color.Info" Href="@DashboardNavigationTargetMapper.ForMetric("running")" />
+            </MudItem>
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Completed" Value="@DashboardMetricFormatter.Count(metrics.Completed)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.CheckCircle" Color="Color.Success" />
+            </MudItem>
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Faulted" Value="@DashboardMetricFormatter.Count(metrics.Faulted)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.ErrorOutline" Color="@(metrics.Faulted > 0 ? Color.Error : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("faulted")" />
+            </MudItem>
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Suspended" Value="@DashboardMetricFormatter.Count(metrics.Suspended)" Caption="Current suspended instances" Icon="@Icons.Material.Outlined.PauseCircle" Color="@(metrics.Suspended > 0 ? Color.Warning : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("suspended")" />
+            </MudItem>
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Avg duration" Value="@DashboardMetricFormatter.Duration(metrics.AverageDuration)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.Timer" Color="Color.Default" />
+            </MudItem>
+            <MudItem xs="12" sm="6" md="4" xl="2">
+                <DashboardMetricCard Label="Needs attention" Value="@DashboardMetricFormatter.Count(_snapshot.NeedsAttention.Findings.Count)" Caption="Prioritized findings" Icon="@Icons.Material.Outlined.ReportProblem" Color="@(_snapshot.NeedsAttention.Findings.Count > 0 ? Color.Warning : Color.Success)" />
+            </MudItem>
+        </MudGrid>
+
+        <MudGrid Spacing="2" Class="mt-1">
+            <MudItem xs="12" lg="4">
+                <DashboardNeedsAttention Items="@_snapshot.NeedsAttention.Findings" Capability="@_snapshot.NeedsAttention.Capability" />
+            </MudItem>
+            <MudItem xs="12" lg="8">
+                <DashboardTrendChart Response="@_snapshot.Trend" Loading="@_loading" />
+            </MudItem>
+            <MudItem xs="12" lg="8">
+                <DashboardRecentActivityTable Items="@_snapshot.RecentActivity.Items" />
+            </MudItem>
+            <MudItem xs="12" lg="4">
+                <MudStack Spacing="2">
+                    <DashboardDiagnosticsSnapshot Summary="@overview.Diagnostics" />
+                    <DashboardWorkflowHotspotsPanel Response="@_snapshot.Hotspots" />
+                </MudStack>
+            </MudItem>
+        </MudGrid>
+    }
 </MudContainer>

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.cs
@@ -1,0 +1,132 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Dashboard.Pages;
+
+public partial class Index : IAsyncDisposable
+{
+    private CancellationTokenSource? _loadCancellationTokenSource;
+    private DashboardSnapshot? _snapshot;
+    private DashboardLoadStatus _status = DashboardLoadStatus.Unavailable;
+    private string _selectedRange = DashboardRangeKeys.TwentyFourHours;
+    private string? _message;
+    private bool _loading;
+    private DateTimeOffset? _lastRefreshedAt;
+
+    [Inject] private IDashboardService DashboardService { get; set; } = null!;
+
+    private string BackendLabel
+    {
+        get
+        {
+            if (_snapshot == null)
+                return "Selected backend";
+
+            var overview = _snapshot.Overview;
+            var backendName = string.IsNullOrWhiteSpace(overview.BackendName) ? "Backend" : overview.BackendName;
+            return string.IsNullOrWhiteSpace(overview.EnvironmentName) ? backendName : $"{backendName} / {overview.EnvironmentName}";
+        }
+    }
+
+    private string LastRefreshedLabel => _lastRefreshedAt == null ? "Not refreshed yet" : $"Refreshed {DashboardMetricFormatter.RelativeTimestamp(_lastRefreshedAt)}";
+
+    private string RangeCaption => _selectedRange switch
+    {
+        DashboardRangeKeys.OneHour => "Last hour",
+        DashboardRangeKeys.SevenDays => "Last 7 days",
+        _ => "Last 24 hours"
+    };
+
+    private string StatusLabel => _status switch
+    {
+        DashboardLoadStatus.Unauthorized => "No access",
+        DashboardLoadStatus.BackendDisconnected => "Backend disconnected",
+        DashboardLoadStatus.Failed => "Refresh failed",
+        DashboardLoadStatus.Loaded => "Loaded",
+        _ => "Dashboard unavailable"
+    };
+
+    private Severity AlertSeverity => _status switch
+    {
+        DashboardLoadStatus.Unauthorized => Severity.Warning,
+        DashboardLoadStatus.Loaded => Severity.Info,
+        _ => Severity.Error
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshAsync();
+    }
+
+    private async Task OnRangeChangedAsync(string? range)
+    {
+        _selectedRange = DashboardRangeMapper.Normalize(range);
+        await RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadAsync(_selectedRange);
+    }
+
+    private async Task LoadAsync(string range)
+    {
+        await CancelCurrentLoadAsync();
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        _loadCancellationTokenSource = cancellationTokenSource;
+        _loading = true;
+        _message = null;
+
+        try
+        {
+            var result = await DashboardService.LoadAsync(range, cancellationToken: cancellationTokenSource.Token);
+            _status = result.Status;
+
+            if (result.Snapshot != null)
+            {
+                _snapshot = result.Snapshot;
+                _lastRefreshedAt = DateTimeOffset.UtcNow;
+                _message = null;
+            }
+            else
+            {
+                _message = result.Message;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception e)
+        {
+            _status = DashboardLoadStatus.Failed;
+            _message = e.Message;
+        }
+        finally
+        {
+            if (ReferenceEquals(_loadCancellationTokenSource, cancellationTokenSource))
+            {
+                _loading = false;
+                _loadCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
+        }
+    }
+
+    private async Task CancelCurrentLoadAsync()
+    {
+        if (_loadCancellationTokenSource == null)
+            return;
+
+        await _loadCancellationTokenSource.CancelAsync();
+        _loadCancellationTokenSource = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CancelCurrentLoadAsync();
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.css
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.css
@@ -1,0 +1,99 @@
+.dashboard-shell {
+    min-height: 100%;
+    padding: 24px;
+    background: #f6f8fb;
+}
+
+.dashboard-header {
+    margin-bottom: 16px;
+}
+
+.dashboard-muted {
+    color: var(--mud-palette-text-secondary);
+}
+
+.dashboard-panel {
+    border-radius: 8px;
+    background: var(--mud-palette-surface);
+}
+
+.dashboard-empty-state {
+    min-height: 240px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.dashboard-metrics {
+    margin-bottom: 8px;
+}
+
+.dashboard-card-link {
+    color: inherit;
+    display: block;
+    height: 100%;
+}
+
+.dashboard-metric-card {
+    min-height: 112px;
+    height: 100%;
+    padding: 14px;
+    transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.dashboard-metric-card-clickable:hover,
+.dashboard-metric-card-clickable:focus-within {
+    border-color: var(--mud-palette-primary);
+    background: rgba(var(--mud-palette-primary-rgb), 0.04);
+}
+
+.dashboard-metric-value {
+    line-height: 1.1;
+    margin-top: 8px;
+}
+
+.dashboard-section {
+    padding: 16px;
+}
+
+.dashboard-section-header {
+    margin-bottom: 12px;
+}
+
+.dashboard-chart-panel {
+    min-height: 342px;
+}
+
+.dashboard-finding-list {
+    margin: -8px;
+}
+
+.dashboard-finding-row {
+    width: 100%;
+}
+
+.dashboard-row-warning {
+    background: rgba(var(--mud-palette-warning-rgb), 0.08);
+}
+
+.dashboard-diagnostics-block {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.dashboard-diagnostics-value {
+    min-height: 28px;
+}
+
+@media (max-width: 768px) {
+    .dashboard-shell {
+        padding: 16px;
+    }
+
+    .dashboard-header {
+        align-items: flex-start;
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardMetricFormatter.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardMetricFormatter.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public static class DashboardMetricFormatter
+{
+    public static string Count(long value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    public static string Count(int value) => Count((long)value);
+
+    public static string Duration(TimeSpan? value)
+    {
+        if (value == null)
+            return "N/A";
+
+        var duration = value.Value;
+
+        if (duration.TotalMilliseconds < 1000)
+            return $"{duration.TotalMilliseconds:N0} ms";
+
+        if (duration.TotalMinutes < 1)
+            return $"{duration.TotalSeconds:N1} s";
+
+        if (duration.TotalHours < 1)
+            return $"{duration.TotalMinutes:N1} min";
+
+        return $"{duration.TotalHours:N1} h";
+    }
+
+    public static string DateTime(DateTimeOffset? value)
+    {
+        return value == null ? "N/A" : value.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    public static string RelativeTimestamp(DateTimeOffset? value)
+    {
+        if (value == null)
+            return "N/A";
+
+        var elapsed = DateTimeOffset.UtcNow - value.Value.ToUniversalTime();
+
+        if (elapsed.TotalSeconds < 60)
+            return "Just now";
+
+        if (elapsed.TotalMinutes < 60)
+            return $"{elapsed.TotalMinutes:N0} min ago";
+
+        if (elapsed.TotalHours < 24)
+            return $"{elapsed.TotalHours:N0} h ago";
+
+        return $"{elapsed.TotalDays:N0} d ago";
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardNavigationTargetMapper.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardNavigationTargetMapper.cs
@@ -1,0 +1,54 @@
+namespace Elsa.Studio.Dashboard.Services;
+
+public static class DashboardNavigationTargetMapper
+{
+    public const string WorkflowInstances = "workflows/instances";
+    public const string StructuredLogs = "diagnostics/structured-logs";
+    public const string Console = "diagnostics/console";
+
+    public static string? ForMetric(string metric)
+    {
+        return metric switch
+        {
+            "running" => WorkflowInstancesWith("status=Running"),
+            "faulted" => WorkflowInstancesWith("subStatus=Faulted&hasIncidents=true"),
+            "suspended" => WorkflowInstancesWith("subStatus=Suspended"),
+            "interrupted" => WorkflowInstancesWith("subStatus=Interrupted"),
+            "incidents" => WorkflowInstancesWith("hasIncidents=true"),
+            _ => null
+        };
+    }
+
+    public static string ForWorkflowInstance(string instanceId) => $"workflows/instances/{Uri.EscapeDataString(instanceId)}/view";
+
+    public static string? ForFinding(string? targetKind, string? target)
+    {
+        return targetKind switch
+        {
+            "WorkflowInstances" => target switch
+            {
+                "faulted" => ForMetric("faulted"),
+                "interrupted" => ForMetric("interrupted"),
+                "incidents" => ForMetric("incidents"),
+                _ => WorkflowInstances
+            },
+            "StructuredLogs" => target switch
+            {
+                "errors" => $"{StructuredLogs}?level=Error",
+                _ => StructuredLogs
+            },
+            "ConsoleLogs" => target switch
+            {
+                "dropped" => $"{Console}?stream=stderr",
+                _ => Console
+            },
+            _ => null
+        };
+    }
+
+    private static string WorkflowInstancesWith(string query)
+    {
+        // TODO: Wire these query keys into the Workflow Instances page once filter deep links are supported there.
+        return $"{WorkflowInstances}?{query}";
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardRangeMapper.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardRangeMapper.cs
@@ -1,0 +1,30 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public record DashboardRangeOption(string Value, string Label);
+
+public static class DashboardRangeMapper
+{
+    public static IReadOnlyList<DashboardRangeOption> Options { get; } =
+    [
+        new(DashboardRangeKeys.OneHour, "1h"),
+        new(DashboardRangeKeys.TwentyFourHours, "24h"),
+        new(DashboardRangeKeys.SevenDays, "7d")
+    ];
+
+    public static string Normalize(string? range)
+    {
+        return Options.Any(x => x.Value == range) ? range! : DashboardRangeKeys.TwentyFourHours;
+    }
+
+    public static string GetDefaultGranularity(string? range)
+    {
+        return Normalize(range) switch
+        {
+            DashboardRangeKeys.OneHour => DashboardTrendGranularity.Minute,
+            DashboardRangeKeys.SevenDays => DashboardTrendGranularity.Day,
+            _ => DashboardTrendGranularity.Hour
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardService.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardService.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Dashboard.Client;
+using Elsa.Studio.Dashboard.Models;
+using Refit;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public class DashboardService(IBackendApiClientProvider backendApiClientProvider) : IDashboardService
+{
+    public async Task<DashboardLoadResult> LoadAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var api = await backendApiClientProvider.GetApiAsync<IDashboardApi>(cancellationToken);
+            var overviewTask = api.GetOverviewAsync(range, includeSystem, cancellationToken);
+            var needsAttentionTask = api.GetNeedsAttentionAsync(range, 8, includeSystem, cancellationToken);
+            var trendsTask = api.GetWorkflowTrendsAsync(new DashboardTrendRequest
+            {
+                Range = range,
+                Granularity = DashboardRangeMapper.GetDefaultGranularity(range),
+                IncludeSystem = includeSystem
+            }, cancellationToken);
+            var recentActivityTask = api.GetRecentActivityAsync(range, 20, includeSystem, cancellationToken);
+            var hotspotsTask = TryGetHotspotsAsync(api, range, includeSystem, cancellationToken);
+
+            await Task.WhenAll(overviewTask, needsAttentionTask, trendsTask, recentActivityTask, hotspotsTask);
+
+            return DashboardLoadResult.Loaded(new DashboardSnapshot(
+                await overviewTask,
+                await needsAttentionTask,
+                await trendsTask,
+                await recentActivityTask,
+                await hotspotsTask));
+        }
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return DashboardLoadResult.Unavailable("Dashboard data is not available from this backend.");
+        }
+        catch (ApiException e) when (e.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return DashboardLoadResult.Unauthorized("You do not have access to dashboard data for this backend.");
+        }
+        catch (HttpRequestException e)
+        {
+            return DashboardLoadResult.BackendDisconnected(e.Message);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return DashboardLoadResult.BackendDisconnected("The dashboard request timed out.");
+        }
+    }
+
+    private static async Task<DashboardWorkflowHotspotsResponse?> TryGetHotspotsAsync(IDashboardApi api, string range, bool includeSystem, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await api.GetWorkflowHotspotsAsync(new DashboardWorkflowHotspotsRequest
+            {
+                Range = range,
+                Metric = DashboardHotspotMetric.Faults,
+                Take = 8,
+                IncludeSystem = includeSystem
+            }, cancellationToken);
+        }
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardUiMapper.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardUiMapper.cs
@@ -1,0 +1,87 @@
+using Elsa.Studio.Dashboard.Models;
+using MudBlazor;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public static class DashboardUiMapper
+{
+    public static Color RuntimeColor(string? status)
+    {
+        return status switch
+        {
+            DashboardRuntimeStatusKeys.AcceptingWork => Color.Success,
+            DashboardRuntimeStatusKeys.Paused => Color.Warning,
+            DashboardRuntimeStatusKeys.Draining => Color.Info,
+            _ => Color.Error
+        };
+    }
+
+    public static string RuntimeLabel(string? status)
+    {
+        return status switch
+        {
+            DashboardRuntimeStatusKeys.AcceptingWork => "Accepting work",
+            DashboardRuntimeStatusKeys.Paused => "Paused",
+            DashboardRuntimeStatusKeys.Draining => "Draining",
+            _ => "Unavailable"
+        };
+    }
+
+    public static Severity Severity(string? severity)
+    {
+        return severity switch
+        {
+            DashboardFindingSeverity.Success => MudBlazor.Severity.Success,
+            DashboardFindingSeverity.Warning => MudBlazor.Severity.Warning,
+            DashboardFindingSeverity.Error => MudBlazor.Severity.Error,
+            DashboardFindingSeverity.Critical => MudBlazor.Severity.Error,
+            _ => MudBlazor.Severity.Info
+        };
+    }
+
+    public static Color SeverityColor(string? severity)
+    {
+        return severity switch
+        {
+            DashboardFindingSeverity.Success => Color.Success,
+            DashboardFindingSeverity.Warning => Color.Warning,
+            DashboardFindingSeverity.Error => Color.Error,
+            DashboardFindingSeverity.Critical => Color.Error,
+            _ => Color.Info
+        };
+    }
+
+    public static string SeverityIcon(string? severity)
+    {
+        return severity switch
+        {
+            DashboardFindingSeverity.Success => Icons.Material.Outlined.CheckCircle,
+            DashboardFindingSeverity.Warning => Icons.Material.Outlined.WarningAmber,
+            DashboardFindingSeverity.Error => Icons.Material.Outlined.ErrorOutline,
+            DashboardFindingSeverity.Critical => Icons.Material.Filled.Report,
+            _ => Icons.Material.Outlined.Info
+        };
+    }
+
+    public static string CapabilityLabel(DashboardCapabilityStatus? capability)
+    {
+        return capability?.Status switch
+        {
+            "Available" => "Available",
+            "Unauthorized" => "No access",
+            "NotInstalled" => "Not installed",
+            _ => "Unavailable"
+        };
+    }
+
+    public static Color CapabilityColor(DashboardCapabilityStatus? capability)
+    {
+        return capability?.Status switch
+        {
+            "Available" => Color.Success,
+            "Unauthorized" => Color.Warning,
+            "NotInstalled" => Color.Default,
+            _ => Color.Error
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/IDashboardService.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/IDashboardService.cs
@@ -1,0 +1,8 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public interface IDashboardService
+{
+    Task<DashboardLoadResult> LoadAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Dashboard/_Imports.razor
+++ b/src/modules/Elsa.Studio.Dashboard/_Imports.razor
@@ -1,6 +1,9 @@
 ﻿@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Web
 @using Elsa.Studio.Components
+@using Elsa.Studio.Dashboard.Components
+@using Elsa.Studio.Dashboard.Models
+@using Elsa.Studio.Dashboard.Services
 @using Elsa.Studio.Localization
 @using MudBlazor
 @attribute [Authorize]


### PR DESCRIPTION
## Summary
- Replace the static Studio dashboard route with an operational MudBlazor dashboard shell.
- Add Refit dashboard API client, response/request models, service orchestration, capability/error states, and navigation/formatting helpers.
- Add metric, runtime, needs-attention, trend, recent activity, diagnostics snapshot, and optional hotspot components.
- Register the dashboard API client in Server/WASM hosts and add focused mapper/formatter tests.

## Validation
- `dotnet build src/modules/Elsa.Studio.Dashboard/Elsa.Studio.Dashboard.csproj --no-restore`
- `dotnet test src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj --no-restore`

Closes #849
Closes #850
Closes #851
Closes #852
Closes #853
Closes #854
Closes #855
Closes #856
Closes #857
Closes #858
Closes #859
Closes #860
Closes #861
Closes #862
Closes #863
Closes #864
Closes #865
Closes #866
Refs #843
Refs #844
Refs #845
Refs #846
Refs #847
Refs #848
