### PR TITLE
Resolve focused build warnings

### DIFF
--- a/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
@@ -10,8 +10,8 @@ internal class ResxLocalizationProvider : ILocalizationProvider
     /// </summary>
     /// <param name="key">The key.</param>
     /// <returns>The result of the operation.</returns>
-    public string? GetTranslation(string key)
+    public string GetTranslation(string key)
     {
-        return Elsa.Studio.Translations.Translations.ResourceManager.GetString(key, CultureInfo.CurrentUICulture);
+        return Elsa.Studio.Translations.Translations.ResourceManager.GetString(key, CultureInfo.CurrentUICulture) ?? key;
     }
 }

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
@@ -57,9 +57,9 @@ public partial class Login
             NavigationManager.NavigateTo(string.Empty, true);
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
 
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs.Tests/SignalRConsoleLogObserverTests.cs
+++ b/src/modules/Elsa.Studio.Diagnostics.ConsoleLogs.Tests/SignalRConsoleLogObserverTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Authentication.Abstractions.Contracts;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Diagnostics.ConsoleLogs.Models;
@@ -65,7 +66,7 @@ public class SignalRConsoleLogObserverTests
     private class TestBackendApiClientProvider(Uri url) : IBackendApiClientProvider
     {
         public Uri Url { get; } = url;
-        public ValueTask<T> GetApiAsync<T>(CancellationToken cancellationToken = default) where T : class => throw new NotSupportedException();
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class => throw new NotSupportedException();
     }
 
     private class NoopConnectionOptionsConfigurator : IHttpConnectionOptionsConfigurator

--- a/src/modules/Elsa.Studio.Environments/Services/EnvironmentBackendApiClientProvider.cs
+++ b/src/modules/Elsa.Studio.Environments/Services/EnvironmentBackendApiClientProvider.cs
@@ -27,13 +27,13 @@ public class EnvironmentBackendApiClientProvider : IBackendApiClientProvider
     public Uri Url => _environmentService.CurrentEnvironment?.Url ?? _remoteBackendAccessor.RemoteBackend.Url;
 
     /// <inheritdoc />
