### PR TITLE
Add output converter authoring support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,14 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview1" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview.5397" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="BlazorMonaco" Version="3.4.0" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="9.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" PrivateAssets="all" />
@@ -38,7 +40,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="8.0.24" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
@@ -57,7 +59,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.18" />
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
@@ -76,7 +78,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IOutputConverterService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IOutputConverterService.cs
@@ -1,0 +1,17 @@
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Provides output converter descriptors that are compatible with declared binding types.
+/// </summary>
+public interface IOutputConverterService
+{
+    /// <summary>
+    /// Gets the output converters compatible with the specified declared types.
+    /// </summary>
+    Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(
+        string sourceType,
+        string destinationType,
+        CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteOutputConverterService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteOutputConverterService.cs
@@ -1,0 +1,29 @@
+using Elsa.Api.Client.Resources.OutputConverters.Contracts;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Requests;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <summary>
+/// Retrieves output converter descriptors from the connected Elsa server.
+/// </summary>
+public class RemoteOutputConverterService(IBackendApiClientProvider backendApiClientProvider) : IOutputConverterService
+{
+    /// <inheritdoc />
+    public async Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(
+        string sourceType,
+        string destinationType,
+        CancellationToken cancellationToken = default)
+    {
+        var api = await backendApiClientProvider.GetApiAsync<IOutputConvertersApi>(cancellationToken);
+        var response = await api.ListAsync(new ListOutputConvertersRequest
+        {
+            SourceType = sourceType,
+            DestinationType = destinationType
+        }, cancellationToken);
+
+        return response.Items;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IStorageDriverService, RemoteStorageDriverService>()
             .AddScoped<IServerInformationProvider, RemoteServerInformationProvider>()
             .AddScoped<IVariableTypeService, RemoteVariableTypeService>()
+            .AddScoped<IOutputConverterService, RemoteOutputConverterService>()
             .AddScoped<IWorkflowActivationStrategyService, RemoteWorkflowActivationStrategyService>()
             .AddScoped<ILogPersistenceStrategyService, RemoteLogPersistenceStrategyService>()
             .AddScoped<IIncidentStrategiesProvider, RemoteIncidentStrategiesProvider>()

--- a/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
@@ -8,6 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" />
+        <PackageReference Include="bunit" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public sealed class OutputConverterSettingsEditorTests : BunitContext, IAsyncLifetime
+{
+    public OutputConverterSettingsEditorTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task RawSettingsRejectANonObjectWithoutChangingTheBinding()
+    {
+        JsonObject? changed = null;
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.Settings, new JsonObject { ["format"] = "compact" })
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("[]"));
+
+        Assert.Null(changed);
+        Assert.Contains("Converter settings must be a valid JSON object.", cut.Markup);
+    }
+
+    [Fact]
+    public async Task SupportedObjectSchemaEditsTypedSettings()
+    {
+        JsonObject? changed = null;
+        using var document = JsonDocument.Parse("""
+            {"type":"object","properties":{"format":{"type":"string","title":"Format","default":"compact"}}}
+            """);
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.SettingsSchema, document.RootElement.Clone())
+            .Add(x => x.Settings, new JsonObject { ["format"] = "compact" })
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("indented"));
+
+        Assert.Equal("indented", changed!["format"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task TypedSettingsShowValidationErrorsWithoutChangingTheBinding()
+    {
+        JsonObject? changed = null;
+        using var document = JsonDocument.Parse("""
+            {"type":"object","properties":{"precision":{"type":"integer"}}}
+            """);
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.SettingsSchema, document.RootElement.Clone())
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("not-an-integer"));
+
+        Assert.Null(changed);
+        Assert.Contains("Enter a valid integer.", cut.Markup);
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.VariableTypes.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
+{
+    private readonly OutputConverterServiceStub _converterService = new();
+    private readonly JsonObject _activity = new()
+    {
+        ["result"] = new JsonObject
+        {
+            ["typeName"] = "Source",
+            ["memoryReference"] = new JsonObject { ["id"] = "result" }
+        }
+    };
+
+    public OutputsTabConverterTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IVariableTypeService>(new VariableTypeServiceStub());
+        Services.AddSingleton<IOutputConverterService>(_converterService);
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void LoadsCompatibleConvertersUsingTheDeclaredBindingTypes()
+    {
+        var cut = RenderOutputsTab();
+
+        Assert.Equal(("Source", "String"), _converterService.Requests.Single());
+        cut.WaitForAssertion(() => Assert.Contains(
+            cut.FindComponents<MudSelectItem<string>>(),
+            item => item.Instance.Value == "sample.to-text"));
+    }
+
+    [Fact]
+    public async Task SelectingAndClearingAConverterRoundTripsOnlyConverterJson()
+    {
+        var cut = RenderOutputsTab();
+        cut.WaitForState(() => cut.FindComponents<MudSelect<string>>().Count == 1);
+        var converter = cut.FindComponents<MudSelect<string>>().Single();
+
+        await cut.InvokeAsync(() => converter.Instance.ValueChanged.InvokeAsync("sample.to-text"));
+
+        var binding = _activity["result"]!.AsObject();
+        Assert.Equal("Source", binding["typeName"]!.GetValue<string>());
+        Assert.Equal("result", binding["memoryReference"]!["id"]!.GetValue<string>());
+        Assert.Equal("sample.to-text", binding["converter"]!["id"]!.GetValue<string>());
+
+        await cut.InvokeAsync(() => converter.Instance.ValueChanged.InvokeAsync(string.Empty));
+
+        Assert.Null(_activity["result"]!["converter"]);
+    }
+
+    [Fact]
+    public void UnavailableDiscoveryDoesNotDiscardPersistedConverterConfiguration()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject
+        {
+            ["id"] = "unavailable.converter",
+            ["settings"] = new JsonObject { ["format"] = "compact" }
+        };
+        _converterService.Exception = new InvalidOperationException();
+
+        var cut = RenderOutputsTab();
+
+        Assert.DoesNotContain("Converter", cut.Markup);
+        Assert.Equal("unavailable.converter", _activity["result"]!["converter"]!["id"]!.GetValue<string>());
+        Assert.Equal("compact", _activity["result"]!["converter"]!["settings"]!["format"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ChangingDestinationClearsAnIncompatibleConverter()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject { ["id"] = "sample.to-text" };
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables =
+            [
+                new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                new Variable { Id = "count", Name = "Count", TypeName = "Integer" }
+            ]
+        });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        await cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(new BindingTargetOption("Count", "count", "Integer", false)));
+
+        Assert.Null(_activity["result"]!["converter"]);
+    }
+
+    [Fact]
+    public void ReadOnlyWorkspaceDisablesConverterSelection()
+    {
+        var cut = RenderOutputsTab(readOnly: true);
+
+        Assert.All(cut.FindComponents<MudSelect<string>>(), select => Assert.True(select.Instance.Disabled));
+    }
+
+    private IRenderedComponent<OutputsTab> RenderOutputsTab(WorkflowDefinition? workflowDefinition = null, bool readOnly = false) => Render<OutputsTab>(parameters => parameters
+        .AddCascadingValue<IWorkspace>(new WorkspaceStub(readOnly))
+        .Add(x => x.WorkflowDefinition, workflowDefinition ?? new WorkflowDefinition
+        {
+            Variables = [new Variable { Id = "result", Name = "Result", TypeName = "String" }]
+        })
+        .Add(x => x.Activity, _activity)
+        .Add(x => x.ActivityDescriptor, new ActivityDescriptor
+        {
+            Outputs = [new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" }]
+        })
+        .Add(x => x.OnActivityUpdated, (Func<JsonObject, Task>)(_ => Task.CompletedTask)));
+
+    private sealed class VariableTypeServiceStub : IVariableTypeService
+    {
+        public Task<IEnumerable<VariableTypeDescriptor>> GetVariableTypesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<VariableTypeDescriptor>>([new("Source", "Source", "Tests", null)]);
+    }
+
+    private sealed class OutputConverterServiceStub : IOutputConverterService
+    {
+        public ICollection<(string SourceType, string DestinationType)> Requests { get; } = [];
+        public Exception? Exception { get; set; }
+
+        public Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(string sourceType, string destinationType, CancellationToken cancellationToken = default)
+        {
+            Requests.Add((sourceType, destinationType));
+            if (Exception != null)
+                throw Exception;
+
+            if (destinationType == "Integer")
+                return Task.FromResult<ICollection<OutputConverterDescriptor>>([]);
+
+            return Task.FromResult<ICollection<OutputConverterDescriptor>>(
+            [
+                new OutputConverterDescriptor
+                {
+                    Id = "sample.to-text",
+                    SourceTypeName = sourceType,
+                    ResultTypeName = destinationType,
+                    DisplayName = "Convert to text",
+                    Description = "Formats the value as text."
+                }
+            ]);
+        }
+    }
+
+    private sealed class WorkspaceStub(bool isReadOnly) : IWorkspace
+    {
+        public bool IsReadOnly { get; } = isReadOnly;
+        public bool HasWorkflowEditPermission => !IsReadOnly;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/RemoteOutputConverterServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/RemoteOutputConverterServiceTests.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics.CodeAnalysis;
+using Elsa.Api.Client.Resources.OutputConverters.Contracts;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Requests;
+using Elsa.Api.Client.Resources.OutputConverters.Responses;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public class RemoteOutputConverterServiceTests
+{
+    [Fact]
+    public async Task GetOutputConvertersAsyncForwardsDeclaredTypesToTheBackend()
+    {
+        var api = new OutputConvertersApiStub();
+        var service = new RemoteOutputConverterService(new BackendApiClientProviderStub(api));
+
+        var converters = await service.GetOutputConvertersAsync("Source", "String");
+
+        Assert.Equal("Source", api.Request!.SourceType);
+        Assert.Equal("String", api.Request.DestinationType);
+        Assert.Single(converters);
+        Assert.Equal("sample.to-text", converters.Single().Id);
+    }
+
+    private sealed class OutputConvertersApiStub : IOutputConvertersApi
+    {
+        public ListOutputConvertersRequest? Request { get; private set; }
+
+        public Task<ListOutputConvertersResponse> ListAsync(ListOutputConvertersRequest request, CancellationToken cancellationToken = default)
+        {
+            Request = request;
+            return Task.FromResult(new ListOutputConvertersResponse(
+            [
+                new OutputConverterDescriptor
+                {
+                    Id = "sample.to-text",
+                    SourceTypeName = "Source",
+                    ResultTypeName = "String",
+                    DisplayName = "Convert to text"
+                }
+            ]));
+        }
+    }
+
+    private sealed class BackendApiClientProviderStub(IOutputConvertersApi api) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://studio.test");
+
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class =>
+            typeof(T) == typeof(IOutputConvertersApi)
+                ? ValueTask.FromResult((T)api)
+                : throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor
@@ -1,0 +1,40 @@
+@using System.Text.Json
+@using System.Text.Json.Nodes
+@using Elsa.Studio.Localization
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+@if (_fields.Count > 0)
+{
+    <MudStack Spacing="2" Class="ml-4">
+        @foreach (var field in _fields)
+        {
+            @if (field.Options.Count > 0)
+            {
+                <MudSelect T="string" Label="@Localizer[field.Label]" HelperText="@Localizer[field.Description]" Value="@GetTextValue(field.Name)" ValueChanged="@(value => UpdateEnumAsync(field, value))" Required="@field.IsRequired" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Dense="true" Variant="Variant.Outlined">
+                    @foreach (var option in field.Options)
+                    {
+                        <MudSelectItem Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+            else if (field.Type == "boolean")
+            {
+                <MudCheckBox T="bool" Label="@Localizer[field.Label]" Value="@GetBooleanValue(field.Name)" ValueChanged="@(value => UpdateBooleanAsync(field.Name, value))" ReadOnly="IsReadOnly" Disabled="IsReadOnly" />
+            }
+            else
+            {
+                <MudTextField T="string" Label="@Localizer[field.Label]" HelperText="@Localizer[field.Description]" Value="@GetTextValue(field.Name)" ValueChanged="@(value => UpdateTextAsync(field, value))" Required="@field.IsRequired" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Variant="Variant.Outlined" />
+            }
+        }
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true">@_error</MudAlert>
+        }
+    </MudStack>
+}
+else
+{
+    <MudTextField T="string" Label="@Localizer["Converter settings"]" HelperText="@Localizer["Enter a JSON object."]" Value="@_rawSettings" ValueChanged="OnRawSettingsChangedAsync" Error="@(!string.IsNullOrEmpty(_error))" ErrorText="@_error" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Lines="6" Variant="Variant.Outlined" Class="ml-4" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
@@ -1,0 +1,190 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+
+/// <summary>
+/// Edits JSON settings for a selected output converter.
+/// </summary>
+public partial class OutputConverterSettingsEditor
+{
+    private readonly List<SettingsField> _fields = [];
+    private JsonObject _settings = [];
+    private string _rawSettings = "{}";
+    private string? _error;
+    private string? _settingsSignature;
+
+    /// <summary>
+    /// The optional JSON schema provided by the selected converter descriptor.
+    /// </summary>
+    [Parameter] public JsonElement? SettingsSchema { get; set; }
+
+    /// <summary>
+    /// The current converter settings.
+    /// </summary>
+    [Parameter] public JsonObject? Settings { get; set; }
+
+    /// <summary>
+    /// Raised when valid converter settings change.
+    /// </summary>
+    [Parameter] public EventCallback<JsonObject> SettingsChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether settings are read-only.
+    /// </summary>
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        var schemaSignature = SettingsSchema?.GetRawText() ?? string.Empty;
+        var settingsSignature = $"{schemaSignature}\n{Settings?.ToJsonString() ?? "{}"}";
+        if (settingsSignature == _settingsSignature)
+            return;
+
+        _settingsSignature = settingsSignature;
+        _settings = Settings?.DeepClone().AsObject() ?? [];
+        _rawSettings = _settings.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        _error = null;
+        BuildFields();
+    }
+
+    private void BuildFields()
+    {
+        _fields.Clear();
+        if (SettingsSchema is not { ValueKind: JsonValueKind.Object } schema ||
+            !schema.TryGetProperty("type", out var type) || type.GetString() != "object" ||
+            !schema.TryGetProperty("properties", out var properties) || properties.ValueKind != JsonValueKind.Object)
+            return;
+
+        var required = schema.TryGetProperty("required", out var requiredElement) && requiredElement.ValueKind == JsonValueKind.Array
+            ? requiredElement.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()).ToHashSet()
+            : [];
+
+        foreach (var property in properties.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.Object)
+            {
+                _fields.Clear();
+                return;
+            }
+
+            var propertySchema = property.Value;
+            var fieldType = propertySchema.TryGetProperty("type", out var fieldTypeElement) ? fieldTypeElement.GetString() : null;
+            var options = propertySchema.TryGetProperty("enum", out var enumElement) && enumElement.ValueKind == JsonValueKind.Array
+                ? enumElement.EnumerateArray().Where(x => x.ValueKind is JsonValueKind.String or JsonValueKind.Number).Select(x => x.ToString()).ToList()
+                : [];
+
+            if (fieldType == null && propertySchema.TryGetProperty("enum", out enumElement) && enumElement.ValueKind == JsonValueKind.Array)
+                fieldType = enumElement.EnumerateArray().All(x => x.ValueKind == JsonValueKind.Number) ? "number" : "string";
+
+            if (fieldType is not ("string" or "number" or "integer" or "boolean") && options.Count == 0)
+            {
+                _fields.Clear();
+                return;
+            }
+
+            if (options.Count > 0 && fieldType is not (null or "string" or "number" or "integer"))
+            {
+                _fields.Clear();
+                return;
+            }
+
+            var label = propertySchema.TryGetProperty("title", out var title) ? title.GetString() : null;
+            var description = propertySchema.TryGetProperty("description", out var descriptionElement) ? descriptionElement.GetString() : null;
+            var field = new SettingsField(property.Name, label ?? property.Name, description ?? string.Empty, fieldType ?? "string", options, required.Contains(property.Name));
+            _fields.Add(field);
+
+            if (!_settings.ContainsKey(property.Name) && propertySchema.TryGetProperty("default", out var defaultValue))
+                _settings[property.Name] = JsonNode.Parse(defaultValue.GetRawText());
+        }
+    }
+
+    private string? GetTextValue(string name) => _settings[name]?.ToString();
+
+    private bool GetBooleanValue(string name) =>
+        _settings[name] is JsonValue value && value.TryGetValue<bool>(out var boolean) && boolean;
+
+    private async Task UpdateEnumAsync(SettingsField field, string value)
+    {
+        await UpdateTextAsync(field, value);
+    }
+
+    private async Task UpdateTextAsync(SettingsField field, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (field.IsRequired)
+            {
+                _error = Localizer["This setting is required."];
+                return;
+            }
+
+            _settings.Remove(field.Name);
+        }
+        else if (field.Type == "number")
+        {
+            if (!decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var number))
+            {
+                _error = Localizer["Enter a valid number."];
+                return;
+            }
+
+            _settings[field.Name] = number;
+        }
+        else if (field.Type == "integer")
+        {
+            if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integer))
+            {
+                _error = Localizer["Enter a valid integer."];
+                return;
+            }
+
+            _settings[field.Name] = integer;
+        }
+        else
+        {
+            _settings[field.Name] = value;
+        }
+
+        _error = null;
+        await RaiseSettingsChangedAsync();
+    }
+
+    private async Task UpdateBooleanAsync(string name, bool value)
+    {
+        _settings[name] = value;
+        _error = null;
+        await RaiseSettingsChangedAsync();
+    }
+
+    private async Task OnRawSettingsChangedAsync(string value)
+    {
+        _rawSettings = value;
+
+        try
+        {
+            var settings = JsonNode.Parse(value) as JsonObject;
+            if (settings == null)
+                throw new JsonException();
+
+            _settings = settings;
+            _error = null;
+            await RaiseSettingsChangedAsync();
+        }
+        catch (JsonException)
+        {
+            _error = Localizer["Converter settings must be a valid JSON object."];
+        }
+    }
+
+    private Task RaiseSettingsChangedAsync()
+    {
+        _settingsSignature = _settings.ToJsonString();
+        return SettingsChanged.InvokeAsync(_settings.DeepClone().AsObject());
+    }
+
+    private sealed record SettingsField(string Name, string Label, string Description, string Type, ICollection<string> Options, bool IsRequired);
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
@@ -2,9 +2,10 @@
 @using Variant = MudBlazor.Variant
 @using Elsa.Api.Client.Extensions
 @using Elsa.Api.Client.Shared.Models
+@using Elsa.Studio.Localization
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models
 @inherits StudioComponentBase
-@using Microsoft.Extensions.Localization
+@implements IDisposable
 @inject ILocalizer Localizer
 
 <MudForm ReadOnly="IsReadOnly">
@@ -12,17 +13,20 @@
         @foreach (var outputDescriptor in OutputDescriptors)
         {
             var activity = Activity;
-            var displayName = string.IsNullOrWhiteSpace(outputDescriptor.DisplayName) ? outputDescriptor.Name : outputDescriptor.DisplayName;
+            var displayName = string.IsNullOrWhiteSpace(outputDescriptor.DisplayName) ? outputDescriptor.Name : outputDescriptor.DisplayName!;
             var propertyName = outputDescriptor.Name.Camelize();
             var propertyValue = activity.GetProperty<ActivityOutput>(propertyName);
             var propertyType = _variableTypes.TryGetValue(outputDescriptor.TypeName, out var type) ? type : default;
             var propertyTypeName = propertyType?.DisplayName ?? outputDescriptor.TypeName;
             var selectedValue = _bindingTargetOptions.FirstOrDefault(x => x.Value == propertyValue?.MemoryReference?.Id);
+            var converterState = GetConverterState(outputDescriptor);
+            var converterId = GetConverterId(propertyName);
+            var selectedConverter = converterState.Descriptors.FirstOrDefault(x => x.Id == converterId);
 
             <MudSelect
                 T="BindingTargetOption"
                 Label="@Localizer[displayName]"
-                HelperText="@Localizer[outputDescriptor.Description ?? string.Empty]"
+                HelperText="@(outputDescriptor.Description is { Length: > 0 } outputDescription ? Localizer[outputDescription].Value : null)"
                 Value="@selectedValue"
                 Dense="false"
                 Variant="Variant.Outlined"
@@ -44,6 +48,30 @@
                     }
                 }
             </MudSelect>
