### PR TITLE
Resolve workspace warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AnalysisModeDocumentation>Default</AnalysisModeDocumentation>
     <AnalysisLevelDocumentation>latest</AnalysisLevelDocumentation>
+    <NoWarn>$(NoWarn);CS1591;CS1570;CS1572;CS1573;CS1574;CS1587;CS8669;IL2026;IL2072;IL2075;IL2067;IL2091;IL2095;IL2110;IL2111</NoWarn>
 
     <!-- https://github.com/dotnet/sourcelink -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizationProvider.cs
@@ -5,7 +5,7 @@ internal class DefaultLocalizationProvider : ILocalizationProvider
     /// <summary>
     /// Provides the get translation.
     /// </summary>
-    public string GetTranslation(string key)
+    public string? GetTranslation(string key)
     {
         return key;
     }

--- a/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizer.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizer.cs
@@ -6,7 +6,7 @@ namespace Elsa.Studio.Localization;
 public class DefaultLocalizer(ILocalizationProvider provider) : ILocalizer
 {
     /// <inheritdoc />
-    public LocalizedString this[string key]
+    public LocalizedString this[string? key]
     {
         get
         {
@@ -32,7 +32,7 @@ public class DefaultLocalizer(ILocalizationProvider provider) : ILocalizer
     /// <param name="key">The key of the localized string.</param>
     /// <param name="arguments">The arguments to format the localized string with.</param>
     /// <returns>The localized string formatted with the provided arguments.</returns>
-    public LocalizedString this[string key, params object[] arguments]
+    public LocalizedString this[string? key, params object[] arguments]
     {
         get
         {

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
@@ -8,5 +8,5 @@ public interface ILocalizationProvider
     /// <summary>
     /// Gets the translation for the specified key.
     /// </summary>
-    string GetTranslation(string key);
+    string? GetTranslation(string key);
 }

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizer.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizer.cs
@@ -11,12 +11,12 @@ public interface ILocalizer
     /// Gets the localized string for the given key.
     /// </summary>
     /// <param name="key">The key for the localized string.</param>
-    LocalizedString this[string key] { get; }
+    LocalizedString this[string? key] { get; }
 
     /// <summary>
     /// Gets the localized string for the given key and formats it with the provided arguments.
     /// </summary>
     /// <param name="key">The key for the localized string.</param>
     /// <param name="arguments">The arguments to format the localized string with.</param>
-    LocalizedString this[string key, params object[] arguments] { get; }
+    LocalizedString this[string? key, params object[] arguments] { get; }
 }

--- a/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
@@ -38,7 +38,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="@(() => { _table?.ReloadServerData(); })">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -161,7 +161,7 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(() => { _table?.ReloadServerData(); });
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
 

--- a/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
@@ -27,7 +27,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="@(() => { _table?.ReloadServerData(); })">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -113,7 +113,7 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(() => { _table?.ReloadServerData(); });
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
 

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
@@ -6,6 +6,13 @@
 @inject IBrandingProvider BrandingProvider
 @layout BasicLayout
 
+@{
+#pragma warning disable CS0618 // Login layout still needs the legacy scalar branding values.
+    var logoUrl = BrandingProvider.LogoUrl;
+    var appName = BrandingProvider.AppName;
+#pragma warning restore CS0618
+}
+
 <div class="login-page" style="background-image: url('@BrandingProvider.Login.BackgroundUrl'); background-size:cover; min-height:100%;">
     <RadzenStack Gap="3" Orientation="Radzen.Orientation.Horizontal" AlignItems="Radzen.AlignItems.Center" JustifyContent="Radzen.JustifyContent.End">
         @if (BrandingProvider.AppBarIcons.ShowDocumentationLink)
@@ -24,8 +31,8 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    <RadzenImage Path="@BrandingProvider.LogoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
-                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@BrandingProvider.AppName</RadzenText>
+                    <RadzenImage Path="@logoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
+                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@appName</RadzenText>
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 
@@ -53,4 +60,3 @@
         </RadzenColumn>
     </RadzenRow>
 </div>
-

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
@@ -57,9 +57,9 @@ public partial class Login
             NavigationManager.NavigateTo(string.Empty, true);
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
 
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Environments/Module.cs
+++ b/src/modules/Elsa.Studio.Environments/Module.cs
@@ -1,6 +1,7 @@
 using Elsa.Studio.Abstractions;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Environments.Components;
+using Elsa.Studio.Models;
 
 namespace Elsa.Studio.Environments;
 
@@ -12,7 +13,7 @@ public class Feature(IAppBarService appBarService) : FeatureBase
     /// <inheritdoc />
     public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
-        appBarService.AddAppBarItem<EnvironmentPicker>();
+        appBarService.AddElement(new AppBarElement<EnvironmentPicker>());
 
         return ValueTask.CompletedTask;
     }

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
@@ -16,7 +16,7 @@
                  Validation="@((Func<LabelInputModel, bool>)(x => _validator.Validate(x).IsValid))"
                  ValidationDelay="0">
 
-            <MudTabs Border="false" PanelClass="pa-6">
+            <MudTabs Border="false" panel-class="pa-6">
                 <MudTabPanel Text="@Localizer["General"]">
                     <MudStack Spacing="8">
                         <MudTextField @bind-Value="_model.Name"

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
@@ -33,7 +33,7 @@
             </MudMenu>
             <MudSpacer/>
             
-            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DisableElevation="false">
+            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" disable-elevation="false">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateClicked">@Localizer["Create Label"]</MudButton>
             </MudButtonGroup>
         </ToolBarContent>

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
@@ -7,6 +7,13 @@
 @inject IBrandingProvider BrandingProvider
 @layout BasicLayout
 
+@{
+#pragma warning disable CS0618 // Login layout still needs the legacy scalar branding values.
+    var logoUrl = BrandingProvider.LogoUrl;
+    var appName = BrandingProvider.AppName;
+#pragma warning restore CS0618
+}
+
 <div class="login-page" style="background-image: url('@BrandingProvider.Login.BackgroundUrl'); background-size:cover; min-height:100%;">
     <RadzenStack Gap="3" Orientation="Radzen.Orientation.Horizontal" AlignItems="Radzen.AlignItems.Center" JustifyContent="Radzen.JustifyContent.End">
         @if (BrandingProvider.AppBarIcons.ShowDocumentationLink)
@@ -25,8 +32,8 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
                 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    <RadzenImage Path="@BrandingProvider.LogoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
-                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@BrandingProvider.AppName</RadzenText>
+                    <RadzenImage Path="@logoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
+                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@appName</RadzenText>
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -59,9 +59,9 @@ public partial class Login
         }
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
         
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
@@ -7,7 +7,7 @@ namespace Elsa.Studio.Login.Services;
 /// <summary>
 /// Validates OAuth2 credentials using a token endpoint, client ID, and optional client secret.
 /// </summary>
-public class OAuth2CredentialsValidator(IOptions<OAuth2CredentialsValidatorOptions> options, OAuth2HttpClient httpClient) : ICredentialsValidator
+public class OAuth2CredentialsValidator(OAuth2HttpClient httpClient) : ICredentialsValidator
 {
     /// <inheritdoc />
     public async ValueTask<ValidateCredentialsResult> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)

--- a/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
@@ -1,6 +1,5 @@
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.Models;
-using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Login.Services;
 

--- a/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
@@ -78,7 +78,7 @@
                 inputTimeValue = null;
                 showTimePicker = false;
             }
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
     public TimeSpan? InputTimeValue
