### PR TITLE
[codex] Show workflow validation API errors

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -1,5 +1,6 @@
 using Elsa.Studio.Workflows.Domain.Models;
 using Refit;
+using System.Text.Json;
 
 namespace Elsa.Studio.Workflows.Domain.Extensions;
 
@@ -19,5 +20,91 @@ public static class ValidationApiExceptionExtensions
             return problemDetails.ToValidationErrors();
 
         return problemDetails?.ToValidationErrors() ?? new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? "The server responded with a Bad Request status code. That's all I know.") });
+    }
+
+    /// <summary>
+    /// Gets the validation errors from a <see cref="ApiException"/>.
+    /// </summary>
+    public static ValidationErrors GetValidationErrors(this ApiException e)
+    {
+        if (e is ValidationApiException validationApiException)
+            return validationApiException.GetValidationErrors();
+
+        var errors = GetValidationErrorsFromContent(e.Content);
+        return errors ?? new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) });
+    }
+
+    private static ValidationErrors? GetValidationErrorsFromContent(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+            var errors = new List<ValidationError>();
+
+            if (TryGetProperty(root, "errors", out var errorsElement))
+                errors.AddRange(GetErrorMessages(errorsElement).Select(x => new ValidationError(x)));
+
+            if (errors.Count == 0)
+                errors.AddRange(GetFallbackMessages(root).Select(x => new ValidationError(x)));
+
+            return errors.Count > 0 ? new ValidationErrors(errors) : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<string> GetErrorMessages(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                    foreach (var propertyMessage in GetErrorMessages(property.Value))
+                        yield return propertyMessage;
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                    foreach (var itemMessage in GetErrorMessages(item))
+                        yield return itemMessage;
+                break;
+            case JsonValueKind.String:
+                var message = element.GetString();
+                if (!string.IsNullOrWhiteSpace(message))
+                    yield return message;
+                break;
+        }
+    }
+
+    private static IEnumerable<string> GetFallbackMessages(JsonElement root)
+    {
+        foreach (var propertyName in new[] { "detail", "title", "message" })
+            if (TryGetProperty(root, propertyName, out var property) && property.ValueKind == JsonValueKind.String)
+            {
+                var message = property.GetString();
+                if (!string.IsNullOrWhiteSpace(message))
+                    yield return message;
+            }
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement property)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var candidate in element.EnumerateObject())
+                if (string.Equals(candidate.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    property = candidate.Value;
+                    return true;
+                }
+        }
+
+        property = default;
+        return false;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -19,7 +19,7 @@ public static class ValidationApiExceptionExtensions
         if (problemDetails != null)
             return problemDetails.ToValidationErrors();
 
-        return problemDetails?.ToValidationErrors() ?? new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? "The server responded with a Bad Request status code. That's all I know.") });
+        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? "The server responded with a Bad Request status code. That's all I know.") });
     }
 
     /// <summary>
@@ -31,7 +31,13 @@ public static class ValidationApiExceptionExtensions
             return validationApiException.GetValidationErrors();
 
         var errors = GetValidationErrorsFromContent(e.Content);
-        return errors ?? new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) });
+        if (errors != null)
+            return errors;
+
+        if (!string.IsNullOrWhiteSpace(e.Content))
+            return new ValidationErrors(new List<ValidationError> { new(e.Content) });
+
+        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) });
     }
 
     private static ValidationErrors? GetValidationErrorsFromContent(string? content)

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionEditorService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionEditorService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
@@ -53,23 +54,23 @@ public class WorkflowDefinitionEditorService(IBackendApiClientProvider backendAp
             },
             Publish = publish,
         };
-        
+
         var api = await GetApiAsync(cancellationToken);
-        
+
         try
         {
             if (request.Publish == true) await mediator.NotifyAsync(new WorkflowDefinitionPublishing(workflowDefinition), cancellationToken);
             await mediator.NotifyAsync(new WorkflowDefinitionSaving(workflowDefinition), cancellationToken);
             var response = await api.SaveAsync(request, cancellationToken);
-            
-            if(workflowSavedCallback != null)
+
+            if (workflowSavedCallback != null)
                 await workflowSavedCallback(response.WorkflowDefinition);
-            
+
             await mediator.NotifyAsync(new WorkflowDefinitionSaved(response.WorkflowDefinition), cancellationToken);
             if (request.Publish == true) await mediator.NotifyAsync(new WorkflowDefinitionPublished(response.WorkflowDefinition), cancellationToken);
             return new(response);
         }