+
+            @if (selectedValue != null && converterState.IsAvailable)
+            {
+                <MudSelect T="string" Label="@Localizer["Converter"]" HelperText="@(selectedConverter?.Description is { Length: > 0 } description ? Localizer[description].Value : null)" Value="@converterId" Dense="true" Variant="Variant.Outlined" Margin="Margin.Dense" ToStringFunc="@(id => GetConverterDisplayName(id, converterState))" ValueChanged="@(id => OnConverterChanged(id, outputDescriptor))" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Class="ml-4">
+                    <MudSelectItem T="string" Value="@string.Empty">@Localizer["None"]</MudSelectItem>
+                    @if (!string.IsNullOrWhiteSpace(converterId) && selectedConverter == null)
+                    {
+                        <MudSelectItem T="string" Value="@converterId">@converterId</MudSelectItem>
+                    }
+                    @foreach (var converter in converterState.Descriptors)
+                    {
+                        <MudSelectItem T="string" Value="@converter.Id">@Localizer[string.IsNullOrWhiteSpace(converter.DisplayName) ? converter.Id : converter.DisplayName]</MudSelectItem>
+                    }
+                </MudSelect>
+
+                @if (!string.IsNullOrWhiteSpace(converterId) && selectedConverter == null)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="ml-4">@Localizer["The configured converter is unavailable."]</MudAlert>
+                }
+                else if (selectedConverter != null)
+                {
+                    <OutputConverterSettingsEditor SettingsSchema="selectedConverter.SettingsSchema" Settings="GetConverterSettings(propertyName)" SettingsChanged="@(settings => OnConverterSettingsChanged(settings, outputDescriptor))" IsReadOnly="IsReadOnly" />
+                }
+            }
         }
     </MudStack>
 </MudForm>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
 using Elsa.Api.Client.Resources.VariableTypes.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
