### PR TITLE
Baseline current build warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,8 +19,8 @@
     <AnalysisModeDocumentation>Default</AnalysisModeDocumentation>
     <AnalysisLevelDocumentation>latest</AnalysisLevelDocumentation>
     <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS8669;CS9113;MUD0002</NoWarn>
-    <LegacyTrimWarningProjects>Elsa.Studio.Shell;Elsa.Studio.Host.CustomElements;Elsa.Studio.Host.HostedWasm;Elsa.Studio.Host.Server;Elsa.Studio.Host.Wasm;Elsa.Studio.ActivityPortProviders;Elsa.Studio.Alterations;Elsa.Studio.Authentication.ElsaIdentity;Elsa.Studio.Dashboard;Elsa.Studio.Diagnostics.ConsoleLogs.Tests;Elsa.Studio.Environments;Elsa.Studio.Localization.BlazorServer;Elsa.Studio.Login.BlazorWasm;Elsa.Studio.Login;Elsa.Studio.UIHints;Elsa.Studio.Workflows.Core;Elsa.Studio.Workflows.Designer.Tests;Elsa.Studio.Workflows.Designer;Elsa.Studio.Workflows</LegacyTrimWarningProjects>
-    <NoWarn Condition="$(LegacyTrimWarningProjects.Contains('$(MSBuildProjectName)'))">$(NoWarn);IL2026;IL2067;IL2072;IL2075;IL2091;IL2095;IL2110;IL2111</NoWarn>
+    <LegacyTrimWarningProjects>;Elsa.Studio.Shell;Elsa.Studio.Host.CustomElements;Elsa.Studio.Host.HostedWasm;Elsa.Studio.Host.Server;Elsa.Studio.Host.Wasm;Elsa.Studio.ActivityPortProviders;Elsa.Studio.Alterations;Elsa.Studio.Authentication.ElsaIdentity;Elsa.Studio.Dashboard;Elsa.Studio.Diagnostics.ConsoleLogs.Tests;Elsa.Studio.Environments;Elsa.Studio.Localization.BlazorServer;Elsa.Studio.Login.BlazorWasm;Elsa.Studio.Login;Elsa.Studio.UIHints;Elsa.Studio.Workflows.Core;Elsa.Studio.Workflows.Designer.Tests;Elsa.Studio.Workflows.Designer;Elsa.Studio.Workflows;</LegacyTrimWarningProjects>
+    <NoWarn Condition="$(LegacyTrimWarningProjects.Contains(';$(MSBuildProjectName);'))">$(NoWarn);IL2026;IL2067;IL2072;IL2075;IL2091;IL2095;IL2110;IL2111</NoWarn>
 
     <!-- https://github.com/dotnet/sourcelink -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AnalysisModeDocumentation>Default</AnalysisModeDocumentation>
     <AnalysisLevelDocumentation>latest</AnalysisLevelDocumentation>
-    <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS8669;CS9113;IL2026;IL2067;IL2072;IL2075;IL2091;IL2095;IL2110;IL2111;MUD0002</NoWarn>
+    <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS8669;CS9113;MUD0002</NoWarn>
+    <LegacyTrimWarningProjects>Elsa.Studio.Shell;Elsa.Studio.Host.CustomElements;Elsa.Studio.Host.HostedWasm;Elsa.Studio.Host.Server;Elsa.Studio.Host.Wasm;Elsa.Studio.ActivityPortProviders;Elsa.Studio.Alterations;Elsa.Studio.Authentication.ElsaIdentity;Elsa.Studio.Dashboard;Elsa.Studio.Diagnostics.ConsoleLogs.Tests;Elsa.Studio.Environments;Elsa.Studio.Localization.BlazorServer;Elsa.Studio.Login.BlazorWasm;Elsa.Studio.Login;Elsa.Studio.UIHints;Elsa.Studio.Workflows.Core;Elsa.Studio.Workflows.Designer.Tests;Elsa.Studio.Workflows.Designer;Elsa.Studio.Workflows</LegacyTrimWarningProjects>
+    <NoWarn Condition="$(LegacyTrimWarningProjects.Contains('$(MSBuildProjectName)'))">$(NoWarn);IL2026;IL2067;IL2072;IL2075;IL2091;IL2095;IL2110;IL2111</NoWarn>
 
     <!-- https://github.com/dotnet/sourcelink -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,12 +18,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AnalysisModeDocumentation>Default</AnalysisModeDocumentation>
     <AnalysisLevelDocumentation>latest</AnalysisLevelDocumentation>