-        catch (ValidationApiException e)
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.BadRequest)
         {
             var errors = e.GetValidationErrors();
             await mediator.NotifyAsync(new WorkflowDefinitionSavingFailed(workflowDefinition, errors), cancellationToken);
@@ -84,7 +85,7 @@ public class WorkflowDefinitionEditorService(IBackendApiClientProvider backendAp
         var api = await GetApiAsync(cancellationToken);
         await mediator.NotifyAsync(new WorkflowDefinitionPublishing(workflowDefinition), cancellationToken);
         var response = await api.PublishAsync(workflowDefinition.DefinitionId, new PublishWorkflowDefinitionRequest(), cancellationToken);
-        if(workflowPublishedCallback != null) await workflowPublishedCallback(workflowDefinition);
+        if (workflowPublishedCallback != null) await workflowPublishedCallback(workflowDefinition);
         await mediator.NotifyAsync(new WorkflowDefinitionPublished(workflowDefinition), cancellationToken);
         return response;
     }
@@ -97,18 +98,18 @@ public class WorkflowDefinitionEditorService(IBackendApiClientProvider backendAp
             var api = await GetApiAsync(cancellationToken);
             await mediator.NotifyAsync(new WorkflowDefinitionRetracting(workflowDefinition), cancellationToken);
             var definition = await api.RetractAsync(workflowDefinition.DefinitionId, new RetractWorkflowDefinitionRequest(), cancellationToken);
-            if(workflowRetractedCallback != null) await workflowRetractedCallback(definition);
+            if (workflowRetractedCallback != null) await workflowRetractedCallback(definition);
             await mediator.NotifyAsync(new WorkflowDefinitionRetracted(definition), cancellationToken);
             return new(definition);
         }
-        catch (ValidationApiException e)
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.BadRequest)
         {
             var errors = e.GetValidationErrors();
             await mediator.NotifyAsync(new WorkflowDefinitionRetractingFailed(workflowDefinition, errors), cancellationToken);
             return new(errors);
         }
     }
-    
+
     /// <inheritdoc />
     public async Task<FileDownload> ExportAsync(WorkflowDefinition workflowDefinition, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default)
     {
@@ -118,10 +119,10 @@ public class WorkflowDefinitionEditorService(IBackendApiClientProvider backendAp
         var fileName = response.GetDownloadedFileNameOrDefault($"workflow-definition-{workflowDefinition.DefinitionId}-v{workflowDefinition.Version}.json");
         var fileDownload = new FileDownload(fileName, response.Content!);
         await mediator.NotifyAsync(new WorkflowDefinitionExported(workflowDefinition, fileDownload), cancellationToken);
-        
+
         return fileDownload;
     }
-    
+
     /// <inheritdoc />
     public async Task<WorkflowDefinitionSummary> RevertAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionHistoryService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionHistoryService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
@@ -24,18 +25,18 @@ public class WorkflowDefinitionHistoryService(IBackendApiClientProvider backendA
             var api = await GetApiAsync(cancellationToken);
             await mediator.NotifyAsync(new WorkflowDefinitionRetracting(workflowDefinition), cancellationToken);
             var definition = await api.RetractAsync(workflowDefinition.DefinitionId, new RetractWorkflowDefinitionRequest(), cancellationToken);
-            if(workflowRetractedCallback != null) await workflowRetractedCallback(definition);
+            if (workflowRetractedCallback != null) await workflowRetractedCallback(definition);
             await mediator.NotifyAsync(new WorkflowDefinitionRetracted(definition), cancellationToken);
             return new(definition);
         }
-        catch (ValidationApiException e)
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.BadRequest)
         {
             var errors = e.GetValidationErrors();
             await mediator.NotifyAsync(new WorkflowDefinitionRetractingFailed(workflowDefinition, errors), cancellationToken);
             return new(errors);
         }
     }
-    
+
     /// <inheritdoc />
     public async Task<WorkflowDefinitionSummary> RevertAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/WorkflowDefinitionService.cs
@@ -88,7 +88,7 @@ public class RemoteWorkflowDefinitionService(
             await mediator.NotifyAsync(new WorkflowDefinitionRetracted(definition), cancellationToken);
             return new(definition);
         }