-    public async ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
+    public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
     {
         var services = new ServiceCollection().AddDefaultApiClients(x =>
         {
             x.BaseAddress = Url;
             //x.ConfigureHttpClient = httpClient => httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         }).BuildServiceProvider();
-        return services.GetRequiredService<T>();
+        return ValueTask.FromResult(services.GetRequiredService<T>());
     }
 }

--- a/src/modules/Elsa.Studio.Environments/Services/EnvironmentBackendApiClientProvider.cs
+++ b/src/modules/Elsa.Studio.Environments/Services/EnvironmentBackendApiClientProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Api.Client.Extensions;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Environments.Contracts;
@@ -26,7 +27,7 @@ public class EnvironmentBackendApiClientProvider : IBackendApiClientProvider
     public Uri Url => _environmentService.CurrentEnvironment?.Url ?? _remoteBackendAccessor.RemoteBackend.Url;
 
     /// <inheritdoc />
-    public async ValueTask<T> GetApiAsync<T>(CancellationToken cancellationToken = default) where T : class
+    public async ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
     {
         var services = new ServiceCollection().AddDefaultApiClients(x =>
         {

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
@@ -16,8 +16,8 @@
                  Validation="@((Func<LabelInputModel, bool>)(x => _validator.Validate(x).IsValid))"
                  ValidationDelay="0">
 
-            <MudTabs Border="false" PanelClass="pa-6">
-                <MudTabPanel Text="@Localizer["General"]">
+            <MudTabs Border="false">
+                <MudTabPanel Text="@Localizer["General"]" PanelClass="pa-6">
                     <MudStack Spacing="8">
                         <MudTextField @bind-Value="_model.Name"
                                       For="@(() => _model.Name)"

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor.cs
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor.cs
@@ -8,6 +8,9 @@ using MudBlazor;
 
 namespace Elsa.Studio.Labels.UI.Pages;
 
+/// <summary>
+/// Displays the label editor page.
+/// </summary>
 public partial class Label : StudioComponentBase
 {
     /// The ID of the label to edit.

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
@@ -33,7 +33,7 @@
             </MudMenu>
             <MudSpacer/>
             
-            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DisableElevation="false">
+            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DropShadow="true">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateClicked">@Localizer["Create Label"]</MudButton>
             </MudButtonGroup>
         </ToolBarContent>

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -59,9 +59,9 @@ public partial class Login
         }
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
         
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
@@ -1,13 +1,12 @@
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.Models;
-using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Login.Services;
 
 /// <summary>
 /// Validates OAuth2 credentials using a token endpoint, client ID, and optional client secret.
 /// </summary>
-public class OAuth2CredentialsValidator(IOptions<OAuth2CredentialsValidatorOptions> options, OAuth2HttpClient httpClient) : ICredentialsValidator
+public class OAuth2CredentialsValidator(OAuth2HttpClient httpClient) : ICredentialsValidator
 {
     /// <inheritdoc />
     public async ValueTask<ValidateCredentialsResult> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Services;
 using Elsa.Studio.Workflows.Domain.Contracts;
@@ -61,7 +62,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds a <see cref="IDiagramDesignerProvider"/> to the service collection.
     /// </summary>
-    public static IServiceCollection AddDiagramDesignerProvider<T>(this IServiceCollection services) where T : class, IDiagramDesignerProvider
+    public static IServiceCollection AddDiagramDesignerProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IDiagramDesignerProvider
     {
         services.AddScoped<IDiagramDesignerProvider, T>();
         return services;
@@ -70,7 +71,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds a <see cref="IActivityDisplaySettingsProvider"/> to the service collection.
     /// </summary>
-    public static IServiceCollection AddActivityDisplaySettingsProvider<T>(this IServiceCollection services) where T : class, IActivityDisplaySettingsProvider
+    public static IServiceCollection AddActivityDisplaySettingsProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IActivityDisplaySettingsProvider
     {
         services.AddScoped<IActivityDisplaySettingsProvider, T>();
         return services;
@@ -79,7 +80,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds a <see cref="IActivityPortProvider"/> to the service collection.
     /// </summary>
-    public static IServiceCollection AddActivityPortProvider<T>(this IServiceCollection services) where T : class, IActivityPortProvider
+    public static IServiceCollection AddActivityPortProvider<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IActivityPortProvider
     {
         services.AddScoped<IActivityPortProvider, T>();
         return services;

--- a/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
@@ -12,12 +12,24 @@ public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
     public string? Name { get; set; }
 
     /// <inheritdoc />
-    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated = default!;
+    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated = default!;
+    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated = default!;
+    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated
+    {
+        add { }
+        remove { }
+    }
     ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
@@ -6,6 +6,10 @@ namespace Elsa.Studio.Workflows.Services;
 /// An implementation of <see cref="IWorkflowInstanceObserver"/> that does nothing.
 public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
 {
+    private Func<WorkflowExecutionLogUpdatedMessage, Task>? _workflowJournalUpdated;
+    private Func<ActivityExecutionLogUpdatedMessage, Task>? _activityExecutionLogUpdated;
+    private Func<WorkflowInstanceUpdatedMessage, Task>? _workflowInstanceUpdated;
+
     /// <summary>
     /// Gets or sets the name.
     /// </summary>
@@ -14,22 +18,22 @@ public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
     /// <inheritdoc />
     public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated
     {
-        add { }
-        remove { }
+        add => _workflowJournalUpdated += value;
+        remove => _workflowJournalUpdated -= value;
     }
 
     /// <inheritdoc />
     public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated
     {
-        add { }
-        remove { }
+        add => _activityExecutionLogUpdated += value;
+        remove => _activityExecutionLogUpdated -= value;
     }
 
     /// <inheritdoc />
     public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated
     {
-        add { }
-        remove { }
+        add => _workflowInstanceUpdated += value;
+        remove => _workflowInstanceUpdated -= value;
     }
     ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
 }


### PR DESCRIPTION
## Summary
- Fix non-null localization provider contract by falling back to the resource key.
- Guard nullable login credentials before validator calls and remove an unused OAuth2 validator dependency.
- Align trim annotations for backend API providers and workflow DI helpers.
- Update MudBlazor label page attributes for v9 analyzer compatibility.

## Verification
- dotnet build Elsa.Studio.sln --nologo --no-restore -t:Rebuild
- dotnet test src/modules/Elsa.Studio.Diagnostics.ConsoleLogs.Tests/Elsa.Studio.Diagnostics.ConsoleLogs.Tests.csproj --nologo --no-restore
- dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --nologo --no-restore
- dotnet test src/modules/Elsa.Studio.AI.Tests/Elsa.Studio.AI.Tests.csproj --nologo --no-restore

## Warning inventory
Forced solution rebuild warning lines reduced from 2,734 to 2,636. Remaining warnings are existing repository-wide XML documentation, trim analyzer, and nullable warnings outside this focused patch.