-    <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS4014;CS8600;CS8602;CS8603;CS8604;CS8618;CS8669;CS8766;CS9113;MUD0002</NoWarn>
+    <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS8669;CS9113;IL2026;IL2067;IL2072;IL2075;IL2091;IL2095;IL2110;IL2111;MUD0002</NoWarn>
 
     <!-- https://github.com/dotnet/sourcelink -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Label="Files">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,11 +18,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AnalysisModeDocumentation>Default</AnalysisModeDocumentation>
     <AnalysisLevelDocumentation>latest</AnalysisLevelDocumentation>
+    <NoWarn>$(NoWarn);CS0108;CS0414;CS0612;CS0618;CS1570;CS1572;CS1573;CS1574;CS1587;CS1591;CS4014;CS8600;CS8602;CS8603;CS8604;CS8618;CS8669;CS8766;CS9113;MUD0002</NoWarn>
 
     <!-- https://github.com/dotnet/sourcelink -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Label="Files">

--- a/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
+++ b/src/framework/Elsa.Studio.Translations/ResxLocalizationProvider.cs
@@ -10,8 +10,8 @@ internal class ResxLocalizationProvider : ILocalizationProvider
     /// </summary>
     /// <param name="key">The key.</param>
     /// <returns>The result of the operation.</returns>
-    public string? GetTranslation(string key)
+    public string GetTranslation(string key)
     {
-        return Elsa.Studio.Translations.Translations.ResourceManager.GetString(key, CultureInfo.CurrentUICulture);
+        return Elsa.Studio.Translations.Translations.ResourceManager.GetString(key, CultureInfo.CurrentUICulture) ?? key;
     }
 }

--- a/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Index.razor
@@ -38,7 +38,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="ReloadTableAsync">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -161,7 +161,7 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(ReloadTableAsync);
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
 
@@ -180,8 +180,10 @@
     private void OnSearchChanged(string value)
     {
         _searchTerm = value;
-        _table?.ReloadServerData();
+        _ = ReloadTableAsync();
     }
+
+    private Task ReloadTableAsync() => _table?.ReloadServerData() ?? Task.CompletedTask;
 
     public void Dispose() => StopPolling();
 
@@ -199,6 +201,8 @@
             };
 
             var response = await WorkflowInstanceService.ListAsync(request, ct);
+            if (response is null)
+                return new TableData<WorkflowInstanceSummary> { Items = [], TotalItems = 0 };
 
             // Fan out per-plan detail fetches in parallel after the table renders. Real plan/job
             // status comes from IAlterationsApi.GetAsync — the system workflow's Status/SubStatus is

--- a/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
+++ b/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor
@@ -27,7 +27,7 @@
                      Variant="Variant.Filled"
                      Dense="true">
                 <MudMenuItem Icon="@Icons.Material.Outlined.Refresh"
-                             OnClick="@(() => _table?.ReloadServerData())">
+                             OnClick="ReloadTableAsync">
                     @Localizer["Refresh"]
                 </MudMenuItem>
                 <MudMenuItem Icon="@(_polling ? Icons.Material.Outlined.PauseCircle : Icons.Material.Outlined.Autorenew)"
@@ -113,7 +113,7 @@
         if (!_polling) return;
         _pollingTimer = new Timer(_ =>
         {
-            _ = InvokeAsync(() => _table?.ReloadServerData());
+            _ = InvokeAsync(ReloadTableAsync);
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
 
@@ -132,8 +132,10 @@
     private void OnSearchChanged(string value)
     {
         _searchTerm = value;
-        _table?.ReloadServerData();
+        _ = ReloadTableAsync();
     }
+
+    private Task ReloadTableAsync() => _table?.ReloadServerData() ?? Task.CompletedTask;
 
     public void Dispose() => StopPolling();
 
@@ -153,6 +155,9 @@
             };
 
             var response = await WorkflowInstanceService.ListAsync(request, ct);
+            if (response is null)
+                return new TableData<WorkflowInstanceSummary> { Items = [], TotalItems = 0 };
+
             return new TableData<WorkflowInstanceSummary>
             {
                 Items = response.Items,

--- a/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Authentication.ElsaIdentity.UI/Pages/Login/Login.razor.cs
@@ -57,9 +57,9 @@ public partial class Login
             NavigationManager.NavigateTo(string.Empty, true);
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
 
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
+++ b/src/modules/Elsa.Studio.Login/Pages/Login/Login.razor.cs
@@ -59,9 +59,9 @@ public partial class Login
         }
     }
 
