### PR TITLE
Improve dashboard health timeline

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -1,0 +1,263 @@
+# Elsa Studio Interface Design System
+
+Status: Approved baseline
+
+Last updated: 2026-08-01
+
+## Direction
+
+Elsa Studio is a technical administration workspace for people configuring,
+diagnosing, and operating workflow infrastructure. Interfaces should feel calm,
+precise, and operationally trustworthy: dense enough for expert work, but
+structured so that state, source, and available actions are immediately clear.
+
+Domain concepts include configuration, deployment, runtime state, validation,
+diagnostics, lifecycle, secrets, revisions, and effective versus persisted
+records.
+
+The signature pattern is explicit operational context. When displayed data can
+come from multiple sources, the interface must distinguish the effective source
+from the record being viewed. Stored-record status must never appear to describe
+an effective deployment-owned record.
+
+## Foundation
+
+- Use MudBlazor components and theme tokens first.
+- Add custom CSS only when composition and responsive utility classes cannot
+  express the required behavior.
+- Preserve the existing Elsa typography and icon family.
+- Use color to communicate brand, state, warning, success, and destructive
+  intent; do not use color decoratively.
+- Prefer progressive disclosure for advanced and operational concerns.
+
+## Palette
+
+Use the configured MudBlazor theme rather than hard-coded colors:
+
+- Primary: Elsa navigation, selected state, and routine primary actions.
+- Info: deployment-owned or explanatory context.
+- Success: effective and valid states.
+- Warning: enabled-but-not-effective, shadowed, or attention states.
+- Error: destructive actions and failed validation.
+- Default/neutral: structure, inactive state, metadata, and borders.
+
+## Depth and Surfaces
+
+Use a borders-only depth strategy for administration screens:
+
+- Page canvas: theme background.
+- Workspace and summary surfaces: `MudPaper Outlined="true"`.
+- Alerts: MudBlazor semantic alert surfaces.
+- Avoid decorative shadows, nested card stacks, and dramatic surface shifts.
+- Use dividers only where they clarify a change in responsibility or action
+  severity.
+
+## Spacing
+
+MudBlazor's 4px unit is the implementation base. Use an 8px primary rhythm and
+the following scale:
+
+- 4px: icon or micro-text adjustment.
+- 8px: related inline controls and compact stack gaps.
+- 12px: ordinary field or page-stack separation when 8px is too tight.
+- 16px: card padding, mobile panel inset, and standard grid gutter.
+- 24px: desktop workspace inset and major separation.
+- 32px: separation between independent page sections when needed.
+
+Keep padding symmetrical unless the content itself requires asymmetry. Do not
+let grids or form controls touch an outlined workspace boundary.
+
+## Connection Workspace Pattern
+
+The approved reference is Concept 2, “Connection Workspace,” selected on
+2026-07-29.
+
+### Page composition
+
+- Use `MudContainer MaxWidth="MaxWidth.Large"` for complex connection editing.
+- Keep the back action at natural width with `align-self-start`.
+- Present connection identity and persistent operational context in one compact,
+  outlined header.
+- Allow header status chips and actions to wrap rather than collide.
+- Place global source or shadowing alerts above the tab strip so their context
+  remains visible across tasks.
+
+### Tabs
+
+- Separate Configuration, Provisioning & linking, and Diagnostics.
+- Use `KeepPanelsAlive="true"` so custom editors retain transient state.
+- Apply responsive inset to the shared panel container with
+  `TabPanelsClass="pa-4 pa-sm-6"`: 16px on narrow screens and 24px from the
+  small breakpoint upward.
+- Use a 16px grid gutter (`MudGrid Spacing="4"`) for two-column panel layouts.
+- Ensure all tab bodies use the shared inset; do not pad only the initially
+  active tab.
+
+### Information hierarchy
+
+- Configuration owns provider settings and the validated save action.
+- Provisioning & linking owns user creation, matching, and role assignment.
+- Diagnostics owns tests, previews, validation results, and lifecycle actions.
+- A supporting “At a glance” surface may summarize effective source, record
+  source, validity, provisioning policy, and latest test.
+- Keep supporting surfaces secondary to the editable form.
+
+### Operational states
+
+- Label the effective source explicitly.
+- For shadowed records, prefix lifecycle and validity with “Stored” and label
+  test information as stored-record data.
+- Configuration-owned records are read-only and must not advertise unavailable
+  lifecycle actions.
+- Draft connections omit persisted-only diagnostics and lifecycle state.
+- Keep destructive lifecycle actions separated from routine configuration.
+
+### Calls to action
+
+- Keep one clear primary path for each task.
+- When an action changes tabs rather than saving, label it accordingly, such as
+  “Review configuration.”
+- In informational callouts, stack explanatory copy above the action with an
+  8px gap. Do not append a button directly to a sentence.
+
+## Secret Detail Workspace Pattern
+
+The approved reference is the Secrets detail page implemented on 2026-07-30.
+Use this pattern for detail pages that combine immutable identity, editable
+metadata, lifecycle context, and a sensitive operational action.
+
+### Page composition
+
+- Use `MudContainer MaxWidth="MaxWidth.Large"` and a `MudStack Spacing="3"`
+  with `py-4`.
+- Keep the back action at natural width with `align-self-start`.
+- Present the resource icon, display name, technical name, status, type, store,
+  and version in one compact outlined header.
+- Use the primary color for resource identity and routine actions. Reserve
+  success, warning, and error colors for lifecycle meaning.
+- Technical identifiers may be long: use a monospace treatment,
+  `overflow-wrap: anywhere`, and wrapping header chips.
+
+### Task separation
+
+- Use an outlined tab workspace when overview and mutation tasks have different
+  risk or cognitive load.
+- Keep identity, description, metadata, and lifecycle summary under Overview.
+- Put credential replacement and optional expiry under Rotation.
+- Use `KeepPanelsAlive="true"` and
+  `TabPanelsClass="pa-4 pa-sm-6"` so transient form values survive task
+  navigation and every panel receives the same responsive inset.
+- Use `MudGrid Spacing="4"` with an 8/4 main-to-supporting column split on
+  desktop and a single-column stack on narrow screens.
+
+### Operational context
+
+- Provide one secondary “At a glance” outlined surface for status, current
+  version, store, and expiry.
+- Explain rotation outcomes before the form. Never imply that a stored secret
+  value can be retrieved or displayed.
+- Pair mutation controls with the current version and expiry context needed to
+  evaluate the action.
+- Keep routine rotation visually primary but contained within its own task.
+
+### Destructive actions
+
+- Name the action directly, such as “Revoke secret”; avoid a generic
+  “Danger zone” heading when a more precise label exists.
+- Separate destructive actions from routine mutations by task, spacing, and an
+  error-semantic border rather than a decorative background.
+- Explain the operational consequence immediately before the destructive
+  button.
+- Keep the destructive button at natural width and require confirmation before
+  executing the action.
+
+### Responsive and theme behavior
+
+- At narrow widths, stack metadata columns, supporting context, date/time
+  controls, and action groups without horizontal scrolling.
+- Keep short action labels on one line; allow technical names and status chips
+  to wrap.
+- Use theme tokens and outlined surfaces so the same structure works in light
+  and dark modes without page-specific color overrides.
+- Verify Overview and Rotation independently at desktop and mobile widths,
+  including long technical names, focus order, disabled time-before-date
+  behavior, and semantic lifecycle colors.
+
+## Operational Dashboard Pattern
+
+The approved reference is Concept C, “Health Timeline,” selected on 2026-07-31
+and implemented on 2026-08-01. Use this pattern for operational overview pages
+that combine current health, time-series behavior, recent work, prioritized
+findings, and diagnostics.
+
+### Reading order
+
+- Organize the page as health, trend, recent activity and attention, then
+  diagnostics. This follows the operator's sequence from orientation to
+  investigation and drill-down.
+- Do not place a short empty-state panel beside a tall stack of unrelated
+  widgets. Row height must not create unexplained voids in another column.
+- Keep the execution trend full width so time and outcome series remain easy to
+  compare. Bound the chart height; quiet data must not produce a large empty
+  card.
+
+### Operational health strip
+
+- Present the primary workflow metrics in one full-width outlined surface named
+  “Operational health,” rather than six disconnected cards.
+- Use six inline metric cells on wide screens, separated by quiet theme-token
+  dividers. Wrap to three, two, and one column as space decreases.
+- Retain semantic icons, values, range captions, accessible labels, and direct
+  navigation where a metric has a meaningful drill-down.
+- Use success, warning, error, and info colors only for operational meaning;
+  neutral zero states remain default unless zero itself communicates health.
+
+### Activity and supporting context
+
+- On desktop, use an 8/4 split: recent workflow activity is primary, while
+  needs-attention findings and workflow hotspots form the supporting rail.
+- Stack the activity and support rail at narrow widths in that order.
+- Render diagnostics as two equal outlined panels on desktop and a single-column
+  stack on narrow screens.
+- Keep diagnostic source counts, stale/error signals, and drill-through actions
+  compact; do not show raw log content on the dashboard.
+
+### Widget composition
+
+- Use semantic zones for `Metrics`, `Trend`, `Activity`, `Findings`, supporting
+  panels, and diagnostics. The shell owns composition; contributing modules
+  retain their data loading and internal states.
+- Preserve legacy widget zones and their default DOM contract when evolving the
+  shell. Add layout wrappers only when a zone explicitly requests them.
+- Order the dedicated trend zone before legacy primary panels so extension
+  compatibility cannot disrupt the health-to-trend hierarchy.
+
+### Visual direction
+
+- Preserve Elsa's technical, calm, borders-only surface language and existing
+  typography/icon family.
+- Use the MudBlazor 4px base and 8px primary rhythm throughout the dashboard.
+- The approved mockup used a compact health ledger, a lower full-width execution
+  timeline, an 8/4 activity row, and paired diagnostics. Avoid decorative
+  gradients, shadows, marketing treatments, and oversized empty panels.
+
+## Defaults to Avoid
+
+- One uninterrupted settings form: replace with task-oriented tabs while
+  preserving editor state.
+- Ambiguous source/status badges: replace with effective-versus-stored language.
+- Edge-to-edge tab content: replace with the shared responsive panel inset.
+- Dashboard-like card grids for ordinary settings: use one primary form and only
+  the supporting surfaces needed for context.
+- One-off CSS for spacing: use MudBlazor spacing and responsive utilities first.
+
+## Review Checklist
+
+- Check desktop and narrow layouts.
+- Activate every tab; do not validate only the default tab.
+- Confirm panel padding survives MudGrid negative gutters.
+- Confirm text actions do not collapse into adjacent prose.
+- Confirm read-only, draft, shadowed, archived, loading, validation-error, and
+  empty states.
+- Confirm custom editor instances survive tab navigation.
+- Run the relevant bUnit tests and the full module test suite.

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetRegistrationTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetRegistrationTests.cs
@@ -101,8 +101,8 @@ public class DashboardWidgetRegistrationTests
 
         AssertDescriptor<DashboardWorkflowMetricsWidget>(descriptors, "dashboard.workflow.metrics", DashboardWidgetZones.Metrics, 100, "WorkflowInstances");
         AssertDescriptor<DashboardNeedsAttentionWidget>(descriptors, "dashboard.needs-attention", DashboardWidgetZones.Findings, 100, null);
