### PR TITLE
Allow choosing workflow root activity type

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowDefinitionService.cs
@@ -99,6 +99,11 @@ public interface IWorkflowDefinitionService
     Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Creates a new workflow definition using the specified root activity template.
+    /// </summary>
+    Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Exports a workflow definition.
     /// </summary>
     Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowRootActivityTemplateProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IWorkflowRootActivityTemplateProvider.cs
@@ -1,0 +1,24 @@
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Provides workflow root activity templates for new workflow definitions.
+/// </summary>
+public interface IWorkflowRootActivityTemplateProvider
+{
+    /// <summary>
+    /// Returns all available workflow root activity templates.
+    /// </summary>
+    IReadOnlyCollection<WorkflowRootActivityTemplate> List();
+
+    /// <summary>
+    /// Returns the default workflow root activity template.
+    /// </summary>
+    WorkflowRootActivityTemplate GetDefault();
+
+    /// <summary>
+    /// Finds a workflow root activity template by key.
+    /// </summary>
+    WorkflowRootActivityTemplate? Find(string? key);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowRootActivityTemplate.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowRootActivityTemplate.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Domain.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Models;
+
+/// <summary>
+/// Describes a selectable root activity template for new workflow definitions.
+/// </summary>
+public record WorkflowRootActivityTemplate(
+    string Key,
+    string DisplayName,
+    string Description,
+    string Icon,
+    string Color,
+    Func<IIdentityGenerator, JsonObject> CreateRoot);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultWorkflowRootActivityTemplateProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultWorkflowRootActivityTemplateProvider.cs
@@ -1,0 +1,85 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <summary>
+/// Provides the built-in workflow root activity templates.
+/// </summary>
+public class DefaultWorkflowRootActivityTemplateProvider : IWorkflowRootActivityTemplateProvider
+{
+    /// <summary>
+    /// The built-in Flowchart root activity type name.
+    /// </summary>
+    public const string FlowchartKey = "Elsa.Flowchart";
+
+    /// <summary>
+    /// The built-in Sequence root activity type name.
+    /// </summary>
+    public const string SequenceKey = "Elsa.Sequence";
+
+    /// <summary>
+    /// The built-in StateMachine root activity type name.
+    /// </summary>
+    public const string StateMachineKey = "Elsa.StateMachine";
+
+    private readonly IReadOnlyCollection<WorkflowRootActivityTemplate> _templates =
+    [
+        new(
+            FlowchartKey,
+            "Flowchart",
+            "Flexible graph-based workflows.",
+            ElsaStudioIcons.Tabler.GitFork,
+            "#06b6d4",
+            identityGenerator => CreateRoot(identityGenerator, FlowchartKey, "Flowchart1")),
+        new(
+            SequenceKey,
+            "Sequence",
+            "Ordered step-by-step workflows.",
+            Icons.Material.Outlined.FormatListNumbered,
+            "#16a34a",
+            identityGenerator =>
+            {
+                var root = CreateRoot(identityGenerator, SequenceKey, "Sequence1");
+                root["activities"] = new JsonArray();
+                return root;
+            }),
+        new(
+            StateMachineKey,
+            "State machine",
+            "State and transition driven workflows.",
+            Icons.Material.Outlined.AccountTree,
+            "#7c3aed",
+            identityGenerator =>
+            {
+                var root = CreateRoot(identityGenerator, StateMachineKey, "StateMachine1");
+                root["states"] = new JsonArray();
+                root["transitions"] = new JsonArray();
+                return root;
+            })
+    ];
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<WorkflowRootActivityTemplate> List() => _templates;
+
+    /// <inheritdoc />
+    public WorkflowRootActivityTemplate GetDefault() => _templates.First();
+
+    /// <inheritdoc />
+    public WorkflowRootActivityTemplate? Find(string? key)
+    {
+        return string.IsNullOrWhiteSpace(key) ? null : _templates.FirstOrDefault(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static JsonObject CreateRoot(IIdentityGenerator identityGenerator, string type, string name) =>
+        new()
+        {
+            ["id"] = identityGenerator.GenerateId(),
+            ["type"] = type,
+            ["version"] = 1,
+            ["name"] = name
+        };
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionService.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
@@ -19,7 +18,11 @@ namespace Elsa.Studio.Workflows.Domain.Services;
 /// <summary>
 /// A workflow definition service that uses a remote backend to retrieve workflow definitions.
 /// </summary>
-public class RemoteWorkflowDefinitionService(IBackendApiClientProvider backendApiClientProvider, IIdentityGenerator identityGenerator, IMediator mediator) : IWorkflowDefinitionService
+public class RemoteWorkflowDefinitionService(
+    IBackendApiClientProvider backendApiClientProvider,
+    IIdentityGenerator identityGenerator,
+    IWorkflowRootActivityTemplateProvider workflowRootActivityTemplateProvider,
+    IMediator mediator) : IWorkflowDefinitionService
 {
     /// <inheritdoc />
     public async Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default)
@@ -211,6 +214,18 @@ public class RemoteWorkflowDefinitionService(IBackendApiClientProvider backendAp
         Action<SaveWorkflowDefinitionRequest>? configureRequest = null,
         CancellationToken cancellationToken = default)
     {
+        return await CreateNewDefinitionAsync(name, description, null, configureRequest, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(
+        string name,
+        string? description,
+        string? rootActivityTemplateKey,
+        Action<SaveWorkflowDefinitionRequest>? configureRequest = null,
+        CancellationToken cancellationToken = default)
+    {
+        var rootActivityTemplate = workflowRootActivityTemplateProvider.Find(rootActivityTemplateKey) ?? workflowRootActivityTemplateProvider.GetDefault();
         var saveRequest = new SaveWorkflowDefinitionRequest
         {
             Model = new()
@@ -221,13 +236,7 @@ public class RemoteWorkflowDefinitionService(IBackendApiClientProvider backendAp
                 ToolVersion = ToolVersion.Version,
                 IsLatest = true,
                 IsPublished = false,
-                Root = new(new Dictionary<string, JsonNode?>
-                {
-                    ["id"] = identityGenerator.GenerateId(),
-                    ["type"] = "Elsa.Flowchart",
-                    ["version"] = 1,
-                    ["name"] = "Flowchart1"
-                })
+                Root = rootActivityTemplate.CreateRoot(identityGenerator)
             }
         };
         

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         services
             .AddScoped<IRemoteFeatureProvider, RemoteFeatureProvider>()
             .AddScoped<IWorkflowDefinitionService, RemoteWorkflowDefinitionService>()
+            .AddScoped<IWorkflowRootActivityTemplateProvider, DefaultWorkflowRootActivityTemplateProvider>()
             .AddScoped<IWorkflowInstanceService, RemoteWorkflowInstanceService>()
             .AddScoped<IWorkflowDefinitionEditorService, WorkflowDefinitionEditorService>()
             .AddScoped<IWorkflowDefinitionImporter, WorkflowDefinitionImporter>()

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionCreationRootTemplateTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionCreationRootTemplateTests.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Services;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public class WorkflowDefinitionCreationRootTemplateTests
+{
+    private readonly CapturingWorkflowDefinitionsApi _api = new();
+    private readonly RemoteWorkflowDefinitionService _service;
+
+    public WorkflowDefinitionCreationRootTemplateTests()
+    {
+        var backendApiClientProvider = new TestBackendApiClientProvider(_api);
+        var identityGenerator = new TestIdentityGenerator();
+        var workflowRootActivityTemplateProvider = new DefaultWorkflowRootActivityTemplateProvider();
+        var mediator = new TestMediator();
+
+        _service = new(backendApiClientProvider, identityGenerator, workflowRootActivityTemplateProvider, mediator);
+    }
+
+    [Fact]
+    public async Task CreateNewDefinitionAsyncUsesFlowchartByDefault()
+    {
+        await _service.CreateNewDefinitionAsync("Test workflow", "Description");
+
+        AssertSavedRoot(DefaultWorkflowRootActivityTemplateProvider.FlowchartKey, "Flowchart1");
+        Assert.Null(_api.SaveRequest!.Model.Root!["activities"]);
+    }
+
+    [Theory]
+    [InlineData(DefaultWorkflowRootActivityTemplateProvider.SequenceKey, "Sequence1", "activities")]
+    [InlineData(DefaultWorkflowRootActivityTemplateProvider.StateMachineKey, "StateMachine1", "states", "transitions")]
+    public async Task CreateNewDefinitionAsyncUsesSelectedRootTemplate(string templateKey, string expectedName, params string[] expectedArrayProperties)
+    {
+        await _service.CreateNewDefinitionAsync("Test workflow", "Description", templateKey);
+
+        AssertSavedRoot(templateKey, expectedName);
+
+        foreach (var propertyName in expectedArrayProperties)
+            Assert.Empty(_api.SaveRequest!.Model.Root![propertyName]!.AsArray());
+    }
+
+    [Fact]
+    public async Task CreateNewDefinitionAsyncFallsBackToFlowchartForUnknownTemplate()
+    {
+        await _service.CreateNewDefinitionAsync("Test workflow", "Description", "Unknown");
+
+        AssertSavedRoot(DefaultWorkflowRootActivityTemplateProvider.FlowchartKey, "Flowchart1");
+    }
+
+    private void AssertSavedRoot(string expectedType, string expectedName)
+    {
+        var root = _api.SaveRequest!.Model.Root!;
+
+        Assert.Equal("activity-1", root["id"]!.GetValue<string>());
+        Assert.Equal(expectedType, root["type"]!.GetValue<string>());
+        Assert.Equal(1, root["version"]!.GetValue<int>());
+        Assert.Equal(expectedName, root["name"]!.GetValue<string>());
+    }
+
+    private class CapturingWorkflowDefinitionsApi : IWorkflowDefinitionsApi
+    {
+        public SaveWorkflowDefinitionRequest? SaveRequest { get; private set; }
+
+        public Task<SaveWorkflowDefinitionResponse> SaveAsync(SaveWorkflowDefinitionRequest request, CancellationToken cancellationToken = default)
+        {
+            SaveRequest = request;
+
+            var workflowDefinition = new WorkflowDefinition
+            {
+                Name = request.Model.Name,
+                Description = request.Model.Description,
+                Root = request.Model.Root!
+            };
+
+            return Task.FromResult(new SaveWorkflowDefinitionResponse(workflowDefinition, false, 0));
+        }
+
+        public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> GetByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> GetByIdAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ListResponse<WorkflowDefinition>> GetManyByIdAsync(ICollection<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityNode?> GetSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetPathSegmentsResponse?> GetPathSegmentsGetAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<CountWorkflowDefinitionsResponse> CountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetConsumingWorkflowDefinitionsResponse> GetConsumersAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetIsNameUniqueResponse> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteVersionAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, PublishWorkflowDefinitionRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition> RetractAsync(string definitionId, RetractWorkflowDefinitionRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkDeleteWorkflowDefinitionsResponse> BulkDeleteAsync(BulkDeleteWorkflowDefinitionsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkDeleteWorkflowDefinitionsResponse> BulkDeleteVersionsAsync(BulkDeleteWorkflowDefinitionVersionsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(BulkPublishWorkflowDefinitionsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(BulkRetractWorkflowDefinitionsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IApiResponse<Stream>> ExportAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IApiResponse<Stream>> BulkExportAsync(BulkExportWorkflowDefinitionsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition> ImportAsync(WorkflowDefinitionModel model, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ImportFilesResponse> ImportFilesAsync(List<StreamPart> files, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, UpdateConsumingWorkflowReferencesRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinitionSummary> RevertVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private class TestBackendApiClientProvider(IWorkflowDefinitionsApi api) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://localhost");
+
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
+        {
+            if (typeof(T) == typeof(IWorkflowDefinitionsApi))
+                return ValueTask.FromResult((T)api);
+
+            throw new NotSupportedException();
+        }
+    }
+
+    private class TestIdentityGenerator : IIdentityGenerator
+    {
+        public string GenerateId() => "activity-1";
+    }
+
+    private class TestMediator : IMediator
+    {
+        public void Subscribe<TNotification, THandler>(THandler handler)
+            where TNotification : INotification
+            where THandler : INotificationHandler<TNotification>
+        {
+        }
+
+        public void Unsubscribe<TNotification, THandler>(THandler handler)
+            where TNotification : INotification
+            where THandler : INotificationHandler<TNotification>
+        {
+        }
+
+        public void Unsubscribe(INotificationHandler handler)
+        {
+        }
+
+        public Task NotifyAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification => Task.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowRootActivityTemplateProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowRootActivityTemplateProviderTests.cs
@@ -1,0 +1,60 @@
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public class WorkflowRootActivityTemplateProviderTests
+{
+    private readonly DefaultWorkflowRootActivityTemplateProvider _provider = new();
+    private readonly TestIdentityGenerator _identityGenerator = new();
+
+    [Fact]
+    public void ListReturnsBuiltInTemplates()
+    {
+        var templates = _provider.List();
+
+        Assert.Collection(
+            templates,
+            template => Assert.Equal(DefaultWorkflowRootActivityTemplateProvider.FlowchartKey, template.Key),
+            template => Assert.Equal(DefaultWorkflowRootActivityTemplateProvider.SequenceKey, template.Key),
+            template => Assert.Equal(DefaultWorkflowRootActivityTemplateProvider.StateMachineKey, template.Key));
+    }
+
+    [Fact]
+    public void GetDefaultReturnsFlowchart()
+    {
+        var template = _provider.GetDefault();
+
+        Assert.Equal(DefaultWorkflowRootActivityTemplateProvider.FlowchartKey, template.Key);
+    }
+
+    [Theory]
+    [MemberData(nameof(RootTemplates))]
+    public void CreateRootReturnsExpectedRootJson(string templateKey, string expectedName, string[] expectedArrayProperties)
+    {
+        var template = _provider.Find(templateKey)!;
+
+        var root = template.CreateRoot(_identityGenerator);
+
+        Assert.Equal("activity-1", root["id"]!.GetValue<string>());
+        Assert.Equal(templateKey, root["type"]!.GetValue<string>());
+        Assert.Equal(1, root["version"]!.GetValue<int>());
+        Assert.Equal(expectedName, root["name"]!.GetValue<string>());
+
+        foreach (var propertyName in expectedArrayProperties)
+            Assert.Empty(root[propertyName]!.AsArray());
+    }
+
+    public static TheoryData<string, string, string[]> RootTemplates => new()
+    {
+        { DefaultWorkflowRootActivityTemplateProvider.FlowchartKey, "Flowchart1", [] },
+        { DefaultWorkflowRootActivityTemplateProvider.SequenceKey, "Sequence1", ["activities"] },
+        { DefaultWorkflowRootActivityTemplateProvider.StateMachineKey, "StateMachine1", ["states", "transitions"] }
+    };
+
+    private class TestIdentityGenerator : IIdentityGenerator
+    {
+        public string GenerateId() => "activity-1";
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
@@ -1,5 +1,6 @@
 @using Variant = MudBlazor.Variant
 @inherits StudioComponentBase
+@using Elsa.Studio.Workflows.Domain.Models
 @using Elsa.Studio.Workflows.Services
 @inject ILocalizer Localizer
 
@@ -9,6 +10,27 @@
             <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator" DisableAssemblyScanning="true"/>
             <MudStack>
                 <MudTextField Label="@Localizer["Name"]" @bind-Value="_metadataModel.Name" For="@(() => _metadataModel.Name)" HelperText="@Localizer["The name of the new workflow."]" Variant="Variant.Outlined" Margin="Margin.Dense" />
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.subtitle2">@Localizer["Workflow type"]</MudText>
+                    <MudStack Spacing="1">
+                        @foreach (var template in _rootActivityTemplates)
+                        {
+                            <MudPaper Outlined="true" Elevation="0" Class="@GetRootActivityTemplateClass(template)" @onclick="@(() => SelectRootActivityTemplate(template.Key))">
+                                <MudStack Row="true" AlignItems="MudBlazor.AlignItems.Center" Spacing="2">
+                                    <MudIcon Icon="@template.Icon" Style="@GetRootActivityTemplateIconStyle(template)" />
+                                    <MudStack Spacing="0" Class="flex-grow-1">
+                                        <MudText Typo="Typo.subtitle2">@Localizer[template.DisplayName]</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@Localizer[template.Description]</MudText>
+                                    </MudStack>
+                                    @if (IsRootActivityTemplateSelected(template))
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Primary" />
+                                    }
+                                </MudStack>
+                            </MudPaper>
+                        }
+                    </MudStack>
+                </MudStack>
                 <MarkdownTextArea Label="@Localizer["Description"]" @bind-Value="_metadataModel.Description" For="@(() => _metadataModel.Description)" HelperText="@Localizer["A brief description of the workflow."]" />
             </MudStack>
         </EditForm>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
@@ -1,6 +1,7 @@
 using Blazored.FluentValidation;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.Validators;
 using Microsoft.AspNetCore.Components;
@@ -15,6 +16,8 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
 public partial class CreateWorkflowDialog
 {
     private readonly WorkflowMetadataModel _metadataModel = new();
+    private IReadOnlyCollection<WorkflowRootActivityTemplate> _rootActivityTemplates = [];
+    private string? _selectedRootActivityTemplateKey;
     private EditContext _editContext = null!;
     private WorkflowPropertiesModelValidator _validator = null!;
     private FluentValidationValidator _fluentValidationValidator = null!;
@@ -24,7 +27,8 @@ public partial class CreateWorkflowDialog
     /// </summary>
     [Parameter] public string WorkflowName { get; set; } = "New workflow";
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
-    [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;    
+    [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;
+    [Inject] private IWorkflowRootActivityTemplateProvider WorkflowRootActivityTemplateProvider { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnParametersSet()
@@ -32,6 +36,8 @@ public partial class CreateWorkflowDialog
         _metadataModel.Name = WorkflowName;
         _editContext = new(_metadataModel);
         _validator = new(WorkflowDefinitionService, Localizer);
+        _rootActivityTemplates = WorkflowRootActivityTemplateProvider.List();
+        _selectedRootActivityTemplateKey ??= WorkflowRootActivityTemplateProvider.GetDefault().Key;
     }
 
     private Task OnCancelClicked()
@@ -50,7 +56,27 @@ public partial class CreateWorkflowDialog
 
     private async Task OnValidSubmit()
     {
-        var result = await WorkflowDefinitionService.CreateNewDefinitionAsync(_metadataModel.Name!, _metadataModel.Description!);
+        var result = await WorkflowDefinitionService.CreateNewDefinitionAsync(_metadataModel.Name!, _metadataModel.Description!, _selectedRootActivityTemplateKey);
         MudDialog.Close(result);
+    }
+
+    private void SelectRootActivityTemplate(string key)
+    {
+        _selectedRootActivityTemplateKey = key;
+    }
+
+    private bool IsRootActivityTemplateSelected(WorkflowRootActivityTemplate template)
+    {
+        return string.Equals(template.Key, _selectedRootActivityTemplateKey, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string GetRootActivityTemplateClass(WorkflowRootActivityTemplate template)
+    {
+        return IsRootActivityTemplateSelected(template) ? "workflow-root-template workflow-root-template-selected" : "workflow-root-template";
+    }
+
+    private static string GetRootActivityTemplateIconStyle(WorkflowRootActivityTemplate template)
+    {
+        return $"color: {template.Color};";
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.css
@@ -1,0 +1,15 @@
+.workflow-root-template {
+    cursor: pointer;
+    padding: 10px 12px;
+    transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.workflow-root-template:hover {
+    border-color: var(--mud-palette-primary);
+    background-color: var(--mud-palette-action-default-hover);
+}
+
+.workflow-root-template-selected {
+    border-color: var(--mud-palette-primary);
+    background-color: var(--mud-palette-primary-hover);
+}


### PR DESCRIPTION
## Summary
- Adds a provider-backed workflow root template abstraction for Flowchart, Sequence, and StateMachine.
- Preserves existing Flowchart creation behavior while allowing selected root types for new workflows.
- Adds a compact Workflow type selector to the New Workflow dialog.
- Adds focused tests for template metadata/root creation and service-level save request roots.

Closes #893

## Merged slice PRs
- #894

## Closed child issues
- #888
- #889
- #890
- #891
- #892

## Verification
- dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --no-restore
- dotnet build src/modules/Elsa.Studio.Workflows.Core/Elsa.Studio.Workflows.Core.csproj --no-restore
- dotnet build src/modules/Elsa.Studio.Workflows/Elsa.Studio.Workflows.csproj --no-restore
- dotnet build src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj --no-restore
- dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj -v minimal

Manual authenticated Studio smoke testing was not available in this worktree; the gap is documented here per #892.