-        catch (ValidationApiException e)
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.BadRequest)
         {
             var errors = e.GetValidationErrors();
             await mediator.NotifyAsync(new WorkflowDefinitionIdRetractingFailed(definitionId, errors), cancellationToken);
@@ -209,7 +209,7 @@ public class RemoteWorkflowDefinitionService(
 
     /// <inheritdoc />
     public async Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(
-        string name, 
+        string name,
         string? description = null,
         Action<SaveWorkflowDefinitionRequest>? configureRequest = null,
         CancellationToken cancellationToken = default)
@@ -239,7 +239,7 @@ public class RemoteWorkflowDefinitionService(
                 Root = rootActivityTemplate.CreateRoot(identityGenerator)
             }
         };
-        
+
         configureRequest?.Invoke(saveRequest);
 
         var api = await GetApiAsync(cancellationToken);
@@ -249,7 +249,7 @@ public class RemoteWorkflowDefinitionService(
             var response = await api.SaveAsync(saveRequest, cancellationToken);
             return new(response.WorkflowDefinition);
         }
-        catch (ValidationApiException e)
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.BadRequest)
         {
             var errors = e.GetValidationErrors();
             return new(errors);
@@ -265,10 +265,10 @@ public class RemoteWorkflowDefinitionService(
         var fileName = response.GetDownloadedFileNameOrDefault($"workflow-definition-{definitionId}.json");
         var fileDownload = new FileDownload(fileName, response.Content!);
         await mediator.NotifyAsync(new WorkflowDefinitionIdExported(definitionId, versionOptions, fileDownload), cancellationToken);
-        
+
         return fileDownload;
     }
-    
+
     /// <inheritdoc />
     public async Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default)
     {
@@ -285,7 +285,7 @@ public class RemoteWorkflowDefinitionService(
         var api = await GetApiAsync(cancellationToken);
         return await api.UpdateReferencesAsync(definitionId, new(), cancellationToken);
     }
-    
+
     /// <inheritdoc />
     public async Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/ValidationApiExceptionExtensionsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ValidationApiExceptionExtensionsTests.cs
@@ -46,6 +46,18 @@ public class ValidationApiExceptionExtensionsTests
         Assert.Equal("The workflow definition is invalid.", error.ErrorMessage);
     }
 
+    [Fact]
+    public async Task GetValidationErrors_PreservesPlainTextContent()
+    {
+        const string content = "The /absence/created path and post method are already in use by another workflow!";
+        var exception = await CreateApiExceptionAsync(content);
+
+        var errors = exception.GetValidationErrors();
+
+        var error = Assert.Single(errors.Errors);
+        Assert.Equal(content, error.ErrorMessage);
+    }
+
     private static async Task<ApiException> CreateApiExceptionAsync(string content)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/workflow-definitions");

--- a/src/modules/Elsa.Studio.Workflows.Tests/ValidationApiExceptionExtensionsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ValidationApiExceptionExtensionsTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Elsa.Studio.Workflows.Domain.Extensions;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public class ValidationApiExceptionExtensionsTests
+{
+    [Fact]
+    public async Task GetValidationErrors_ReadsGeneralErrorsFromApiExceptionContent()
+    {
+        const string content = """
+        {
+          "statusCode": 400,
+          "message": "One or more errors occurred!",
+          "errors": {
+            "generalErrors": [
+              "The /absence/created path and post method are already in use by another workflow!"
+            ]
+          }
+        }
+        """;
+        var exception = await CreateApiExceptionAsync(content);
+
+        var errors = exception.GetValidationErrors();
+
+        var error = Assert.Single(errors.Errors);
+        Assert.Equal("The /absence/created path and post method are already in use by another workflow!", error.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetValidationErrors_UsesMessageWhenErrorsAreMissing()
+    {
+        const string content = """
+        {
+          "statusCode": 400,
+          "message": "The workflow definition is invalid."
+        }
+        """;
+        var exception = await CreateApiExceptionAsync(content);
+
+        var errors = exception.GetValidationErrors();
+
+        var error = Assert.Single(errors.Errors);
+        Assert.Equal("The workflow definition is invalid.", error.ErrorMessage);
+    }
+
+    private static async Task<ApiException> CreateApiExceptionAsync(string content)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/workflow-definitions");
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            RequestMessage = request,
+            ReasonPhrase = "Bad Request",
+            Content = new StringContent(content)
+        };
+
+        return await ApiException.Create(request, HttpMethod.Post, response, new RefitSettings());
+    }
+}


### PR DESCRIPTION
## Summary
- Parse plain JSON 400 responses from workflow definition save/retract/create calls into `ValidationErrors`.
- Preserve Elsa Core validation messages such as `errors.generalErrors` so the existing workflow editor snackbar shows the actionable server message.
- Add regression coverage for the duplicate HTTP endpoint payload reported in elsa-core#7678.

## Why
Elsa Core already returns useful validation details for duplicate HTTP trigger endpoints, but Studio could surface the generic Refit `ApiException` text when the response is not materialized as `ValidationApiException`. The workflow editor already displays `ValidationErrors`; this change makes the service layer feed it the useful API messages.

Fixes elsa-workflows/elsa-studio#904 from the Studio UI side.

## Validation
- `dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj`
- `dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --no-restore`

## Notes
A full browser repro was not run because it requires a configured Elsa backend with conflicting HTTP-trigger workflow definitions. The behavior is covered at the service conversion layer that feeds the existing editor snackbar.