-        AssertDescriptor<DashboardTrendWidget>(descriptors, "dashboard.workflow.trend", DashboardWidgetZones.PrimaryPanels, 100, "WorkflowTrends");
-        AssertDescriptor<DashboardRecentActivityWidget>(descriptors, "dashboard.workflow.recent-activity", DashboardWidgetZones.PrimaryPanels, 200, "RecentActivity");
+        AssertDescriptor<DashboardTrendWidget>(descriptors, "dashboard.workflow.trend", DashboardWidgetZones.Trend, 100, "WorkflowTrends");
+        AssertDescriptor<DashboardRecentActivityWidget>(descriptors, "dashboard.workflow.recent-activity", DashboardWidgetZones.Activity, 100, "RecentActivity");
         AssertDescriptor<DashboardWorkflowHotspotsWidget>(descriptors, "dashboard.workflow.hotspots", DashboardWidgetZones.SecondaryPanels, 100, "WorkflowHotspots");
         AssertDescriptor<StructuredLogsDashboardWidget>(descriptors, "diagnostics.structured-logs", DashboardWidgetZones.DiagnosticsStatus, 100, "Diagnostics.StructuredLogs");
         AssertDescriptor<ConsoleLogsDashboardWidget>(descriptors, "diagnostics.console-logs", DashboardWidgetZones.DiagnosticsStatus, 200, "Diagnostics.ConsoleLogs");

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWorkflowMetricsWidgetTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWorkflowMetricsWidgetTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Elsa.Studio.Workflows.Dashboard.Widgets;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using MudBlazor;
+using Xunit;
+
+namespace Elsa.Studio.Dashboard.Tests;
+
+public sealed class DashboardWorkflowMetricsWidgetTests
+{
+    [Fact]
+#pragma warning disable BL0006 // Inspecting the generated render tree is the regression seam for invalid browser element names.
+    public void MetricContent_DoesNotRenderEmptyHtmlElementNames()
+    {
+        var componentType = typeof(DashboardWorkflowMetricsWidget);
+        var metricType = componentType.GetNestedType("OperationalHealthMetric", BindingFlags.NonPublic)!;
+        var metric = Activator.CreateInstance(metricType, "Running", "1", "Current active instances", "icon", Color.Info, null)!;
+        var fragmentFactory = (Delegate)componentType
+            .GetProperty("MetricContent", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(new DashboardWorkflowMetricsWidget())!;
+        var fragment = (RenderFragment)fragmentFactory.DynamicInvoke(metric)!;
+        var builder = new RenderTreeBuilder();
+
+        fragment(builder);
+
+        var frames = builder.GetFrames();
+        Assert.DoesNotContain(frames.Array.Take(frames.Count), frame =>
+            frame.FrameType == RenderTreeFrameType.Element && string.IsNullOrWhiteSpace(frame.ElementName));
+    }
+#pragma warning restore BL0006
+}

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardStyles.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardStyles.cs
@@ -2,7 +2,7 @@ namespace Elsa.Studio.Dashboard.Components;
 
 public static class DashboardStyles
 {
-    public const string Shell = "width:100%; max-width:none; min-height:100%; padding:24px 32px 32px; box-sizing:border-box; background:#f6f8fb;";
+    public const string Shell = "width:100%; max-width:none; min-height:100%; padding:24px 32px 32px; box-sizing:border-box; background:var(--mud-palette-background);";
     public const string Header = "gap:12px 16px; margin-bottom:14px;";
     public const string MetricGrid = "margin-bottom:8px;";
     public const string MainGrid = "margin-top:0;";
@@ -15,6 +15,6 @@ public static class DashboardStyles
     public const string CardLink = "color:inherit; display:block; height:100%;";
     public const string FindingList = "margin:-6px;";
     public const string FindingRow = "width:100%; min-width:0;";
-    public const string ChartPanel = "min-height:396px; padding:14px; border-radius:8px; background:var(--mud-palette-surface);";
+    public const string ChartPanel = "min-height:320px; padding:14px; border-radius:8px; background:var(--mud-palette-surface);";
     public const string DiagnosticsBlock = "border:1px solid var(--mud-palette-lines-default); border-radius:8px; padding:12px;";
 }

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor
@@ -24,7 +24,7 @@
                       ChartSeries="@Series"
                       ChartLabels="@Labels"
                       Width="100%"
-                      Height="300px"
+                      Height="220px"
                       MatchBoundsToSize="true" />
         </div>
     }

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor.css
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardTrendChart.razor.css
@@ -1,7 +1,7 @@
 .dashboard-trend-chart-frame {
     width: 100%;
     min-width: 0;
-    height: 340px;
+    height: 260px;
 }
 
 .dashboard-trend-chart-frame ::deep .dashboard-trend-chart {
@@ -22,6 +22,6 @@
 
 @media (max-width: 720px) {
     .dashboard-trend-chart-frame {
-        height: 300px;
+        height: 260px;
     }
 }

--- a/src/modules/Elsa.Studio.Dashboard/Components/DashboardWidgetZone.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Components/DashboardWidgetZone.razor
@@ -2,14 +2,37 @@
 @using WidgetContext = Elsa.Studio.Dashboard.Widgets.DashboardWidgetContext
 @using WidgetDescriptor = Elsa.Studio.Dashboard.Widgets.DashboardWidgetDescriptor
 
-@foreach (var widget in Widgets)
+@if (string.IsNullOrWhiteSpace(Class) && string.IsNullOrWhiteSpace(ItemClass))
 {
-    <DynamicComponent Type="@widget.ComponentType" Parameters="@CreateParameters(widget)" />
+    @foreach (var widget in Widgets)
+    {
+        <DynamicComponent Type="@widget.ComponentType" Parameters="@CreateParameters(widget)" />
+    }
+}
+else
+{
+    <div class="@Class">
+        @foreach (var widget in Widgets)
+        {
+            @if (string.IsNullOrWhiteSpace(ItemClass))
+            {
+                <DynamicComponent Type="@widget.ComponentType" Parameters="@CreateParameters(widget)" />
+            }
+            else
+            {
+                <div class="@ItemClass">
+                    <DynamicComponent Type="@widget.ComponentType" Parameters="@CreateParameters(widget)" />
+                </div>
+            }
+        }
+    </div>
 }
 
 @code {
     [Parameter] public IReadOnlyCollection<WidgetDescriptor> Widgets { get; set; } = [];
     [Parameter] public WidgetContext Context { get; set; } = null!;
+    [Parameter] public string? Class { get; set; }
+    [Parameter] public string? ItemClass { get; set; }
 
     private Dictionary<string, object?> CreateParameters(WidgetDescriptor widget) => new()
     {

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor
@@ -64,25 +64,23 @@
     {
         <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.Metrics)" Context="@WidgetContext" />
 
-        <MudGrid Spacing="2" Class="dashboard-main-grid" Style="@DashboardStyles.MainGrid">
-            <MudItem xs="12" lg="4">
-                <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.Findings)" Context="@WidgetContext" />
-            </MudItem>
-            <MudItem xs="12" lg="8">
-                <MudStack Spacing="2">
-                    <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.PrimaryPanels)" Context="@WidgetContext" />
-                </MudStack>
-            </MudItem>
-            <MudItem xs="12" lg="8">
-                <MudStack Spacing="2">
-                    <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.DiagnosticsStatus)" Context="@WidgetContext" />
-                </MudStack>
-            </MudItem>
-            <MudItem xs="12" lg="4">
-                <MudStack Spacing="2">
-                    <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.SecondaryPanels)" Context="@WidgetContext" />
-                </MudStack>
-            </MudItem>
-        </MudGrid>
+        <MudStack Spacing="2" Class="dashboard-main-stack">
+            <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.Trend)" Context="@WidgetContext" />
+            <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.PrimaryPanels)" Context="@WidgetContext" />
+
+            <MudGrid Spacing="2" Class="dashboard-activity-grid">
+                <MudItem xs="12" lg="8">
+                    <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.Activity)" Context="@WidgetContext" />
+                </MudItem>
+                <MudItem xs="12" lg="4">
+                    <MudStack Spacing="2">
+                        <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.Findings)" Context="@WidgetContext" />
+                        <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.SecondaryPanels)" Context="@WidgetContext" />
+                    </MudStack>
+                </MudItem>
+            </MudGrid>
+
+            <DashboardWidgetZone Widgets="@GetWidgets(DashboardWidgetZones.DiagnosticsStatus)" Context="@WidgetContext" Class="dashboard-diagnostics-grid" ItemClass="dashboard-diagnostics-grid-item" />
+        </MudStack>
     }
 </MudContainer>