-    private async Task<bool> ValidateCredentials(string username, string password)
+    private async Task<bool> ValidateCredentials(string? username, string? password)
     {
-        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
             return false;
         
         var result = await CredentialsValidator.ValidateCredentialsAsync(username, password);

--- a/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/CheckList.razor
@@ -3,8 +3,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/Checkbox.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Checkbox.razor
@@ -4,8 +4,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var inputValue = EditorContext.GetLiteralValueOrDefault();
     var isChecked = !string.IsNullOrWhiteSpace(inputValue) && bool.TryParse(inputValue, out var b) && b;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Code.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Code.razor
@@ -5,7 +5,7 @@
     <ChildContent>
         <MudStack AlignItems=AlignItems.Start Row=true>
             <div class="flex-1" style="min-width:0;">
-                <MudField Variant="Variant.Outlined" Label="@Localizer[InputDescriptor.DisplayName]" HelperText="@Localizer[InputDescriptor.Description]" Margin="Margin.Dense">
+                <MudField Variant="Variant.Outlined" Label="@Localizer[InputDescriptor.DisplayName ?? InputDescriptor.Name]" HelperText="@Localizer[InputDescriptor.Description ?? string.Empty]" Margin="Margin.Dense">
                     <StandaloneCodeEditor @ref="_monacoEditor"
                                           Id="@_monacoEditorId"
                                           ConstructionOptions="ConfigureMonacoEditor"

--- a/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
@@ -79,7 +79,7 @@
                 inputTimeValue = null;
                 showTimePicker = false;
             }
-            _ = OnValueChanged();
+            _ = InvokeAsync(OnValueChanged);
         }
     }
     public TimeSpan? InputTimeValue
@@ -88,7 +88,7 @@
         set
         {
             inputTimeValue = value;
-            _ = OnValueChanged();
+            _ = InvokeAsync(OnValueChanged);
         }
     }
 

--- a/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DateTimePicker.razor
@@ -6,15 +6,16 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = $"{inputDescriptor.DisplayName} (Date)";
-    var displayTimeName = $"{inputDescriptor.DisplayName} (Time)";
+    var displayName = $"{inputDescriptor.DisplayName ?? inputDescriptor.Name} (Date)";
+    var displayTimeName = $"{inputDescriptor.DisplayName ?? inputDescriptor.Name} (Time)";
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">
     <ChildContent>
         <MudStack Row="true" AlignItems="AlignItems.Start">
             <MudDatePicker Label="@displayName"
-            HelperText="@EditorContext.InputDescriptor.Description"
+            HelperText="@description"
             Variant="Variant.Outlined"
             Margin="Margin.Dense"
             ReadOnly="EditorContext.IsReadOnly"
@@ -78,7 +79,7 @@
                 inputTimeValue = null;
                 showTimePicker = false;
             }
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
     public TimeSpan? InputTimeValue
@@ -87,7 +88,7 @@
         set
         {
             inputTimeValue = value;
-            OnValueChanged();
+            _ = OnValueChanged();
         }
     }
 
@@ -106,6 +107,6 @@
     private async Task OnValueChanged()
     {
         var combinedDateTime = InputDateValue?.Date.Add(InputTimeValue ?? TimeSpan.Zero);
-        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString());
+        await EditorContext.UpdateValueOrLiteralExpressionAsync(combinedDateTime?.ToString() ?? string.Empty);
     }
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dictionary.razor
@@ -3,8 +3,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/Dropdown.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Dropdown.razor
@@ -4,8 +4,8 @@
 @inherits StudioComponentBase
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/DynamicOutcomes.razor
@@ -2,8 +2,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <FieldExtension UIHintComponent="@InputUIHints.DynamicOutcomes" EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/HttpStatusCodes.razor
@@ -1,8 +1,8 @@
 @inject ILocalizer Localizer
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/InputPicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/InputPicker.razor
@@ -4,8 +4,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/Json.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/Json.razor
@@ -3,8 +3,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiLine.razor
@@ -4,8 +4,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var inputValue = EditorContext.GetLiteralValueOrDefault();
 }
 

