### PR TITLE
Resolve focused Studio warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.24" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.JSInterop" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -59,7 +59,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -78,7 +78,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
     <PackageVersion Include="Refit" Version="10.0.1" />
   </ItemGroup>

--- a/src/framework/Elsa.Studio.Core/Contracts/IAppBarService.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IAppBarService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Models;
 using Microsoft.AspNetCore.Components;
 
@@ -28,13 +29,13 @@ public interface IAppBarService
     /// </summary>
     /// <typeparam name="T">The type of the component.</typeparam>
     [Obsolete("Use AddElement instead.")]
-    void AddAppBarItem<T>() where T : IComponent;
+    void AddAppBarItem<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : IComponent;
 
     /// <summary>
     /// Adds a component of the specified type to the app bar.
     /// </summary>
     /// <typeparam name="T">The type of the component to add.</typeparam>
-    void AddComponent<T>(float? order = null) where T : IComponent;
+    void AddComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(float? order = null) where T : IComponent;
 
     /// <summary>
     /// Adds an element of the specified type to the app bar.

--- a/src/framework/Elsa.Studio.Core/Contracts/IUIHintService.cs
+++ b/src/framework/Elsa.Studio.Core/Contracts/IUIHintService.cs
@@ -5,6 +5,9 @@ namespace Elsa.Studio.Contracts;
 /// </summary>
 public interface IUIHintService
 {
+    /// <summary>
+    /// Gets the UI hint handler for the specified UI hint.
+    /// </summary>
     IUIHintHandler GetHandler(string uiHint);
     //RenderFragment DisplayInputEditor(DisplayInputEditorContext context);
 }

--- a/src/framework/Elsa.Studio.Core/ElsaStudioIcons.cs
+++ b/src/framework/Elsa.Studio.Core/ElsaStudioIcons.cs
@@ -70,6 +70,9 @@ public static class ElsaStudioIcons
         /// Provides the flask value.
         /// </summary>
         public const string Flask = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <line x1="9" y1="3" x2="15" y2="3" />  <line x1="10" y1="9" x2="14" y2="9" />  <path d="M10 3v6l-4 11a.7 .7 0 0 0 .5 1h11a.7 .7 0 0 0 .5 -1l-4 -11v-6" /></svg>""";
+        /// <summary>
+        /// Provides the magic wand value.
+        /// </summary>
         public const string MagicWand = """<svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">  <path stroke="none" d="M0 0h24v24H0z"/>  <polyline points="6 21 21 6 18 3 3 18 6 21" />  <line x1="15" y1="6" x2="18" y2="9" />  <path d="M9 3a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2" />  <path d="M19 13a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2" /></svg>""";
     }
 

--- a/src/framework/Elsa.Studio.Core/Extensions/MediatorExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/MediatorExtensions.cs
@@ -7,9 +7,6 @@ namespace Elsa.Studio.Extensions;
 /// Contains extension methods for <see cref="IMediator"/>.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Provides extension methods for mediator.
