### PR TITLE
Add feature-gated dashboard widget composition

### DIFF
--- a/src/bundles/Elsa.Studio/Readme.md
+++ b/src/bundles/Elsa.Studio/Readme.md
@@ -2,7 +2,12 @@
 
 This is a bundle package that includes the following packages:
 
-- Elsa.Studio.Backend
 - Elsa.Studio.Dashboard
 - Elsa.Studio.Workflows
+- Elsa.Studio.Diagnostics.ConsoleLogs
+- Elsa.Studio.Diagnostics.OpenTelemetry
+- Elsa.Studio.Diagnostics.StructuredLogs
+- Elsa.Studio.Secrets
 - Elsa.Studio.Shell
+
+The dashboard package provides the shell. Workflow and diagnostics dashboard widgets are registered by their companion modules only when the selected backend advertises the matching dashboard shell features.

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardModuleRegistrationTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardModuleRegistrationTests.cs
@@ -1,0 +1,116 @@
+using Elsa.Api.Client.Resources.Features.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Dashboard.Extensions;
+using Elsa.Studio.Dashboard.Services;
+using Elsa.Studio.Diagnostics.ConsoleLogs.Dashboard;
+using Elsa.Studio.Diagnostics.ConsoleLogs.Extensions;
+using Elsa.Studio.Diagnostics.StructuredLogs.Dashboard;
+using Elsa.Studio.Diagnostics.StructuredLogs.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Services;
+using Elsa.Studio.Workflows.Dashboard;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardModuleRegistrationTests
+{
+    private readonly BackendApiConfig _backendApiConfig = new();
+
+    [Fact]
+    public async Task InitializeFeaturesAsync_WhenDashboardRemoteFeaturesDisabled_RegistersNoCompanionWidgets()
+    {
+        using var provider = BuildProvider([]);
+
+        await InitializeFeaturesAsync(provider);
+
+        var widgets = provider.GetRequiredService<IDashboardWidgetProvider>().GetWidgets();
+        Assert.Empty(widgets);
+    }
+
+    [Fact]
+    public async Task InitializeFeaturesAsync_WhenDashboardRemoteFeaturesEnabled_RegistersExpectedCompanionWidgets()
+    {
+        using var provider = BuildProvider(
+            WorkflowDashboardFeature.RemoteFeatureName,
+            ConsoleLogsDashboardFeature.RemoteFeatureName,
+            StructuredLogsDashboardFeature.RemoteFeatureName);
+
+        await InitializeFeaturesAsync(provider);
+
+        var widgetIds = provider.GetRequiredService<IDashboardWidgetProvider>().GetWidgets().Select(x => x.Id).ToList();
+        Assert.Equal(
+            [
+                "workflows.metrics",
+                "workflows.needs-attention",
+                "workflows.execution-trend",
+                "workflows.recent-activity",
+                "workflows.hotspots",
+                "diagnostics.structured-logs",
+                "diagnostics.console-logs"
+            ],
+            widgetIds);
+    }
+
+    [Fact]
+    public void DashboardModule_DoesNotReferenceWorkflowOrDiagnosticsModules()
+    {
+        var references = typeof(Feature).Assembly.GetReferencedAssemblies().Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.DoesNotContain("Elsa.Studio.Workflows", references);
+        Assert.DoesNotContain("Elsa.Studio.Diagnostics.ConsoleLogs", references);
+        Assert.DoesNotContain("Elsa.Studio.Diagnostics.StructuredLogs", references);
+    }
+
+    private ServiceProvider BuildProvider(params string[] enabledRemoteFeatures)
+    {
+        var services = new ServiceCollection();
+        services.AddDashboardModule();
+        services.AddWorkflowsModule();
+        services.AddConsoleLogsModule(_backendApiConfig);
+        services.AddStructuredLogsModule(_backendApiConfig);
+        services.AddSingleton<IRemoteFeatureProvider>(new TestRemoteFeatureProvider(enabledRemoteFeatures));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task InitializeFeaturesAsync(ServiceProvider provider)
+    {
+        var featureService = new DefaultFeatureService(
+            provider.GetRequiredService<IEnumerable<IFeature>>(),
+            provider.GetRequiredService<IRemoteFeatureProvider>());
+
+        await featureService.InitializeFeaturesAsync();
+    }
+
+    private class TestRemoteFeatureProvider(params string[] enabledRemoteFeatures) : IRemoteFeatureProvider
+    {
+        public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(enabledRemoteFeatures.Contains(featureName, StringComparer.Ordinal));
+        }
+
+        public Task<IEnumerable<FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(enabledRemoteFeatures.Select(ToDescriptor).AsEnumerable());
+        }
+
+        private static FeatureDescriptor ToDescriptor(string fullName)
+        {
+            var separatorIndex = fullName.LastIndexOf('.');
+            var name = fullName[(separatorIndex + 1)..];
+            var ns = fullName[..separatorIndex];
+
+            return new FeatureDescriptor
+            {
+                Name = name,
+                Namespace = ns,
+                FullName = fullName,
+                DisplayName = name,
+                Description = string.Empty
+            };
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetProviderTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetProviderTests.cs
@@ -1,0 +1,53 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public class DashboardWidgetProviderTests
+{
+    private readonly DashboardWidgetRegistry _registry = new();
+
+    [Fact]
+    public void GetWidgets_OrdersByZoneOrderAndId()
+    {
+        _registry.Add(Descriptor("secondary.b", DashboardWidgetZone.Secondary, 20));
+        _registry.Add(Descriptor("primary.a", DashboardWidgetZone.Primary, 20));
+        _registry.Add(Descriptor("primary.b", DashboardWidgetZone.Primary, 10));
+
+        var provider = new DashboardWidgetProvider([], _registry);
+
+        var results = provider.GetWidgets();
+
+        Assert.Equal(["primary.b", "primary.a", "secondary.b"], results.Select(x => x.Id));
+    }
+
+    [Fact]
+    public void Add_WhenDuplicateId_Throws()
+    {
+        _registry.Add(Descriptor("duplicate", DashboardWidgetZone.Primary, 0));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => _registry.Add(Descriptor("DUPLICATE", DashboardWidgetZone.Primary, 1)));
+
+        Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetWidgets_WhenStaticAndRegistryDuplicateId_Throws()
+    {
+        _registry.Add(Descriptor("duplicate", DashboardWidgetZone.Primary, 0));
+        var provider = new DashboardWidgetProvider([Descriptor("duplicate", DashboardWidgetZone.Secondary, 0)], _registry);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetWidgets());
+
+        Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static DashboardWidgetDescriptor Descriptor(string id, DashboardWidgetZone zone, int order) => new()
+    {
+        Id = id,
+        ComponentType = typeof(object),
+        Zone = zone,
+        Order = order
+    };
+}

--- a/src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj
@@ -15,6 +15,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Elsa.Studio.Dashboard\Elsa.Studio.Dashboard.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Diagnostics.ConsoleLogs\Elsa.Studio.Diagnostics.ConsoleLogs.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Diagnostics.StructuredLogs\Elsa.Studio.Diagnostics.StructuredLogs.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardConsoleLogsSnapshot.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardConsoleLogsSnapshot.razor
@@ -1,0 +1,23 @@
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section" Style="@DashboardStyles.Panel">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header" Style="@DashboardStyles.SectionHeader">
+        <MudText Typo="Typo.subtitle1">Console</MudText>
+        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DashboardUiMapper.CapabilityColor(Summary.Capability)">
+            @DashboardUiMapper.CapabilityLabel(Summary.Capability)
+        </MudChip>
+    </MudStack>
+
+    <div class="dashboard-diagnostics-block" style="@DashboardStyles.DiagnosticsBlock">
+        <DashboardDiagnosticsValue Label="Sources" Value="@DashboardMetricFormatter.Count(Summary.SourceCount)" />
+        <DashboardDiagnosticsValue Label="Stale" Value="@DashboardMetricFormatter.Count(Summary.StaleSourceCount)" Color="@StaleColor(Summary.StaleSourceCount)" />
+        <DashboardDiagnosticsValue Label="stderr" Value="@DashboardMetricFormatter.Count(Summary.RecentStderrCount)" Color="@ErrorColor(Summary.RecentStderrCount)" />
+        <DashboardDiagnosticsValue Label="Dropped lines" Value="@DashboardMetricFormatter.Count(Summary.DroppedLineCount)" Color="@ErrorColor(Summary.DroppedLineCount)" />
+        <MudButton Href="@DashboardNavigationTargetMapper.Console" Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Outlined.OpenInNew">Open console</MudButton>
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter] public DashboardConsoleLogSummary Summary { get; set; } = new();
+
+    private static Color StaleColor(long value) => value > 0 ? Color.Warning : Color.Default;
+    private static Color ErrorColor(long value) => value > 0 ? Color.Error : Color.Default;
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardOverviewWidgetBase.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardOverviewWidgetBase.cs
@@ -1,0 +1,86 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Dashboard.Components;
+
+public abstract class DashboardOverviewWidgetBase : ComponentBase, IAsyncDisposable
+{
+    private CancellationTokenSource? _loadCancellationTokenSource;
+    private DashboardWidgetContext? _loadedContext;
+
+    [Inject] private IDashboardService DashboardService { get; set; } = null!;
+    [CascadingParameter] public DashboardWidgetContext? WidgetContext { get; set; }
+
+    protected DashboardOverview? Overview { get; private set; }
+    protected DashboardLoadStatus Status { get; private set; } = DashboardLoadStatus.Unavailable;
+    protected string? Message { get; private set; }
+    protected bool Loading { get; private set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (WidgetContext == null || _loadedContext == WidgetContext)
+            return;
+
+        await LoadAsync(WidgetContext);
+    }
+
+    private async Task LoadAsync(DashboardWidgetContext context)
+    {
+        await CancelCurrentLoadAsync();
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        _loadCancellationTokenSource = cancellationTokenSource;
+        Loading = true;
+        Message = null;
+
+        try
+        {
+            var result = await DashboardService.LoadOverviewAsync(context.Range, cancellationToken: cancellationTokenSource.Token);
+            Status = result.Status;
+            _loadedContext = context;
+
+            if (result.Value != null)
+            {
+                Overview = result.Value;
+                Message = null;
+            }
+            else
+            {
+                Message = result.Message;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception e)
+        {
+            Status = DashboardLoadStatus.Failed;
+            Message = e.Message;
+        }
+        finally
+        {
+            if (ReferenceEquals(_loadCancellationTokenSource, cancellationTokenSource))
+            {
+                Loading = false;
+                _loadCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
+        }
+    }
+
+    protected async Task CancelCurrentLoadAsync()
+    {
+        if (_loadCancellationTokenSource == null)
+            return;
+
+        await _loadCancellationTokenSource.CancelAsync();
+        _loadCancellationTokenSource = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CancelCurrentLoadAsync();
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardStructuredLogsSnapshot.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardStructuredLogsSnapshot.razor
@@ -1,0 +1,23 @@
+<MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-section" Style="@DashboardStyles.Panel">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="dashboard-section-header" Style="@DashboardStyles.SectionHeader">
+        <MudText Typo="Typo.subtitle1">Structured logs</MudText>
+        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@DashboardUiMapper.CapabilityColor(Summary.Capability)">
+            @DashboardUiMapper.CapabilityLabel(Summary.Capability)
+        </MudChip>
+    </MudStack>
+
+    <div class="dashboard-diagnostics-block" style="@DashboardStyles.DiagnosticsBlock">
+        <DashboardDiagnosticsValue Label="Sources" Value="@DashboardMetricFormatter.Count(Summary.SourceCount)" />
+        <DashboardDiagnosticsValue Label="Stale" Value="@DashboardMetricFormatter.Count(Summary.StaleSourceCount)" Color="@StaleColor(Summary.StaleSourceCount)" />
+        <DashboardDiagnosticsValue Label="Errors / critical" Value="@DashboardMetricFormatter.Count(Summary.RecentErrorOrCriticalCount)" Color="@ErrorColor(Summary.RecentErrorOrCriticalCount)" />
+        <DashboardDiagnosticsValue Label="Dropped writes" Value="@DashboardMetricFormatter.Count(Summary.DroppedWriteCount)" Color="@ErrorColor(Summary.DroppedWriteCount)" />
+        <MudButton Href="@DashboardNavigationTargetMapper.StructuredLogs" Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Outlined.OpenInNew">Open logs</MudButton>
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter] public DashboardStructuredLogSummary Summary { get; set; } = new();
+
+    private static Color StaleColor(long value) => value > 0 ? Color.Warning : Color.Default;
+    private static Color ErrorColor(long value) => value > 0 ? Color.Error : Color.Default;
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardStyles.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardStyles.cs
@@ -1,6 +1,6 @@
 namespace Elsa.Studio.Dashboard.Components;
 
-internal static class DashboardStyles
+public static class DashboardStyles
 {
     public const string Shell = "min-height:100%; padding:20px 24px 28px; background:#f6f8fb;";
     public const string Header = "gap:12px 16px; margin-bottom:14px;";

--- a/src/modules/Elsa.Studio.Dashboard/Elsa.Studio.Dashboard.csproj
+++ b/src/modules/Elsa.Studio.Dashboard/Elsa.Studio.Dashboard.csproj
@@ -12,7 +12,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\framework\Elsa.Studio.Shared\Elsa.Studio.Shared.csproj" />
-      <ProjectReference Include="..\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,8 @@ public static class ServiceCollectionExtensions
         return services
             .AddScoped<IFeature, Feature>()
             .AddScoped<IMenuProvider, DashboardMenu>()
+            .AddScoped<IDashboardWidgetRegistry, DashboardWidgetRegistry>()
+            .AddScoped<IDashboardWidgetProvider, DashboardWidgetProvider>()
             .AddScoped<IDashboardService, DashboardService>();
     }
 

--- a/src/modules/Elsa.Studio.Dashboard/Menu/DashboardMenu.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Menu/DashboardMenu.cs
@@ -1,7 +1,6 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Models;
-using Elsa.Studio.Workflows.Services;
 using Microsoft.AspNetCore.Components.Routing;
 using MudBlazor;
 

--- a/src/modules/Elsa.Studio.Dashboard/Models/DashboardModels.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Models/DashboardModels.cs
@@ -185,6 +185,15 @@ public record DashboardLoadResult(DashboardLoadStatus Status, DashboardSnapshot?
     public static DashboardLoadResult Failed(string message) => new(DashboardLoadStatus.Failed, null, message);
 }
 
+public record DashboardLoadResult<T>(DashboardLoadStatus Status, T? Value = default, string? Message = null)
+{
+    public static DashboardLoadResult<T> Loaded(T value) => new(DashboardLoadStatus.Loaded, value);
+    public static DashboardLoadResult<T> Unavailable(string message) => new(DashboardLoadStatus.Unavailable, default, message);
+    public static DashboardLoadResult<T> Unauthorized(string message) => new(DashboardLoadStatus.Unauthorized, default, message);
+    public static DashboardLoadResult<T> BackendDisconnected(string message) => new(DashboardLoadStatus.BackendDisconnected, default, message);
+    public static DashboardLoadResult<T> Failed(string message) => new(DashboardLoadStatus.Failed, default, message);
+}
+
 public enum DashboardLoadStatus
 {
     Loaded,

--- a/src/modules/Elsa.Studio.Dashboard/Models/DashboardWidgetContext.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Models/DashboardWidgetContext.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Studio.Dashboard.Models;
+
+public record DashboardWidgetContext(string Range, int RefreshVersion);

--- a/src/modules/Elsa.Studio.Dashboard/Models/DashboardWidgetDescriptor.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Models/DashboardWidgetDescriptor.cs
@@ -1,0 +1,30 @@
+namespace Elsa.Studio.Dashboard.Models;
+
+public record DashboardWidgetDescriptor
+{
+    public required string Id { get; init; }
+    public required Type ComponentType { get; init; }
+    public DashboardWidgetZone Zone { get; init; }
+    public int Order { get; init; }
+    public string? Title { get; init; }
+    public DashboardWidgetSpan Span { get; init; } = DashboardWidgetSpan.Auto;
+    public string? RequiredRemoteFeatureName { get; init; }
+    public IReadOnlyDictionary<string, object?> Parameters { get; init; } = new Dictionary<string, object?>();
+}
+
+public enum DashboardWidgetZone
+{
+    Metrics,
+    Findings,
+    Primary,
+    Secondary,
+    Diagnostics
+}
+
+public enum DashboardWidgetSpan
+{
+    Auto,
+    Compact,
+    Wide,
+    Full
+}

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
@@ -10,14 +10,7 @@
             <MudText Typo="Typo.h4">Dashboard</MudText>
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="flex-wrap">
                 <MudText Typo="Typo.body2" Class="dashboard-muted">@BackendLabel</MudText>
-                @if (_snapshot != null)
-                {
-                    <DashboardRuntimeChip Runtime="@_snapshot.Overview.Runtime" />
-                }
-                else
-                {
-                    <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="Color.Error" Icon="@Icons.Material.Outlined.CloudOff">@StatusLabel</MudChip>
-                }
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="@(_widgets.Count > 0 ? Color.Success : Color.Default)" Icon="@Icons.Material.Outlined.Widgets">@WidgetCountLabel</MudChip>
                 <MudText Typo="Typo.caption" Class="dashboard-muted">@LastRefreshedLabel</MudText>
             </MudStack>
         </MudStack>
@@ -30,78 +23,35 @@
                 }
             </MudToggleGroup>
             <MudTooltip Text="Refresh dashboard" Delay="400">
-                <MudIconButton Icon="@Icons.Material.Outlined.Refresh" Color="Color.Primary" Disabled="@_loading" OnClick="RefreshAsync" aria-label="Refresh dashboard" />
+                <MudIconButton Icon="@Icons.Material.Outlined.Refresh" Color="Color.Primary" OnClick="RefreshAsync" aria-label="Refresh dashboard" />
             </MudTooltip>
         </MudStack>
     </MudStack>
 
-    @if (!string.IsNullOrWhiteSpace(_message))
-    {
-        <MudAlert Severity="@AlertSeverity" Dense="true" Class="mb-4">@_message</MudAlert>
-    }
-
-    @if (_loading && _snapshot == null)
-    {
-        <MudGrid Spacing="2" Class="mb-4">
-            @for (var i = 0; i < 6; i++)
-            {
-                <MudItem xs="12" sm="6" md="4" xl="2">
-                    <MudSkeleton Height="112px" Animation="Animation.Wave" />
-                </MudItem>
-            }
-        </MudGrid>
-        <MudSkeleton Height="360px" Animation="Animation.Wave" />
-    }
-    else if (_snapshot == null)
+    @if (_widgets.Count == 0)
     {
         <MudPaper Outlined="true" Elevation="0" Class="dashboard-panel dashboard-empty-state" Style="@DashboardStyles.EmptyPanel">
             <MudIcon Icon="@Icons.Material.Outlined.DashboardCustomize" Color="Color.Default" />
-            <MudText Typo="Typo.h6">@StatusLabel</MudText>
-            <MudText Typo="Typo.body2" Class="dashboard-muted">@(_message ?? "Dashboard data is unavailable from the selected backend.")</MudText>
+            <MudText Typo="Typo.h6">No dashboard widgets</MudText>
+            <MudText Typo="Typo.body2" Class="dashboard-muted">Install a companion dashboard module for this backend to show operational widgets.</MudText>
         </MudPaper>
     }
     else
     {
-        var overview = _snapshot.Overview;
-        var metrics = overview.WorkflowInstances;
+        <CascadingValue Value="@WidgetContext">
+            @if (HasWidgets(DashboardWidgetZone.Metrics))
+            {
+                <MudGrid Spacing="2" Class="dashboard-metrics" Style="@DashboardStyles.MetricGrid">
+                    @RenderZone(DashboardWidgetZone.Metrics)
+                </MudGrid>
+            }
 
-        <MudGrid Spacing="2" Class="dashboard-metrics" Style="@DashboardStyles.MetricGrid">
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Running" Value="@DashboardMetricFormatter.Count(metrics.Running)" Caption="Current active instances" Icon="@Icons.Material.Outlined.PlayCircle" Color="Color.Info" Href="@DashboardNavigationTargetMapper.ForMetric("running")" />
-            </MudItem>
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Completed" Value="@DashboardMetricFormatter.Count(metrics.Completed)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.CheckCircle" Color="Color.Success" />
-            </MudItem>
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Faulted" Value="@DashboardMetricFormatter.Count(metrics.Faulted)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.ErrorOutline" Color="@(metrics.Faulted > 0 ? Color.Error : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("faulted")" />
-            </MudItem>
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Suspended" Value="@DashboardMetricFormatter.Count(metrics.Suspended)" Caption="Current suspended instances" Icon="@Icons.Material.Outlined.PauseCircle" Color="@(metrics.Suspended > 0 ? Color.Warning : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("suspended")" />
-            </MudItem>
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Avg duration" Value="@DashboardMetricFormatter.Duration(metrics.AverageDuration)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.Timer" Color="Color.Default" />
-            </MudItem>
-            <MudItem xs="12" sm="6" md="4" lg="2">
-                <DashboardMetricCard Label="Needs attention" Value="@DashboardMetricFormatter.Count(_snapshot.NeedsAttention.Findings.Count)" Caption="Prioritized findings" Icon="@Icons.Material.Outlined.ReportProblem" Color="@(_snapshot.NeedsAttention.Findings.Count > 0 ? Color.Warning : Color.Success)" />
-            </MudItem>
-        </MudGrid>
-
-        <MudGrid Spacing="2" Class="dashboard-main-grid" Style="@DashboardStyles.MainGrid">
-            <MudItem xs="12" lg="4">
-                <DashboardNeedsAttention Items="@_snapshot.NeedsAttention.Findings" Capability="@_snapshot.NeedsAttention.Capability" />
-            </MudItem>
-            <MudItem xs="12" lg="8">
-                <DashboardTrendChart Response="@_snapshot.Trend" Loading="@_loading" />
-            </MudItem>
-            <MudItem xs="12" lg="8">
-                <DashboardRecentActivityTable Items="@_snapshot.RecentActivity.Items" />
-            </MudItem>
-            <MudItem xs="12" lg="4">
-                <MudStack Spacing="2">
-                    <DashboardDiagnosticsSnapshot Summary="@overview.Diagnostics" />
-                    <DashboardWorkflowHotspotsPanel Response="@_snapshot.Hotspots" />
-                </MudStack>
-            </MudItem>
-        </MudGrid>
+            <MudGrid Spacing="2" Class="dashboard-main-grid" Style="@DashboardStyles.MainGrid">
+                @foreach (var zone in MainZones)
+                {
+                    @RenderZone(zone)
+                }
+            </MudGrid>
+        </CascadingValue>
     }
 </MudContainer>

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.cs
@@ -7,126 +7,81 @@ namespace Elsa.Studio.Dashboard.Pages;
 
 public partial class Index : IAsyncDisposable
 {
-    private CancellationTokenSource? _loadCancellationTokenSource;
-    private DashboardSnapshot? _snapshot;
-    private DashboardLoadStatus _status = DashboardLoadStatus.Unavailable;
+    private static readonly DashboardWidgetZone[] MainZones =
+    [
+        DashboardWidgetZone.Findings,
+        DashboardWidgetZone.Primary,
+        DashboardWidgetZone.Secondary,
+        DashboardWidgetZone.Diagnostics
+    ];
+
+    private IReadOnlyList<DashboardWidgetDescriptor> _widgets = [];
     private string _selectedRange = DashboardRangeKeys.TwentyFourHours;
-    private string? _message;
-    private bool _loading;
+    private int _refreshVersion;
     private DateTimeOffset? _lastRefreshedAt;
 
-    [Inject] private IDashboardService DashboardService { get; set; } = null!;
+    [Inject] private IDashboardWidgetProvider DashboardWidgetProvider { get; set; } = null!;
 
-    private string BackendLabel
-    {
-        get
-        {
-            if (_snapshot == null)
-                return "Selected backend";
-
-            var overview = _snapshot.Overview;
-            var backendName = string.IsNullOrWhiteSpace(overview.BackendName) ? "Backend" : overview.BackendName;
-            return string.IsNullOrWhiteSpace(overview.EnvironmentName) ? backendName : $"{backendName} / {overview.EnvironmentName}";
-        }
-    }
+    private string BackendLabel => "Selected backend";
 
     private string LastRefreshedLabel => _lastRefreshedAt == null ? "Not refreshed yet" : $"Refreshed {DashboardMetricFormatter.RelativeTimestamp(_lastRefreshedAt)}";
+    private string WidgetCountLabel => _widgets.Count == 1 ? "1 widget" : $"{_widgets.Count} widgets";
+    private DashboardWidgetContext WidgetContext => new(_selectedRange, _refreshVersion);
 
-    private string RangeCaption => _selectedRange switch
+    protected override void OnInitialized()
     {
-        DashboardRangeKeys.OneHour => "Last hour",
-        DashboardRangeKeys.SevenDays => "Last 7 days",
-        _ => "Last 24 hours"
-    };
-
-    private string StatusLabel => _status switch
-    {
-        DashboardLoadStatus.Unauthorized => "No access",
-        DashboardLoadStatus.BackendDisconnected => "Backend disconnected",
-        DashboardLoadStatus.Failed => "Refresh failed",
-        DashboardLoadStatus.Loaded => "Loaded",
-        _ => "Dashboard unavailable"
-    };
-
-    private Severity AlertSeverity => _status switch
-    {
-        DashboardLoadStatus.Unauthorized => Severity.Warning,
-        DashboardLoadStatus.Loaded => Severity.Info,
-        _ => Severity.Error
-    };
-
-    protected override async Task OnInitializedAsync()
-    {
-        await RefreshAsync();
+        _widgets = DashboardWidgetProvider.GetWidgets();
+        Refresh();
     }
 
     private async Task OnRangeChangedAsync(string? range)
     {
         _selectedRange = DashboardRangeMapper.Normalize(range);
-        await RefreshAsync();
+        Refresh();
+        await Task.CompletedTask;
     }
 
-    private async Task RefreshAsync()
+    private Task RefreshAsync()
     {
-        await LoadAsync(_selectedRange);
+        Refresh();
+        return Task.CompletedTask;
     }
 
-    private async Task LoadAsync(string range)
+    private void Refresh()
     {
-        await CancelCurrentLoadAsync();
-
-        var cancellationTokenSource = new CancellationTokenSource();
-        _loadCancellationTokenSource = cancellationTokenSource;
-        _loading = true;
-        _message = null;
-
-        try
-        {
-            var result = await DashboardService.LoadAsync(range, cancellationToken: cancellationTokenSource.Token);
-            _status = result.Status;
-
-            if (result.Snapshot != null)
-            {
-                _snapshot = result.Snapshot;
-                _lastRefreshedAt = DateTimeOffset.UtcNow;
-                _message = null;
-            }
-            else
-            {
-                _message = result.Message;
-            }
-        }
-        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
-        {
-        }
-        catch (Exception e)
-        {
-            _status = DashboardLoadStatus.Failed;
-            _message = e.Message;
-        }
-        finally
-        {
-            if (ReferenceEquals(_loadCancellationTokenSource, cancellationTokenSource))
-            {
-                _loading = false;
-                _loadCancellationTokenSource = null;
-            }
-
-            cancellationTokenSource.Dispose();
-        }
+        _refreshVersion++;
+        _lastRefreshedAt = DateTimeOffset.UtcNow;
     }
 
-    private async Task CancelCurrentLoadAsync()
+    private bool HasWidgets(DashboardWidgetZone zone) => _widgets.Any(x => x.Zone == zone);
+
+    private RenderFragment RenderZone(DashboardWidgetZone zone) => builder =>
     {
-        if (_loadCancellationTokenSource == null)
-            return;
+        var sequence = 0;
 
-        await _loadCancellationTokenSource.CancelAsync();
-        _loadCancellationTokenSource = null;
-    }
+        foreach (var widget in _widgets.Where(x => x.Zone == zone))
+        {
+            builder.OpenComponent<MudItem>(sequence++);
+            builder.AddAttribute(sequence++, "xs", 12);
+            builder.AddAttribute(sequence++, "sm", GetSmallColumns(widget));
+            builder.AddAttribute(sequence++, "lg", GetLargeColumns(widget));
+            builder.OpenComponent<DynamicComponent>(sequence++);
+            builder.AddAttribute(sequence++, "Type", widget.ComponentType);
+            builder.AddAttribute(sequence++, "Parameters", widget.Parameters);
+            builder.CloseComponent();
+            builder.CloseComponent();
+        }
+    };
 
-    public async ValueTask DisposeAsync()
+    private static int GetSmallColumns(DashboardWidgetDescriptor widget) => widget.Span == DashboardWidgetSpan.Compact ? 6 : 12;
+
+    private static int GetLargeColumns(DashboardWidgetDescriptor widget) => widget.Span switch
     {
-        await CancelCurrentLoadAsync();
-    }
+        DashboardWidgetSpan.Compact => 4,
+        DashboardWidgetSpan.Wide => 8,
+        DashboardWidgetSpan.Full => 12,
+        _ => widget.Zone is DashboardWidgetZone.Diagnostics or DashboardWidgetZone.Findings ? 4 : 8
+    };
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/modules/Elsa.Studio.Dashboard/README.md
+++ b/src/modules/Elsa.Studio.Dashboard/README.md
@@ -1,0 +1,71 @@
+# Elsa.Studio.Dashboard
+
+`Elsa.Studio.Dashboard` provides the dashboard shell and shared widget composition contracts. It does not own workflow, console log, or structured log data loading. Companion Studio modules register dashboard widgets only when their matching backend dashboard feature is enabled.
+
+## Widget Composition
+
+Dashboard widgets are contributed through `DashboardWidgetDescriptor`:
+
+- `Id`: stable unique ID, for example `workflows.execution-trend`
+- `ComponentType`: Blazor component rendered by the shell
+- `Zone`: semantic placement, not a concrete grid coordinate
+- `Order`: deterministic ordering within the zone
+- `Title`: optional display name for tooling and diagnostics
+- `Span`: optional size hint for compact, wide, or full-width widgets
+- `RequiredRemoteFeatureName`: backend feature that enables the widget
+
+Supported zones are:
+
+- `Metrics`: top-level KPI bands and compact counters
+- `Findings`: prioritized status and attention panels
+- `Primary`: wide charts or primary operational panels
+- `Secondary`: supporting tables and activity panels
+- `Diagnostics`: status cards and health panels
+
+## Remote-Gated Registration
+
+Register widgets from a companion feature that is marked with `RemoteFeatureAttribute`. The default feature service initializes that feature only when the backend advertises the matching shell feature.
+
+```csharp
+[RemoteFeature(RemoteFeatureName)]
+public class ExampleDashboardFeature(IServiceProvider serviceProvider) : FeatureBase
+{
+    public const string RemoteFeatureName = "Example.Backend.ShellFeatures.ExampleDashboard";
+
+    public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        serviceProvider.GetService<IDashboardWidgetRegistry>()?.Add(new DashboardWidgetDescriptor
+        {
+            Id = "example.status",
+            Title = "Example status",
+            ComponentType = typeof(ExampleStatusDashboardWidget),
+            Zone = DashboardWidgetZone.Diagnostics,
+            Order = 10,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        });
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+The optional registry lookup keeps companion modules usable when a host does not install `Elsa.Studio.Dashboard`.
+
+## Widget Data Loading
+
+The shell supplies a cascading `DashboardWidgetContext` with the selected range and refresh version. Widgets should load only the backend APIs needed by that widget, cancel in-flight work when the context changes, and keep their own empty, loading, error, and unavailable states.
+
+Use a scoped provider when multiple widgets from the same companion module share one backend snapshot. For example, workflow dashboard widgets share `IWorkflowDashboardDataProvider`, while console and structured log widgets load only dashboard overview data.
+
+## Host Registration
+
+Install the dashboard shell and the companion modules you want:
+
+```csharp
+services.AddDashboardModule(backendApiConfig);
+services.AddWorkflowsModule();
+services.AddConsoleLogsModule(backendApiConfig);
+services.AddStructuredLogsModule(backendApiConfig);
+```
+
+The shell remains coherent when any companion is absent or when the backend does not advertise a companion dashboard feature.

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardService.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardService.cs
@@ -8,6 +8,31 @@ namespace Elsa.Studio.Dashboard.Services;
 
 public class DashboardService(IBackendApiClientProvider backendApiClientProvider) : IDashboardService
 {
+    public async Task<DashboardLoadResult<DashboardOverview>> LoadOverviewAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var api = await backendApiClientProvider.GetApiAsync<IDashboardApi>(cancellationToken);
+            return DashboardLoadResult<DashboardOverview>.Loaded(await api.GetOverviewAsync(range, includeSystem, cancellationToken));
+        }
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            return DashboardLoadResult<DashboardOverview>.Unavailable("Dashboard data is not available from this backend.");
+        }
+        catch (ApiException e) when (e.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return DashboardLoadResult<DashboardOverview>.Unauthorized("You do not have access to dashboard data for this backend.");
+        }
+        catch (HttpRequestException e)
+        {
+            return DashboardLoadResult<DashboardOverview>.BackendDisconnected(e.Message);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return DashboardLoadResult<DashboardOverview>.BackendDisconnected("The dashboard request timed out.");
+        }
+    }
+
     public async Task<DashboardLoadResult> LoadAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default)
     {
         try

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetProvider.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetProvider.cs
@@ -1,0 +1,27 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public class DashboardWidgetProvider(
+    IEnumerable<DashboardWidgetDescriptor> descriptors,
+    IDashboardWidgetRegistry registry) : IDashboardWidgetProvider
+{
+    public IReadOnlyList<DashboardWidgetDescriptor> GetWidgets()
+    {
+        return descriptors
+            .Concat(registry.List())
+            .Select(DashboardWidgetValidator.Validate)
+            .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                if (group.Count() > 1)
+                    throw new InvalidOperationException($"Dashboard widget descriptor '{group.Key}' is registered more than once.");
+
+                return group.Single();
+            })
+            .OrderBy(x => x.Zone)
+            .ThenBy(x => x.Order)
+            .ThenBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetRegistry.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetRegistry.cs
@@ -1,0 +1,20 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public class DashboardWidgetRegistry : IDashboardWidgetRegistry
+{
+    private readonly List<DashboardWidgetDescriptor> _descriptors = [];
+
+    public void Add(DashboardWidgetDescriptor descriptor)
+    {
+        DashboardWidgetValidator.Validate(descriptor);
+
+        if (_descriptors.Any(x => string.Equals(x.Id, descriptor.Id, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Dashboard widget descriptor '{descriptor.Id}' is already registered.");
+
+        _descriptors.Add(descriptor);
+    }
+
+    public IReadOnlyCollection<DashboardWidgetDescriptor> List() => _descriptors.ToList();
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetValidator.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/DashboardWidgetValidator.cs
@@ -1,0 +1,20 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public static class DashboardWidgetValidator
+{
+    public static DashboardWidgetDescriptor Validate(DashboardWidgetDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(descriptor.Id))
+            throw new InvalidOperationException("Dashboard widget descriptors require a stable non-empty ID.");
+
+        if (!Enum.IsDefined(descriptor.Zone))
+            throw new InvalidOperationException($"Dashboard widget descriptor '{descriptor.Id}' uses unsupported zone '{descriptor.Zone}'.");
+
+        if (!Enum.IsDefined(descriptor.Span))
+            throw new InvalidOperationException($"Dashboard widget descriptor '{descriptor.Id}' uses unsupported span '{descriptor.Span}'.");
+
+        return descriptor;
+    }
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/IDashboardService.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/IDashboardService.cs
@@ -4,5 +4,6 @@ namespace Elsa.Studio.Dashboard.Services;
 
 public interface IDashboardService
 {
+    Task<DashboardLoadResult<DashboardOverview>> LoadOverviewAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default);
     Task<DashboardLoadResult> LoadAsync(string range, bool includeSystem = false, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Dashboard/Services/IDashboardWidgetProvider.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/IDashboardWidgetProvider.cs
@@ -1,0 +1,8 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public interface IDashboardWidgetProvider
+{
+    IReadOnlyList<DashboardWidgetDescriptor> GetWidgets();
+}

--- a/src/modules/Elsa.Studio.Dashboard/Services/IDashboardWidgetRegistry.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Services/IDashboardWidgetRegistry.cs
@@ -1,0 +1,9 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Dashboard.Services;
+
+public interface IDashboardWidgetRegistry
+{
+    void Add(DashboardWidgetDescriptor descriptor);
+    IReadOnlyCollection<DashboardWidgetDescriptor> List();
+}

--- a/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Dashboard/Components/ConsoleLogsDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Dashboard/Components/ConsoleLogsDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits DashboardOverviewWidgetBase
+
+@if (Loading && Overview == null)
+{
+    <MudSkeleton Height="220px" Animation="Animation.Wave" />
+}
+else if (Overview == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardConsoleLogsSnapshot Summary="@Overview.Diagnostics.ConsoleLogs" />
+}

--- a/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Dashboard/ConsoleLogsDashboardFeature.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Dashboard/ConsoleLogsDashboardFeature.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Abstractions;
+using Elsa.Studio.Attributes;
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Elsa.Studio.Diagnostics.ConsoleLogs.Dashboard.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Studio.Diagnostics.ConsoleLogs.Dashboard;
+
+[RemoteFeature(RemoteFeatureName)]
+public class ConsoleLogsDashboardFeature(IServiceProvider serviceProvider) : FeatureBase
+{
+    public const string RemoteFeatureName = "Elsa.Diagnostics.ConsoleLogs.Dashboard.ShellFeatures.ConsoleLogsDashboard";
+
+    public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        serviceProvider.GetService<IDashboardWidgetRegistry>()?.Add(new DashboardWidgetDescriptor
+        {
+            Id = "diagnostics.console-logs",
+            Title = "Console logs",
+            ComponentType = typeof(ConsoleLogsDashboardWidget),
+            Zone = DashboardWidgetZone.Diagnostics,
+            Order = 20,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        });
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Elsa.Studio.Diagnostics.ConsoleLogs.csproj
+++ b/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Elsa.Studio.Diagnostics.ConsoleLogs.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\framework\Elsa.Studio.Shared\Elsa.Studio.Shared.csproj" />
         <ProjectReference Include="..\Elsa.Studio.Authentication.Abstractions\Elsa.Studio.Authentication.Abstractions.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Dashboard\Elsa.Studio.Dashboard.csproj" />
         <ProjectReference Include="..\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
     </ItemGroup>
 

--- a/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Diagnostics.ConsoleLogs.Client;
 using Elsa.Studio.Diagnostics.ConsoleLogs.Contracts;
+using Elsa.Studio.Diagnostics.ConsoleLogs.Dashboard;
 using Elsa.Studio.Diagnostics.ConsoleLogs.Menu;
 using Elsa.Studio.Diagnostics.ConsoleLogs.Services;
 using Elsa.Studio.Diagnostics.ConsoleLogs.UI.Widgets;
@@ -22,6 +23,7 @@ public static class ServiceCollectionExtensions
     {
         return services
             .AddScoped<IFeature, Feature>()
+            .AddScoped<IFeature, ConsoleLogsDashboardFeature>()
             .AddScoped<IMenuProvider, ConsoleLogsMenu>()
             .AddScoped<IWidget, WorkflowInstanceConsoleLogsTabWidget>()
             .AddScoped<IWidget, WorkflowInstanceConsoleLogsLeftPanelTabWidget>()

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Dashboard/Components/StructuredLogsDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Dashboard/Components/StructuredLogsDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits DashboardOverviewWidgetBase
+
+@if (Loading && Overview == null)
+{
+    <MudSkeleton Height="220px" Animation="Animation.Wave" />
+}
+else if (Overview == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardStructuredLogsSnapshot Summary="@Overview.Diagnostics.StructuredLogs" />
+}

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Dashboard/StructuredLogsDashboardFeature.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Dashboard/StructuredLogsDashboardFeature.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Abstractions;
+using Elsa.Studio.Attributes;
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Elsa.Studio.Diagnostics.StructuredLogs.Dashboard.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Studio.Diagnostics.StructuredLogs.Dashboard;
+
+[RemoteFeature(RemoteFeatureName)]
+public class StructuredLogsDashboardFeature(IServiceProvider serviceProvider) : FeatureBase
+{
+    public const string RemoteFeatureName = "Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures.StructuredLogsDashboard";
+
+    public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        serviceProvider.GetService<IDashboardWidgetRegistry>()?.Add(new DashboardWidgetDescriptor
+        {
+            Id = "diagnostics.structured-logs",
+            Title = "Structured logs",
+            ComponentType = typeof(StructuredLogsDashboardWidget),
+            Zone = DashboardWidgetZone.Diagnostics,
+            Order = 10,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        });
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Elsa.Studio.Diagnostics.StructuredLogs.csproj
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Elsa.Studio.Diagnostics.StructuredLogs.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\framework\Elsa.Studio.Shared\Elsa.Studio.Shared.csproj" />
         <ProjectReference Include="..\Elsa.Studio.Authentication.Abstractions\Elsa.Studio.Authentication.Abstractions.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Dashboard\Elsa.Studio.Dashboard.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Elsa.Studio.Extensions;
 using Elsa.Studio.Models;
 using Elsa.Studio.Diagnostics.StructuredLogs.Client;
 using Elsa.Studio.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Studio.Diagnostics.StructuredLogs.Dashboard;
 using Elsa.Studio.Diagnostics.StructuredLogs.Menu;
 using Elsa.Studio.Diagnostics.StructuredLogs.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,7 @@ public static class ServiceCollectionExtensions
     {
         return services
             .AddScoped<IFeature, Feature>()
+            .AddScoped<IFeature, StructuredLogsDashboardFeature>()
             .AddScoped<IMenuProvider, StructuredLogsMenu>()
             .AddScoped<IStructuredLogService, RemoteStructuredLogService>()
             .AddScoped<IStructuredLogObserver, SignalRStructuredLogObserver>()

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowDashboardWidgetBase.cs
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowDashboardWidgetBase.cs
@@ -1,0 +1,85 @@
+using Elsa.Studio.Dashboard.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Workflows.Dashboard.Components;
+
+public abstract class WorkflowDashboardWidgetBase : ComponentBase, IAsyncDisposable
+{
+    private CancellationTokenSource? _loadCancellationTokenSource;
+    private DashboardWidgetContext? _loadedContext;
+
+    [Inject] private IWorkflowDashboardDataProvider DataProvider { get; set; } = null!;
+    [CascadingParameter] public DashboardWidgetContext? WidgetContext { get; set; }
+
+    protected DashboardSnapshot? Snapshot { get; private set; }
+    protected DashboardLoadStatus Status { get; private set; } = DashboardLoadStatus.Unavailable;
+    protected string? Message { get; private set; }
+    protected bool Loading { get; private set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (WidgetContext == null || _loadedContext == WidgetContext)
+            return;
+
+        await LoadAsync(WidgetContext);
+    }
+
+    private async Task LoadAsync(DashboardWidgetContext context)
+    {
+        await CancelCurrentLoadAsync();
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        _loadCancellationTokenSource = cancellationTokenSource;
+        Loading = true;
+        Message = null;
+
+        try
+        {
+            var result = await DataProvider.LoadAsync(context, cancellationTokenSource.Token);
+            Status = result.Status;
+            _loadedContext = context;
+
+            if (result.Snapshot != null)
+            {
+                Snapshot = result.Snapshot;
+                Message = null;
+            }
+            else
+            {
+                Message = result.Message;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception e)
+        {
+            Status = DashboardLoadStatus.Failed;
+            Message = e.Message;
+        }
+        finally
+        {
+            if (ReferenceEquals(_loadCancellationTokenSource, cancellationTokenSource))
+            {
+                Loading = false;
+                _loadCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
+        }
+    }
+
+    protected async Task CancelCurrentLoadAsync()
+    {
+        if (_loadCancellationTokenSource == null)
+            return;
+
+        await _loadCancellationTokenSource.CancelAsync();
+        _loadCancellationTokenSource = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CancelCurrentLoadAsync();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowHotspotsDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowHotspotsDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits WorkflowDashboardWidgetBase
+
+@if (Loading && Snapshot == null)
+{
+    <MudSkeleton Height="220px" Animation="Animation.Wave" />
+}
+else if (Snapshot == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardWorkflowHotspotsPanel Response="@Snapshot.Hotspots" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowMetricsDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowMetricsDashboardWidget.razor
@@ -1,0 +1,47 @@
+@using Elsa.Studio.Dashboard.Components
+@using Elsa.Studio.Dashboard.Models
+@using Elsa.Studio.Dashboard.Services
+@inherits WorkflowDashboardWidgetBase
+
+@if (Loading && Snapshot == null)
+{
+    <MudSkeleton Height="112px" Animation="Animation.Wave" />
+}
+else if (Snapshot == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    var metrics = Snapshot.Overview.WorkflowInstances;
+
+    <MudGrid Spacing="2">
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Running" Value="@DashboardMetricFormatter.Count(metrics.Running)" Caption="Current active instances" Icon="@Icons.Material.Outlined.PlayCircle" Color="Color.Info" Href="@DashboardNavigationTargetMapper.ForMetric("running")" />
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Completed" Value="@DashboardMetricFormatter.Count(metrics.Completed)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.CheckCircle" Color="Color.Success" />
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Faulted" Value="@DashboardMetricFormatter.Count(metrics.Faulted)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.ErrorOutline" Color="@(metrics.Faulted > 0 ? Color.Error : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("faulted")" />
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Suspended" Value="@DashboardMetricFormatter.Count(metrics.Suspended)" Caption="Current suspended instances" Icon="@Icons.Material.Outlined.PauseCircle" Color="@(metrics.Suspended > 0 ? Color.Warning : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("suspended")" />
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Avg duration" Value="@DashboardMetricFormatter.Duration(metrics.AverageDuration)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.Timer" Color="Color.Default" />
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" xl="2">
+            <DashboardMetricCard Label="Needs attention" Value="@DashboardMetricFormatter.Count(Snapshot.NeedsAttention.Findings.Count)" Caption="Prioritized findings" Icon="@Icons.Material.Outlined.ReportProblem" Color="@(Snapshot.NeedsAttention.Findings.Count > 0 ? Color.Warning : Color.Success)" />
+        </MudItem>
+    </MudGrid>
+}
+
+@code {
+    private string RangeCaption => WidgetContext?.Range switch
+    {
+        DashboardRangeKeys.OneHour => "Last hour",
+        DashboardRangeKeys.SevenDays => "Last 7 days",
+        _ => "Last 24 hours"
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowNeedsAttentionDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowNeedsAttentionDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits WorkflowDashboardWidgetBase
+
+@if (Loading && Snapshot == null)
+{
+    <MudSkeleton Height="220px" Animation="Animation.Wave" />
+}
+else if (Snapshot == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardNeedsAttention Items="@Snapshot.NeedsAttention.Findings" Capability="@Snapshot.NeedsAttention.Capability" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowRecentActivityDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowRecentActivityDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits WorkflowDashboardWidgetBase
+
+@if (Loading && Snapshot == null)
+{
+    <MudSkeleton Height="280px" Animation="Animation.Wave" />
+}
+else if (Snapshot == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardRecentActivityTable Items="@Snapshot.RecentActivity.Items" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowTrendDashboardWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/Components/WorkflowTrendDashboardWidget.razor
@@ -1,0 +1,15 @@
+@using Elsa.Studio.Dashboard.Components
+@inherits WorkflowDashboardWidgetBase
+
+@if (Loading && Snapshot == null)
+{
+    <MudSkeleton Height="260px" Animation="Animation.Wave" />
+}
+else if (Snapshot == null)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Message</MudAlert>
+}
+else
+{
+    <DashboardTrendChart Response="@Snapshot.Trend" Loading="@Loading" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/IWorkflowDashboardDataProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/IWorkflowDashboardDataProvider.cs
@@ -1,0 +1,8 @@
+using Elsa.Studio.Dashboard.Models;
+
+namespace Elsa.Studio.Workflows.Dashboard;
+
+public interface IWorkflowDashboardDataProvider
+{
+    Task<DashboardLoadResult> LoadAsync(DashboardWidgetContext context, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/WorkflowDashboardDataProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/WorkflowDashboardDataProvider.cs
@@ -1,0 +1,24 @@
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+
+namespace Elsa.Studio.Workflows.Dashboard;
+
+public class WorkflowDashboardDataProvider(IDashboardService dashboardService) : IWorkflowDashboardDataProvider
+{
+    private DashboardLoadRequest? _currentRequest;
+
+    public Task<DashboardLoadResult> LoadAsync(DashboardWidgetContext context, CancellationToken cancellationToken = default)
+    {
+        if (_currentRequest?.Matches(context) == true)
+            return _currentRequest.Task.WaitAsync(cancellationToken);
+
+        var task = dashboardService.LoadAsync(context.Range, cancellationToken: cancellationToken);
+        _currentRequest = new DashboardLoadRequest(context.Range, context.RefreshVersion, task);
+        return task;
+    }
+
+    private record DashboardLoadRequest(string Range, int RefreshVersion, Task<DashboardLoadResult> Task)
+    {
+        public bool Matches(DashboardWidgetContext context) => Range == context.Range && RefreshVersion == context.RefreshVersion;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Dashboard/WorkflowDashboardFeature.cs
+++ b/src/modules/Elsa.Studio.Workflows/Dashboard/WorkflowDashboardFeature.cs
@@ -1,0 +1,78 @@
+using Elsa.Studio.Abstractions;
+using Elsa.Studio.Attributes;
+using Elsa.Studio.Dashboard.Models;
+using Elsa.Studio.Dashboard.Services;
+using Elsa.Studio.Workflows.Dashboard.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Studio.Workflows.Dashboard;
+
+[RemoteFeature(RemoteFeatureName)]
+public class WorkflowDashboardFeature(IServiceProvider serviceProvider) : FeatureBase
+{
+    public const string RemoteFeatureName = "Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard";
+
+    public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var registry = serviceProvider.GetService<IDashboardWidgetRegistry>();
+        if (registry == null)
+            return ValueTask.CompletedTask;
+
+        foreach (var descriptor in Descriptors)
+            registry.Add(descriptor);
+
+        return ValueTask.CompletedTask;
+    }
+
+    private static IReadOnlyCollection<DashboardWidgetDescriptor> Descriptors =>
+    [
+        new()
+        {
+            Id = "workflows.metrics",
+            Title = "Workflow metrics",
+            ComponentType = typeof(WorkflowMetricsDashboardWidget),
+            Zone = DashboardWidgetZone.Metrics,
+            Order = 0,
+            Span = DashboardWidgetSpan.Full,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        },
+        new()
+        {
+            Id = "workflows.needs-attention",
+            Title = "Needs attention",
+            ComponentType = typeof(WorkflowNeedsAttentionDashboardWidget),
+            Zone = DashboardWidgetZone.Findings,
+            Order = 0,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        },
+        new()
+        {
+            Id = "workflows.execution-trend",
+            Title = "Execution trend",
+            ComponentType = typeof(WorkflowTrendDashboardWidget),
+            Zone = DashboardWidgetZone.Primary,
+            Order = 0,
+            Span = DashboardWidgetSpan.Wide,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        },
+        new()
+        {
+            Id = "workflows.recent-activity",
+            Title = "Recent activity",
+            ComponentType = typeof(WorkflowRecentActivityDashboardWidget),
+            Zone = DashboardWidgetZone.Secondary,
+            Order = 0,
+            Span = DashboardWidgetSpan.Wide,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        },
+        new()
+        {
+            Id = "workflows.hotspots",
+            Title = "Workflow hotspots",
+            ComponentType = typeof(WorkflowHotspotsDashboardWidget),
+            Zone = DashboardWidgetZone.Diagnostics,
+            Order = 0,
+            RequiredRemoteFeatureName = RemoteFeatureName
+        }
+    ];
+}

--- a/src/modules/Elsa.Studio.Workflows/Elsa.Studio.Workflows.csproj
+++ b/src/modules/Elsa.Studio.Workflows/Elsa.Studio.Workflows.csproj
@@ -19,6 +19,7 @@
       <ProjectReference Include="..\..\framework\Elsa.Studio.Shared\Elsa.Studio.Shared.csproj" />
       <ProjectReference Include="..\Elsa.Studio.ActivityPortProviders\Elsa.Studio.ActivityPortProviders.csproj" />
       <ProjectReference Include="..\Elsa.Studio.Authentication.Abstractions\Elsa.Studio.Authentication.Abstractions.csproj" />
+      <ProjectReference Include="..\Elsa.Studio.Dashboard\Elsa.Studio.Dashboard.csproj" />
       <ProjectReference Include="..\Elsa.Studio.UIHints\Elsa.Studio.UIHints.csproj" />
       <ProjectReference Include="..\Elsa.Studio.Workflows.Core\Elsa.Studio.Workflows.Core.csproj" />
       <ProjectReference Include="..\Elsa.Studio.Workflows.Designer\Elsa.Studio.Workflows.Designer.csproj" />

--- a/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Elsa.Studio.Workflows.ActivityPickers.Accordion;
 using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.Models;
 using Elsa.Studio.Workflows.Components.WorkflowInstanceList.Models;
 using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Dashboard;
 using Elsa.Studio.Workflows.Designer.Extensions;
 using Elsa.Studio.Workflows.DiagramDesigners.Fallback;
 using Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
@@ -33,7 +34,9 @@ public static class ServiceCollectionExtensions
     {
         services
             .AddScoped<IFeature, Feature>()
+            .AddScoped<IFeature, WorkflowDashboardFeature>()
             .AddScoped<IMenuProvider, WorkflowsMenu>()
+            .AddScoped<IWorkflowDashboardDataProvider, WorkflowDashboardDataProvider>()
             .AddScoped<IWorkflowInstanceObserverFactory, WorkflowInstanceObserverFactory>()
             .AddScoped<IWorkflowCloningDialogService, WorkflowCloningDialogService>()
             .AddScoped<IWorkflowExportDialogService, WorkflowExportDialogService>()


### PR DESCRIPTION
## Summary

Delivers the Studio dashboard project board for layout-driven, remotely gated dashboard widgets.

## Project Board

https://github.com/orgs/elsa-workflows/projects/15

## Scope

- Parent issue: #880
- Closed child issues: #881, #882, #883, #884, #885
- Merged slice PR: #886

## Changes

- Adds dashboard widget descriptors, semantic zones, registry/provider validation, and cascading widget context.
- Refactors the dashboard page to render registered widgets instead of hardcoded workflow/diagnostics content.
- Adds workflow dashboard widgets registered by `Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard`.
- Adds console and structured log dashboard widgets registered by their matching dashboard shell features.
- Removes the dashboard module reference to workflows and adds tests for registration, ordering, duplicates, and shell independence.
- Documents companion widget registration, zones, widget-scoped loading, and host setup.

## Verification

- `dotnet test src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj --no-restore`
- Focused module builds for `Elsa.Studio.Dashboard`, `Elsa.Studio.Workflows`, `Elsa.Studio.Diagnostics.ConsoleLogs`, and `Elsa.Studio.Diagnostics.StructuredLogs` succeeded.

## Known External Blocker

`dotnet build src/hosts/Elsa.Studio.Host.Server/Elsa.Studio.Host.Server.csproj` is blocked during restore by existing package downgrade errors in `Elsa.Studio.Authentication.OpenIdConnect.BlazorServer` for `Microsoft.Extensions.Http.Polly` (`9.0.16 -> 9.0.13`, `10.0.8 -> 10.0.3`).
