### PR TITLE
Add root activity selection to new workflow dialog

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa.Api.Client" Version="3.7.0-rc1" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.JSInterop" Version="8.0.24" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
@@ -76,7 +76,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v2.css
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v2.css
@@ -99,3 +99,11 @@
 .elsa-flowchart-diagram-designer-v2 .activity-menu {
     align-self: center;
 }
+
+.elsa-sequence-diagram-designer .x6-port {
+    display: none;
+}
+
+.elsa-sequence-diagram-designer .x6-edge {
+    pointer-events: none;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/add-activity-node.ts
@@ -1,9 +1,11 @@
 import {Node} from "@antv/x6";
 import {graphBindings} from "./graph-bindings";
+import {arrangeSequenceGraph, withSuppressedGraphUpdated} from "./sequence-mode";
 
 export async function addActivityNode(graphId: string, node: Node.Properties) {
     // Get graph reference.
-    const {graph} = graphBindings[graphId];
+    const binding = graphBindings[graphId];
+    const {graph} = binding;
 
     // Convert the node coordinates from page to local.
     const {x, y} = graph.pageToLocal(node.position);
@@ -13,7 +15,14 @@ export async function addActivityNode(graphId: string, node: Node.Properties) {
     node.id = node.id!;
 
     // Add the node to the graph.
-    graph.addNode(node);
+    if (binding.mode === 'sequence') {
+        withSuppressedGraphUpdated(binding, () => graph.addNode(node));
+        arrangeSequenceGraph(binding);
+        await binding.interop.raiseGraphUpdated();
+    } else {
+        graph.addNode(node);
+    }
+
     graph.cleanSelection();
     graph.select(node.id);
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/auto-layout.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/auto-layout.ts
@@ -2,6 +2,7 @@ import {Model} from '@antv/x6';
 import {DagreLayout} from '@antv/layout';
 import {loadGraph} from './load-graph';
 import {graphBindings} from './graph-bindings';
+import {arrangeSequenceGraph} from './sequence-mode';
 
 const dagreLayout = new DagreLayout({
     type: 'dagre',
@@ -12,7 +13,15 @@ const dagreLayout = new DagreLayout({
 })
 
 export async function autoLayout(graphId: string, data: string | Model.FromJSONData) {
-    const {graph, interop} = graphBindings[graphId];
+    const binding = graphBindings[graphId];
+    const {graph, interop} = binding;
+
+    if (binding.mode === 'sequence') {
+        arrangeSequenceGraph(binding);
+        await interop.raiseGraphUpdated();
+        return;
+    }
+
     const model = typeof data === 'string' ? JSON.parse(data) : data;
     const newModel = dagreLayout.layout(model);
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -9,11 +9,15 @@ import {DotNetComponentRef, graphBindings} from "./graph-bindings";
 import {DotNetFlowchartDesigner} from "./dotnet-flowchart-designer";
 import {Activity} from "../models";
 import {enforceMinimumNodeSize} from "./update-activity-size";
+import {arrangeSequenceGraph, moveSelectedSequenceNode, normalizeSequenceOrientation, withSuppressedGraphUpdated} from "./sequence-mode";
 
 export async function createGraph(containerId: string, componentRef: DotNetComponentRef, readOnly: boolean, settings?: any): Promise<string> {
     const containerElement = document.getElementById(containerId);
     const interop = new DotNetFlowchartDesigner(componentRef);
     let lastSelectedNode: any = null;
+    const graphId = containerId;
+    const mode = settings?.mode === 'sequence' ? 'sequence' : 'flowchart';
+    const isSequenceMode = mode === 'sequence';
 
     const graph = new Graph({
         container: containerElement,
@@ -39,15 +43,15 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         },
         interacting: {
             nodeMovable: () => !readOnly,
-            arrowheadMovable: () => !readOnly,
-            edgeMovable: () => !readOnly,
-            vertexMovable: () => !readOnly,
-            vertexAddable: () => !readOnly,
-            vertexDeletable: () => !readOnly,
-            edgeLabelMovable: () => !readOnly,
-            magnetConnectable: () => !readOnly,
-            toolsAddable: () => !readOnly,
-            useEdgeTools: () => !readOnly,
+            arrowheadMovable: () => !readOnly && !isSequenceMode,
+            edgeMovable: () => !readOnly && !isSequenceMode,
+            vertexMovable: () => !readOnly && !isSequenceMode,
+            vertexAddable: () => !readOnly && !isSequenceMode,
+            vertexDeletable: () => !readOnly && !isSequenceMode,
+            edgeLabelMovable: () => !readOnly && !isSequenceMode,
+            magnetConnectable: () => !readOnly && !isSequenceMode,
+            toolsAddable: () => !readOnly && !isSequenceMode,
+            useEdgeTools: () => !readOnly && !isSequenceMode,
         },
         connecting: {
             router: 'manhattan',
@@ -76,6 +80,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                 })
             },
             validateConnection({sourceMagnet, targetMagnet}) {
+                if (isSequenceMode) {
+                    return false;
+                }
+
                 if (!sourceMagnet || sourceMagnet.getAttribute('port-group') === 'in') {
                     return false
                 }
@@ -176,6 +184,16 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         graph.bindKey(['meta+x', 'ctrl+x'], () => {
             const cells = graph.getSelectedCells()
             if (cells.length) {
+                if (isSequenceMode) {
+                    const binding = graphBindings[graphId];
+                    const nodes = cells.filter(cell => cell.isNode());
+                    graph.copy(nodes);
+                    withSuppressedGraphUpdated(binding, () => graph.removeCells(nodes));
+                    arrangeSequenceGraph(binding);
+                    interop.raiseGraphUpdated();
+                    return false;
+                }
+
                 graph.cut(cells)
             }
 
@@ -191,7 +209,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                     return;
 
                 const activityCells = cells.filter(x => x.shape == 'elsa-activity');
-                const edgeCells: Edge[] = cells.filter(x => x.shape == 'elsa-edge');
+                const edgeCells: Edge[] = isSequenceMode ? [] : cells.filter(x => x.shape == 'elsa-edge');
 
                 interop.raisePasteCellsRequested(activityCells, edgeCells);
             }
@@ -219,6 +237,15 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         graph.bindKey('del', () => {
             const cells = graph.getSelectedCells()
             if (cells.length) {
+                if (isSequenceMode) {
+                    const binding = graphBindings[graphId];
+                    const nodes = cells.filter(cell => cell.isNode());
+                    withSuppressedGraphUpdated(binding, () => graph.removeCells(nodes));
+                    arrangeSequenceGraph(binding);
+                    interop.raiseGraphUpdated();
+                    return false;
+                }
+
                 graph.removeCells(cells)
             }
 
@@ -278,6 +305,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
     });
 
     graph.on("edge:mouseenter", ({cell}) => {
+        if (isSequenceMode) {
+            return false;
+        }
+
         cell.addTools([
             {name: "vertices"},
             {
@@ -289,6 +320,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
     });
 
     graph.on("edge:mouseleave", ({cell}) => {
+        if (isSequenceMode) {
+            return false;
+        }
+
         if (cell.hasTool("button-remove")) {
             cell.removeTool("button-remove");
         }
@@ -356,6 +391,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
     });
 
     const onGraphUpdated = async (e: any) => {
+        const binding = graphBindings[graphId];
+        if (binding?.suppressGraphUpdated && binding.suppressGraphUpdated > 0)
+            return false;
+
         await interop.raiseGraphUpdated();
         return false;
     };
@@ -400,22 +439,54 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         return false;
     };
 
-    graph.on('node:moved', onGraphUpdated);
-    graph.on('node:added', onNodeAdded);
-    graph.on('node:removed', onNodeRemoved);
+    graph.on('node:moved', async () => {
+        if (!isSequenceMode)
+            return await onGraphUpdated({});
+
+        if (readOnly)
+            return false;
+
+        const binding = graphBindings[graphId];
+        arrangeSequenceGraph(binding);
+        await interop.raiseGraphUpdated();
+        return false;
+    });
+    graph.on('node:added', async e => {
+        if (!isSequenceMode)
+            return await onNodeAdded(e);
+
+        const binding = graphBindings[graphId];
+        if (binding?.suppressGraphUpdated && binding.suppressGraphUpdated > 0)
+            return false;
+
+        arrangeSequenceGraph(binding);
+        await interop.raiseGraphUpdated();
+        return false;
+    });
+    graph.on('node:removed', async e => {
+        if (!isSequenceMode)
+            return await onNodeRemoved(e);
+
+        const binding = graphBindings[graphId];
+        if (binding?.suppressGraphUpdated && binding.suppressGraphUpdated > 0)
+            return false;
+
+        arrangeSequenceGraph(binding);
+        await interop.raiseGraphUpdated();
+        return false;
+    });
     graph.on('node:change:size', onNodeSizeChanged);
     graph.on('edge:removed', onGraphUpdated);
     graph.on('edge:connected', onGraphUpdated);
     graph.on('edge:vertexs:added', onGraphUpdated);
     graph.on('edge:vertexs:removed', onGraphUpdated);
 
-    // Register the graph.
-    const graphId = containerId;
-
     graphBindings[graphId] = {
         graphId: graphId,
         graph: graph,
-        interop: interop
+        interop: interop,
+        mode,
+        layoutOrientation: normalizeSequenceOrientation(settings?.layoutOrientation),
     };
 
     return graphId;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/graph-bindings.ts
@@ -14,6 +14,7 @@ export interface GraphBinding {
     graphId: string;
     graph: Graph;
     interop: DotNetFlowchartDesigner;
+    mode?: 'flowchart' | 'sequence';
+    layoutOrientation?: 'vertical' | 'horizontal';
     suppressGraphUpdated?: number;
 }
-

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
@@ -11,6 +11,7 @@ export * from './raise-activity-selected';
 export * from './raise-activity-embedded-port-selected';
 export * from './select-activity';
 export * from './set-grid-color';
+export * from './sequence-commands';
 export * from './update-activity';
 export * from './update-activity-size';
 export * from './update-activity-stats';

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/load-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/load-graph.ts
@@ -1,10 +1,17 @@
 import {Graph, Model} from '@antv/x6';
 import {graphBindings} from "./graph-bindings";
+import {arrangeSequenceGraph, normalizeSequenceOrientation} from "./sequence-mode";
 
 export function loadGraph(graphId: string, data: string | Model.FromJSONData) {
-    const {graph} = graphBindings[graphId];
+    const binding = graphBindings[graphId];
+    const {graph} = binding;
     const model = typeof data === 'string' ? JSON.parse(data) : data;
     graph.fromJSON(model);
+
+    if (binding.mode === 'sequence') {
+        binding.layoutOrientation = normalizeSequenceOrientation((model as any).layoutOrientation);
+        arrangeSequenceGraph(binding);
+    }
 
     waitUntilCanvasHasNonZeroHeight(graph).then(() => graph.centerContent({padding: 20}));
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/paste-cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/paste-cells.ts
@@ -1,21 +1,29 @@
-import {Cell, Node, Edge} from "@antv/x6";
+import {Node, Edge} from "@antv/x6";
 import {graphBindings} from "./graph-bindings";
+import {arrangeSequenceGraph, withSuppressedGraphUpdated} from "./sequence-mode";
 
 export async function pasteCells(graphId: string, nodeProps: Node.Properties[], edgeProps: Edge.Properties[]) {
     // Get graph reference.
-    const {graph} = graphBindings[graphId];
+    const binding = graphBindings[graphId];
+    const {graph} = binding;
 
     // Create nodes and edges from node props and edge props.
     const nodes = nodeProps.map(x => graph.createNode(x));
     const edges = edgeProps.map(x => graph.createEdge(x));
 
     // Add the nodes and edges to the graph.
-    graph.addCell(nodes);
-    graph.addCell(edges);
+    if (binding.mode === 'sequence') {
+        withSuppressedGraphUpdated(binding, () => graph.addCell(nodes));
+        arrangeSequenceGraph(binding);
+        await binding.interop.raiseGraphUpdated();
+    } else {
+        graph.addCell(nodes);
+        graph.addCell(edges);
+    }
 
     // Wait for the new cells to be rendered.
     requestAnimationFrame(() => {
         graph.cleanSelection();
-        graph.select([...nodes, ...edges]);
+        graph.select(binding.mode === 'sequence' ? nodes : [...nodes, ...edges]);
     });
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/read-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/read-graph.ts
@@ -3,8 +3,9 @@ import {graphBindings} from "./graph-bindings";
 
 export function readGraph(graphId: string): {
     cells: Cell.Properties[];
+    layoutOrientation?: string;
 } {
-    const {graph} = graphBindings[graphId];
+    const {graph, layoutOrientation} = graphBindings[graphId];
     const model = graph.toJSON();
     
     // Filter out edges that don't have both a star and end node.
@@ -23,6 +24,7 @@ export function readGraph(graphId: string): {
         
         return false;
     });
-    
+
+    (model as any).layoutOrientation = layoutOrientation;
     return model;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/sequence-commands.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/sequence-commands.ts
@@ -1,0 +1,18 @@
+import {graphBindings} from './graph-bindings';
+import {moveSelectedSequenceNode, setSequenceOrientation} from './sequence-mode';
+
+export async function setX6SequenceOrientation(graphId: string, orientation: string) {
+    const binding = graphBindings[graphId];
+    if (!binding || binding.mode !== 'sequence') return;
+
+    setSequenceOrientation(binding, orientation);
+    await binding.interop.raiseGraphUpdated();
+}
+
+export async function moveSelectedX6SequenceNode(graphId: string, direction: number) {
+    const binding = graphBindings[graphId];
+    if (!binding || binding.mode !== 'sequence') return;
+
+    if (moveSelectedSequenceNode(binding, direction))
+        await binding.interop.raiseGraphUpdated();
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/sequence-mode.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/sequence-mode.ts
@@ -1,0 +1,88 @@
+import {Edge, Graph, Node} from '@antv/x6';
+import {GraphBinding} from './graph-bindings';
+
+export type SequenceLayoutOrientation = 'vertical' | 'horizontal';
+
+const SequenceGap = 160;
+
+export function normalizeSequenceOrientation(value?: string | null): SequenceLayoutOrientation {
+    return value === 'horizontal' ? 'horizontal' : 'vertical';
+}
+
+export function isHorizontalSequence(binding: GraphBinding): boolean {
+    return normalizeSequenceOrientation(binding.layoutOrientation) === 'horizontal';
+}
+
+export function withSuppressedGraphUpdated<T>(binding: GraphBinding, action: () => T): T {
+    binding.suppressGraphUpdated = (binding.suppressGraphUpdated || 0) + 1;
+    try {
+        return action();
+    } finally {
+        binding.suppressGraphUpdated = Math.max(0, (binding.suppressGraphUpdated || 0) - 1);
+    }
+}
+
+export function arrangeSequenceGraph(binding: GraphBinding, orderedNodes?: Node<Node.Properties>[]) {
+    const graph = binding.graph;
+    const nodes = orderedNodes ?? sortSequenceNodes(graph.getNodes(), binding);
+
+    withSuppressedGraphUpdated(binding, () => {
+        nodes.forEach((node, index) => {
+            node.setPosition(
+                isHorizontalSequence(binding)
+                    ? {x: index * SequenceGap, y: 0}
+                    : {x: 0, y: index * SequenceGap},
+                {silent: true},
+            );
+        });
+
+        graph.getEdges().forEach(edge => graph.removeCell(edge, {silent: true}));
+        buildSequenceEdges(graph, nodes).forEach(edge => graph.addEdge(edge, {silent: true}));
+    });
+}
+
+export function setSequenceOrientation(binding: GraphBinding, orientation: string) {
+    binding.layoutOrientation = normalizeSequenceOrientation(orientation);
+    arrangeSequenceGraph(binding);
+}
+
+export function moveSelectedSequenceNode(binding: GraphBinding, direction: number): boolean {
+    const delta = direction < 0 ? -1 : 1;
+    const ordered = sortSequenceNodes(binding.graph.getNodes(), binding);
+    const selectedIndex = ordered.findIndex(node => binding.graph.isSelected(node));
+    if (selectedIndex < 0) return false;
+
+    const targetIndex = selectedIndex + delta;
+    if (targetIndex < 0 || targetIndex >= ordered.length) return false;
+
+    const next = [...ordered];
+    [next[selectedIndex], next[targetIndex]] = [next[targetIndex], next[selectedIndex]];
+    arrangeSequenceGraph(binding, next);
+    binding.graph.cleanSelection();
+    binding.graph.select(next[targetIndex]);
+    return true;
+}
+
+export function sortSequenceNodes(nodes: Node<Node.Properties>[], binding: GraphBinding): Node<Node.Properties>[] {
+    const horizontal = isHorizontalSequence(binding);
+    return [...nodes].sort((a, b) => {
+        const aPosition = a.getPosition();
+        const bPosition = b.getPosition();
+        const primary = horizontal ? aPosition.x - bPosition.x : aPosition.y - bPosition.y;
+        if (primary !== 0) return primary;
+        return horizontal ? aPosition.y - bPosition.y : aPosition.x - bPosition.x;
+    });
+}
+
+function buildSequenceEdges(graph: Graph, nodes: Node<Node.Properties>[]): Edge<Edge.Properties>[] {
+    return nodes.slice(0, -1).map((node, index) => {
+        const next = nodes[index + 1];
+        return graph.createEdge({
+            id: `${node.id}:sequence:${next.id}`,
+            shape: 'elsa-sequence-edge',
+            source: {cell: node.id},
+            target: {cell: next.id},
+            zIndex: -1,
+        });
+    });
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
@@ -77,4 +77,29 @@ export function initialize() {
         true,
     );
 
+    Graph.registerEdge(
+        'elsa-sequence-edge',
+        {
+            inherit: 'edge',
+            attrs: {
+                line: {
+                    stroke: '#94a3b8',
+                    strokeWidth: 2,
+                    targetMarker: 'classic',
+                    size: 6,
+                },
+            },
+            connector: {
+                name: 'rounded',
+                args: {
+                    radius: 8,
+                },
+            },
+            router: {
+                name: 'orth',
+            },
+        },
+        true,
+    );
+
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/api/create-react-graph.tsx
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/api/create-react-graph.tsx
@@ -35,6 +35,7 @@ export async function createReactGraph(
         centerContent: () => handleRef.current?.centerContent(),
         readGraph: () => handleRef.current?.readGraph() ?? { nodes: [], edges: [] },
         setSequenceOrientation: (orientation) => handleRef.current?.setSequenceOrientation(orientation),
+        moveSelectedSequenceNode: (direction) => handleRef.current?.moveSelectedSequenceNode(direction),
         addNode: (node, dropPagePosition) => handleRef.current?.addNode(node, dropPagePosition),
         updateNode: (node) => handleRef.current?.updateNode(node),
         updateNodeStats: (activityId, stats) => handleRef.current?.updateNodeStats(activityId, stats),

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/api/index.ts
@@ -72,6 +72,10 @@ export function setSequenceOrientation(graphId: string, orientation: SequenceLay
     reactBindings[graphId]?.setSequenceOrientation(orientation);
 }
 
+export function moveSelectedReactSequenceNode(graphId: string, direction: -1 | 1): void {
+    reactBindings[graphId]?.moveSelectedSequenceNode(direction);
+}
+
 // Called by .NET after it regenerates IDs server-side
 // (ReactFlowDesigner.HandlePasteCellsRequested). Mirrors the X6 path's pasteCells.
 export function pasteReactCells(graphId: string, activityNodes: ElsaActivityNode[], edges: ElsaEdge[]): void {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/bindings.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/bindings.ts
@@ -13,6 +13,7 @@ export interface ReactDesignerBinding {
     centerContent: () => void;
     readGraph: () => ElsaGraph;
     setSequenceOrientation: (orientation: SequenceLayoutOrientation) => void;
+    moveSelectedSequenceNode: (direction: -1 | 1) => void;
     addNode: (node: ElsaActivityNode, dropPagePosition?: { x: number; y: number }) => void;
     updateNode: (node: ElsaActivityNode) => void;
     updateNodeStats: (activityId: string, stats: ElsaActivityStats) => void;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/components/Designer.tsx
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/react-designer/components/Designer.tsx
@@ -45,6 +45,7 @@ export interface DesignerHandle {
     centerContent: () => void;
     readGraph: () => ElsaGraph;
     setSequenceOrientation: (orientation: SequenceLayoutOrientation) => void;
+    moveSelectedSequenceNode: (direction: -1 | 1) => void;
     addNode: (node: ElsaActivityNode, dropPagePosition?: { x: number; y: number }) => void;
     updateNode: (node: ElsaActivityNode) => void;
     updateNodeStats: (activityId: string, stats: ElsaActivityStats) => void;
@@ -492,6 +493,16 @@ const InnerDesigner = forwardRef<DesignerHandle, DesignerProps>(function InnerDe
             requestAnimationFrame(fitToContent);
             interop.raiseGraphUpdated();
         },
+        moveSelectedSequenceNode: (direction) => {
+            if (readOnlyRef.current) return;
+            const moved = moveSequenceSelection(nodesRef.current, sequenceOrientation, direction);
+            if (moved === nodesRef.current) return;
+            const nextEdges = buildSequenceEdges(moved);
+            setNodes(moved);
+            setEdges(nextEdges);
+            snapshot(moved, nextEdges);
+            interop.raiseGraphUpdated();
+        },
         addNode: (node, dropPagePosition) => {
             const reactNode = toReactFlowNode(node, onEmbeddedPortClick, onDeleteNode, readOnly);
             if (dropPagePosition) {
@@ -933,29 +944,6 @@ const InnerDesigner = forwardRef<DesignerHandle, DesignerProps>(function InnerDe
         setConnectMenu({ kind: 'fromEmpty', clientX: event.clientX, clientY: event.clientY });
     }, [ensureCatalogLoaded]);
 
-    const changeSequenceOrientation = useCallback((orientation: SequenceLayoutOrientation) => {
-        const normalized = normalizeOrientation(orientation);
-        setSequenceOrientationState(normalized);
-        const arranged = arrangeSequenceNodes(nodesRef.current, normalized);
-        const nextEdges = buildSequenceEdges(arranged);
-        setNodes(arranged);
-        setEdges(nextEdges);
-        snapshot(arranged, nextEdges);
-        requestAnimationFrame(fitToContent);
-        interop.raiseGraphUpdated();
-    }, [snapshot, fitToContent, interop]);
-
-    const moveSelectedSequenceNode = useCallback((direction: -1 | 1) => {
-        if (readOnlyRef.current) return;
-        const moved = moveSequenceSelection(nodesRef.current, sequenceOrientation, direction);
-        if (moved === nodesRef.current) return;
-        const nextEdges = buildSequenceEdges(moved);
-        setNodes(moved);
-        setEdges(nextEdges);
-        snapshot(moved, nextEdges);
-        interop.raiseGraphUpdated();
-    }, [sequenceOrientation, snapshot, interop]);
-
     const isValidConnection: IsValidConnection = useCallback((connection) => {
         if (isSequenceMode) return false;
         const { source, target, sourceHandle, targetHandle } = connection as Connection;
@@ -1242,48 +1230,8 @@ const InnerDesigner = forwardRef<DesignerHandle, DesignerProps>(function InnerDe
                 <Controls showInteractive={!readOnly} />
                 <MiniMap pannable zoomable nodeColor={miniMapNodeColor} maskColor="rgba(15, 23, 42, 0.06)" />
                 <SnapLines guides={snapGuides} />
-                {!readOnly && (
+                {!readOnly && !isSequenceMode && (
                     <Panel position="top-right" className="elsa-react-flow-toolbar">
-                        {isSequenceMode && (
-                            <>
-                                <button
-                                    type="button"
-                                    className={`elsa-react-flow-toolbar-btn${sequenceOrientation === 'vertical' ? ' active' : ''}`}
-                                    onClick={() => changeSequenceOrientation('vertical')}
-                                    title="Use vertical Sequence layout"
-                                    aria-label="Use vertical Sequence layout"
-                                >
-                                    Vertical
-                                </button>
-                                <button
-                                    type="button"
-                                    className={`elsa-react-flow-toolbar-btn${sequenceOrientation === 'horizontal' ? ' active' : ''}`}
-                                    onClick={() => changeSequenceOrientation('horizontal')}
-                                    title="Use horizontal Sequence layout"
-                                    aria-label="Use horizontal Sequence layout"
-                                >
-                                    Horizontal
-                                </button>
-                                <button
-                                    type="button"
-                                    className="elsa-react-flow-toolbar-btn"
-                                    onClick={() => moveSelectedSequenceNode(-1)}
-                                    title="Move selected activity earlier"
-                                    aria-label="Move selected activity earlier"
-                                >
-                                    Earlier
-                                </button>
-                                <button
-                                    type="button"
-                                    className="elsa-react-flow-toolbar-btn"
-                                    onClick={() => moveSelectedSequenceNode(1)}
-                                    title="Move selected activity later"
-                                    aria-label="Move selected activity later"
-                                >
-                                    Later
-                                </button>
-                            </>
-                        )}
                         <button
                             type="button"
                             className="elsa-react-flow-toolbar-btn"

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor
@@ -1,0 +1,7 @@
+@inherits StudioComponentBase
+
+<CascadingValue Value="@this">
+    <div class="elsa-sequence-diagram-designer elsa-flowchart-diagram-designer-v2" style="width:100%; height:100%">
+        <div id="@_containerId" class="graph-container"></div>
+    </div>
+</CascadingValue>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor.cs
@@ -14,30 +14,33 @@ using Elsa.Studio.Workflows.Domain.Extensions;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.UI.Args;
-using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using MudBlazor.Utilities;
 using ThrottleDebounce;
 
 namespace Elsa.Studio.Workflows.Designer.Components;
 
 /// <summary>
-/// A constrained React Flow designer for Sequence activities.
+/// A constrained X6 designer for Sequence activities.
 /// </summary>
-public partial class SequenceFlowDesigner : IAsyncDisposable
+public partial class SequenceDesigner : IDisposable, IAsyncDisposable
 {
-    private readonly string _containerId = $"sequence-rf-container-{Guid.NewGuid():N}";
+    private readonly string _containerId = $"sequence-container-{Guid.NewGuid():N}";
+    private readonly PendingActionsQueue _pendingGraphActions;
     private readonly RateLimitedFunc<Task> _rateLimitedLoadSequenceAction;
-    private DotNetObjectReference<SequenceFlowDesigner>? _componentRef;
+    private DotNetObjectReference<SequenceDesigner>? _componentRef;
     private ISequenceMapper? _sequenceMapper;
-    private ReactFlowGraphApi? _graphApi;
     private JsonObject? _sequence;
     private IDictionary<string, ActivityStats>? _activityStats;
+    private X6GraphApi _graphApi = null!;
 
-    public SequenceFlowDesigner()
+    public SequenceDesigner()
     {
+        _pendingGraphActions = new(() => new(_graphApi != null!), () => Logger);
         _rateLimitedLoadSequenceAction = Debouncer.Debounce(
             async () => await InvokeAsync(async () => await LoadSequenceAsync(Sequence, ActivityStats)),
             TimeSpan.FromMilliseconds(100));
@@ -53,12 +56,13 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
     [Parameter] public EventCallback CanvasSelected { get; set; }
     [Parameter] public EventCallback GraphUpdated { get; set; }
 
-    [Inject] private ReactFlowJsInterop JsInterop { get; set; } = null!;
+    [Inject] private DesignerJsInterop DesignerJsInterop { get; set; } = null!;
+    [Inject] private IThemeService ThemeService { get; set; } = null!;
     [Inject] private IMapperFactory MapperFactory { get; set; } = null!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
     [Inject] private IIdentityGenerator IdentityGenerator { get; set; } = null!;
     [Inject] private IActivityNameGenerator ActivityNameGenerator { get; set; } = null!;
-    [Inject] private IActivityDisplaySettingsRegistry ActivityDisplaySettingsRegistry { get; set; } = null!;
+    [Inject] private ILogger<SequenceDesigner> Logger { get; set; } = null!;
 
     [JSInvokable]
     public async Task HandleActivitySelected(JsonObject activity)
@@ -98,8 +102,6 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
     [JSInvokable]
     public async Task HandlePasteCellsRequested(X6ActivityNode[] activityNodes, X6Edge[] edges)
     {
-        if (_graphApi is null) return;
-
         var allActivities = Sequence.GetActivities().ToList();
         var container = Sequence;
 
@@ -115,7 +117,7 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
             allActivities.Add(activity);
         }
 
-        await _graphApi.PasteCellsAsync(activityNodes, []);
+        await ScheduleGraphActionAsync(() => _graphApi.PasteCellsAsync(activityNodes, []));
     }
 
     public async Task LoadSequenceAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStats)
@@ -125,135 +127,84 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
         _sequence = activity;
         _activityStats = activityStats;
 
-        if (_graphApi is null) return;
-
         var mapper = await GetSequenceMapperAsync();
         var graph = mapper.Map(activity, activityStats);
-        await _graphApi.LoadGraphAsync(graph);
+        await ScheduleGraphActionAsync(() => _graphApi.LoadGraphAsync(graph));
     }
 
     public async Task<JsonObject> ReadSequenceAsync()
     {
-        if (_graphApi is null) return Sequence;
-
         var serializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-        var data = await _graphApi.ReadGraphAsync();
-        var cells = data.GetProperty("cells").EnumerateArray();
-        var nodes = cells.Where(x => x.TryGetProperty("shape", out var shape) && shape.GetString() == "elsa-activity")
-            .Select(x => x.Deserialize<X6ActivityNode>(serializerOptions)!)
-            .ToList();
-        var graph = new X6Graph(nodes, [])
+
+        return await ScheduleGraphActionAsync(async () =>
         {
-            LayoutOrientation = data.TryGetProperty("layoutOrientation", out var orientation) ? orientation.GetString() : null
-        };
-        var mapper = await GetSequenceMapperAsync();
-        return mapper.Map(Sequence, graph);
-    }
-
-    public async Task ZoomToFitAsync()
-    {
-        if (_graphApi is not null)
-            await _graphApi.ZoomToFitAsync();
-    }
-
-    public async Task CenterContentAsync()
-    {
-        if (_graphApi is not null)
-            await _graphApi.CenterContentAsync();
-    }
-
-    public async Task AutoLayoutAsync()
-    {
-        if (_graphApi is not null)
-            await _graphApi.AutoLayoutAsync();
-    }
-
-    public async Task SetLayoutOrientationAsync(string orientation)
-    {
-        if (_graphApi is not null)
-            await _graphApi.SetSequenceOrientationAsync(orientation);
-    }
-
-    public async Task MoveSelectedActivityAsync(int direction)
-    {
-        if (_graphApi is not null)
-            await _graphApi.MoveSelectedSequenceNodeAsync(direction);
-    }
-
-    public async Task SelectActivityAsync(string id)
-    {
-        if (_graphApi is not null)
-            await _graphApi.SelectActivityAsync(id);
-    }
-
-    public async Task UpdateActivityAsync(string id, JsonObject activity)
-    {
-        if (_graphApi is null) return;
-        var mapper = await MapperFactory.CreateActivityMapperAsync();
-        var node = mapper.MapActivity(activity);
-        await _graphApi.UpdateActivityAsync(node);
-        await NotifyActivityUpdatedAsync(activity);
-    }
-
-    public async Task UpdateActivityStatsAsync(string activityId, ActivityStats stats)
-    {
-        if (_graphApi is not null)
-            await _graphApi.UpdateActivityStatsAsync(activityId, stats);
+            var data = await _graphApi.ReadGraphAsync();
+            var cells = data.GetProperty("cells").EnumerateArray();
+            var nodes = cells.Where(x => x.TryGetProperty("shape", out var shape) && shape.GetString() == "elsa-activity")
+                .Select(x => x.Deserialize<X6ActivityNode>(serializerOptions)!)
+                .ToList();
+            var graph = new X6Graph(nodes, [])
+            {
+                LayoutOrientation = data.TryGetProperty("layoutOrientation", out var orientation) ? orientation.GetString() : null
+            };
+            var mapper = await GetSequenceMapperAsync();
+            return mapper.Map(Sequence, graph);
+        });
     }
 
     public async Task AddActivityAsync(JsonObject activity)
     {
-        if (_graphApi is null) return;
         var mapper = await MapperFactory.CreateActivityMapperAsync();
         var node = mapper.MapActivity(activity);
-        await _graphApi.AddActivityNodeAsync(node);
+        await ScheduleGraphActionAsync(() => _graphApi.AddActivityNodeAsync(node));
     }
 
-    [JSInvokable]
-    public async Task<IList<ActivityDescriptorDto>> GetAvailableActivities()
+    public async Task UpdateActivityAsync(string id, JsonObject activity)
     {
-        await ActivityRegistry.EnsureLoadedAsync();
-        return ActivityRegistry.ListBrowsable().Select(d =>
-        {
-            var settings = ActivityDisplaySettingsRegistry.GetSettings(d.TypeName);
-            return new ActivityDescriptorDto(
-                d.TypeName,
-                d.Version,
-                d.Name,
-                d.DisplayName ?? d.Name,
-                d.Category,
-                d.Description,
-                settings.Color,
-                settings.Icon);
-        })
-        .OrderBy(d => d.Category)
-        .ThenBy(d => d.DisplayName)
-        .ToList();
+        await ScheduleGraphActionAsync(() => _graphApi.UpdateActivityAsync(activity));
+
+        if (ActivityUpdated.HasDelegate)
+            await ActivityUpdated.InvokeAsync(activity);
     }
 
-    [JSInvokable]
-    public async Task<JsonObject?> AddActivityAtPosition(string typeName, int version, double x, double y)
+    public async Task UpdateActivityStatsAsync(string activityId, ActivityStats stats) =>
+        await ScheduleGraphActionAsync(() => DesignerJsInterop.UpdateActivityStatsAsync($"activity-{activityId}", activityId, stats));
+
+    public async Task SelectActivityAsync(string id) =>
+        await ScheduleGraphActionAsync(() => _graphApi.SelectActivityAsync(id));
+
+    public async Task ZoomToFitAsync() =>
+        await ScheduleGraphActionAsync(() => _graphApi.ZoomToFitAsync());
+
+    public async Task CenterContentAsync() =>
+        await ScheduleGraphActionAsync(() => _graphApi.CenterContentAsync());
+
+    public async Task AutoLayoutAsync()
     {
-        if (_graphApi is null) return null;
-
-        await ActivityRegistry.EnsureLoadedAsync();
-        var descriptor = ActivityRegistry.Find(typeName, version);
-        if (descriptor == null) return null;
-
-        var newActivity = SequenceActivityFactory.CreateActivity(Sequence, descriptor, IdentityGenerator, ActivityNameGenerator, x, y);
-        await AddActivityAsync(newActivity);
-        await NotifyActivityUpdatedAsync(newActivity);
-        return newActivity;
+        var mapper = await GetSequenceMapperAsync();
+        var graph = mapper.Map(Sequence, ActivityStats);
+        await ScheduleGraphActionAsync(() => _graphApi.AutoLayoutAsync(graph));
     }
 
-    protected override void OnInitialized() => _sequence = Sequence;
+    public async Task SetLayoutOrientationAsync(string orientation) =>
+        await ScheduleGraphActionAsync(() => _graphApi.SetSequenceOrientationAsync(orientation));
+
+    public async Task MoveSelectedActivityAsync(int direction) =>
+        await ScheduleGraphActionAsync(() => _graphApi.MoveSelectedSequenceNodeAsync(direction));
+
+    protected override void OnInitialized()
+    {
+        ThemeService.IsDarkModeChanged += OnDarkModeChanged;
+        _sequence = Sequence;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
 
         _componentRef = DotNetObjectReference.Create(this);
-        _graphApi = await JsInterop.CreateGraphAsync(_containerId, _componentRef, IsReadOnly, "sequence");
+        _graphApi = await DesignerJsInterop.CreateGraphAsync(_containerId, _componentRef, IsReadOnly, "sequence");
+        await _pendingGraphActions.ProcessAsync();
         await LoadSequenceAsync(Sequence, ActivityStats);
     }
 
@@ -280,11 +231,11 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
     private async Task<ISequenceMapper> GetSequenceMapperAsync() =>
         _sequenceMapper ??= await MapperFactory.CreateSequenceMapperAsync();
 
-    private async Task NotifyActivityUpdatedAsync(JsonObject activity)
-    {
-        if (ActivityUpdated.HasDelegate)
-            await ActivityUpdated.InvokeAsync(activity);
-    }
+    private async Task ScheduleGraphActionAsync(Func<Task> action) =>
+        await _pendingGraphActions.EnqueueAsync(action);
+
+    private async Task<T> ScheduleGraphActionAsync<T>(Func<Task<T>> action) =>
+        await _pendingGraphActions.EnqueueAsync(action);
 
     private void GenerateNewActivityIds(JsonObject container)
     {
@@ -325,11 +276,24 @@ public partial class SequenceFlowDesigner : IAsyncDisposable
         }
     }
 
-    public async ValueTask DisposeAsync()
+    private async void OnDarkModeChanged()
     {
-        if (_graphApi is not null)
+        var palette = ThemeService.CurrentPalette;
+        var gridColor = palette.BackgroundGray;
+        await ScheduleGraphActionAsync(() => _graphApi.SetGridColorAsync(gridColor.ToString(MudColorOutputFormats.HexA)));
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_graphApi != null!)
             await _graphApi.DisposeGraphAsync();
 
+        ((IDisposable)this).Dispose();
+    }
+
+    void IDisposable.Dispose()
+    {
+        ThemeService.IsDarkModeChanged -= OnDarkModeChanged;
         _componentRef?.Dispose();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
@@ -26,12 +26,29 @@ public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> o
     /// <param name="componentRef">A reference to the <see cref="FlowchartDesigner"/> component.</param>
     /// <param name="isReadOnly">Whether the graph is read-only.</param>
     /// <returns>The ID of the graph.</returns>
-    public async ValueTask<X6GraphApi> CreateGraphAsync(string containerId, DotNetObjectReference<FlowchartDesigner> componentRef, bool isReadOnly = false)
+    public ValueTask<X6GraphApi> CreateGraphAsync(string containerId, DotNetObjectReference<FlowchartDesigner> componentRef, bool isReadOnly = false) =>
+        CreateGraphAsync<FlowchartDesigner>(containerId, componentRef, isReadOnly);
+
+    /// <summary>
+    /// Creates a new X6 graph object and returns its API wrapper.
+    /// </summary>
+    public async ValueTask<X6GraphApi> CreateGraphAsync<TComponent>(string containerId, DotNetObjectReference<TComponent> componentRef, bool isReadOnly = false, string mode = "flowchart")
+        where TComponent : class
     {
         return await TryInvokeAsync(async module =>
         {
             var graphSettings = options.Value.GraphSettings;
-            await module.InvokeAsync<string>("createGraph", containerId, componentRef, isReadOnly, graphSettings);
+            var settings = new
+            {
+                graphSettings.Grid,
+                graphSettings.MagnetThreshold,
+                graphSettings.Panning,
+                graphSettings.Mousewheel,
+                graphSettings.ResizingEnabled,
+                Mode = mode
+            };
+
+            await module.InvokeAsync<string>("createGraph", containerId, componentRef, isReadOnly, settings);
             return new X6GraphApi(module, serviceProvider, containerId);
         });
     }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/ReactFlowGraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/ReactFlowGraphApi.cs
@@ -78,6 +78,14 @@ public class ReactFlowGraphApi
     public async Task AutoLayoutAsync() =>
         await _module.InvokeVoidAsync("autoLayoutReactGraph", _containerId);
 
+    /// <summary>Sets the Sequence layout orientation.</summary>
+    public async Task SetSequenceOrientationAsync(string orientation) =>
+        await _module.InvokeVoidAsync("setSequenceOrientation", _containerId, orientation);
+
+    /// <summary>Moves the selected Sequence activity earlier or later.</summary>
+    public async Task MoveSelectedSequenceNodeAsync(int direction) =>
+        await _module.InvokeVoidAsync("moveSelectedReactSequenceNode", _containerId, direction);
+
     /// <summary>Adds the specified activity nodes and edges (after .NET regenerated their IDs).</summary>
     public async Task PasteCellsAsync(IEnumerable<X6ActivityNode> activityNodes, X6Edge[] edges)
     {

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
@@ -101,6 +101,18 @@ public class X6GraphApi
     }
 
     /// <summary>
+    /// Sets the Sequence layout orientation on constrained graph designers.
+    /// </summary>
+    public async Task SetSequenceOrientationAsync(string orientation) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("setX6SequenceOrientation", _containerId, orientation));
+
+    /// <summary>
+    /// Moves the selected Sequence activity earlier or later.
+    /// </summary>
+    public async Task MoveSelectedSequenceNodeAsync(int direction) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("moveSelectedX6SequenceNode", _containerId, direction));
+
+    /// <summary>
     /// Updates the node with the specified activity. 
     /// </summary>
     /// <param name="activity">The activity.</param>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDesignerWrapper.razor
@@ -1,16 +1,34 @@
 @if (IsReadOnly)
 {
     <div style="height:100%">
-        <SequenceFlowDesigner @ref="@Designer" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
-            ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected" IsReadOnly="true"
-            ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        @if (UseReactFlow)
+        {
+            <SequenceFlowDesigner @ref="@ReactDesigner" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
+                ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected" IsReadOnly="true"
+                ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        }
+        else
+        {
+            <SequenceDesigner @ref="@Designer" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
+                ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected" IsReadOnly="true"
+                ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        }
     </div>
 }
 else
 {
     <div class="sequence-diagram-designer-wrapper" style="height: 100%" @ondragover="@OnDragOver" @ondragover:preventDefault @ondrop="@OnDrop">
-        <SequenceFlowDesigner @ref="@Designer" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
-            ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected"
-            GraphUpdated="@GraphUpdated" ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        @if (UseReactFlow)
+        {
+            <SequenceFlowDesigner @ref="@ReactDesigner" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
+                ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected"
+                GraphUpdated="@GraphUpdated" ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        }
+        else
+        {
+            <SequenceDesigner @ref="@Designer" Sequence="@Sequence" ActivitySelected="@ActivitySelected"
+                ActivityUpdated="@ActivityUpdated" ActivityEmbeddedPortSelected="ActivityEmbeddedPortSelected" CanvasSelected="@OnCanvasSelected"
+                GraphUpdated="@GraphUpdated" ActivityStats="ActivityStats" ActivityDoubleClick="@ActivityDoubleClick" />
+        }
     </div>
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDesignerWrapper.razor.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Designer.Services;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
@@ -10,6 +11,7 @@ using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.UI.Args;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.Sequences;
 
@@ -30,8 +32,11 @@ public partial class SequenceDesignerWrapper
     [CascadingParameter] private DragDropManager DragDropManager { get; set; } = null!;
     [Inject] private IIdentityGenerator IdentityGenerator { get; set; } = null!;
     [Inject] private IActivityNameGenerator ActivityNameGenerator { get; set; } = null!;
+    [Inject] private IOptions<DesignerOptions> DesignerOptions { get; set; } = null!;
 
-    private SequenceFlowDesigner? Designer { get; set; }
+    private SequenceDesigner? Designer { get; set; }
+    private SequenceFlowDesigner? ReactDesigner { get; set; }
+    private bool UseReactFlow => DesignerOptions.Value.UseReactFlow;
     private string? _lastSequenceId;
 
     public async Task LoadSequenceAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStats = null)
@@ -48,7 +53,9 @@ public partial class SequenceDesignerWrapper
         Sequence = sequence;
         ActivityStats = activityStats;
 
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.LoadSequenceAsync(sequence, activityStats);
+        else if (Designer is not null)
             await Designer.LoadSequenceAsync(sequence, activityStats);
     }
 
@@ -59,24 +66,32 @@ public partial class SequenceDesignerWrapper
 
         if (activity == Sequence) return;
 
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.UpdateActivityAsync(id, activity);
+        else if (Designer is not null)
             await Designer.UpdateActivityAsync(id, activity);
     }
 
     public async Task UpdateActivityStatsAsync(string id, ActivityStats stats)
     {
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.UpdateActivityStatsAsync(id, stats);
+        else if (Designer is not null)
             await Designer.UpdateActivityStatsAsync(id, stats);
     }
 
     public async Task SelectActivityAsync(string id)
     {
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.SelectActivityAsync(id);
+        else if (Designer is not null)
             await Designer.SelectActivityAsync(id);
     }
 
     public async Task<JsonObject> ReadRootActivityAsync()
     {
+        if (ReactDesigner is not null)
+            return await ReactDesigner.ReadSequenceAsync();
         if (Designer is not null)
             return await Designer.ReadSequenceAsync();
 
@@ -85,27 +100,51 @@ public partial class SequenceDesignerWrapper
 
     public async Task ZoomToFitAsync()
     {
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.ZoomToFitAsync();
+        else if (Designer is not null)
             await Designer.ZoomToFitAsync();
     }
 
     public async Task CenterContentAsync()
     {
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.CenterContentAsync();
+        else if (Designer is not null)
             await Designer.CenterContentAsync();
     }
 
     public async Task AutoLayoutAsync()
     {
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.AutoLayoutAsync();
+        else if (Designer is not null)
             await Designer.AutoLayoutAsync();
+    }
+
+    public async Task SetLayoutOrientationAsync(string orientation)
+    {
+        if (ReactDesigner is not null)
+            await ReactDesigner.SetLayoutOrientationAsync(orientation);
+        else if (Designer is not null)
+            await Designer.SetLayoutOrientationAsync(orientation);
+    }
+
+    public async Task MoveSelectedActivityAsync(int direction)
+    {
+        if (ReactDesigner is not null)
+            await ReactDesigner.MoveSelectedActivityAsync(direction);
+        else if (Designer is not null)
+            await Designer.MoveSelectedActivityAsync(direction);
     }
 
     private async Task AddNewActivityAsync(ActivityDescriptor activityDescriptor, double x, double y)
     {
         var newActivity = SequenceActivityFactory.CreateActivity(Sequence, activityDescriptor, IdentityGenerator, ActivityNameGenerator, x, y);
 
-        if (Designer is not null)
+        if (ReactDesigner is not null)
+            await ReactDesigner.AddActivityAsync(newActivity);
+        else if (Designer is not null)
             await Designer.AddActivityAsync(newActivity);
 
         if (ActivitySelected.HasDelegate)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Sequences/SequenceDiagramDesigner.cs
@@ -74,6 +74,14 @@ public class SequenceDiagramDesigner(ILocalizer localizer) : IDiagramDesignerToo
     /// <inheritdoc />
     public IEnumerable<RenderFragment> GetToolboxItems(bool isReadonly)
     {
+        if (!isReadonly)
+        {
+            yield return DisplayToolboxItem(localizer["Vertical layout"], Icons.Material.Outlined.SwapVert, localizer["Use vertical Sequence layout"], OnVerticalLayoutClicked);
+            yield return DisplayToolboxItem(localizer["Horizontal layout"], Icons.Material.Outlined.SwapHoriz, localizer["Use horizontal Sequence layout"], OnHorizontalLayoutClicked);
+            yield return DisplayToolboxItem(localizer["Move earlier"], Icons.Material.Outlined.KeyboardArrowUp, localizer["Move selected activity earlier"], OnMoveEarlierClicked);
+            yield return DisplayToolboxItem(localizer["Move later"], Icons.Material.Outlined.KeyboardArrowDown, localizer["Move selected activity later"], OnMoveLaterClicked);
+        }
+
         yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
         yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
         yield return DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
@@ -106,4 +114,8 @@ public class SequenceDiagramDesigner(ILocalizer localizer) : IDiagramDesignerToo
     private Task OnZoomToFitClicked() => _designerWrapper != null ? _designerWrapper.ZoomToFitAsync() : Task.CompletedTask;
     private Task OnCenterClicked() => _designerWrapper != null ? _designerWrapper.CenterContentAsync() : Task.CompletedTask;
     private Task OnAutoLayoutClicked() => _designerWrapper != null ? _designerWrapper.AutoLayoutAsync() : Task.CompletedTask;
+    private Task OnVerticalLayoutClicked() => _designerWrapper != null ? _designerWrapper.SetLayoutOrientationAsync("vertical") : Task.CompletedTask;
+    private Task OnHorizontalLayoutClicked() => _designerWrapper != null ? _designerWrapper.SetLayoutOrientationAsync("horizontal") : Task.CompletedTask;
+    private Task OnMoveEarlierClicked() => _designerWrapper != null ? _designerWrapper.MoveSelectedActivityAsync(-1) : Task.CompletedTask;
+    private Task OnMoveLaterClicked() => _designerWrapper != null ? _designerWrapper.MoveSelectedActivityAsync(1) : Task.CompletedTask;
 }


### PR DESCRIPTION
## Summary
- Add a root activity selector to the New Workflow dialog so users can choose Flowchart, Sequence, or StateMachine up front
- Introduce a small root-template abstraction so workflow creation can generate the correct root JSON without hard-coded dialog logic
- Keep Flowchart as the default to preserve current behavior for existing users and callers

## Testing
- Not run (not requested)