@@ -21,6 +22,7 @@ public partial class OutputsTab
     private ICollection<BindingTargetGroup> _bindingTargetGroups = new List<BindingTargetGroup>();
     private ICollection<BindingTargetOption> _bindingTargetOptions = new List<BindingTargetOption>();
     private IDictionary<string, VariableTypeDescriptor> _variableTypes = new Dictionary<string, VariableTypeDescriptor>();
+    private readonly IDictionary<string, OutputConverterState> _converterStates = new Dictionary<string, OutputConverterState>();
 
     /// <summary>
     /// The workflow definition.
@@ -48,6 +50,7 @@ public partial class OutputsTab
     [CascadingParameter] public IWorkspace? Workspace { get; set; }
 
     [Inject] IVariableTypeService VariableTypeService { get; set; } = default!;
+    [Inject] IOutputConverterService OutputConverterService { get; set; } = default!;
 
     private IReadOnlyCollection<OutputDescriptor> OutputDescriptors => ActivityDescriptor.Outputs;
     private bool IsReadOnly => Workspace?.IsReadOnly == true;
@@ -62,18 +65,18 @@ public partial class OutputsTab
     }
 
     /// <inheritdoc />
-    protected override Task OnParametersSetAsync()
+    protected override async Task OnParametersSetAsync()
     {
         var bindingTargetGroups = new List<BindingTargetGroup>();
         var variables = WorkflowDefinition.Variables;
         var outputDefinitions = WorkflowDefinition.Outputs;
 
         var variableBindingTargets = variables
-            .Select(variable => new BindingTargetOption(variable.Name, variable.Id))
+            .Select(variable => new BindingTargetOption(variable.Name, variable.Id, variable.TypeName, variable.IsArray))
             .ToList();
 
         var outputBindingTargets = outputDefinitions
-            .Select(outputDefinition => new BindingTargetOption(outputDefinition.DisplayName, outputDefinition.Name))
+            .Select(outputDefinition => new BindingTargetOption(outputDefinition.DisplayName, outputDefinition.Name, outputDefinition.Type, outputDefinition.IsArray))
             .ToList();
 
         if (variableBindingTargets.Any()) bindingTargetGroups.Add(new BindingTargetGroup("Variables", BindingKind.Variable, variableBindingTargets));
@@ -82,7 +85,14 @@ public partial class OutputsTab
 
         _bindingTargetGroups = bindingTargetGroups;
         _bindingTargetOptions = variableBindingTargets.Concat(outputBindingTargets).ToList();
-        return Task.CompletedTask;
+
+        foreach (var outputDescriptor in OutputDescriptors)
+        {
+            var propertyName = outputDescriptor.Name.Camelize();
+            var binding = Activity.GetProperty<ActivityOutput>(propertyName);
+            var target = _bindingTargetOptions.FirstOrDefault(x => x.Value == binding?.MemoryReference?.Id);
+            await LoadConvertersAsync(outputDescriptor, target, clearIncompatibleConverter: false);
+        }
     }
 
     private async Task OnBindingChanged(BindingTargetOption? bindingTargetOption, OutputDescriptor outputDescriptor)