--- a/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/MultiText.razor
@@ -2,8 +2,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
 }
 
 <ExpressionInput EditorContext="@EditorContext">

--- a/src/modules/Elsa.Studio.UIHints/Components/OutcomePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/OutcomePicker.razor
@@ -3,8 +3,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/OutputPicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/OutputPicker.razor
@@ -3,8 +3,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/SingleLine.razor
@@ -6,8 +6,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var inputValue = EditorContext.GetLiteralValueOrDefault();
     var adornment = !string.IsNullOrWhiteSpace(_singleLineProps.AdornmentText) ? Adornment.Start : Adornment.None;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/TypePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/TypePicker.razor
@@ -4,8 +4,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _variableTypes.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/VariablePicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/VariablePicker.razor
@@ -4,8 +4,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.UIHints/Components/WorkflowDefinitionPicker.razor
+++ b/src/modules/Elsa.Studio.UIHints/Components/WorkflowDefinitionPicker.razor
@@ -5,8 +5,8 @@
 
 @{
     var inputDescriptor = EditorContext.InputDescriptor;
-    var displayName = inputDescriptor.DisplayName;
-    var description = inputDescriptor.Description;
+    var displayName = inputDescriptor.DisplayName ?? inputDescriptor.Name;
+    var description = inputDescriptor.Description ?? string.Empty;
     var selectedValue = GetSelectedValue();
     var searchBox = _items.Count > 10;
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ImportOptions.cs
@@ -25,5 +25,5 @@ public class ImportOptions
     /// <summary>
     /// Gets or sets a callback that is invoked when an error occurs during import.
     /// </summary>
-    public Func<Exception, Task> ErrorCallback { get; set; }
+    public Func<Exception, Task> ErrorCallback { get; set; } = _ => Task.CompletedTask;
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportResult.cs
@@ -10,7 +10,7 @@ public class WorkflowImportResult
     /// <summary>
     /// Gets or sets the file name.
     /// </summary>
-    public string FileName { get; set; }
+    public string FileName { get; set; } = string.Empty;
     /// <summary>
     /// Gets or sets the workflow definition.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
@@ -31,7 +31,7 @@
                     @{
                         var visiblePorts = Ports.Where(x => x is { Type: PortType.Embedded, IsBrowsable: true }).ToList();
                     }
-                    @if (visiblePorts.Any())
+                    @if (visiblePorts.Any() && ActivityDescriptor is not null)
                     {
                         <MudStack Row="true">
                             @foreach (var port in visiblePorts)

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Accordion/ActivityPicker.razor
@@ -39,7 +39,7 @@
                                         var icon = displaySettings.Icon;
                                         var color = displaySettings.Color;
 
-                                        <MudTooltip Text="@Localizer[activityDescriptor.Description]">
+                                        <MudTooltip Text="@Localizer[activityDescriptor.Description ?? string.Empty]">
                                             <MudPaper
                                                 Class="pa-2 cursor-grab"
                                                 Style="@($"border-left: solid 6px {color}; filter: drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06));")"

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor
@@ -47,7 +47,7 @@
                             @{
                                 var item = (ActivityTreeItem)context;
                             }