-/// </summary>
 public static class MediatorExtensions
 {
     /// <summary>

--- a/src/framework/Elsa.Studio.Core/Extensions/ObjectExtension.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ObjectExtension.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Elsa.Studio.Extensions;
@@ -13,6 +14,7 @@ public static class ObjectExtension
     /// <param name="obj"></param>
     /// <returns>The result of the operation.</returns>
     /// <exception cref="ArgumentNullException"></exception>
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "This helper intentionally reflects over anonymous UI attribute bags.")]
     public static Dictionary<string, object?> ToDictionary(this object obj)
     {
         if (obj == null)

--- a/src/framework/Elsa.Studio.Core/Extensions/RenderTreeBuilderExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/RenderTreeBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -11,7 +12,7 @@ public static class RenderTreeBuilderExtensions
     /// <summary>
     /// Creates a component of the specified type.
     /// </summary>
-    public static void CreateComponent<T>(this RenderTreeBuilder builder) where T : IComponent
+    public static void CreateComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this RenderTreeBuilder builder) where T : IComponent
     {
         var sequence = 0;
         CreateComponent<T>(builder, ref sequence);
@@ -20,7 +21,7 @@ public static class RenderTreeBuilderExtensions
     /// <summary>
     /// Creates a component of the specified type.
     /// </summary>
-    public static void CreateComponent<T>(this RenderTreeBuilder builder, ref int sequence) where T : IComponent
+    public static void CreateComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this RenderTreeBuilder builder, ref int sequence) where T : IComponent
     {
         builder.OpenComponent<T>(sequence++);
         builder.CloseComponent();
@@ -30,9 +31,8 @@ public static class RenderTreeBuilderExtensions
     /// Creates a component of the specified type at the specified sequence.
     /// </summary>
     /// <param name="builder">The <see cref="RenderTreeBuilder"/> to append the component to.</param>
-    /// <param name="sequence">The sequence number for the component.</param>
     /// <param name="componentType">The type of the component to create.</param>
-    public static void CreateComponent(this RenderTreeBuilder builder, Type componentType)
+    public static void CreateComponent(this RenderTreeBuilder builder, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType)
     {
         var sequence = 0;
         CreateComponent(builder, ref sequence, componentType);
@@ -44,7 +44,7 @@ public static class RenderTreeBuilderExtensions
     /// <param name="builder">The <see cref="RenderTreeBuilder"/> to append the component to.</param>
     /// <param name="sequence">The sequence number for the component.</param>
     /// <param name="componentType">The type of the component to create.</param>
-    public static void CreateComponent(this RenderTreeBuilder builder, ref int sequence, Type componentType)
+    public static void CreateComponent(this RenderTreeBuilder builder, ref int sequence, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type componentType)
     {
         builder.OpenComponent(sequence++, componentType);
         builder.CloseComponent();

--- a/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/framework/Elsa.Studio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Api.Client.Extensions;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Localization;
@@ -81,7 +82,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the specified <see cref="INotificationHandler"/>.
     /// </summary>
-    public static IServiceCollection AddNotificationHandler<T>(this IServiceCollection services) where T: class, INotificationHandler
+    public static IServiceCollection AddNotificationHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T: class, INotificationHandler
     {
         return services.AddScoped<INotificationHandler, T>();
     }
@@ -89,7 +90,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the specified <see cref="IUIHintHandler"/>.
     /// </summary>
-    public static IServiceCollection AddUIHintHandler<T>(this IServiceCollection services) where T : class, IUIHintHandler
+    public static IServiceCollection AddUIHintHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IUIHintHandler
     {
         return services.AddScoped<IUIHintHandler, T>();
     }
@@ -97,7 +98,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the specified <see cref="IUIFieldExtensionHandler"/>.
     /// </summary>
-    public static IServiceCollection AddUIFieldEnhancerHandler<T>(this IServiceCollection services) where T : class, IUIFieldExtensionHandler
+    public static IServiceCollection AddUIFieldEnhancerHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IUIFieldExtensionHandler
     {
         return services.AddScoped<IUIFieldExtensionHandler, T>();
     }
@@ -105,7 +106,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the specified <see cref="IUserMessageService"/>.
     /// </summary>
-    public static IServiceCollection AddUserMessageService<T>(this IServiceCollection services) where T : class, IUserMessageService
+    public static IServiceCollection AddUserMessageService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IUserMessageService
     {
         return services.AddScoped<IUserMessageService, T>();
     }
@@ -113,7 +114,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the specified <see cref="IContentVisualizer"/>.
     /// </summary>
-    public static IServiceCollection AddContentVisualizer<T>(this IServiceCollection services) where T : class, IContentVisualizer
+    public static IServiceCollection AddContentVisualizer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IContentVisualizer
     {
         return services.AddTransient<IContentVisualizer, T>();
     }

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
@@ -5,5 +5,8 @@
 /// </summary>
 public interface ILocalizationProvider
 {
+    /// <summary>
+    /// Gets the translation for the specified key.
+    /// </summary>
     string GetTranslation(string key);
 }

--- a/src/framework/Elsa.Studio.Core/Models/AppBarElement.cs
+++ b/src/framework/Elsa.Studio.Core/Models/AppBarElement.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Extensions;
 using Microsoft.AspNetCore.Components;
 
@@ -41,7 +42,7 @@ public class AppBarElement
 /// This generic specialization of the `AppBarElement` class enforces that only components of the specified type
 /// are allowed. The rendering logic uses the type parameter to instantiate the specified component.
 /// </remarks>
-public class AppBarElement<T> : AppBarElement where T : IComponent
+public class AppBarElement<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : AppBarElement where T : IComponent
 {
     /// <inheritdoc />
     public override RenderFragment Component { get; set; } = builder => builder.CreateComponent<T>();

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
@@ -186,6 +187,7 @@ public class DisplayInputEditorContext
         await UpdateValueAsync(value);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Input editor values are runtime UI models that cannot use a fixed source-generated context.")]
     private static string Serialize(object? value)
     {
         var options = new JsonSerializerOptions

--- a/src/framework/Elsa.Studio.Core/Services/DefaultAppBarService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultAppBarService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Extensions;
 using Elsa.Studio.Models;
@@ -20,13 +21,13 @@ public class DefaultAppBarService : IAppBarService
     public IEnumerable<RenderFragment> AppBarComponents => AppBarElements.Select(x => x.Component).ToList();
 
     /// <inheritdoc />
-    public void AddAppBarItem<T>() where T : IComponent
+    public void AddAppBarItem<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : IComponent
     {
         AddComponent<T>();
     }
 
     /// <inheritdoc />
-    public void AddComponent<T>(float? order = null) where T : IComponent
+    public void AddComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(float? order = null) where T : IComponent
     {
         var element = new AppBarElement
         {

--- a/src/framework/Elsa.Studio.Core/Visualizers/JsonContentVisualizer.cs
+++ b/src/framework/Elsa.Studio.Core/Visualizers/JsonContentVisualizer.cs
@@ -1,4 +1,5 @@
-﻿using Elsa.Studio.Contracts;
+﻿using System.Diagnostics.CodeAnalysis;
+using Elsa.Studio.Contracts;
 using System.Text.Json;
 using Elsa.Studio.Models;
 
@@ -9,6 +10,8 @@ namespace Elsa.Studio.Visualizers;
 /// </summary>
 public class JsonContentVisualizer : IContentVisualizer
 {
+    private static readonly JsonSerializerOptions IndentedJsonSerializerOptions = new() { WriteIndented = true };
+
     /// <inheritdoc/>
     public string Name => "Json";
 
@@ -28,11 +31,11 @@ public class JsonContentVisualizer : IContentVisualizer
     {
         try
         {
-            string formatted = input is string str
-                ? JsonSerializer.Serialize(JsonDocument.Parse(str), new JsonSerializerOptions { WriteIndented = true })
-                : JsonSerializer.Serialize(input, new JsonSerializerOptions { WriteIndented = true });
+            if (input is not string str)
+                return input?.ToString() ?? string.Empty;
 
-            return formatted;
+            using var document = JsonDocument.Parse(str);
+            return FormatJsonElement(document.RootElement);
         }
         catch
         {
@@ -100,7 +103,10 @@ public class JsonContentVisualizer : IContentVisualizer
             JsonValueKind.True => "true",
             JsonValueKind.False => "false",
             JsonValueKind.Null => "null",
-            _ => JsonSerializer.Serialize(element)
+            _ => FormatJsonElement(element)
         };
     }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JsonElement serialization does not require runtime type discovery.")]
+    private static string FormatJsonElement(JsonElement element) => JsonSerializer.Serialize(element, IndentedJsonSerializerOptions);
 }

--- a/src/framework/Elsa.Studio.Shared/Components/AppBar/Documentation.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/AppBar/Documentation.razor
@@ -1,1 +1,3 @@
-<MudIconButton Icon="@Icons.Material.Outlined.Book" Color="Color.Inherit" Href="https://v3.elsaworkflows.io/" Target="_blank" Title="Documentation"/>
+<MudTooltip Text="Documentation">
+    <MudIconButton Icon="@Icons.Material.Outlined.Book" Color="Color.Inherit" Href="https://v3.elsaworkflows.io/" Target="_blank" />
+</MudTooltip>

--- a/src/framework/Elsa.Studio.Shared/Components/AppBar/Documentation.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/AppBar/Documentation.razor
@@ -1,3 +1,3 @@
 <MudTooltip Text="Documentation">
-    <MudIconButton Icon="@Icons.Material.Outlined.Book" Color="Color.Inherit" Href="https://v3.elsaworkflows.io/" Target="_blank" />
+    <MudIconButton Icon="@Icons.Material.Outlined.Book" Color="Color.Inherit" Href="https://v3.elsaworkflows.io/" Target="_blank" aria-label="Documentation" />
 </MudTooltip>

--- a/src/framework/Elsa.Studio.Shared/Components/AppBar/GitHub.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/AppBar/GitHub.razor
@@ -1,3 +1,3 @@
 <MudTooltip Text="Source code">
-    <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/elsa-workflows/elsa-core" Target="_blank" />
+    <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/elsa-workflows/elsa-core" Target="_blank" aria-label="Source code" />
 </MudTooltip>

--- a/src/framework/Elsa.Studio.Shared/Components/AppBar/GitHub.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/AppBar/GitHub.razor
@@ -1,1 +1,3 @@
-<MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/elsa-workflows/elsa-core" Target="_blank" Title="Source code"/>
+<MudTooltip Text="Source code">
+    <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/elsa-workflows/elsa-core" Target="_blank" />
+</MudTooltip>

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
@@ -5,6 +5,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Components;
 
+/// <summary>
+/// Represents a dialog for editing code with Monaco.
+/// </summary>
 public partial class CodeEditorDialog : IDisposable
 {
     private readonly string _monacoEditorId = $"monaco-editor-{Guid.NewGuid():N}";

--- a/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/ContentVisualizer.razor
@@ -73,7 +73,7 @@
                      Outlined="true"
                      KeepPanelsAlive="true"
                      ApplyEffectsToContainer="true"
-                     PanelClass="pa-4">
+                     TabPanelsClass="pa-4">
                 <MudPaper Height="655px" Width="100%" Elevation="0">
                     <MudTabPanel Text="@Localizer["Pretty"]" Visible="@(_pretty is not null)">
                         <StandaloneCodeEditor @ref="_monacoEditor"
@@ -93,14 +93,14 @@
                             {
                                 <thead>
                                     <tr>
-                                        @foreach (var header in _table?.Headers)
+                                        @foreach (var header in _table.Headers)
                                         {
                                             <th>@header</th>
                                         }
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach (var row in _table?.Rows)
+                                    @foreach (var row in _table.Rows)
                                     {
                                         <tr>
                                             @foreach (var x in row)

--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Elsa.Studio.Components.DataPanelRenderers;
@@ -147,6 +148,7 @@ public partial class DataPanel : ComponentBase
         return value is bool b ? (b ? Localizer["Yes"] : Localizer["No"]) : value.ToString() ?? string.Empty;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Data panel values are runtime UI objects that cannot use a fixed source-generated context.")]
     private string FormatJson(object value)
     {
         return value as string ?? JsonSerializer.Serialize(value, JsonSerializerOptions);
@@ -168,7 +170,7 @@ public partial class DataPanel : ComponentBase
     {
         var textToCopy = !string.IsNullOrWhiteSpace(item.Text) ? item.Text : GetFormattedValue(item);
         await Clipboard.CopyText(textToCopy);
-        Snackbar.Add(Localizer["{0} copied", item.Label], Severity.Success);
+        Snackbar.Add(Localizer["{0} copied", item.Label ?? string.Empty], Severity.Success);
     }
 
     private async Task OnViewClicked(DataPanelItem item)

--- a/src/framework/Elsa.Studio.Shared/Components/DefaultBranding.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DefaultBranding.razor
@@ -2,12 +2,17 @@
 
 <MudStack>
     <div class="d-flex gap-2 align-center">
-        <MudImage Src="@BrandingProvider.LogoUrl" ObjectFit="ObjectFit.ScaleDown" Fluid="true" Width="32"
+        <MudImage Src="@LogoUrl" ObjectFit="ObjectFit.ScaleDown" Fluid="true" Width="32"
                   Height="32"></MudImage>
-        <MudText Typo="Typo.h6">@BrandingProvider.AppNameWithVersion </MudText>
+        <MudText Typo="Typo.h6">@AppNameWithVersion </MudText>
     </div>
 </MudStack>
 
 @code{
-    [Parameter] public IBrandingProvider BrandingProvider { get; set; }
+    [Parameter] public IBrandingProvider BrandingProvider { get; set; } = default!;
+
+#pragma warning disable CS0618 // Default branding renders the legacy values for backward-compatible providers.
+    private string? LogoUrl => BrandingProvider.LogoUrl;
+    private string AppNameWithVersion => BrandingProvider.AppNameWithVersion;
+#pragma warning restore CS0618
 }

--- a/src/framework/Elsa.Studio.Shared/Components/Error.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/Error.razor.cs
@@ -7,5 +7,8 @@ namespace Elsa.Studio.Components;
 /// </summary>
 public partial class Error : ComponentBase
 {
+    /// <summary>
+    /// Gets or sets the exception to display.
+    /// </summary>
     [Parameter] public Exception Context { get; set; } = null!;
 }

--- a/src/framework/Elsa.Studio.Shared/Components/FieldExtension.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/FieldExtension.razor
@@ -64,7 +64,7 @@ else
     /// </summary>
     [Parameter] public RenderFragment ChildContent { get; set; } = default!;
 
-    [Inject] private IUIFieldExtensionService FieldExtensionService { get; set; }
+    [Inject] private IUIFieldExtensionService FieldExtensionService { get; set; } = default!;
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/MarkdownEditor.razor
@@ -29,7 +29,7 @@
                          Outlined="true"
                          KeepPanelsAlive="true"
                          ApplyEffectsToContainer="true"
-                         PanelClass="pa-4">
+                         TabPanelsClass="pa-4">
                     <MudPaper Height="100%" Width="100%" Elevation="0">
                         @if (!IsReadOnly)
                         {

--- a/src/framework/Elsa.Studio.Shared/Components/Zone.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/Zone.razor.cs
@@ -12,18 +12,12 @@ public partial class Zone : IDisposable
     /// Gets or sets the zone name.
     /// </summary>
     [Parameter]
-    /// <summary>
-    /// Gets or sets the name.
-    /// </summary>
     public string Name { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the attributes that are passed to the widgets.
     /// </summary>
     [Parameter]
-    /// <summary>
-    /// Gets or sets the attributes.
-    /// </summary>
     public IDictionary<string, object?> Attributes { get; set; } = new Dictionary<string, object?>();
 
     [Inject] private IWidgetRegistry WidgetRegistry { get; set; } = default!;

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 
 namespace Elsa.Studio.Models;
@@ -27,4 +28,5 @@ public record DataPanelItem(
     DataPanelItemFormat Format = DataPanelItemFormat.Auto,
     string? FormatString = null,
     RenderFragment<DataPanelItemContext>? ValueTemplate = null,
+    [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     Type? ValueComponentType = null);

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelModel.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelModel.cs
@@ -5,10 +5,17 @@ namespace Elsa.Studio.Models;
 /// </summary>
 public class DataPanelModel : List<DataPanelItem>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataPanelModel"/> class.
+    /// </summary>
     public DataPanelModel()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataPanelModel"/> class.
+    /// </summary>
+    /// <param name="collection">The items to include in the model.</param>
     public DataPanelModel(IEnumerable<DataPanelItem> collection) : base(collection)
     {
     }

--- a/src/framework/Elsa.Studio.Shared/Monaco/Handlers/JavaScriptMonacoHandler.cs
+++ b/src/framework/Elsa.Studio.Shared/Monaco/Handlers/JavaScriptMonacoHandler.cs
@@ -24,7 +24,7 @@ public class JavaScriptMonacoHandler(IJSRuntime jsRuntime, TypeDefinitionService
         var activityTypeName = activityDescriptor?.TypeName;
         var propertyName = propertyDescriptor?.Name;
 
-        if (activityTypeName == null || workflowDefinitionId == null)
+        if (activityTypeName == null || workflowDefinitionId == null || propertyName == null)
             return;
 
         var data = await typeDefinitionService.GetTypeDefinition(workflowDefinitionId, activityTypeName, propertyName);

--- a/src/modules/Elsa.Studio.Authentication.Abstractions/ComponentProviders/UnauthorizedComponentProvider.cs
+++ b/src/modules/Elsa.Studio.Authentication.Abstractions/ComponentProviders/UnauthorizedComponentProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Extensions;
 using Microsoft.AspNetCore.Components;
@@ -9,7 +10,7 @@ namespace Elsa.Studio.Authentication.Abstractions.ComponentProviders;
 /// Eliminates the need for separate provider classes for each component.
 /// </summary>
 /// <typeparam name="TComponent">The component type to render.</typeparam>
-public class UnauthorizedComponentProvider<TComponent> : IUnauthorizedComponentProvider where TComponent : IComponent
+public class UnauthorizedComponentProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TComponent> : IUnauthorizedComponentProvider where TComponent : IComponent
 {
     /// <inheritdoc />
     public RenderFragment GetUnauthorizedComponent() => builder => builder.CreateComponent<TComponent>();


### PR DESCRIPTION
## Summary

- align Microsoft.Extensions.Http.Polly central package versions with Elsa.Api.Client transitive requirements so solution restore no longer fails on NU1605
- add trim annotations and targeted suppressions for shared component activation and runtime UI serialization helpers
- fix targeted XML doc, nullability, obsolete branding, and MudBlazor analyzer warnings in the OpenTelemetry dependency graph

## Verification
- dotnet restore Elsa.Studio.sln
- dotnet build src/modules/Elsa.Studio.Diagnostics.OpenTelemetry/Elsa.Studio.Diagnostics.OpenTelemetry.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=false
- dotnet build src/modules/Elsa.Studio.Diagnostics.OpenTelemetry.Tests/Elsa.Studio.Diagnostics.OpenTelemetry.Tests.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=false
- dotnet test src/modules/Elsa.Studio.Diagnostics.OpenTelemetry.Tests/Elsa.Studio.Diagnostics.OpenTelemetry.Tests.csproj --configuration Release --no-build
- dotnet build Elsa.Studio.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=false (succeeds with remaining repository-wide warning backlog)