@@ -90,20 +100,184 @@ public partial class OutputsTab
         var activity = Activity;
         var propertyName = outputDescriptor.Name.Camelize();
 
-        var activityOutput = bindingTargetOption == null
-            ? default
-            : new ActivityOutput
+        if (bindingTargetOption == null)
+        {
+            activity.SetProperty(default(JsonNode), propertyName);
+            await RaiseActivityUpdatedAsync(activity);
+            return;
+        }
+
+        var currentBinding = activity.GetProperty<JsonObject>(propertyName);
+        var activityOutput = new JsonObject
+        {
+            ["typeName"] = outputDescriptor.TypeName,
+            ["memoryReference"] = new JsonObject { ["id"] = bindingTargetOption.Value }
+        };
+
+        if (currentBinding?["converter"] is JsonObject converter)
+            activityOutput["converter"] = converter.DeepClone();
+
+        activity.SetProperty(activityOutput, propertyName);
+        await RaiseActivityUpdatedAsync(activity);
+        await LoadConvertersAsync(outputDescriptor, bindingTargetOption, clearIncompatibleConverter: true);
+    }
+
+    private async Task OnConverterChanged(string? converterId, OutputDescriptor outputDescriptor)
+    {
+        var propertyName = outputDescriptor.Name.Camelize();
+        var binding = Activity.GetProperty<JsonObject>(propertyName);
+        if (binding == null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(converterId))
+        {
+            binding.Remove("converter");
+        }
+        else
+        {
+            var existingConverter = binding["converter"] as JsonObject;
+            var settings = existingConverter?["id"]?.GetValue<string>() == converterId
+                ? existingConverter["settings"]?.DeepClone()
+                : new JsonObject();
+            binding["converter"] = new JsonObject
             {
-                TypeName = outputDescriptor.TypeName,
-                MemoryReference = new MemoryReference
-                {
-                    Id = bindingTargetOption.Value
-                }
+                ["id"] = converterId,
+                ["settings"] = settings
             };
+        }
 
-        activity.SetProperty(activityOutput!.SerializeToNode(), propertyName);
+        Activity.SetProperty(binding, propertyName);
+        await RaiseActivityUpdatedAsync(Activity);
+    }
 