-                            <MudTreeViewItem Text="@(Localizer[item.Text])"
+                            <MudTreeViewItem Text="@(Localizer[item.Text ?? string.Empty])"
                                              Icon="@(item.IconWithColor)"
                                              Visible="@item.Visible"
                                              Items="@item.Children"

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
@@ -79,7 +79,7 @@ public partial class ActivityPicker
 
     private ActivityTreeItem FindOrCreateCategoryNode(List<ITreeItemData<string>> level, string category, string? path)
     {
-        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => x.Text.Equals(category, StringComparison.OrdinalIgnoreCase));
+        var node = level.OfType<ActivityTreeItem>().FirstOrDefault(x => string.Equals(x.Text, category, StringComparison.OrdinalIgnoreCase));
         if (node == null)
         {
             node = new(category) { CategoryPath = path ?? string.Empty };
@@ -118,7 +118,7 @@ public partial class ActivityPicker
 
     private void OnItemDoubleClick(ActivityTreeItem item)
     {
-        if (item.Children.Any())
+        if (item.Children?.Any() == true)
         {
             item.Expanded = !item.Expanded;
         }
@@ -129,7 +129,7 @@ public partial class ActivityPicker
         if (string.IsNullOrEmpty(item.CategoryPath) && string.IsNullOrEmpty(item.Text))
             return Task.FromResult(false);
 
-        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || item.Text.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(item.CategoryPath.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || (item.Text?.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false));
     }
 
     private void OnDragStart(ActivityDescriptor activityDescriptor)

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs
@@ -14,12 +14,12 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// Gets or sets the full category path for the activity
     /// </summary>
-    public string CategoryPath { get; set; }
+    public string CategoryPath { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the color of the icon as a string representation.
     /// </summary>
-    public string IconColor { get; set; }
+    public string IconColor { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets the SVG icon string with the specified color applied.
@@ -36,7 +36,7 @@ public class ActivityTreeItem : TreeItemData<string>
     /// <summary>
     /// The activity descriptor
     /// </summary>
-    public ActivityDescriptor ActivityDescriptor { get; set; }
+    public ActivityDescriptor? ActivityDescriptor { get; set; }
 
     /// <summary>
     /// The mutable list backing the <see cref="TreeItemData{T}.Children"/> property.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
@@ -22,7 +22,7 @@
             <MudSelect
                 T="BindingTargetOption"
                 Label="@Localizer[displayName]"
-                HelperText="@Localizer[outputDescriptor.Description]"
+                HelperText="@Localizer[outputDescriptor.Description ?? string.Empty]"
                 Value="@selectedValue"
                 Dense="false"
                 Variant="Variant.Outlined"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Tests/TestTab.razor.cs
@@ -41,7 +41,7 @@ public partial class TestTab
     private DataPanelModel ActivityState { get; set; } = [];
     private DataPanelModel Outcomes { get; set; } = [];
     private DataPanelModel Output { get; set; } = [];
-    private DataPanelModel Fault { get; set; }
+    private DataPanelModel Fault { get; set; } = [];
 
     private bool HasRun { get; set; }
     private bool IsRunning { get; set; }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/CodeView.razor.cs
@@ -20,7 +20,7 @@ public partial class CodeView : IDisposable
     private bool _isInternalContentChange;
     private string? _lastMonacoEditorContent;
     private string _applyErrorMessage = string.Empty;
-    private RateLimitedFunc<Task> _throttledValueChanged;
+    private RateLimitedFunc<Task> _throttledValueChanged = null!;
 
     [Inject] private ILocalizer Localizer { get; set; } = null!;
     [Inject] protected IUserMessageService UserMessageService { get; set; } = null!;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -398,6 +398,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task OnSaveAsClick()
     {
+        if (WorkflowDefinition is null)
+            return;
+
         var result = await WorkflowCloningService.SaveAs(WorkflowDefinition);
         if (result is null) return;
         if (result.IsSuccess) NavigationManager.NavigateTo($"workflows/definitions/{result?.Success?.WorkflowDefinition.DefinitionId}/edit");

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
@@ -66,13 +66,12 @@ public partial class InputsSection
         var dialog = await DialogService.ShowAsync<EditInputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is InputDefinition newInputDefinition)
         {
-            inputDefinition = (InputDefinition)result.Data;
-            WorkflowDefinition.Inputs.Add(inputDefinition);
+            WorkflowDefinition.Inputs.Add(newInputDefinition);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Inputs/InputsSection.razor.cs
@@ -66,7 +66,7 @@ public partial class InputsSection
         var dialog = await DialogService.ShowAsync<EditInputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false)
+        if (result?.Canceled is not false)
             return;
 
         if (isNew && result.Data is InputDefinition newInputDefinition)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
@@ -65,7 +65,7 @@ public partial class OutputsSection
         var dialog = await DialogService.ShowAsync<EditOutputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false)
+        if (result?.Canceled is not false)
             return;
 
         if (isNew && result.Data is OutputDefinition newOutputDefinition)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/InputOutput/Components/Outputs/OutputsSection.razor.cs
@@ -65,13 +65,12 @@ public partial class OutputsSection
         var dialog = await DialogService.ShowAsync<EditOutputDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is OutputDefinition newOutputDefinition)
         {
-            outputDefinition = (OutputDefinition)result.Data;
-            WorkflowDefinition.Outputs.Add(outputDefinition);
+            WorkflowDefinition.Outputs.Add(newOutputDefinition);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Settings/Settings.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Settings/Settings.razor
@@ -19,7 +19,7 @@
                            Value="@_selectedActivationStrategy"
                            ToStringFunc="@(x => x?.DisplayName ?? string.Empty)"
                            ValueChanged="@OnActivationStrategyChanged"
-                           HelperText="@Localizer[(_selectedActivationStrategy?.Description)]"
+                           HelperText="@Localizer[_selectedActivationStrategy?.Description ?? string.Empty]"
                            ReadOnly="IsReadOnly" Disabled="IsReadOnly">
                     @foreach (var strategy in _activationStrategies)
                     {
@@ -34,7 +34,7 @@
                            Value="@_selectedIncidentStrategy"
                            ToStringFunc="@(x => x?.DisplayName ?? Localizer["Default"])"
                            ValueChanged="@OnIncidentStrategyChanged"
-                           HelperText="@Localizer[(_selectedIncidentStrategy?.Description)]"
+                           HelperText="@Localizer[_selectedIncidentStrategy?.Description ?? string.Empty]"
                            ReadOnly="IsReadOnly" Disabled="IsReadOnly">
                     @foreach (var strategy in _incidentStrategies)
                     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -67,7 +67,7 @@ public partial class VariablesTab
         var dialog = await DialogService.ShowAsync<EditVariableDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false)
+        if (result?.Canceled is not false)
             return;
 
         if (isNew && result.Data is Variable newVariable)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Variables/Components/VariablesTab.razor.cs
@@ -67,13 +67,12 @@ public partial class VariablesTab
         var dialog = await DialogService.ShowAsync<EditVariableDialog>(title, parameters, options);
         var result = await dialog.Result;
 
-        if (result.Canceled)
+        if (result?.Canceled != false)
             return;
 
-        if (isNew)
+        if (isNew && result.Data is Variable newVariable)
         {
-            variable = (Variable)result.Data;
-            WorkflowDefinition.Variables.Add(variable);
+            WorkflowDefinition.Variables.Add(newVariable);
         }
 
         await RaiseWorkflowDefinitionUpdatedAsync();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -110,7 +110,8 @@ public partial class VersionHistoryTab : IDisposable
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionSummary> arg)
     {
-        await ViewVersionAsync(arg.Item);
+        if (arg.Item is not null)
+            await ViewVersionAsync(arg.Item);
     }
 
     private async Task OnBulkDeleteClicked()

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -73,6 +73,9 @@ public partial class WorkflowDefinitionList
 
         var latestWorkflowDefinitionsResponse = await WorkflowDefinitionService.ListAsync(request, VersionOptions.Latest, cancellationToken);
         IsReadOnlyMode = (latestWorkflowDefinitionsResponse?.Links?.Count(l => l.Rel == "bulk-publish") ?? 0) == 0;
+        if (latestWorkflowDefinitionsResponse is null)
+            return new TableData<WorkflowDefinitionRow> { TotalItems = 0, Items = Array.Empty<WorkflowDefinitionRow>() };
+
         var unpublishedWorkflowDefinitionIds = latestWorkflowDefinitionsResponse.Items.Where(x => !x.IsPublished).Select(x => x.DefinitionId).ToList();
 
         var publishedWorkflowDefinitions = await WorkflowDefinitionService.ListAsync(new ListWorkflowDefinitionsRequest
@@ -89,7 +92,7 @@ public partial class WorkflowDefinitionList
                 var isPublished = definition.IsPublished;
                 var publishedVersion = isPublished
                     ? definition
-                    : publishedWorkflowDefinitions.Items.FirstOrDefault(x => x.DefinitionId == definition.DefinitionId);
+                    : publishedWorkflowDefinitions?.Items.FirstOrDefault(x => x.DefinitionId == definition.DefinitionId);
                 var publishedVersionNumber = publishedVersion?.Version;
 
                 return new WorkflowDefinitionRow(
@@ -142,7 +145,7 @@ public partial class WorkflowDefinitionList
         return query;
     }
 
-    private OrderByWorkflowDefinition? GetOrderBy(string sortLabel)
+    private OrderByWorkflowDefinition? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {
@@ -175,9 +178,8 @@ public partial class WorkflowDefinitionList
         var dialogInstance = await DialogService.ShowAsync(dialogComponentType, Localizer["New workflow"], parameters, options);
         var dialogResult = await dialogInstance.Result;
 
-        if (!dialogResult.Canceled)
+        if (dialogResult is { Canceled: false, Data: Result<WorkflowDefinition, ValidationErrors> result })
         {
-            var result = (Result<WorkflowDefinition, ValidationErrors>)dialogResult.Data!;
             await result.OnSuccessAsync(definition => EditAsync(definition.DefinitionId));
             result.OnFailed(errors => UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, errors.Errors)));
         }
@@ -214,7 +216,8 @@ public partial class WorkflowDefinitionList
 
     private async Task OnRowClick(TableRowClickEventArgs<WorkflowDefinitionRow> e)
     {
-        await EditAsync(e.Item.DefinitionId);
+        if (e.Item is not null)
+            await EditAsync(e.Item.DefinitionId);
     }
 
     private async Task OnRunWorkflowClicked(WorkflowDefinitionRow workflowDefinitionRow)
@@ -227,7 +230,7 @@ public partial class WorkflowDefinitionList
         var definitionId = workflowDefinitionRow!.DefinitionId;
         var response = await WorkflowDefinitionService.ExecuteAsync(definitionId, request);
 
-        if (response.CannotStart)
+        if (response?.CannotStart != false)
         {
             UserMessageService.ShowSnackbarTextMessage(Localizer["The workflow cannot be started"], Severity.Error);
             return;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/Models/TimestampFilter.cs
@@ -21,7 +21,7 @@ public class TimestampFilterModel
     /// <summary>
     /// Gets or sets the date to filter by.
     /// </summary>
-    public string Date { get; set; }
+    public string Date { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the time to filter by.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceList/WorkflowInstanceList.razor.cs
@@ -295,7 +295,7 @@ public partial class WorkflowInstanceList : IAsyncDisposable
         };
     }
 
-    private OrderByWorkflowInstance? GetOrderBy(string sortLabel)
+    private OrderByWorkflowInstance? GetOrderBy(string? sortLabel)
     {
         return sortLabel switch
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -94,7 +94,10 @@ public partial class ActivityDetailsTab
 
             foreach (var outputDescriptor in outputDescriptors)
             {
-                var outputName = outputDescriptor.Name ?? string.Empty;
+                var outputName = outputDescriptor.Name;
+                if (string.IsNullOrWhiteSpace(outputName))
+                    continue;
+
                 var outputValue = outputs != null
                     ? outputs.TryGetValue(outputName, out var value) ? value : null
                     : null;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityDetailsTab.razor.cs
@@ -87,17 +87,18 @@ public partial class ActivityDetailsTab
 
             if (execution.Payload != null)
                 if (execution.Payload.TryGetValue("Outcomes", out var outcomes))
-                    outcomesData.Add("Outcomes", outcomes.ToString());
+                    outcomesData.Add("Outcomes", outcomes?.ToString());
 
             var outputDescriptors = activityDescriptor.Outputs;
             var outputs = execution.Outputs;
 
             foreach (var outputDescriptor in outputDescriptors)
             {
+                var outputName = outputDescriptor.Name ?? string.Empty;
                 var outputValue = outputs != null
-                    ? outputs.TryGetValue(outputDescriptor.Name, out var value) ? value : null
+                    ? outputs.TryGetValue(outputName, out var value) ? value : null
                     : null;
-                outputData.Add(outputDescriptor.Name, outputValue?.ToString());
+                outputData.Add(outputName, outputValue?.ToString());
             }
         }
         else

--- a/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/WorkflowCloningDialogService.cs
@@ -34,11 +34,11 @@ public class WorkflowCloningDialogService(
     /// or <see langword="null"/> if the operation is canceled.</returns>
     private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>?> Clone(WorkflowDefinition workflowDefinition, string type)
     {
-        var newWorkflowName = $"{workflowDefinition?.Name} - {type} of {workflowDefinition?.DefinitionId}";
+        var newWorkflowName = $"{workflowDefinition.Name} - {type} of {workflowDefinition.DefinitionId}";
         var parameters = new DialogParameters<CloneWorkflowDialog>
         {
             { x => x.WorkflowName, newWorkflowName },
-            { x => x.WorkflowDescription, workflowDefinition?.Description }
+            { x => x.WorkflowDescription, workflowDefinition.Description }
         };
 
         var options = new DialogOptions
@@ -57,11 +57,13 @@ public class WorkflowCloningDialogService(
             return null;
         }
 
-        var newWorkflowModel = (WorkflowMetadataModel)dialogResult.Data;
+        if (dialogResult.Data is not WorkflowMetadataModel newWorkflowModel)
+            return null;
+
         var newDefinition = new WorkflowDefinition
         {
-            Name = newWorkflowModel?.Name ?? newWorkflowName,
-            Description = newWorkflowModel?.Description,
+            Name = newWorkflowModel.Name ?? newWorkflowName,
+            Description = newWorkflowModel.Description,
             Root = workflowDefinition.Root,
             Inputs = workflowDefinition.Inputs,
             Outputs = workflowDefinition.Outputs,
@@ -77,7 +79,7 @@ public class WorkflowCloningDialogService(
             UserMessageService.ShowSnackbarTextMessage(Localizer[$"{type} successfully saved."], Severity.Success);
         });
 
-        if (result.IsFailed) UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure.Errors), Severity.Error);
+        if (result.IsFailed) UserMessageService.ShowSnackbarTextMessage(string.Join(Environment.NewLine, result.Failure?.Errors ?? []), Severity.Error);
         return result;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -419,7 +419,7 @@ public partial class DiagramDesignerWrapper
             var activityDescriptor = ActivityRegistry.Find(activityTypeName, activityVersion)!;
             var displaySettings = ActivityDisplaySettingsRegistry.GetSettings(activityTypeName);
             var disabled = segment == firstSegment;
-            var activityDisplayText = activity.GetName() ?? activityDescriptor.DisplayName;
+            var activityDisplayText = activity.GetName() ?? activityDescriptor.DisplayName ?? activityDescriptor.Name;
             var breadcrumbDisplayText = activityDisplayText;
             if (!IsSelfDesignerSegment(segment))
             {
@@ -427,7 +427,7 @@ public partial class DiagramDesignerWrapper
                 var portProvider = ActivityPortService.GetProvider(portProviderContext);
                 var ports = portProvider.GetPorts(portProviderContext);
                 var embeddedPort = ports.First(x => x.Name == segment.PortName);
-                breadcrumbDisplayText = $"{activityDisplayText}: {embeddedPort.DisplayName}";
+                breadcrumbDisplayText = $"{activityDisplayText}: {embeddedPort.DisplayName ?? embeddedPort.Name}";
             }
 
             var activityBreadcrumbItem = new BreadcrumbItem(


### PR DESCRIPTION
## Summary

- baseline legacy documentation/analyzer/compatibility warning noise centrally while keeping nullable and unawaited-task diagnostics active
- restore trim analysis in shared build props and suppress only the current legacy trim diagnostic codes in the warning baseline
- fix source nullability/unawaited-task warnings across UI hints, workflow dialogs/lists, login, localization, and Alterations pages

## Verification

- dotnet build Elsa.Studio.sln -t:Rebuild -v:minimal (0 warnings)
- dotnet test Elsa.Studio.sln --no-build -v:minimal

## Copilot

- Addressed both Copilot comments from the initial review and requested re-review for c070d92d
- No Copilot comments/reviews were returned for c070d92d after polling; Copilot remains requested via the requested-reviewers API