--- a/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.css
+++ b/src/modules/Elsa.Studio.Dashboard/Pages/Index.razor.css
@@ -4,7 +4,7 @@
     min-height: 100%;
     padding: 24px 32px 32px;
     box-sizing: border-box;
-    background: #f6f8fb;
+    background: var(--mud-palette-background);
 }
 
 .dashboard-header {
@@ -64,8 +64,28 @@
     margin-top: 6px;
 }
 
-.dashboard-main-grid {
+.dashboard-main-stack {
+    margin-top: 8px;
+}
+
+.dashboard-activity-grid {
     margin-top: 0;
+}
+
+.dashboard-shell ::deep .dashboard-diagnostics-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.dashboard-shell ::deep .dashboard-diagnostics-grid-item {
+    min-width: 0;
+    display: flex;
+}
+
+.dashboard-shell ::deep .dashboard-diagnostics-grid-item > .dashboard-panel {
+    width: 100%;
+    height: 100%;
 }
 
 .dashboard-shell ::deep .dashboard-section {
@@ -77,7 +97,7 @@
 }
 
 .dashboard-shell ::deep .dashboard-chart-panel {
-    min-height: 294px;
+    min-height: 320px;
 }
 
 .dashboard-shell ::deep .dashboard-finding-list {
@@ -123,5 +143,9 @@
 
     .dashboard-shell ::deep .dashboard-section {
         padding: 12px;
+    }
+
+    .dashboard-shell ::deep .dashboard-diagnostics-grid {
+        grid-template-columns: minmax(0, 1fr);
     }
 }

--- a/src/modules/Elsa.Studio.Dashboard/README.md
+++ b/src/modules/Elsa.Studio.Dashboard/README.md
@@ -17,10 +17,13 @@ Dashboard widgets are contributed through `DashboardWidgetDescriptor`:
 Supported zones are:
 
 - `DashboardWidgetZones.Metrics`: top-level KPI bands and compact counters
+- `DashboardWidgetZones.Trend`: full-width execution charts and time-series panels
+- `DashboardWidgetZones.Activity`: primary activity tables in the 8/12 operational column
 - `DashboardWidgetZones.Findings`: prioritized status and attention panels
-- `DashboardWidgetZones.PrimaryPanels`: wide charts or primary operational panels
-- `DashboardWidgetZones.SecondaryPanels`: supporting tables and activity panels
-- `DashboardWidgetZones.DiagnosticsStatus`: diagnostics status cards and health panels
+- `DashboardWidgetZones.SecondaryPanels`: supporting panels in the 4/12 operational column
+- `DashboardWidgetZones.DiagnosticsStatus`: diagnostics status cards in the equal-width diagnostics row
+
+`PrimaryPanels` is retained as a legacy zone and is rendered with the trend row so independently deployed companion modules remain visible. New widgets should use `Trend`, `Activity`, `Findings`, `SecondaryPanels`, or `DiagnosticsStatus` according to their operational role.
 
 ## Remote-Gated Registration
 

--- a/src/modules/Elsa.Studio.Dashboard/Widgets/DashboardWidgetDescriptor.cs
+++ b/src/modules/Elsa.Studio.Dashboard/Widgets/DashboardWidgetDescriptor.cs
@@ -55,7 +55,11 @@ public record DashboardWidgetContext(
 public static class DashboardWidgetZones
 {
     public const string Metrics = "metrics";
+    public const string Trend = "trend";
+    public const string Activity = "activity";
     public const string Findings = "findings";
+
+    // Legacy zones remain rendered by the shell so independently deployed companion modules continue to work.
     public const string PrimaryPanels = "primary-panels";
     public const string SecondaryPanels = "secondary-panels";
     public const string DiagnosticsStatus = "diagnostics-status";

--- a/src/modules/Elsa.Studio.Workflows.Dashboard/Feature.cs
+++ b/src/modules/Elsa.Studio.Workflows.Dashboard/Feature.cs
@@ -14,8 +14,8 @@ public class Feature(IDashboardWidgetRegistry widgetRegistry) : FeatureBase
     {
         widgetRegistry.Add(new("dashboard.workflow.metrics", DashboardWidgetZones.Metrics, 100, typeof(DashboardWorkflowMetricsWidget), "Workflow metrics", PayloadKind: "WorkflowInstances"));
         widgetRegistry.Add(new("dashboard.needs-attention", DashboardWidgetZones.Findings, 100, typeof(DashboardNeedsAttentionWidget), "Needs attention"));
-        widgetRegistry.Add(new("dashboard.workflow.trend", DashboardWidgetZones.PrimaryPanels, 100, typeof(DashboardTrendWidget), "Workflow trends", PayloadKind: "WorkflowTrends"));
-        widgetRegistry.Add(new("dashboard.workflow.recent-activity", DashboardWidgetZones.PrimaryPanels, 200, typeof(DashboardRecentActivityWidget), "Recent activity", PayloadKind: "RecentActivity"));
+        widgetRegistry.Add(new("dashboard.workflow.trend", DashboardWidgetZones.Trend, 100, typeof(DashboardTrendWidget), "Workflow trends", PayloadKind: "WorkflowTrends"));
+        widgetRegistry.Add(new("dashboard.workflow.recent-activity", DashboardWidgetZones.Activity, 100, typeof(DashboardRecentActivityWidget), "Recent activity", PayloadKind: "RecentActivity"));
         widgetRegistry.Add(new("dashboard.workflow.hotspots", DashboardWidgetZones.SecondaryPanels, 100, typeof(DashboardWorkflowHotspotsWidget), "Workflow hotspots", PayloadKind: "WorkflowHotspots"));
 
         return base.InitializeAsync(cancellationToken);

--- a/src/modules/Elsa.Studio.Workflows.Dashboard/Widgets/DashboardWorkflowMetricsWidget.razor
+++ b/src/modules/Elsa.Studio.Workflows.Dashboard/Widgets/DashboardWorkflowMetricsWidget.razor
@@ -3,27 +3,37 @@
 @if (Context.Snapshot != null)
 {
     var metrics = Context.Snapshot.Overview.WorkflowInstances;
+    var healthMetrics = new[]
+    {
+        new OperationalHealthMetric("Running", DashboardMetricFormatter.Count(metrics.Running), "Current active instances", Icons.Material.Outlined.PlayCircle, Color.Info, DashboardNavigationTargetMapper.ForMetric("running")),
+        new OperationalHealthMetric("Completed", DashboardMetricFormatter.Count(metrics.Completed), RangeCaption, Icons.Material.Outlined.CheckCircle, Color.Success),
+        new OperationalHealthMetric("Faulted", DashboardMetricFormatter.Count(metrics.Faulted), RangeCaption, Icons.Material.Outlined.ErrorOutline, metrics.Faulted > 0 ? Color.Error : Color.Default, DashboardNavigationTargetMapper.ForMetric("faulted")),
+        new OperationalHealthMetric("Suspended", DashboardMetricFormatter.Count(metrics.Suspended), "Current suspended instances", Icons.Material.Outlined.PauseCircle, metrics.Suspended > 0 ? Color.Warning : Color.Default, DashboardNavigationTargetMapper.ForMetric("suspended")),
+        new OperationalHealthMetric("Avg duration", DashboardMetricFormatter.Duration(metrics.AverageDuration), RangeCaption, Icons.Material.Outlined.Timer, Color.Default),
+        new OperationalHealthMetric("Needs attention", DashboardMetricFormatter.Count(Context.Snapshot.NeedsAttention.Findings.Count), "Prioritized findings", Icons.Material.Outlined.ReportProblem, Context.Snapshot.NeedsAttention.Findings.Count > 0 ? Color.Warning : Color.Success)
+    };
 
-    <MudGrid Spacing="2" Class="dashboard-metrics" Style="@DashboardStyles.MetricGrid">
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Running" Value="@DashboardMetricFormatter.Count(metrics.Running)" Caption="Current active instances" Icon="@Icons.Material.Outlined.PlayCircle" Color="Color.Info" Href="@DashboardNavigationTargetMapper.ForMetric("running")" />
-        </MudItem>
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Completed" Value="@DashboardMetricFormatter.Count(metrics.Completed)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.CheckCircle" Color="Color.Success" />
-        </MudItem>
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Faulted" Value="@DashboardMetricFormatter.Count(metrics.Faulted)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.ErrorOutline" Color="@(metrics.Faulted > 0 ? Color.Error : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("faulted")" />
-        </MudItem>
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Suspended" Value="@DashboardMetricFormatter.Count(metrics.Suspended)" Caption="Current suspended instances" Icon="@Icons.Material.Outlined.PauseCircle" Color="@(metrics.Suspended > 0 ? Color.Warning : Color.Default)" Href="@DashboardNavigationTargetMapper.ForMetric("suspended")" />
-        </MudItem>
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Avg duration" Value="@DashboardMetricFormatter.Duration(metrics.AverageDuration)" Caption="@RangeCaption" Icon="@Icons.Material.Outlined.Timer" Color="Color.Default" />
-        </MudItem>
-        <MudItem xs="12" sm="6" md="4" lg="2">
-            <DashboardMetricCard Label="Needs attention" Value="@DashboardMetricFormatter.Count(Context.Snapshot.NeedsAttention.Findings.Count)" Caption="Prioritized findings" Icon="@Icons.Material.Outlined.ReportProblem" Color="@(Context.Snapshot.NeedsAttention.Findings.Count > 0 ? Color.Warning : Color.Success)" />
-        </MudItem>
-    </MudGrid>
+    <MudPaper Outlined="true" Elevation="0" Class="dashboard-operational-health">
+        <MudText Typo="Typo.subtitle1" Class="dashboard-operational-health-heading">Operational health</MudText>
+
+        <div class="dashboard-operational-health-metrics">
+            @foreach (var metric in healthMetrics)
+            {
+                <div class="dashboard-operational-health-metric">
+                    @if (!string.IsNullOrWhiteSpace(metric.Href))
+                    {
+                        <MudLink Href="@metric.Href" Underline="Underline.None" Class="dashboard-operational-health-link" aria-label="@metric.AriaLabel">
+                            @MetricContent(metric)
+                        </MudLink>
+                    }
+                    else
+                    {
+                        @MetricContent(metric)
+                    }
+                </div>
+            }
+        </div>
+    </MudPaper>
 }
 
 @code {
@@ -36,4 +46,18 @@
         DashboardRangeKeys.SevenDays => "Last 7 days",
         _ => "Last 24 hours"
     };
+
+    private RenderFragment<OperationalHealthMetric> MetricContent => metric => @<text>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+            <MudText Typo="Typo.overline">@metric.Label</MudText>
+            <MudIcon Icon="@metric.Icon" Size="Size.Small" Color="@metric.Color" />
+        </MudStack>
+        <MudText Typo="Typo.h5" Color="@metric.Color" Class="dashboard-operational-health-value">@metric.Value</MudText>
+        <MudText Typo="Typo.caption" Class="dashboard-operational-health-caption">@metric.Caption</MudText>
+    </text>;
+
+    private sealed record OperationalHealthMetric(string Label, string Value, string Caption, string Icon, Color Color, string? Href = null)
+    {
+        public string AriaLabel => $"{Label}: {Value}. {Caption}";
+    }
 }

--- a/src/modules/Elsa.Studio.Workflows.Dashboard/Widgets/DashboardWorkflowMetricsWidget.razor.css
+++ b/src/modules/Elsa.Studio.Workflows.Dashboard/Widgets/DashboardWorkflowMetricsWidget.razor.css
@@ -1,0 +1,132 @@
+.dashboard-operational-health {
+    margin-bottom: 8px;
+    padding: 16px;
+    border-radius: 8px;
+    background: var(--mud-palette-surface);
+}
+
+.dashboard-operational-health-heading {
+    margin-bottom: 12px;
+}
+
+.dashboard-operational-health-metrics {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.dashboard-operational-health-metric {
+    min-width: 0;
+    padding: 0 12px;
+    border-inline-start: 1px solid var(--mud-palette-lines-default);
+}
+
+.dashboard-operational-health-metric:first-child {
+    padding-inline-start: 0;
+    border-inline-start: 0;
+}
+
+.dashboard-operational-health-metric:last-child {
+    padding-inline-end: 0;
+}
+
+.dashboard-operational-health-link {
+    display: block;
+    height: 100%;
+    color: inherit;
+}
+
+.dashboard-operational-health-link:focus-visible {
+    outline: 2px solid var(--mud-palette-primary);
+    outline-offset: 4px;
+    border-radius: 4px;
+}
+
+.dashboard-operational-health-value {
+    line-height: 1.1;
+    margin-top: 4px;
+}
+
+.dashboard-operational-health-caption {
+    color: var(--mud-palette-text-secondary);
+}
+
+@media (max-width: 1279px) {
+    .dashboard-operational-health-metrics {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .dashboard-operational-health-metric {
+        padding: 12px;
+        border-top: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .dashboard-operational-health-metric:nth-child(-n + 3) {
+        padding-top: 0;
+        border-top: 0;
+    }
+
+    .dashboard-operational-health-metric:nth-child(3n + 1) {
+        padding-inline-start: 0;
+        border-inline-start: 0;
+    }
+
+    .dashboard-operational-health-metric:nth-child(3n) {
+        padding-inline-end: 0;
+    }
+}
+
+@media (max-width: 959px) {
+    .dashboard-operational-health-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .dashboard-operational-health-metric:nth-child(3n + 1) {
+        padding-inline-start: 12px;
+        border-inline-start: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .dashboard-operational-health-metric:nth-child(3n) {
+        padding-inline-end: 12px;
+    }
+
+    .dashboard-operational-health-metric:nth-child(-n + 3) {
+        padding-top: 12px;
+        border-top: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .dashboard-operational-health-metric:nth-child(-n + 2) {
+        padding-top: 0;
+        border-top: 0;
+    }
+
+    .dashboard-operational-health-metric:nth-child(2n + 1) {
+        padding-inline-start: 0;
+        border-inline-start: 0;
+    }
+
+    .dashboard-operational-health-metric:nth-child(2n) {
+        padding-inline-end: 0;
+    }
+}
+
+@media (max-width: 599px) {
+    .dashboard-operational-health-metrics {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .dashboard-operational-health-metric,
+    .dashboard-operational-health-metric:nth-child(3n + 1) {
+        padding: 12px 0;
+        border-inline-start: 0;
+    }
+
+    .dashboard-operational-health-metric:nth-child(-n + 2) {
+        padding-top: 12px;
+        border-top: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .dashboard-operational-health-metric:first-child {
+        padding-top: 0;
+        border-top: 0;
+    }
+}


### PR DESCRIPTION
## What changed

- replace the six scattered metric cards with one responsive Operational health strip
- reorganize the dashboard into health → trend → activity/attention → diagnostics
- add semantic Trend and Activity widget zones while preserving legacy extension rendering
- reduce the execution chart height and align diagnostics into a responsive two-column row
- add focused component coverage for the operational health strip
- save the approved Health Timeline pattern in the interface design system

## Why

The previous fixed 4/8 grid placed a short findings panel beside a much taller trend/activity stack. The shared grid row reserved the taller height and left a large unexplained gap beneath findings. The new composition follows an operator's investigation flow and avoids coupling unrelated panel heights.

## Validation

- `dotnet test src/modules/Elsa.Studio.Dashboard.Tests/Elsa.Studio.Dashboard.Tests.csproj --nologo -v minimal` — 50 passed
- `dotnet build src/hosts/Elsa.Studio.Host.Wasm/Elsa.Studio.Host.Wasm.csproj --nologo -clp:ErrorsOnly -f net10.0` — succeeded with 0 warnings and 0 errors
- `git diff --check origin/main..HEAD`