+    private async Task OnConverterSettingsChanged(JsonObject settings, OutputDescriptor outputDescriptor)
+    {
+        var propertyName = outputDescriptor.Name.Camelize();
+        var binding = Activity.GetProperty<JsonObject>(propertyName);
+        if (binding?["converter"] is not JsonObject converter)
+            return;
+
+        converter["settings"] = settings.DeepClone();
+        Activity.SetProperty(binding, propertyName);
+        await RaiseActivityUpdatedAsync(Activity);
+    }
+
+    private async Task LoadConvertersAsync(OutputDescriptor outputDescriptor, BindingTargetOption? target, bool clearIncompatibleConverter)
+    {
+        var state = GetConverterState(outputDescriptor);
+        var cancellationToken = state.BeginRequest();
+        var requestVersion = state.RequestVersion;
+
+        if (target == null)
+        {
+            state.Reset();
+            return;
+        }
+
+        try
+        {
+            var descriptors = await OutputConverterService.GetOutputConvertersAsync(outputDescriptor.TypeName, target.DeclaredTypeName, cancellationToken);
+            if (requestVersion != state.RequestVersion)
+                return;
+
+            state.Descriptors = descriptors;
+            state.IsAvailable = true;
+
+            if (clearIncompatibleConverter && !IsCurrentConverterCompatible(outputDescriptor, state))
+            {
+                var propertyName = outputDescriptor.Name.Camelize();
+                var binding = Activity.GetProperty<JsonObject>(propertyName);
+                binding?.Remove("converter");
+                if (binding != null)
+                {
+                    Activity.SetProperty(binding, propertyName);
+                    await RaiseActivityUpdatedAsync(Activity);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception)
+        {
+            if (requestVersion != state.RequestVersion)
+                return;
+
+            state.Reset();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var state in _converterStates.Values)
+            state.Dispose();
+    }
+
+    private OutputConverterState GetConverterState(OutputDescriptor outputDescriptor)
+    {
+        if (_converterStates.TryGetValue(outputDescriptor.Name, out var state))
+            return state;
+
+        state = new OutputConverterState();
+        _converterStates[outputDescriptor.Name] = state;
+        return state;
+    }
+
+    private string GetConverterDisplayName(string? converterId, OutputConverterState state)
+    {
+        if (string.IsNullOrWhiteSpace(converterId))
+            return Localizer["None"];
+
+        var descriptor = state.Descriptors.FirstOrDefault(x => x.Id == converterId);
+        return Localizer[descriptor == null || string.IsNullOrWhiteSpace(descriptor.DisplayName) ? converterId : descriptor.DisplayName];
+    }
+
+    private string? GetConverterId(string propertyName) =>
+        (Activity.GetProperty<JsonObject>(propertyName)?["converter"] as JsonObject)?["id"]?.GetValue<string>();
+
+    private JsonObject? GetConverterSettings(string propertyName) =>
+        (Activity.GetProperty<JsonObject>(propertyName)?["converter"] as JsonObject)?["settings"] as JsonObject;
+
+    private bool IsCurrentConverterCompatible(OutputDescriptor outputDescriptor, OutputConverterState state)
+    {
+        var converterId = GetConverterId(outputDescriptor.Name.Camelize());
+        return string.IsNullOrWhiteSpace(converterId) || state.Descriptors.Any(x => x.Id == converterId);
+    }
+
+    private async Task RaiseActivityUpdatedAsync(JsonObject activity)
+    {
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);
+    }
+
+    private sealed class OutputConverterState : IDisposable
+    {
+        private CancellationTokenSource? _cancellationTokenSource;
+
+        public ICollection<OutputConverterDescriptor> Descriptors { get; set; } = [];
+        public bool IsAvailable { get; set; }
+        public int RequestVersion { get; set; }
+
+        public CancellationToken BeginRequest()
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = new();
+            RequestVersion++;
+            return _cancellationTokenSource.Token;
+        }
+
+        public void Reset()
+        {
+            Descriptors = [];
+            IsAvailable = false;
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+        }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
@@ -3,4 +3,10 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// <summary>
 /// Represents the binding target option record.
 /// </summary>
-public record BindingTargetOption(string Text, string Value);
+public record BindingTargetOption(string Text, string Value, string TypeName, bool IsArray)
+{
+    /// <summary>
+    /// Gets the declared type name, including the array suffix when applicable.
+    /// </summary>
+    public string DeclaredTypeName => IsArray ? $"{TypeName}[]" : TypeName;
+}


### PR DESCRIPTION
## Summary

- discover output converters through the Elsa API client
- add converter selection, unavailable-converter handling, and schema-driven settings editing to workflow outputs
- update Elsa.Api.Client to 3.8.0-preview.5397, produced after elsa-core#7902 merged
- align dependency patch levels required by the new client and add focused component-test dependencies

## Validation

- `dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --framework net10.0 --filter FullyQualifiedName~OutputConverters`
- 9 tests passed

Depends on elsa-workflows/elsa-core#7902, which is merged and whose preview package has been published successfully.
