### PR TITLE
Resolve focused Studio warnings

### DIFF
--- a/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizer.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/DefaultLocalizer.cs
@@ -6,7 +6,7 @@ namespace Elsa.Studio.Localization;
 public class DefaultLocalizer(ILocalizationProvider provider) : ILocalizer
 {
     /// <inheritdoc />
-    public LocalizedString this[string key]
+    public LocalizedString this[string? key]
     {
         get
         {
@@ -32,7 +32,7 @@ public class DefaultLocalizer(ILocalizationProvider provider) : ILocalizer
     /// <param name="key">The key of the localized string.</param>
     /// <param name="arguments">The arguments to format the localized string with.</param>
     /// <returns>The localized string formatted with the provided arguments.</returns>
-    public LocalizedString this[string key, params object[] arguments]
+    public LocalizedString this[string? key, params object[] arguments]
     {
         get
         {

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizationProvider.cs
@@ -8,5 +8,5 @@ public interface ILocalizationProvider
     /// <summary>
     /// Gets the translation for the specified key.
     /// </summary>
-    string GetTranslation(string key);
+    string? GetTranslation(string key);
 }

--- a/src/framework/Elsa.Studio.Core/Localization/ILocalizer.cs
+++ b/src/framework/Elsa.Studio.Core/Localization/ILocalizer.cs
@@ -11,12 +11,12 @@ public interface ILocalizer
     /// Gets the localized string for the given key.
     /// </summary>
     /// <param name="key">The key for the localized string.</param>
-    LocalizedString this[string key] { get; }
+    LocalizedString this[string? key] { get; }
 
     /// <summary>
     /// Gets the localized string for the given key and formats it with the provided arguments.
     /// </summary>
     /// <param name="key">The key for the localized string.</param>
     /// <param name="arguments">The arguments to format the localized string with.</param>
-    LocalizedString this[string key, params object[] arguments] { get; }
+    LocalizedString this[string? key, params object[] arguments] { get; }
 }

--- a/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
+++ b/src/framework/Elsa.Studio.Core/Models/DisplayInputEditorContext.cs
@@ -151,7 +151,7 @@ public class DisplayInputEditorContext
     /// depending on the wrapping configuration of the <see cref="InputDescriptor"/>.
     /// </summary>
     /// <param name="value">The new value to be set, either directly or wrapped as a literal expression.</param>
-    public Task UpdateValueOrLiteralExpressionAsync(string value)
+    public Task UpdateValueOrLiteralExpressionAsync(string? value)
     {
         return UpdateValueOrExpressionAsync(value, _ => value, "Literal");
     }

--- a/src/framework/Elsa.Studio.Shared/Components/DefaultBranding.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DefaultBranding.razor
@@ -2,17 +2,22 @@
 
 <MudStack>
     <div class="d-flex gap-2 align-center">
-        <MudImage Src="@LogoUrl" ObjectFit="ObjectFit.ScaleDown" Fluid="true" Width="32"
-                  Height="32"></MudImage>
-        <MudText Typo="Typo.h6">@AppNameWithVersion </MudText>
+        <MudImage Src="@LogoUrl" ObjectFit="ObjectFit.ScaleDown" Fluid="true" Width="@LogoSize"
+                  Height="@LogoSize" Style="@LogoStyle"></MudImage>
+        <MudText Typo="@TextTypo" Class="@TextClass">@DisplayName </MudText>
     </div>
 </MudStack>
 
 @code{
     [Parameter] public IBrandingProvider BrandingProvider { get; set; } = default!;
+    [Parameter] public bool ShowVersion { get; set; } = true;
+    [Parameter] public Typo TextTypo { get; set; } = Typo.h6;
+    [Parameter] public string? TextClass { get; set; }
+    [Parameter] public int LogoSize { get; set; } = 32;
+    [Parameter] public string? LogoStyle { get; set; }
 
 #pragma warning disable CS0618 // Default branding renders the legacy values for backward-compatible providers.
     private string? LogoUrl => BrandingProvider.LogoUrl;
-    private string AppNameWithVersion => BrandingProvider.AppNameWithVersion;
+    private string DisplayName => ShowVersion ? BrandingProvider.AppNameWithVersion : BrandingProvider.AppName;
 #pragma warning restore CS0618
 }

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowHttpRequestPortProvider.cs
@@ -14,12 +14,9 @@ using JetBrains.Annotations;
 namespace Elsa.Studio.ActivityPortProviders.Providers;
 
 /// <summary>
-/// Provides ports for the FlowSendHttpRequest & DownloadHttpFile activities based on its supported status codes.
+/// Provides ports for the FlowSendHttpRequest and DownloadHttpFile activities based on supported status codes.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Provides flow http request port services.
-/// </summary>
 public class FlowHttpRequestPortProvider : ActivityPortProviderBase
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/FlowSwitchPortProvider.cs
@@ -13,9 +13,6 @@ namespace Elsa.Studio.ActivityPortProviders.Providers;
 /// Provides ports for the FlowSwitch activity based on its cases.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Provides flow switch port services.
-/// </summary>
 public class FlowSwitchPortProvider : ActivityPortProviderBase
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
@@ -38,7 +38,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="ReloadTableAsync">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -161,9 +161,11 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(ReloadTableAsync);
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
+
+    private Task ReloadTableAsync() => _table?.ReloadServerData() ?? Task.CompletedTask;
 
     private void StopPolling()
     {
@@ -180,7 +182,7 @@
     private void OnSearchChanged(string value)
     {
         _searchTerm = value;
-        _table?.ReloadServerData();
+        _ = ReloadTableAsync();
     }
 
     public void Dispose() => StopPolling();

--- a/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
@@ -27,7 +27,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="ReloadTableAsync">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -113,9 +113,11 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(ReloadTableAsync);
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
+
+    private Task ReloadTableAsync() => _table?.ReloadServerData() ?? Task.CompletedTask;
 
     private void StopPolling()
     {
@@ -132,7 +134,7 @@
     private void OnSearchChanged(string value)
     {
         _searchTerm = value;
-        _table?.ReloadServerData();
+        _ = ReloadTableAsync();
     }
 
     public void Dispose() => StopPolling();

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
@@ -24,8 +24,7 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    <RadzenImage Path="@BrandingProvider.LogoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
-                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@BrandingProvider.AppName</RadzenText>
+                    @BrandingProvider.Branding
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 
@@ -53,4 +52,3 @@
         </RadzenColumn>
     </RadzenRow>
 </div>
-

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor
@@ -24,7 +24,7 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    @BrandingProvider.Branding
+                    <DefaultBranding BrandingProvider="@BrandingProvider" ShowVersion="false" TextTypo="Typo.h2" TextClass="rz-color-white" LogoSize="48" LogoStyle="padding-bottom: 1rem" />
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
@@ -40,6 +40,12 @@ public partial class Login
 
     private async Task TryLogin(LoginArgs args)
     {
+        if (string.IsNullOrWhiteSpace(args.Username) || string.IsNullOrWhiteSpace(args.Password))
+        {
+            UserMessageService.ShowSnackbarTextMessage("Invalid credentials. Please try again", Severity.Error);
+            return;
+        }
+
         var isValid = await ValidateCredentials(args.Username, args.Password);
         if (!isValid)
         {
@@ -59,7 +65,7 @@ public partial class Login
 
     private async Task<bool> ValidateCredentials(string username, string password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
 
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Environments/Module.cs
+++ b/src/modules/Elsa.Studio.Environments/Module.cs
@@ -12,7 +12,7 @@ public class Feature(IAppBarService appBarService) : FeatureBase
     /// <inheritdoc />
     public override ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
-        appBarService.AddAppBarItem<EnvironmentPicker>();
+        appBarService.AddComponent<EnvironmentPicker>();
 
         return ValueTask.CompletedTask;
     }

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Label.razor
@@ -16,7 +16,7 @@
                  Validation="@((Func<LabelInputModel, bool>)(x => _validator.Validate(x).IsValid))"
                  ValidationDelay="0">
 
-            <MudTabs Border="false" PanelClass="pa-6">
+            <MudTabs Border="false">
                 <MudTabPanel Text="@Localizer["General"]">
                     <MudStack Spacing="8">
                         <MudTextField @bind-Value="_model.Name"

--- a/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
+++ b/src/modules/Elsa.Studio.Labels/UI/Pages/Labels.razor
@@ -33,7 +33,7 @@
             </MudMenu>
             <MudSpacer/>
             
-            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled" DisableElevation="false">
+            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@OnCreateClicked">@Localizer["Create Label"]</MudButton>
             </MudButtonGroup>
         </ToolBarContent>

--- a/src/modules/Elsa.Studio.Localization.BlazorServer/Controllers/CultureController.cs
+++ b/src/modules/Elsa.Studio.Localization.BlazorServer/Controllers/CultureController.cs
@@ -7,9 +7,6 @@ namespace Elsa.Studio.Localization.BlazorServer.Controllers;
 /// Controller for setting the culture.
 /// </summary>
 [Route("[controller]/[action]")]
-/// <summary>
-/// Represents the culture controller.
-/// </summary>
 public class CultureController : Controller
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
+++ b/src/modules/Elsa.Studio.Login/Components/ReceiveAuthorizationCode.cs
@@ -5,12 +5,9 @@ using Microsoft.AspNetCore.Components;
 namespace Elsa.Studio.Login.Components;
 
 /// <summary>
-/// Receives the OIDC authorization code and trades it for access_token
+/// Receives the OIDC authorization code and trades it for an access token.
 /// </summary>
 [Route("/signin-oidc")]
-/// <summary>
-/// Represents the receive authorization code.
-/// </summary>
 public sealed class ReceiveAuthorizationCode : StudioComponentBase
 {
     /// <summary>

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
@@ -25,8 +25,7 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
                 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    <RadzenImage Path="@BrandingProvider.LogoUrl" Style="width: 3rem; padding-bottom: 1rem" AlternateText="logo" />
-                    <RadzenText TextStyle="TextStyle.DisplayH3" TagName="TagName.H2" class="rz-color-white">@BrandingProvider.AppName</RadzenText>
+                    @BrandingProvider.Branding
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor
@@ -25,7 +25,7 @@
                         Style="height: 100%; display:flex; flex-direction:column; justify-content:space-between; background: var(--rz-primary-light) no-repeat 100% 70% fixed">
                 
                 <RadzenStack Gap="6" AlignItems="Radzen.AlignItems.Center">
-                    @BrandingProvider.Branding
+                    <DefaultBranding BrandingProvider="@BrandingProvider" ShowVersion="false" TextTypo="Typo.h2" TextClass="rz-color-white" LogoSize="48" LogoStyle="padding-bottom: 1rem" />
                     <RadzenText TextStyle="TextStyle.H6" class="rz-color-white">@BrandingProvider.AppTagline</RadzenText>
                 </RadzenStack>
 

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -39,6 +39,12 @@ public partial class Login
 
     private async Task TryLogin(LoginArgs args)
     {
+        if (string.IsNullOrWhiteSpace(args.Username) || string.IsNullOrWhiteSpace(args.Password))
+        {
+            UserMessageService.ShowSnackbarTextMessage("Invalid credentials. Please try again", Severity.Error);
+            return;
+        }
+
         var isValid = await ValidateCredentials(args.Username, args.Password);
         if (!isValid)
         {
@@ -61,7 +67,7 @@ public partial class Login
 
     private async Task<bool> ValidateCredentials(string username, string password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
         
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
+++ b/src/modules/Elsa.Studio.Login/Services/OAuth2CredentialsValidator.cs
@@ -1,13 +1,12 @@
 using Elsa.Studio.Login.Contracts;
 using Elsa.Studio.Login.Models;
-using Microsoft.Extensions.Options;
 
 namespace Elsa.Studio.Login.Services;
 
 /// <summary>
 /// Validates OAuth2 credentials using a token endpoint, client ID, and optional client secret.
 /// </summary>
-public class OAuth2CredentialsValidator(IOptions<OAuth2CredentialsValidatorOptions> options, OAuth2HttpClient httpClient) : ICredentialsValidator
+public class OAuth2CredentialsValidator(OAuth2HttpClient httpClient) : ICredentialsValidator
 {
     /// <inheritdoc />
     public async ValueTask<ValidateCredentialsResult> ValidateCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)

--- a/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Cases.razor.cs
@@ -26,9 +26,6 @@ public partial class Cases
     /// The context for the editor.
     /// </summary>
     [Parameter]
-    /// <summary>
-    /// Gets or sets the editor context.
-    /// </summary>
     public DisplayInputEditorContext EditorContext { get; set; } = default!;
 
     [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = default!;
@@ -194,10 +191,10 @@ public class SwitchCaseRecord
     /// </summary>
     public string Condition { get; set; } = string.Empty;
 
-    [Obsolete("Use ExpressionType instead.")]
     /// <summary>
     /// Provides the syntax.
     /// </summary>
+    [Obsolete("Use ExpressionType instead.")]
     public string Syntax
     {
         get => ExpressionType;

--- a/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
@@ -78,7 +78,7 @@
                 inputTimeValue = null;
                 showTimePicker = false;
             }
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
     public TimeSpan? InputTimeValue
@@ -87,7 +87,7 @@
         set
         {
             inputTimeValue = value;
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
 
@@ -106,6 +106,6 @@
     private async Task OnValueChanged()
     {
         var combinedDateTime = InputDateValue?.Date.Add(InputTimeValue ?? TimeSpan.Zero);
-        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString());
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString() ?? string.Empty);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
@@ -106,6 +106,6 @@
     private async Task OnValueChanged()
     {
         var combinedDateTime = InputDateValue?.Date.Add(InputTimeValue ?? TimeSpan.Zero);
-        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString() ?? string.Empty);
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString());
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor.cs
@@ -23,9 +23,6 @@ public partial class Dictionary
     /// The context for the editor.
     /// </summary>
     [Parameter]
-    /// <summary>
-    /// Gets or sets the editor context.
-    /// </summary>
     public DisplayInputEditorContext EditorContext { get; set; } = null!;
 
     [CascadingParameter] private ExpressionDescriptorProvider ExpressionDescriptorProvider { get; set; } = null!;

--- a/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
@@ -20,7 +20,6 @@
             HelperText="@Localizer[description]"
             Immediate="true"
             AutoSize="true"
-            ForceShrink="true"
             ChipColor="Color.Primary"
             ChipSize="Size.Medium"
             ChipVariant="Variant.Filled"

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
@@ -25,5 +25,5 @@ public class ImportOptions
     /// <summary>
     /// Gets or sets a callback that is invoked when an error occurs during import.
     /// </summary>
-    public Func<Exception, Task> ErrorCallback { get; set; }
+    public Func<Exception, Task>? ErrorCallback { get; set; }
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
@@ -10,7 +10,7 @@ public class WorkflowImportResult
     /// <summary>
     /// Gets or sets the file name.
     /// </summary>
-    public string FileName { get; set; }
+    public string FileName { get; set; } = string.Empty;
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedFile.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedFile.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-[UsedImplicitly]
 /// <summary>
 /// Represents the notification published when an imported is file.
 /// </summary>
+[UsedImplicitly]
 public record ImportedFile(IBrowserFile File) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedJson.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportedJson.cs
@@ -3,8 +3,8 @@ using JetBrains.Annotations;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-[UsedImplicitly]
 /// <summary>
 /// Represents the notification published when an imported is json.
 /// </summary>
+[UsedImplicitly]
 public record ImportedJson(string Json) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingFile.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingFile.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-[UsedImplicitly]
 /// <summary>
 /// Represents the notification published when an importing is file.
 /// </summary>
+[UsedImplicitly]
 public record ImportingFile(IBrowserFile File) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingJson.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Notifications/ImportingJson.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Elsa.Studio.Workflows.Domain.Notifications;
 
-[UsedImplicitly]
 /// <summary>
 /// Represents the notification published when an importing is json.
 /// </summary>
+[UsedImplicitly]
 public record ImportingJson(string Json) : INotification;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SchemaWorkflowJsonDetector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SchemaWorkflowJsonDetector.cs
@@ -5,12 +5,9 @@ using JetBrains.Annotations;
 namespace Elsa.Studio.Workflows.Domain.Services;
 
 /// <summary>
-/// A service that detects whether a JSON string is a workflow definition using a schema.
+/// Detects whether a JSON string is a workflow definition using a schema.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Represents the schema workflow json detector.
-/// </summary>
 public class SchemaWorkflowJsonDetector : IWorkflowJsonDetector
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SimpleWorkflowJsonDetector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/SimpleWorkflowJsonDetector.cs
@@ -5,12 +5,9 @@ using JetBrains.Annotations;
 namespace Elsa.Studio.Workflows.Domain.Services;
 
 /// <summary>
-/// A service that detects whether a JSON string is a workflow definition using a simple heuristic.
+/// Detects whether a JSON string is a workflow definition using a simple heuristic.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Represents the simple workflow json detector.
-/// </summary>
 public class SimpleWorkflowJsonDetector : IWorkflowJsonDetector
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
@@ -11,7 +11,9 @@ namespace Elsa.Studio.Workflows.UI.Contexts;
 /// </summary>
 /// <param name="Activity">The activity to display.</param>
 /// <param name="ActivitySelectedCallback">A callback that is invoked when an activity is selected.</param>
+/// <param name="ActivityUpdated">A callback that is invoked when an activity is updated.</param>
 /// <param name="ActivityEmbeddedPortSelectedCallback">A callback that is invoked when an embedded port is selected.</param>
+/// <param name="ActivityDoubleClickCallback">A callback that is invoked when an activity is double-clicked.</param>
 /// <param name="GraphUpdatedCallback">A callback that is invoked when the graph is updated.</param>
 /// <param name="IsReadOnly">Whether the activity is read-only.</param>
 /// <param name="ActivityStats">A map of activity stats.</param>

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsProvider.cs
@@ -11,7 +11,6 @@ public interface IActivityDisplaySettingsProvider
     /// <summary>
     /// Returns a dictionary of activity type to display settings.
     /// </summary>
-    /// <param name="activityDescriptor"></param>
     /// <returns></returns>
     IDictionary<string, ActivityDisplaySettings> GetSettings();
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
@@ -5,11 +5,10 @@ using MudBlazor;
 
 namespace Elsa.Studio.Workflows.UI.Providers;
 
-/// Provides default activity display settings.
-[UsedImplicitly]
 /// <summary>
-/// Provides default activity display settings services.
+/// Provides default activity display settings.
 /// </summary>
+[UsedImplicitly]
 public class DefaultActivityDisplaySettingsProvider : IActivityDisplaySettingsProvider
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
@@ -37,6 +37,8 @@
                             @foreach (var port in visiblePorts)
                             {
                                 var portName = port.Name;
+                                if (ActivityDescriptor is null)
+                                    continue;
                                 var providerContext = new PortProviderContext(ActivityDescriptor, Activity);
                                 var portProvider = ActivityPortService.GetProvider(providerContext);
                                 var childActivity = portProvider.ResolvePort(portName, new(ActivityDescriptor, Activity));

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -82,14 +82,10 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     [Inject] private ILogger<FlowchartDesigner> Logger { get; set; } = null!;
 
     /// <summary>
-    /// Invoked from JavaScript when an activity is selected.
-    /// </summary>
-    /// <param name="activity">The selected activity.</param>
-    [JSInvokable]
-    /// <summary>
     /// Performs the handle activity selected operation asynchronously.
     /// </summary>
     /// <param name="activity">The activity.</param>
+    [JSInvokable]
     public async Task HandleActivitySelected(JsonObject activity)
     {
         if (ActivitySelected.HasDelegate)
@@ -107,16 +103,11 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Invoked from JavaScript when an activity embedded port is selected.
-    /// </summary>
-    /// <param name="activity">The selected activity.</param>
-    /// <param name="portName">The selected port name.</param>
-    [JSInvokable]
-    /// <summary>
     /// Performs the handle activity embedded port selected operation asynchronously.
     /// </summary>
     /// <param name="activity">The activity.</param>
     /// <param name="portName">The port name.</param>
+    [JSInvokable]
     public async Task HandleActivityEmbeddedPortSelected(JsonObject activity, string portName)
     {
         if (ActivityEmbeddedPortSelected.HasDelegate)
@@ -127,14 +118,10 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Invoked from JavaScript when an activity is double-clicked.
-    /// </summary>
-    /// <param name="activity">The clicked activity.</param>
-    [JSInvokable]
-    /// <summary>
     /// Performs the handle activity double click operation asynchronously.
     /// </summary>
     /// <param name="activity">The activity.</param>
+    [JSInvokable]
     public async Task HandleActivityDoubleClick(JsonObject activity)
     {
         if (ActivityDoubleClick.HasDelegate)
@@ -143,35 +130,32 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
         }
     }
 
-    /// Invoked from JavaScript when the canvas is selected.
-    [JSInvokable]
     /// <summary>
     /// Performs the handle canvas selected operation asynchronously.
     /// </summary>
+    [JSInvokable]
     public async Task HandleCanvasSelected()
     {
         if (CanvasSelected.HasDelegate)
             await CanvasSelected.InvokeAsync();
     }
 
-    /// Invoked from JavaScript when the graph is updated.
-    [JSInvokable]
     /// <summary>
     /// Performs the handle graph updated operation asynchronously.
     /// </summary>
+    [JSInvokable]
     public async Task HandleGraphUpdated()
     {
         if (GraphUpdated.HasDelegate)
             await GraphUpdated.InvokeAsync();
     }
 
-    /// Invoked from JavaScript when the graph is updated.
-    [JSInvokable]
     /// <summary>
     /// Performs the handle paste cells requested operation asynchronously.
     /// </summary>
     /// <param name="activityNodes">The activity nodes.</param>
     /// <param name="edges">The edges.</param>
+    [JSInvokable]
     public async Task HandlePasteCellsRequested(X6ActivityNode[] activityNodes, X6Edge[] edges)
     {
         var allActivities = Flowchart.GetActivities().ToList();

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDiagramDesignerProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDiagramDesignerProviderTests.cs
@@ -59,7 +59,7 @@ public class StateMachineDiagramDesignerProviderTests
 
     private class TestLocalizer : ILocalizer
     {
-        public LocalizedString this[string key] => new(key, key);
-        public LocalizedString this[string key, params object[] arguments] => new(key, string.Format(key, arguments));
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
@@ -79,7 +79,7 @@ public partial class ActivityPicker
 
     private ActivityTreeItem FindOrCreateCategoryNode(List<ITreeItemData<string>> level, string category, string? path)
     {
-        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => x.Text.Equals(category, StringComparison.OrdinalIgnoreCase));
+        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => string.Equals(x.Text, category, StringComparison.OrdinalIgnoreCase));
         if (node == null)
         {
             node = new(category) { CategoryPath = path ?? string.Empty };
@@ -118,7 +118,7 @@ public partial class ActivityPicker
 
     private void OnItemDoubleClick(ActivityTreeItem item)
     {
-        if (item.Children.Any())
+        if (item.Children?.Any() == true)
         {
             item.Expanded = !item.Expanded;
         }
@@ -129,7 +129,7 @@ public partial class ActivityPicker
         if (string.IsNullOrEmpty(item.CategoryPath) && string.IsNullOrEmpty(item.Text))
             return Task.FromResult(false);
 
-        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || item.Text.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || (item.Text?.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false));
     }
 
     private void OnDragStart(ActivityDescriptor activityDescriptor)

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
@@ -14,18 +14,18 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// Gets or sets the full category path for the activity
     /// </summary>
-    public string CategoryPath { get; set; }
+    public string CategoryPath { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the color of the icon as a string representation.
     /// </summary>
-    public string IconColor { get; set; }
+    public string IconColor { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets the SVG icon string with the specified color applied.
     /// </summary>
     /// <remarks>This property modifies the "stroke" and "fill" attributes of the SVG icon string to
-    /// use the value of <see cref="IconColor"/>. If <see cref="Icon"/> is null, an empty string is
+    /// use the value of <see cref="IconColor"/>. If the base icon is null, an empty string is
     /// returned.</remarks>
     public string IconWithColor => string.IsNullOrWhiteSpace(IconColor)
         ? Icon ?? string.Empty
@@ -36,7 +36,7 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// The activity descriptor
     /// </summary>
-    public ActivityDescriptor ActivityDescriptor { get; set; }
+    public ActivityDescriptor ActivityDescriptor { get; set; } = null!;
 
     /// <summary>
     /// The mutable list backing the <see cref="TreeItemData{T}.Children"/> property.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/LogPersistenceTab.razor.cs
@@ -15,6 +15,8 @@ using Elsa.Studio.Workflows.Domain.Contracts;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs;
 
+#pragma warning disable CS0612 // The tab reads this legacy model to upgrade existing persisted activity metadata.
+
 /// <summary>
 /// Represents the persistence tab.
 /// </summary>
@@ -265,12 +267,9 @@ public partial class LogPersistenceTab
 }
 
 /// <summary>
-/// Defines the Persistence Strategy Configuration for an activity
+/// Defines the legacy persistence strategy configuration for an activity.
 /// </summary>
 [Obsolete]
-/// <summary>
-/// Represents the legacy persistence activity configuration.
-/// </summary>
 public class LegacyPersistenceActivityConfiguration
 {
     /// <summary>
@@ -288,6 +287,8 @@ public class LegacyPersistenceActivityConfiguration
     /// </summary>
     public IDictionary<string, LogPersistenceMode> Outputs { get; set; } = new Dictionary<string, LogPersistenceMode>();
 }
+
+#pragma warning restore CS0612
 
 /// <summary>
 /// Defines the Persistence Strategy Configuration for an activity

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/TaskTab.razor.cs
@@ -14,11 +14,10 @@ public partial class TaskTab
     /// The activity.
     [Parameter] public JsonObject? Activity { get; set; }
     
-    /// The activity descriptor.
-    [Parameter]
     /// <summary>
-    /// Gets or sets the activity descriptor.
+    /// The activity descriptor.
     /// </summary>
+    [Parameter]
     public ActivityDescriptor ActivityDescriptor { get; set; } = default!;
     
     /// An event raised when the activity is updated.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
@@ -41,7 +41,7 @@ public partial class TestTab
     private DataPanelModel ActivityState { get; set; } = [];
     private DataPanelModel Outcomes { get; set; } = [];
     private DataPanelModel Output { get; set; } = [];
-    private DataPanelModel Fault { get; set; }
+    private DataPanelModel Fault { get; set; } = [];
 
     private bool HasRun { get; set; }
     private bool IsRunning { get; set; }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor
@@ -31,7 +31,7 @@
                 <MudTooltip Text="@Localizer["Apply changes to editor."]" Delay="500">
                     <MudIconButton Icon="@Icons.Material.Outlined.Check"
                                    Color="Color.Success"
-                                   Label="@Localizer["Apply"]"
+                                   aria-label="@Localizer["Apply"]"
                                    OnClick="OnApplyClicked" />
                 </MudTooltip>
             </MudToolBar>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
@@ -64,7 +64,6 @@ public partial class CodeView : IDisposable
     /// <param name="json">The JSON string representing the new content to display in the code editor.</param>
     public async Task UpdateCodeViewFromEditorAsync(string json)
     {
-        _isInternalContentChange = true;
         if (_monacoEditor is null)
             return;
 
@@ -72,8 +71,16 @@ public partial class CodeView : IDisposable
         if (json == _lastMonacoEditorContent)
             return;
 
-        _lastMonacoEditorContent = json;
-        await model.SetValue(json);
+        _isInternalContentChange = true;
+        try
+        {
+            _lastMonacoEditorContent = json;
+            await model.SetValue(json);
+        }
+        finally
+        {
+            _isInternalContentChange = false;
+        }
     }
 
     private StandaloneEditorConstructionOptions ConfigureMonacoEditor(StandaloneCodeEditor editor)
@@ -176,9 +183,16 @@ public partial class CodeView : IDisposable
     private async Task ReloadMonacoClick()
     {
         _isInternalContentChange = true;
-        var model = await _monacoEditor!.GetModel();
-        await model.SetValue(WorkflowDefinitionSerialized);
-        _lastMonacoEditorContent = WorkflowDefinitionSerialized;
+        try
+        {
+            var model = await _monacoEditor!.GetModel();
+            await model.SetValue(WorkflowDefinitionSerialized);
+            _lastMonacoEditorContent = WorkflowDefinitionSerialized;
+        }
+        finally
+        {
+            _isInternalContentChange = false;
+        }
     }
 
     private async Task OnAutoApplyChanged(bool value)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
@@ -137,7 +137,6 @@ public partial class CodeView : IDisposable
             return false;
         }
 
-        _lastMonacoEditorContent = value;
         WorkflowDefinition? deserialized = null;
         try
         {
@@ -165,11 +164,15 @@ public partial class CodeView : IDisposable
         }
 
         if (ApplyWorkflowDefinition is null)
+        {
+            _lastMonacoEditorContent = value;
             return true;
+        }
 
         try
         {
             await ApplyWorkflowDefinition(deserialized);
+            _lastMonacoEditorContent = value;
             return true;
         }
         catch (Exception ex)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
@@ -20,7 +20,7 @@ public partial class CodeView : IDisposable
     private bool _isInternalContentChange;
     private string? _lastMonacoEditorContent;
     private string _applyErrorMessage = string.Empty;
-    private RateLimitedFunc<Task> _throttledValueChanged;
+    private RateLimitedFunc<Task>? _throttledValueChanged;
 
     [Inject] private ILocalizer Localizer { get; set; } = null!;
     [Inject] protected IUserMessageService UserMessageService { get; set; } = null!;
@@ -110,7 +110,8 @@ public partial class CodeView : IDisposable
         if (_isInternalContentChange || !AutoApply || IsReadOnly)
             return;
 
-        await _throttledValueChanged.InvokeAsync();
+        if (_throttledValueChanged is not null)
+            await _throttledValueChanged.InvokeAsync();
     }
 
     private async Task OnApplyClicked()
@@ -190,5 +191,5 @@ public partial class CodeView : IDisposable
             await UpdateEditorFromCodeViewAsync();
     }
 
-    void IDisposable.Dispose() => _throttledValueChanged.Dispose();
+    void IDisposable.Dispose() => _throttledValueChanged?.Dispose();
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -398,6 +398,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task OnSaveAsClick()
     {
+        if (WorkflowDefinition is null)
+            return;
+
         var result = await WorkflowCloningService.SaveAs(WorkflowDefinition);
         if (result is null) return;
         if (result.IsSuccess) NavigationManager.NavigateTo($"workflows/definitions/{result?.Success?.WorkflowDefinition.DefinitionId}/edit");

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
@@ -66,13 +66,12 @@ public partial class InputsSection
         var dialog = await DialogService.ShowAsync<EditInputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is InputDefinition newInput)
         {
-            inputDefinition = (InputDefinition)result.Data;
-            WorkflowDefinition.Inputs.Add(inputDefinition);
+            WorkflowDefinition.Inputs.Add(newInput);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outcomes/OutcomesSection.razor
@@ -17,7 +17,6 @@
         HelperText="@Localizer["Enter a list of possible outcomes for this workflow."]"
         Immediate="true"
         AutoSize="true"
-        ForceShrink="true"
         ChipColor="Color.Primary"
         ChipSize="Size.Medium"
         ChipVariant="Variant.Filled"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
@@ -65,13 +65,12 @@ public partial class OutputsSection
         var dialog = await DialogService.ShowAsync<EditOutputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is OutputDefinition newOutput)
         {
-            outputDefinition = (OutputDefinition)result.Data;
-            WorkflowDefinition.Outputs.Add(outputDefinition);
+            WorkflowDefinition.Outputs.Add(newOutput);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableTestValueDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/EditVariableTestValueDialog.razor.cs
@@ -55,7 +55,7 @@ public partial class EditVariableTestValueDialog
             WorkflowDefinition.ClearVariableTestValue(Variable.Id);
         else
             WorkflowDefinition.SetVariableTestValue(Variable.Id, _model.TestValue);
-        MudDialog.Close();
+        MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void OnClearTestValueClick()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -67,13 +67,12 @@ public partial class VariablesTab
         var dialog = await DialogService.ShowAsync<EditVariableDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is Variable newVariable)
         {
-            variable = (Variable)result.Data;
-            WorkflowDefinition.Variables.Add(variable);
+            WorkflowDefinition.Variables.Add(newVariable);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -98,7 +98,7 @@ public partial class VariablesTab
         var dialog = await DialogService.ShowAsync<EditVariableTestValueDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled == true)
+        if (result?.Canceled != false)
             return;
         
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -110,6 +110,9 @@ public partial class VersionHistoryTab : IDisposable
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionSummary> arg)
     {
+        if (arg.Item is null)
+            return;
+
         await ViewVersionAsync(arg.Item);
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -40,7 +40,7 @@ public partial class WorkflowDefinitionList
     [Inject] private ICreateWorkflowDialogComponentProvider CreateWorkflowDialogComponentProvider { get; set; } = null!;
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
     [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = null!;
-    [Inject] private ILogger<WorkflowDefinitionList> Logger { get; set; } = default!;
+    [Inject] private new ILogger<WorkflowDefinitionList> Logger { get; set; } = default!;
 
     private string SearchTerm { get; set; } = string.Empty;
     private bool IsReadOnlyMode { get; set; }
@@ -72,17 +72,18 @@ public partial class WorkflowDefinitionList
         };
 
         var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest, cancellationToken);
+        var latestWorkflowDefinitions = latestWorkflowDefinitionsResponse?.Items ?? [];
         IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l => l.Rel == "bulk-publish") ?? 0) == 0;
-        var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitionsResponse.Items.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
+        var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitions.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 
         var publishedWorkflowDefinitions = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
         {
             DefinitionIds = unpublishedWorkflowDefinitionIds,
         }, VersionOptions.Published);
 
-        _totalCount = latestWorkflowDefinitionsResponse.TotalCount;
+        _totalCount = latestWorkflowDefinitionsResponse?.TotalCount ?? 0;
 
-        var workflowDefinitionRows = latestWorkflowDefinitionsResponse.Items
+        var workflowDefinitionRows = latestWorkflowDefinitions
             .Select(definition =>
             {
                 var latestVersionNumber = definition.Version;
@@ -142,7 +143,7 @@ public partial class WorkflowDefinitionList
         return query;
     }
 
-    private OrderByWorkflowDefinition? GetOrderBy(string sortLabel)
+    private OrderByWorkflowDefinition? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {
@@ -175,9 +176,8 @@ public partial class WorkflowDefinitionList
         var dialogInstance = await DialogService.ShowAsync(dialogComponentType, Localizer["New workflow"], parameters, options);
         var dialogResult = await dialogInstance.Result;
 
-        if (!dialogResult.Canceled)
+        if (dialogResult?.Canceled == false && dialogResult.Data is Result<WorkflowDefinition, ValidationErrors> result)
         {
-            var result = (Result<WorkflowDefinition, ValidationErrors>)dialogResult.Data!;
             await result.OnSuccessAsync(definition => EditAsync(definition.DefinitionId));
             result.OnFailed(errors => UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, errors.Errors)));
         }
@@ -214,6 +214,9 @@ public partial class WorkflowDefinitionList
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionRow> e)
     {
+        if (e.Item is null)
+            return;
+
         await EditAsync(e.Item.DefinitionId);
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -76,10 +76,11 @@ public partial class WorkflowDefinitionList
         IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l => l.Rel == "bulk-publish") ?? 0) == 0;
         var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitions.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 
-        var publishedWorkflowDefinitions = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
+        var publishedWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
         {
             DefinitionIds = unpublishedWorkflowDefinitionIds,
         }, VersionOptions.Published);
+        var publishedWorkflowDefinitions = publishedWorkflowDefinitionsResponse?.Items ?? [];
 
         _totalCount = latestWorkflowDefinitionsResponse?.TotalCount ?? 0;
 
@@ -90,7 +91,7 @@ public partial class WorkflowDefinitionList
                 var isPublished = definition.IsPublished;
                 var publishedVersion = isPublished
                     ? definition
-                    : publishedWorkflowDefinitions.Items.FirstOrDefault(x => x.DefinitionId == definition.DefinitionId);
+                    : publishedWorkflowDefinitions.FirstOrDefault(x => x.DefinitionId == definition.DefinitionId);
                 var publishedVersionNumber = publishedVersion?.Version;
 
                 return new WorkflowDefinitionRow(

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
@@ -21,7 +21,7 @@ public class TimestampFilterModel
     /// <summary>
     /// Gets or sets the date to filter by.
     /// </summary>
-    public string Date { get; set; }
+    public string Date { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the time to filter by.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -50,9 +50,9 @@ public partial class WorkflowInstanceList : IAsyncDisposable
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
     [Inject] private IFiles Files { get; set; } = default!;
     [Inject] private IDomAccessor DomAccessor { get; set; } = default!;
-    [Inject] private ILogger<WorkflowInstanceList> Logger { get; set; } = default!;
+    [Inject] private new ILogger<WorkflowInstanceList> Logger { get; set; } = default!;
     [Inject] private IOptions<WorkflowInstanceListPollingOptions> PollingOptions { get; set; } = default!;
-    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+    [Inject] private new NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private IRemoteFeatureProvider RemoteFeatureProvider { get; set; } = default!;
 
     /// <summary>
@@ -295,7 +295,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
         };
     }
 
-    private OrderByWorkflowInstance? GetOrderBy(string sortLabel)
+    private OrderByWorkflowInstance? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -89,15 +89,20 @@ public partial class ActivityDetailsTab
                 if (execution.Payload.TryGetValue("Outcomes", out var outcomes))
                     outcomesData.Add("Outcomes", outcomes?.ToString());
 
-            var outputDescriptors = activityDescriptor?.Outputs ?? [];
             var outputs = execution.Outputs;
-
-            foreach (var outputDescriptor in outputDescriptors)
+            if (activityDescriptor != null)
             {
-                var outputValue = outputs != null
-                    ? outputs.TryGetValue(outputDescriptor.Name, out var value) ? value : null
-                    : null;
-                outputData.Add(outputDescriptor.Name, outputValue?.ToString());
+                foreach (var outputDescriptor in activityDescriptor.Outputs)
+                {
+                    var outputValue = outputs != null
+                        ? outputs.TryGetValue(outputDescriptor.Name, out var value) ? value : null
+                        : null;
+                    outputData.Add(outputDescriptor.Name, outputValue?.ToString());
+                }
+            }
+            else if (outputs != null)
+            {
+                AddRawDataItems(outputData, outputs);
             }
         }
         else
@@ -121,10 +126,17 @@ public partial class ActivityDetailsTab
 
         if (activityState != null)
         {
-            foreach (var inputDescriptor in activityDescriptor?.Inputs ?? [])
+            if (activityDescriptor != null)
             {
-                var inputValue = activityState.TryGetValue(inputDescriptor.Name, out var value) ? value : null;
-                activityStateData.Add(inputDescriptor.Name, inputValue?.ToString());
+                foreach (var inputDescriptor in activityDescriptor.Inputs)
+                {
+                    var inputValue = activityState.TryGetValue(inputDescriptor.Name, out var value) ? value : null;
+                    activityStateData.Add(inputDescriptor.Name, inputValue?.ToString());
+                }
+            }
+            else
+            {
+                AddRawDataItems(activityStateData, activityState.Where(x => !x.Key.StartsWith("_")));
             }
         }
 
@@ -153,5 +165,11 @@ public partial class ActivityDetailsTab
         OutputData = outputData;
         ExceptionData = exceptionData;
         ResilienceStrategyData = resilienceStrategyData;
+    }
+
+    private static void AddRawDataItems(DataPanelModel target, IEnumerable<KeyValuePair<string, object?>> values)
+    {
+        foreach (var (key, value) in values)
+            target.Add(key, value?.ToString());
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -51,7 +51,7 @@ public partial class ActivityDetailsTab
     private void CreateDataModels()
     {
         var activity = Activity;
-        var activityDescriptor = ActivityRegistry.Find(activity.GetTypeName(), activity.GetVersion())!;
+        var activityDescriptor = ActivityRegistry.Find(activity.GetTypeName(), activity.GetVersion());
         var activityId = activity.GetId();
         var activityNodeId = activity.GetNodeId();
         var activityName = activity.GetName();
@@ -69,7 +69,7 @@ public partial class ActivityDetailsTab
             new DataPanelItem("ID", activityId),
             new DataPanelItem("Node ID", activityNodeId),
             new DataPanelItem(Localizer["Name"], activityName),
-            new DataPanelItem(Localizer["Type"], activityType,
+            new DataPanelItem(Localizer["Type"], activityDescriptor?.DisplayName ?? activityType,
                 string.IsNullOrWhiteSpace(workflowDefinitionId)
                     ? null
                     : $"/workflows/definitions/{workflowDefinitionId}/edit"),
@@ -87,9 +87,9 @@ public partial class ActivityDetailsTab
 
             if (execution.Payload != null)
                 if (execution.Payload.TryGetValue("Outcomes", out var outcomes))
-                    outcomesData.Add("Outcomes", outcomes.ToString());
+                    outcomesData.Add("Outcomes", outcomes?.ToString());
 
-            var outputDescriptors = activityDescriptor.Outputs;
+            var outputDescriptors = activityDescriptor?.Outputs ?? [];
             var outputs = execution.Outputs;
 
             foreach (var outputDescriptor in outputDescriptors)
@@ -121,7 +121,7 @@ public partial class ActivityDetailsTab
 
         if (activityState != null)
         {
-            foreach (var inputDescriptor in activityDescriptor.Inputs)
+            foreach (var inputDescriptor in activityDescriptor?.Inputs ?? [])
             {
                 var inputValue = activityState.TryGetValue(inputDescriptor.Name, out var value) ? value : null;
                 activityStateData.Add(inputDescriptor.Name, inputValue?.ToString());

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ElapsedTime.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ElapsedTime.razor.cs
@@ -15,10 +15,10 @@ public partial class ElapsedTime
     /// The start time represents the point in time from which the property should be considered.
     /// The default value is set to the current UTC time.
     /// </remarks>
-    [Parameter]
     /// <summary>
     /// Gets or sets the start time.
     /// </summary>
+    [Parameter]
     public DateTimeOffset StartTime { get; set; } = DateTimeOffset.UtcNow;
 
     /// <summary>
@@ -31,10 +31,10 @@ public partial class ElapsedTime
     /// <value>
     /// The end time as a <see cref="DateTimeOffset"/> value.
     /// </value>
-    [Parameter]
     /// <summary>
     /// Gets or sets the end time.
     /// </summary>
+    [Parameter]
     public DateTimeOffset EndTime { get; set; } = DateTimeOffset.UtcNow;
     
     private TimeSpan Elapsed => EndTime < StartTime ? TimeSpan.Zero : EndTime - StartTime;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
@@ -8,7 +8,7 @@
         <MudToggleIconButton
             Icon="@Icons.Material.Outlined.Timer"
             ToggledIcon="@Icons.Material.Outlined.AccessTime"
-            Title="@(TimeMetricMode == TimeMetricMode.Accumulated ? @Localizer["Show relative time"] : @Localizer["Show accumulated time"])"
+            title="@(TimeMetricMode == TimeMetricMode.Accumulated ? @Localizer["Show relative time"] : @Localizer["Show accumulated time"])"
             Toggled="@(TimeMetricMode == TimeMetricMode.Accumulated)"
             ToggledChanged="OnTimeMetricButtonToggleChanged"/>
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
@@ -11,9 +11,6 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 /// A diagram designer provider for the Flowchart designer.
 /// </summary>
 [UsedImplicitly]
-/// <summary>
-/// Provides flowchart diagram designer services.
-/// </summary>
 public class FlowchartDiagramDesignerProvider(ILocalizer localizer) : IDiagramDesignerProvider
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
+++ b/src/modules/Elsa.Studio.Workflows/Handlers/RefreshActivityRegistry.cs
@@ -5,11 +5,10 @@ using JetBrains.Annotations;
 
 namespace Elsa.Studio.Workflows.Handlers;
 
-/// A handler that refreshes the activity registry when a workflow definition is deleted, published or retracted.
-[UsedImplicitly]
 /// <summary>
-/// Represents the refresh activity registry.
+/// Refreshes the activity registry when a workflow definition is deleted, published, or retracted.
 /// </summary>
+[UsedImplicitly]
 public class RefreshActivityRegistry : INotificationHandler<WorkflowDefinitionDeleted>,
     INotificationHandler<WorkflowDefinitionPublished>,
     INotificationHandler<WorkflowDefinitionRetracted>,

--- a/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/DisconnectedWorkflowInstanceObserver.cs
@@ -12,12 +12,24 @@ public class DisconnectedWorkflowInstanceObserver : IWorkflowInstanceObserver
     public string? Name { get; set; }
 
     /// <inheritdoc />
-    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated = default!;
+    public event Func<WorkflowExecutionLogUpdatedMessage, Task> WorkflowJournalUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated = default!;
+    public event Func<ActivityExecutionLogUpdatedMessage, Task> ActivityExecutionLogUpdated
+    {
+        add { }
+        remove { }
+    }
 
     /// <inheritdoc />
-    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated = default!;
+    public event Func<WorkflowInstanceUpdatedMessage, Task> WorkflowInstanceUpdated
+    {
+        add { }
+        remove { }
+    }
     ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
@@ -34,11 +34,11 @@ public class WorkflowCloningDialogService(
     /// or <see langword="null"/> if the operation is canceled.</returns>
     private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>?> Clone(WorkflowDefinition workflowDefinition, string type)
     {
-        var newWorkflowName = $"{workflowDefinition?.Name} - {type} of {workflowDefinition?.DefinitionId}";
+        var newWorkflowName = $"{workflowDefinition.Name} - {type} of {workflowDefinition.DefinitionId}";
         var parameters = new DialogParameters<CloneWorkflowDialog>
         {
             { x => x.WorkflowName, newWorkflowName },
-            { x => x.WorkflowDescription, workflowDefinition?.Description }
+            { x => x.WorkflowDescription, workflowDefinition.Description }
         };
 
         var options = new DialogOptions
@@ -57,11 +57,13 @@ public class WorkflowCloningDialogService(
             return null;
         }
 
-        var newWorkflowModel = (WorkflowMetadataModel)dialogResult.Data;
+        if (dialogResult.Data is not WorkflowMetadataModel newWorkflowModel)
+            return null;
+
         var newDefinition = new WorkflowDefinition
         {
-            Name = newWorkflowModel?.Name ?? newWorkflowName,
-            Description = newWorkflowModel?.Description,
+            Name = newWorkflowModel.Name ?? newWorkflowName,
+            Description = newWorkflowModel.Description,
             Root = workflowDefinition.Root,
             Inputs = workflowDefinition.Inputs,
             Outputs = workflowDefinition.Outputs,
@@ -77,7 +79,9 @@ public class WorkflowCloningDialogService(
             UserMessageService.ShowSnackbarTextMessage(Localizer[$"{type} successfully saved."], Severity.Success);
         });
 
-        if (result.IsFailed) UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure.Errors), Severity.Error);
+        if (result.IsFailed && result.Failure is not null)
+            UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure.Errors), Severity.Error);
+
         return result;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -33,11 +33,10 @@ public partial class DiagramDesignerWrapper
     private IDictionary<string, ActivityNode> _indexedActivityNodes =
         new Dictionary<string, ActivityNode>();
 
-    /// The workflow definition version ID.
-    [Parameter]
     /// <summary>
-    /// Gets or sets the workflow definition version id.
+    /// The workflow definition version ID.
     /// </summary>
+    [Parameter]
     public string WorkflowDefinitionVersionId { get; set; } = null!;
 
     /// The root activity to display.
@@ -56,9 +55,10 @@ public partial class DiagramDesignerWrapper
     [Parameter]
     public RenderFragment? CustomToolbarItems { get; set; }
 
-    /// Whether the designer is progressing.
-    [Parameter]
     /// <summary>
+    /// Whether the designer is progressing.
+    /// </summary>
+    [Parameter]
     public bool IsProgressing { get; set; }
 
     /// An event raised when an activity is selected.
@@ -431,7 +431,7 @@ public partial class DiagramDesignerWrapper
             }
 
             var activityBreadcrumbItem = new BreadcrumbItem(
-                breadcrumbDisplayText,
+                breadcrumbDisplayText ?? string.Empty,
                 $"#{activity.GetId()}",
                 disabled,
                 displaySettings.Icon


### PR DESCRIPTION
## Summary
- fix focused nullable, obsolete API, XML doc placement, and MudBlazor analyzer warnings
- guard dialog results and workflow/activity lookups against nulls
- keep intentional legacy persistence upgrade support with scoped obsolete suppression

## Verification
- dotnet build Elsa.Studio.sln --no-restore --configuration Release -t:Rebuild
- dotnet test Elsa.Studio.sln --no-build --configuration Release

## Remaining warnings
- forced rebuild still reports broad CS1591 XML documentation and trim-analysis warnings that need a separate documentation/source-generation/trimming policy pass