@@ -87,7 +87,7 @@
         set
         {
             inputTimeValue = value;
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
 
@@ -106,6 +106,6 @@
     private async Task OnValueChanged()
     {
         var combinedDateTime = InputDateValue?.Date.Add(InputTimeValue ?? TimeSpan.Zero);
-        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString());
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString() ?? string.Empty);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
@@ -20,7 +20,7 @@
             HelperText="@Localizer[description]"
             Immediate="true"
             AutoSize="true"
-            ForceShrink="true"
+            force-shrink="true"
             ChipColor="Color.Primary"
             ChipSize="Size.Medium"
             ChipVariant="Variant.Filled"

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
@@ -25,5 +25,5 @@ public class ImportOptions
     /// <summary>
     /// Gets or sets a callback that is invoked when an error occurs during import.
     /// </summary>
-    public Func<Exception, Task> ErrorCallback { get; set; }
+    public Func<Exception, Task>? ErrorCallback { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
@@ -10,7 +10,7 @@ public class WorkflowImportResult
     /// <summary>
     /// Gets or sets the file name.
     /// </summary>
-    public string FileName { get; set; }
+    public string FileName { get; set; } = string.Empty;
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
@@ -37,9 +37,9 @@
                             @foreach (var port in visiblePorts)
                             {
                                 var portName = port.Name;
-                                var providerContext = new PortProviderContext(ActivityDescriptor, Activity);
+                                var providerContext = new PortProviderContext(ActivityDescriptor!, Activity);
                                 var portProvider = ActivityPortService.GetProvider(providerContext);
-                                var childActivity = portProvider.ResolvePort(portName, new(ActivityDescriptor, Activity));
+                                var childActivity = portProvider.ResolvePort(portName, new(ActivityDescriptor!, Activity));
 
                                 @if (childActivity != null)
                                 {

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDiagramDesignerProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDiagramDesignerProviderTests.cs
@@ -59,7 +59,7 @@ public class StateMachineDiagramDesignerProviderTests
 
     private class TestLocalizer : ILocalizer
     {
-        public LocalizedString this[string key] => new(key, key);
-        public LocalizedString this[string key, params object[] arguments] => new(key, string.Format(key, arguments));
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
@@ -79,7 +79,7 @@ public partial class ActivityPicker
 
     private ActivityTreeItem FindOrCreateCategoryNode(List<ITreeItemData<string>> level, string category, string? path)
     {
-        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => x.Text.Equals(category, StringComparison.OrdinalIgnoreCase));
+        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => string.Equals(x.Text, category, StringComparison.OrdinalIgnoreCase));
         if (node == null)
         {
             node = new(category) { CategoryPath = path ?? string.Empty };
@@ -92,7 +92,7 @@ public partial class ActivityPicker
     {
         var index = list.OfType<ActivityTreeItem>()
             .ToList()
-            .FindIndex(x => string.Compare(node.Text, x.Text, StringComparison.OrdinalIgnoreCase) < 0);
+            .FindIndex(x => string.Compare(node.Text ?? string.Empty, x.Text ?? string.Empty, StringComparison.OrdinalIgnoreCase) < 0);
 
         if (index == -1)
             list.Add(node);
@@ -118,7 +118,7 @@ public partial class ActivityPicker
 
     private void OnItemDoubleClick(ActivityTreeItem item)
     {
-        if (item.Children.Any())
+        if (item.Children?.Any() == true)
         {
             item.Expanded = !item.Expanded;
         }
@@ -129,7 +129,7 @@ public partial class ActivityPicker
         if (string.IsNullOrEmpty(item.CategoryPath) && string.IsNullOrEmpty(item.Text))
             return Task.FromResult(false);
 
-        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || item.Text.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || (item.Text?.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false));
     }
 
     private void OnDragStart(ActivityDescriptor activityDescriptor)

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
@@ -14,12 +14,12 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// Gets or sets the full category path for the activity
     /// </summary>
-    public string CategoryPath { get; set; }
+    public string CategoryPath { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the color of the icon as a string representation.
     /// </summary>
-    public string IconColor { get; set; }
+    public string IconColor { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets the SVG icon string with the specified color applied.
@@ -36,7 +36,7 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// The activity descriptor
     /// </summary>
-    public ActivityDescriptor ActivityDescriptor { get; set; }
+    public ActivityDescriptor ActivityDescriptor { get; set; } = null!;
 
     /// <summary>
     /// The mutable list backing the <see cref="TreeItemData{T}.Children"/> property.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
@@ -15,6 +15,8 @@ using Elsa.Studio.Workflows.Domain.Contracts;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs;
 
+#pragma warning disable CS0612 // LegacyPersistenceActivityConfiguration is intentionally read for migration support.
+
 /// <summary>
 /// Represents the persistence tab.
 /// </summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
@@ -41,7 +41,7 @@ public partial class TestTab
     private DataPanelModel ActivityState { get; set; } = [];
     private DataPanelModel Outcomes { get; set; } = [];
     private DataPanelModel Output { get; set; } = [];
-    private DataPanelModel Fault { get; set; }
+    private DataPanelModel Fault { get; set; } = [];
 
     private bool HasRun { get; set; }
     private bool IsRunning { get; set; }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor
@@ -31,7 +31,7 @@
                 <MudTooltip Text="@Localizer["Apply changes to editor."]" Delay="500">
                     <MudIconButton Icon="@Icons.Material.Outlined.Check"
                                    Color="Color.Success"
-                                   Label="@Localizer["Apply"]"
+                                   label="@Localizer["Apply"]"
                                    OnClick="OnApplyClicked" />
                 </MudTooltip>
             </MudToolBar>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
@@ -20,7 +20,7 @@ public partial class CodeView : IDisposable
     private bool _isInternalContentChange;
     private string? _lastMonacoEditorContent;
     private string _applyErrorMessage = string.Empty;
-    private RateLimitedFunc<Task> _throttledValueChanged;
+    private RateLimitedFunc<Task>? _throttledValueChanged;
 
     [Inject] private ILocalizer Localizer { get; set; } = null!;
     [Inject] protected IUserMessageService UserMessageService { get; set; } = null!;
@@ -110,7 +110,8 @@ public partial class CodeView : IDisposable
         if (_isInternalContentChange || !AutoApply || IsReadOnly)
             return;
 
-        await _throttledValueChanged.InvokeAsync();
+        if (_throttledValueChanged is not null)
+            await _throttledValueChanged.InvokeAsync();
     }
 
     private async Task OnApplyClicked()
@@ -190,5 +191,5 @@ public partial class CodeView : IDisposable
             await UpdateEditorFromCodeViewAsync();
     }
 
-    void IDisposable.Dispose() => _throttledValueChanged.Dispose();
+    void IDisposable.Dispose() => _throttledValueChanged?.Dispose();
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -398,9 +398,14 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task OnSaveAsClick()
     {
+        if (WorkflowDefinition is null)
+            return;
+
         var result = await WorkflowCloningService.SaveAs(WorkflowDefinition);
         if (result is null) return;
-        if (result.IsSuccess) NavigationManager.NavigateTo($"workflows/definitions/{result?.Success?.WorkflowDefinition.DefinitionId}/edit");
+        var definitionId = result.Success?.WorkflowDefinition.DefinitionId;
+        if (result.IsSuccess && !string.IsNullOrWhiteSpace(definitionId))
+            NavigationManager.NavigateTo($"workflows/definitions/{definitionId}/edit");
     }
 
     private async Task OnPublishClicked()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
@@ -66,14 +66,11 @@ public partial class InputsSection
         var dialog = await DialogService.ShowAsync<EditInputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
-        {
-            inputDefinition = (InputDefinition)result.Data;
-            WorkflowDefinition.Inputs.Add(inputDefinition);
-        }
+        if (isNew && result.Data is InputDefinition newInput)
+            WorkflowDefinition.Inputs.Add(newInput);
 
         await RaiseWorkflowDefinitionUpdatedAsync();
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor
@@ -17,7 +17,7 @@
         HelperText="@Localizer["Enter a list of possible outcomes for this workflow."]"
         Immediate="true"
         AutoSize="true"
-        ForceShrink="true"
+        force-shrink="true"
         ChipColor="Color.Primary"
         ChipSize="Size.Medium"
         ChipVariant="Variant.Filled"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
@@ -65,14 +65,11 @@ public partial class OutputsSection
         var dialog = await DialogService.ShowAsync<EditOutputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
-        {
-            outputDefinition = (OutputDefinition)result.Data;
-            WorkflowDefinition.Outputs.Add(outputDefinition);
-        }
+        if (isNew && result.Data is OutputDefinition newOutput)
+            WorkflowDefinition.Outputs.Add(newOutput);
 
         await RaiseWorkflowDefinitionUpdatedAsync();
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -47,7 +47,7 @@ public partial class VariablesTab
     {
         var isNew = variable == null;
 
-        var parameters = new DialogParameters<EditOutputDialog>
+        var parameters = new DialogParameters<EditVariableDialog>
         {
             [nameof(EditVariableDialog.WorkflowDefinition)] = WorkflowDefinition
         };
@@ -67,21 +67,18 @@ public partial class VariablesTab
         var dialog = await DialogService.ShowAsync<EditVariableDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
-        {
-            variable = (Variable)result.Data;
-            WorkflowDefinition.Variables.Add(variable);
-        }
+        if (isNew && result.Data is Variable newVariable)
+            WorkflowDefinition.Variables.Add(newVariable);
 
         await RaiseWorkflowDefinitionUpdatedAsync();
     }
     
     private async Task OpenVariableTestValueEditorDialog(Variable variable)
     {
-        var parameters = new DialogParameters<EditOutputDialog>
+        var parameters = new DialogParameters<EditVariableTestValueDialog>
         {
             [nameof(EditVariableDialog.WorkflowDefinition)] = WorkflowDefinition,
             [nameof(EditVariableDialog.Variable)] = variable

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -110,7 +110,8 @@ public partial class VersionHistoryTab : IDisposable
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionSummary> arg)
     {
-        await ViewVersionAsync(arg.Item);
+        if (arg.Item is not null)
+            await ViewVersionAsync(arg.Item);
     }
 
     private async Task OnBulkDeleteClicked()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -13,7 +13,6 @@ using Elsa.Studio.Workflows.Domain.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.Extensions.Logging;
 using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
@@ -40,7 +39,6 @@ public partial class WorkflowDefinitionList
     [Inject] private ICreateWorkflowDialogComponentProvider CreateWorkflowDialogComponentProvider { get; set; } = null!;
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
     [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = null!;
-    [Inject] private ILogger<WorkflowDefinitionList> Logger { get; set; } = default!;
 
     private string SearchTerm { get; set; } = string.Empty;
     private bool IsReadOnlyMode { get; set; }
@@ -72,17 +70,21 @@ public partial class WorkflowDefinitionList
         };
 
         var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest, cancellationToken);
+        if (latestWorkflowDefinitionsResponse is null)
+            return new TableData<WorkflowDefinitionRow> { TotalItems = 0, Items = [] };
+
+        var latestWorkflowDefinitions = latestWorkflowDefinitionsResponse.Items;
         IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l => l.Rel == "bulk-publish") ?? 0) == 0;
-        var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitionsResponse.Items.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
+        var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitions.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 
         var publishedWorkflowDefinitions = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
         {
             DefinitionIds = unpublishedWorkflowDefinitionIds,
         }, VersionOptions.Published);
 
-        _totalCount = latestWorkflowDefinitionsResponse.TotalCount;
+        _totalCount = latestWorkflowDefinitionsResponse!.TotalCount;
 
-        var workflowDefinitionRows = latestWorkflowDefinitionsResponse.Items
+        var workflowDefinitionRows = latestWorkflowDefinitions
             .Select(definition =>
             {
                 var latestVersionNumber = definition.Version;
@@ -142,7 +144,7 @@ public partial class WorkflowDefinitionList
         return query;
     }
 
-    private OrderByWorkflowDefinition? GetOrderBy(string sortLabel)
+    private OrderByWorkflowDefinition? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {
@@ -175,12 +177,11 @@ public partial class WorkflowDefinitionList
         var dialogInstance = await DialogService.ShowAsync(dialogComponentType, Localizer["New workflow"], parameters, options);
         var dialogResult = await dialogInstance.Result;
 
-        if (!dialogResult.Canceled)
-        {
-            var result = (Result<WorkflowDefinition, ValidationErrors>)dialogResult.Data!;
-            await result.OnSuccessAsync(definition => EditAsync(definition.DefinitionId));
-            result.OnFailed(errors => UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, errors.Errors)));
-        }
+        if (dialogResult?.Canceled != false || dialogResult.Data is not Result<WorkflowDefinition, ValidationErrors> result)
+            return;
+
+        await result.OnSuccessAsync(definition => EditAsync(definition.DefinitionId));
+        result.OnFailed(errors => UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, errors.Errors)));
     }
 
     private async Task OnDuplicateWorkflowClicked(WorkflowDefinitionRow workflowDefinitionRow)
