### PR TITLE
Keep agent instructions feature-neutral

### DIFF
--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -136,10 +136,10 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
    - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
-3. **Agent context update**:
-   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `AGENTS.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+3. **Agent context**:
+   - Keep feature-specific implementation context in the feature's `plan.md`. Do not write a feature-specific plan path into the repository-level `AGENTS.md`; repository-wide agent instructions must remain feature-neutral.
 
-**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 *.sln.docstates
 .DS_Store
 
+# Spec Kit's active feature pointer is local workflow state.
+.specify/feature.json
+
 # Release output from CustomElements - Wasm
 src/hosts/Elsa.Studio.Host.CustomElements/wasm 
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,0 @@
-{
-  "feature_directory": "specs/009-weaver-copilot-ui"
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,4 @@
-<!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan:
-specs/009-weaver-copilot-ui/plan.md
-<!-- SPECKIT END -->
+# Repository instructions
+
+Keep repository-wide guidance feature-neutral. Feature-specific requirements,
+plans, and tasks belong under their feature directory in `specs/`.


### PR DESCRIPTION
## Summary
- remove the stale Weaver-specific repository plan pointer
- keep repository guidance feature-neutral
- prevent Spec Kit from rewriting root agent instructions and keep its active feature state local

## Validation
- `git diff --check`
- Bash syntax validation for `.specify` scripts
- JSON parsing validation for `.specify` configuration
- stale-pointer and ignore-rule assertions