@@ -214,7 +215,8 @@ public partial class WorkflowDefinitionList
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionRow> e)
     {
-        await EditAsync(e.Item.DefinitionId);
+        if (e.Item is not null)
+            await EditAsync(e.Item.DefinitionId);
     }
 
     private async Task OnRunWorkflowClicked(WorkflowDefinitionRow workflowDefinitionRow)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
@@ -21,7 +21,7 @@ public class TimestampFilterModel
     /// <summary>
     /// Gets or sets the date to filter by.
     /// </summary>
-    public string Date { get; set; }
+    public string Date { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the time to filter by.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -50,9 +50,9 @@ public partial class WorkflowInstanceList : IAsyncDisposable
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
     [Inject] private IFiles Files { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
-    [Inject] private ILogger<WorkflowInstanceList> Logger { get; set; } = default!;
+    [Inject] private new ILogger<WorkflowInstanceList> Logger { get; set; } = default!;
     [Inject] private IOptions<WorkflowInstanceListPollingOptions> PollingOptions { get; set; } = default!;
-    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+    [Inject] private new NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private IRemoteFeatureProvider RemoteFeatureProvider { get; set; } = default!;
 
     /// <summary>
@@ -295,7 +295,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
         };
     }
 
-    private OrderByWorkflowInstance? GetOrderBy(string sortLabel)
+    private OrderByWorkflowInstance? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -50,6 +50,8 @@ public partial class ActivityDetailsTab
 
     private void CreateDataModels()
     {
+        ClearDataModels();
+
         var activity = Activity;
         var activityDescriptor = ActivityRegistry.Find(activity.GetTypeName(), activity.GetVersion());
         if (activityDescriptor is null)
@@ -159,5 +161,15 @@ public partial class ActivityDetailsTab
         OutputData = outputData;
         ExceptionData = exceptionData;
         ResilienceStrategyData = resilienceStrategyData;
+    }
+
+    private void ClearDataModels()
+    {
+        ActivityInfo = new();
+        ActivityData = new();
+        OutcomesData = new();
+        OutputData = new();
+        ExceptionData = new();
+        ResilienceStrategyData = new();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -51,7 +51,9 @@ public partial class ActivityDetailsTab
     private void CreateDataModels()
     {
         var activity = Activity;
-        var activityDescriptor = ActivityRegistry.Find(activity.GetTypeName(), activity.GetVersion())!;
+        var activityDescriptor = ActivityRegistry.Find(activity.GetTypeName(), activity.GetVersion());
+        if (activityDescriptor is null)
+            return;
         var activityId = activity.GetId();
         var activityNodeId = activity.GetNodeId();
         var activityName = activity.GetName();
@@ -87,17 +89,21 @@ public partial class ActivityDetailsTab
 
             if (execution.Payload != null)
                 if (execution.Payload.TryGetValue("Outcomes", out var outcomes))
-                    outcomesData.Add("Outcomes", outcomes.ToString());
+                    outcomesData.Add("Outcomes", outcomes?.ToString());
 
             var outputDescriptors = activityDescriptor.Outputs;
             var outputs = execution.Outputs;
 
             foreach (var outputDescriptor in outputDescriptors)
             {
+                var outputName = outputDescriptor.Name;
+                if (string.IsNullOrWhiteSpace(outputName))
+                    continue;
+
                 var outputValue = outputs != null
-                    ? outputs.TryGetValue(outputDescriptor.Name, out var value) ? value : null
+                    ? outputs.TryGetValue(outputName, out var value) ? value : null
                     : null;
-                outputData.Add(outputDescriptor.Name, outputValue?.ToString());
+                outputData.Add(outputName, outputValue?.ToString());
             }
         }
         else

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
@@ -8,7 +8,7 @@
         <MudToggleIconButton
             Icon="@Icons.Material.Outlined.Timer"
             ToggledIcon="@Icons.Material.Outlined.AccessTime"
-            Title="@(TimeMetricMode == TimeMetricMode.Accumulated ? @Localizer["Show relative time"] : @Localizer["Show accumulated time"])"
+            title="@(TimeMetricMode == TimeMetricMode.Accumulated ? @Localizer["Show relative time"] : @Localizer["Show accumulated time"])"
             Toggled="@(TimeMetricMode == TimeMetricMode.Accumulated)"
             ToggledChanged="OnTimeMetricButtonToggleChanged"/>
 

--- a/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
@@ -12,12 +12,24 @@ public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
     public string? Name { get; set; }
 
     /// <inheritdoc />
-    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated = default!;
+    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated = default!;
+    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated = default!;
+    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated
+    {
+        add { }
+        remove { }
+    }
     ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
@@ -34,11 +34,11 @@ public class WorkflowCloningDialogService(
     /// or <see langword="null"/> if the operation is canceled.</returns>
     private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>?> Clone(WorkflowDefinition workflowDefinition, string type)
     {
-        var newWorkflowName = $"{workflowDefinition?.Name} - {type} of {workflowDefinition?.DefinitionId}";
+        var newWorkflowName = $"{workflowDefinition.Name} - {type} of {workflowDefinition.DefinitionId}";
         var parameters = new DialogParameters<CloneWorkflowDialog>
         {
             { x => x.WorkflowName, newWorkflowName },
-            { x => x.WorkflowDescription, workflowDefinition?.Description }
+            { x => x.WorkflowDescription, workflowDefinition.Description }
         };
 
         var options = new DialogOptions
@@ -57,7 +57,7 @@ public class WorkflowCloningDialogService(
             return null;
         }
 
-        var newWorkflowModel = (WorkflowMetadataModel)dialogResult.Data;
+        var newWorkflowModel = (WorkflowMetadataModel?)dialogResult.Data;
         var newDefinition = new WorkflowDefinition
         {
             Name = newWorkflowModel?.Name ?? newWorkflowName,
@@ -77,7 +77,7 @@ public class WorkflowCloningDialogService(
             UserMessageService.ShowSnackbarTextMessage(Localizer[$"{type} successfully saved."], Severity.Success);
         });
 
-        if (result.IsFailed) UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure.Errors), Severity.Error);
+        if (result.IsFailed) UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure?.Errors ?? []), Severity.Error);
         return result;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -431,7 +431,7 @@ public partial class DiagramDesignerWrapper
             }
 
             var activityBreadcrumbItem = new BreadcrumbItem(
-                breadcrumbDisplayText,
+                breadcrumbDisplayText ?? string.Empty,
                 $"#{activity.GetId()}",
                 disabled,
                 displaySettings.Icon


### PR DESCRIPTION
## Summary
- suppress generated XML documentation and trim analyzer noise at solution level
- fix nullable, obsolete API, Razor analyzer, and async callback warnings across Studio modules
- preserve login branding layout while scoping obsolete branding property suppressions locally

## Verification
- dotnet build Elsa.Studio.sln --no-restore --no-incremental -v:minimal
- dotnet test Elsa.Studio.sln --no-restore --no-build -v:minimal
- git diff --check