### PR TITLE
[4/7] Redesign the connection management workspace

### DIFF
--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionContractTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionContractTests.cs
@@ -27,6 +27,36 @@ public sealed class ConnectionContractTests
     }
 
     [Fact]
+    public void ConnectionSummaryDeserializesNamedShadowRelationships()
+    {
+        var connection = JsonSerializer.Deserialize<ConnectionSummary>(
+            """
+            {
+              "id": "deployment-keycloak",
+              "shadowed": true,
+              "shadowedBy": {
+                "id": "database-keycloak",
+                "displayName": "Keycloak",
+                "source": "database"
+              },
+              "shadows": [
+                {
+                  "id": "legacy-keycloak",
+                  "displayName": "Legacy Keycloak",
+                  "source": "configuration"
+                }
+              ]
+            }
+            """,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(connection);
+        Assert.Equal("database-keycloak", connection.ShadowedBy?.Id);
+        Assert.Equal("Keycloak", connection.ShadowedBy?.DisplayName);
+        Assert.Equal("legacy-keycloak", Assert.Single(connection.Shadows).Id);
+    }
+
+    [Fact]
     public void ValidationResultDeserializesStringWarnings()
     {
         var result = JsonSerializer.Deserialize<ConnectionValidationResult>(

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionEditorTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionEditorTests.cs
@@ -60,7 +60,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         Assert.Contains("configuration-owned and read-only", cut.Markup, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("override is unavailable", cut.Markup, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("Create full Studio override", cut.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("Create full Database override", cut.Markup, StringComparison.Ordinal);
         Assert.DoesNotContain("Save changes", cut.Markup, StringComparison.Ordinal);
     }
 
@@ -84,24 +84,90 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void TagsArrayField_AllowsAddingAValueWhenNoOptionsAreProvided()
+    public void GenericEditor_UsesTheOutlinedDenseMudBlazorFieldTreatment()
     {
-        var settings = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal)
-        {
-            ["scopes"] = System.Text.Json.JsonSerializer.SerializeToElement(Array.Empty<string>())
-        };
-        var cut = Render<DescriptorField>(parameters => parameters
+        var cut = Render<ConnectionEditor>(parameters => parameters
+            .Add(component => component.Connection, CreateConnection())
+            .Add(component => component.Adapter, CreateAdapter())
+            .Add(component => component.Model, CreateMutation()));
+
+        Assert.All(cut.FindComponents<MudTextField<string>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
+        Assert.All(cut.FindComponents<MudNumericField<int>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
+        Assert.All(cut.FindComponents<MudSelect<string>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
+    }
+
+    [Fact]
+    public void DescriptorFields_UseTheOutlinedDenseMudBlazorFieldTreatment()
+    {
+        var settings = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+        var text = Render<DescriptorField>(parameters => parameters
             .Add(component => component.Field, new ConnectionFieldDescriptor
             {
-                Name = "scopes",
-                DisplayName = "Scopes",
-                ValueType = "string-array",
-                UiHint = "tags"
+                Name = "description",
+                DisplayName = "Description",
+                UiHint = "multiline"
+            })
+            .Add(component => component.Settings, settings));
+        var integer = Render<DescriptorField>(parameters => parameters
+            .Add(component => component.Field, new ConnectionFieldDescriptor
+            {
+                Name = "order",
+                DisplayName = "Order",
+                ValueType = "integer"
+            })
+            .Add(component => component.Settings, settings));
+        var number = Render<DescriptorField>(parameters => parameters
+            .Add(component => component.Field, new ConnectionFieldDescriptor
+            {
+                Name = "weight",
+                DisplayName = "Weight",
+                ValueType = "number"
+            })
+            .Add(component => component.Settings, settings));
+        var select = Render<DescriptorField>(parameters => parameters
+            .Add(component => component.Field, new ConnectionFieldDescriptor
+            {
+                Name = "mode",
+                DisplayName = "Mode",
+                AllowedValues = ["discovery", "manual"]
             })
             .Add(component => component.Settings, settings));
 
+        var textField = text.FindComponent<MudTextField<string>>().Instance;
+        Assert.Equal(4, textField.Lines);
+        AssertOutlinedDense(textField.Variant, textField.Margin);
+        var integerField = integer.FindComponent<MudNumericField<int?>>().Instance;
+        AssertOutlinedDense(integerField.Variant, integerField.Margin);
+        var numberField = number.FindComponent<MudNumericField<decimal?>>().Instance;
+        AssertOutlinedDense(numberField.Variant, numberField.Margin);
+        var selectField = select.FindComponent<MudSelect<string>>().Instance;
+        AssertOutlinedDense(selectField.Variant, selectField.Margin);
+    }
+
+    [Fact]
+    public void TagsArrayField_AllowsAddingAValueWhenNoOptionsAreProvided()
+    {
+        var (cut, settings) = RenderTagsArrayField();
+
         cut.Find("input").Input("email");
         cut.FindAll("button").Single(button => button.TextContent.Contains("Add", StringComparison.Ordinal)).Click();
+
+        Assert.Equal(["email"], settings["scopes"].EnumerateArray().Select(item => item.GetString()));
+        Assert.Equal(AlignItems.Start, cut.FindComponents<MudStack>().Single(stack => stack.Instance.Row).Instance.AlignItems);
+        Assert.Contains("mt-1", cut.FindComponent<MudButton>().Instance.Class?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? []);
+    }
+
+    [Fact]
+    public void TagsArrayField_AddsPendingValueWhenEnterIsPressed()
+    {
+        var (cut, settings) = RenderTagsArrayField();
+
+        cut.Find("input").Input("email");
+        cut.Find("input").KeyDown(Key.Enter);
 
         Assert.Equal(["email"], settings["scopes"].EnumerateArray().Select(item => item.GetString()));
     }
@@ -157,6 +223,8 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         var roleSelect = cut.FindComponents<MudSelect<string>>().Last().Instance;
         Assert.True(roleSelect.MultiSelection);
         Assert.False(roleSelect.Disabled);
+        Assert.All(cut.FindComponents<MudSelect<string>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
         Assert.DoesNotContain("Enter role IDs", cut.Markup, StringComparison.OrdinalIgnoreCase);
 
         cut.Render(parameters => parameters
@@ -210,10 +278,19 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         _api.ManagedSecretResolvers = [];
 
         var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
+        cut.WaitForAssertion(() => Assert.Equal(
+            "Managed secret storage is not available on this Elsa server.",
+            cut.FindComponents<ConnectionEditor>()
+                .Single(component => component.Instance.Section == ConnectionEditorSection.Provider)
+                .Instance.ManagedSecretResolverError));
+        cut.FindAll(".mud-tab").Single(tab => tab.TextContent.Contains("Provider", StringComparison.Ordinal)).Click();
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Managed secret storage is not available on this Elsa server.", cut.Markup, StringComparison.Ordinal);
+            var field = cut.FindComponent<SecretBindingField>().Instance;
+            Assert.False(field.ReadOnly);
+            Assert.True(field.CanManage);
+            Assert.Equal("Managed secret storage is not available on this Elsa server.", field.ManagedSecretResolverError);
             Assert.DoesNotContain("ManagedSecretResolverError", cut.Markup, StringComparison.Ordinal);
         });
     }
@@ -233,7 +310,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             Assert.Equal(
-                ["Settings", "Provisioning", "Diagnostics"],
+                ["General", "Provider", "Provisioning", "Diagnostics"],
                 cut.FindComponents<MudTabPanel>().Select(panel => panel.Instance.Text));
             var tabs = cut.FindComponent<MudTabs>().Instance;
             Assert.True(tabs.KeepPanelsAlive);
@@ -242,35 +319,129 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             var tabPanels = cut.Find(".mud-tabs-panels");
             Assert.Contains("pa-4", tabPanels.ClassList);
             Assert.Contains("pa-sm-6", tabPanels.ClassList);
-            Assert.NotNull(tabPanels.QuerySelector(".connection-workspace__configuration"));
+            Assert.NotNull(tabPanels.QuerySelector(".connection-workspace__general"));
+            Assert.NotNull(tabPanels.QuerySelector(".connection-workspace__provider"));
             Assert.NotNull(tabPanels.QuerySelector(".connection-workspace__provisioning"));
             Assert.NotNull(tabPanels.QuerySelector(".connection-workspace__diagnostics"));
             var header = cut.Find(".connection-workspace__header");
-            Assert.Contains("Effective: Studio", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("OpenID Connect settings", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("At a glance", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Open Diagnostics", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
+            var general = cut.Find(".connection-workspace__general");
+            var provider = cut.Find(".connection-workspace__provider");
+            Assert.Contains("Effective: Database", header.TextContent, StringComparison.Ordinal);
+            Assert.Contains("Display name", general.TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("OpenID Connect settings", general.TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("Secret bindings", general.TextContent, StringComparison.Ordinal);
+            Assert.Contains("OpenID Connect settings", provider.TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("At a glance", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Effective source", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Record source", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Open Diagnostics", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("User provisioning and linking", cut.Find(".connection-workspace__provisioning").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Operations", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+            Assert.Contains("Provider connectivity", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
             Assert.Contains("Enabled", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Valid", cut.Markup, StringComparison.Ordinal);
+            var actions = cut.Find(".connection-workspace__actions");
+            Assert.Contains("pa-4", actions.ClassList);
+            Assert.Contains("pa-sm-6", actions.ClassList);
+            var actionButtons = actions.QuerySelectorAll("button");
+            Assert.Equal(["Cancel", "Save changes"], actionButtons.Select(button => button.TextContent.Trim()));
+            Assert.All(actionButtons, button =>
+            {
+                Assert.Contains("mud-button-text", button.ClassList);
+                Assert.DoesNotContain("mud-button-outlined", button.ClassList);
+                Assert.DoesNotContain("mud-button-filled", button.ClassList);
+            });
+            var saveButton = actionButtons.Single(button => button.TextContent.Contains("Save changes", StringComparison.Ordinal));
+            Assert.Contains("mud-button-text-primary", saveButton.ClassList);
+            Assert.True(saveButton.HasAttribute("disabled"));
         });
 
         cut.FindAll(".mud-tab").Single(tab => tab.TextContent.Contains("Provisioning", StringComparison.Ordinal)).Click();
         cut.WaitForAssertion(() =>
         {
-            Assert.Equal(1, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex));
+            Assert.Equal(2, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex));
             Assert.Equal(1, cut.Find(".connection-workspace__provisioning").TextContent.Split("User provisioning and linking", StringSplitOptions.None).Length - 1);
-            Assert.Contains("Review configuration", cut.Find(".connection-workspace__provisioning").TextContent, StringComparison.Ordinal);
         });
-        cut.Find(".connection-workspace__provisioning")
-            .QuerySelectorAll("button")
-            .Single(button => button.TextContent.Contains("Review configuration", StringComparison.Ordinal))
-            .Click();
-        cut.WaitForAssertion(() => Assert.Equal(0, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex)));
 
         cut.FindAll(".mud-tab").Single(tab => tab.TextContent.Contains("Diagnostics", StringComparison.Ordinal)).Click();
-        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex)));
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex)));
+    }
+
+    [Fact]
+    public void ConnectionWorkspace_UsesTheWideCanvasAndEnablesItsCompactSaveActionAfterAnEdit()
+    {
+        var connection = CreateConnection();
+        connection.AdapterSettings["authority"] = JsonSerializer.SerializeToElement("https://login.example.test");
+        _api.GetResult = connection;
+        _api.Adapters = [CreateAdapter()];
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(MaxWidth.ExtraLarge, cut.FindComponent<MudContainer>().Instance.MaxWidth);
+            var actions = cut.Find(".connection-workspace__actions");
+            Assert.Equal(2, actions.QuerySelectorAll("button").Length);
+            Assert.True(actions.QuerySelectorAll("button")
+                .Single(button => button.TextContent.Contains("Save changes", StringComparison.Ordinal))
+                .HasAttribute("disabled"));
+        });
+
+        var displayNameLabel = cut.FindAll("label").Single(element => element.TextContent.Contains("Display name", StringComparison.Ordinal));
+        cut.Find($"#{displayNameLabel.GetAttribute("for")}").Change("Updated connection");
+
+        cut.WaitForAssertion(() => Assert.False(cut.Find(".connection-workspace__actions")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Save changes", StringComparison.Ordinal))
+            .HasAttribute("disabled")));
+        cut.Find(".connection-workspace__actions")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Save changes", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() => Assert.NotNull(_api.UpdatedRequest));
+        Assert.Equal("Updated connection", _api.UpdatedRequest!.DisplayName);
+    }
+
+    [Fact]
+    public void NewConnection_KeepsDraftSecretGuidanceInsideTheProviderTask()
+    {
+        _api.Adapters = [CreateAdapter(includeSecret: true)];
+
+        var cut = Render<ConnectionEdit>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var provider = cut.Find(".connection-workspace__provider");
+            Assert.Equal(1, provider.TextContent.Split("Save the connection draft before configuring secrets.", StringSplitOptions.None).Length - 1);
+            Assert.Empty(cut.FindComponents<SecretBindingField>());
+            Assert.DoesNotContain("Secret bindings", cut.Find(".connection-workspace__general").TextContent, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ConnectionWorkspace_EnablesSaveOnlyWhenDirtyAndStructurallyValid()
+    {
+        _api.Adapters = [CreateAdapter()];
+
+        var cut = Render<ConnectionEdit>();
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find(".connection-workspace__actions")));
+
+        ChangeField("Display name", "Contoso");
+        ChangeField("Connection key", "contoso");
+        Assert.True(SaveButton().HasAttribute("disabled"));
+
+        ChangeField("Authority", "https://login.example.test");
+        cut.WaitForAssertion(() => Assert.False(SaveButton().HasAttribute("disabled")));
+
+        void ChangeField(string label, string value)
+        {
+            var fieldLabel = cut.FindAll("label").Single(element => element.TextContent.Contains(label, StringComparison.Ordinal));
+            cut.Find($"#{fieldLabel.GetAttribute("for")}").Change(value);
+        }
+
+        AngleSharp.Dom.IElement SaveButton() => cut.Find(".connection-workspace__actions")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Save changes", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -283,14 +454,18 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             Assert.Equal(
-                ["Settings", "Provisioning"],
+                ["General", "Provider", "Provisioning"],
                 cut.FindComponents<MudTabPanel>().Select(panel => panel.Instance.Text));
             var header = cut.Find(".connection-workspace__header");
             Assert.Contains("Create identity provider connection", header.TextContent, StringComparison.Ordinal);
             Assert.Contains("Draft", header.TextContent, StringComparison.Ordinal);
             Assert.DoesNotContain("Validate", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("Provider protocol", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
+            Assert.Contains("Provider protocol", cut.Find(".connection-workspace__general").TextContent, StringComparison.Ordinal);
             Assert.DoesNotContain("Diagnostics", cut.Markup, StringComparison.Ordinal);
+            Assert.NotNull(cut.Find(".connection-workspace__actions"));
+            var providerProtocol = cut.FindComponents<MudSelect<string>>()
+                .Single(field => string.Equals(field.Instance.Label, "Provider protocol", StringComparison.Ordinal));
+            AssertOutlinedDense(providerProtocol.Instance.Variant, providerProtocol.Instance.Margin);
         });
     }
 
@@ -330,13 +505,15 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            var editor = cut.FindComponent<ConnectionEditor>().Instance;
+            var editor = cut.FindComponents<ConnectionEditor>()
+                .Single(component => component.Instance.Section == ConnectionEditorSection.Provider)
+                .Instance;
             Assert.Equal("client_secret_basic", DescriptorEditorState.ToDisplayString(editor.Model.AdapterSettings["clientAuthenticationMethod"]));
             Assert.Equal("discovery", DescriptorEditorState.ToDisplayString(editor.Model.AdapterSettings["mode"]));
             Assert.False(cut.FindComponent<Microsoft.AspNetCore.Components.Routing.NavigationLock>().Instance.ConfirmExternalNavigation);
-            Assert.Contains("Discovery URL", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Client secret (basic authentication)", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Discovery", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
+            Assert.Contains("Discovery URL", cut.Find(".connection-workspace__provider").TextContent, StringComparison.Ordinal);
+            Assert.Contains("Client secret (basic authentication)", cut.Find(".connection-workspace__provider").TextContent, StringComparison.Ordinal);
+            Assert.Contains("Discovery", cut.Find(".connection-workspace__provider").TextContent, StringComparison.Ordinal);
         });
     }
 
@@ -399,7 +576,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void SavedConnection_AllowsManagedSecretConfiguration()
+    public async Task SavedConnection_AllowsManagedSecretConfiguration()
     {
         var connection = CreateConnection();
         _api.GetResult = connection;
@@ -407,6 +584,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         _api.ManagedSecretResolvers = [new ManagedSecretResolverDescriptor { Type = "elsa-secrets", DisplayName = "Elsa Secrets" }];
 
         var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
+        await cut.InvokeAsync(() => cut.FindComponent<MudTabs>().Instance.ActivatePanelAsync(1));
 
         cut.WaitForAssertion(() =>
         {
@@ -430,11 +608,12 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             var header = cut.Find(".connection-workspace__header");
             Assert.Contains("Effective: Deployment", header.TextContent, StringComparison.Ordinal);
             Assert.DoesNotContain("Validate", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("configuration-owned and read-only", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("Save changes", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Tests and previews are available under Diagnostics.", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.DoesNotContain("lifecycle actions are available", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
-            Assert.Contains("Operations", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+            Assert.Contains("deployment-owned connection is read-only", cut.Find(".connection-workspace__ownership").TextContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(cut.FindAll(".connection-workspace__actions"));
+            Assert.DoesNotContain("Save changes", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("At a glance", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Open Diagnostics", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Provider connectivity", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
             Assert.DoesNotContain("Lifecycle", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
         });
     }
@@ -468,8 +647,267 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Equal(2, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex));
+            Assert.Equal(3, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex));
             Assert.Contains("Authority could not be resolved.", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void InvalidConnection_ShowsAuthoritativeReasonsInDiagnosticsWithoutRevalidation()
+    {
+        var connection = CreateConnection();
+        connection.Validity = "invalid";
+        connection.ValidationErrors =
+        [
+            new ConnectionValidationMessage
+            {
+                Field = "adapterSettings.authority",
+                Code = "invalid",
+                Message = "Authority could not be resolved."
+            }
+        ];
+        connection.ValidationWarnings = ["Provider metadata omitted an optional capability."];
+        _api.GetResult = connection;
+        _api.Adapters = [CreateAdapter()];
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Invalid", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal);
+            var diagnostics = cut.Find(".connection-workspace__diagnostics").TextContent;
+            Assert.Contains("The current revision is invalid.", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("Authority could not be resolved.", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("Provider metadata omitted an optional capability.", diagnostics, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ValidationResponseCannotContradictAuthoritativeRevisionStatus()
+    {
+        var initial = CreateConnection();
+        initial.Validity = "unknown";
+        var invalid = CreateConnection();
+        invalid.Validity = "invalid";
+        invalid.ValidationErrors =
+        [
+            new ConnectionValidationMessage
+            {
+                Field = "adapterSettings.authority",
+                Code = "invalid",
+                Message = "Authority could not be resolved."
+            }
+        ];
+        _api.GetResults.Enqueue(initial);
+        _api.GetResults.Enqueue(invalid);
+        _api.Adapters = [CreateAdapter()];
+        _api.ValidationResult = new ConnectionValidationResult { Valid = true };
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, initial.Id));
+        cut.WaitForAssertion(() => Assert.Contains("Validate", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal));
+
+        cut.Find(".connection-workspace__header")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Validate", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Invalid", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal);
+            var diagnostics = cut.Find(".connection-workspace__diagnostics").TextContent;
+            Assert.Contains("The current revision is invalid.", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("Authority could not be resolved.", diagnostics, StringComparison.Ordinal);
+            Assert.DoesNotContain("structurally valid", diagnostics, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void MissingSecretValidation_ExplainsConnectivityAndNavigatesToProviderRepair()
+    {
+        var initial = CreateConnection();
+        initial.Validity = "unknown";
+        initial.LatestObservation = new ConnectionObservation
+        {
+            Status = "succeeded",
+            Summary = "Provider metadata was resolved."
+        };
+        var invalid = CreateConnection();
+        invalid.Validity = "invalid";
+        invalid.LatestObservation = initial.LatestObservation;
+        _api.GetResults.Enqueue(initial);
+        _api.GetResults.Enqueue(invalid);
+        _api.Adapters = [CreateAdapter(includeSecret: true)];
+        _api.ValidationResult = new ConnectionValidationResult
+        {
+            Valid = false,
+            Errors =
+            [
+                new ConnectionValidationMessage
+                {
+                    Field = "secretBindings.clientSecret",
+                    Code = "required",
+                    Message = "A required secret binding is missing."
+                }
+            ]
+        };
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, initial.Id));
+        cut.WaitForAssertion(() => Assert.Contains("Validate", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal));
+
+        cut.Find(".connection-workspace__header")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Validate", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var diagnostics = cut.Find(".connection-workspace__diagnostics").TextContent;
+            Assert.Contains("Provider connectivity", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("Configuration validation", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("Client secret", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("A required secret binding is missing.", diagnostics, StringComparison.Ordinal);
+            Assert.Contains("does not verify complete connection configuration", diagnostics, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Review secret binding", diagnostics, StringComparison.Ordinal);
+        });
+
+        cut.Find(".connection-workspace__diagnostics")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Review secret binding", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(1, cut.FindComponent<MudTabs>().Instance.GetState(component => component.ActivePanelIndex)));
+    }
+
+    [Fact]
+    public void SuccessfulValidation_RefreshesStatusAndEnablesTheConnection()
+    {
+        var initial = CreateConnection();
+        initial.Validity = "unknown";
+        var validated = CreateConnection();
+        validated.Validity = "valid";
+        _api.GetResults.Enqueue(initial);
+        _api.GetResults.Enqueue(validated);
+        _api.Adapters = [CreateAdapter()];
+        _api.ValidationResult = new ConnectionValidationResult { Valid = true };
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, initial.Id));
+        cut.WaitForAssertion(() => Assert.Contains("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal));
+        var displayNameLabel = cut.FindAll("label").Single(element => element.TextContent.Contains("Display name", StringComparison.Ordinal));
+        cut.Find($"#{displayNameLabel.GetAttribute("for")}").Change("Unsaved display name");
+
+        cut.Find(".connection-workspace__header")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Validate", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(initial.Id, _api.ValidatedConnectionId);
+            Assert.Equal([initial.Id, initial.Id], _api.GetRequests);
+            Assert.Equal("Unsaved display name", cut.FindComponent<ConnectionEditor>().Instance.Model.DisplayName);
+            Assert.DoesNotContain("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal);
+            Assert.Contains("The current revision is valid.", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+            var enable = cut.Find(".connection-workspace__diagnostics")
+                .QuerySelectorAll("button")
+                .Single(button => button.TextContent.Contains("Enable", StringComparison.Ordinal));
+            Assert.False(enable.HasAttribute("disabled"));
+        });
+    }
+
+    [Fact]
+    public void Validation_WhenStatusRefreshFails_DoesNotPresentUnverifiedSuccess()
+    {
+        var initial = CreateConnection();
+        initial.Validity = "valid";
+        _api.GetResults.Enqueue(initial);
+        _api.Adapters = [CreateAdapter()];
+        _api.ValidationResult = new ConnectionValidationResult { Valid = true };
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, initial.Id));
+        cut.WaitForAssertion(() => Assert.DoesNotContain("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal));
+
+        cut.Find(".connection-workspace__header")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Validate", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal([initial.Id, initial.Id], _api.GetRequests);
+            Assert.Contains("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("The current revision is valid.", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+            var enable = cut.Find(".connection-workspace__diagnostics")
+                .QuerySelectorAll("button")
+                .Single(button => button.TextContent.Contains("Enable", StringComparison.Ordinal));
+            Assert.True(enable.HasAttribute("disabled"));
+        });
+    }
+
+    [Fact]
+    public void ValidationOfAChangedRevision_DoesNotEnableTheConnection()
+    {
+        var initial = CreateConnection();
+        initial.Validity = "valid";
+        var changed = CreateConnection();
+        changed.Validity = "valid";
+        changed.Revision = initial.Revision + 1;
+        _api.GetResults.Enqueue(initial);
+        _api.GetResults.Enqueue(changed);
+        _api.Adapters = [CreateAdapter()];
+        _api.ValidationResult = new ConnectionValidationResult { Valid = true };
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, initial.Id));
+        cut.WaitForAssertion(() => Assert.DoesNotContain("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal));
+
+        cut.Find(".connection-workspace__header")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Contains("Validate", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal([initial.Id, initial.Id], _api.GetRequests);
+            Assert.Contains("Not validated", cut.Find(".connection-workspace__header").TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("The current revision is valid.", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal);
+            Assert.Contains(
+                "changed while it was being validated",
+                Assert.Single(Services.GetRequiredService<ISnackbar>().ShownSnackbars).Message,
+                StringComparison.Ordinal);
+            var enable = cut.Find(".connection-workspace__diagnostics")
+                .QuerySelectorAll("button")
+                .Single(button => button.TextContent.Contains("Enable", StringComparison.Ordinal));
+            Assert.True(enable.HasAttribute("disabled"));
+        });
+    }
+
+    [Fact]
+    public async Task EnableDomainConflict_ShowsItsActionableReasonInsteadOfAConcurrencyDialog()
+    {
+        var connection = CreateConnection();
+        connection.Validity = "valid";
+        connection.IsPreferred = true;
+        _api.GetResult = connection;
+        _api.Adapters = [CreateAdapter()];
+        _api.EnableException = await CreateApiExceptionAsync(
+            HttpStatusCode.Conflict,
+            """{"error":"conflict","message":"The requested connection change conflicts with current state.","details":{"code":"configuration_preferred_connection"}}""");
+
+        var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
+        cut.WaitForAssertion(() => Assert.Contains("Enable", cut.Find(".connection-workspace__diagnostics").TextContent, StringComparison.Ordinal));
+
+        cut.Find(".connection-workspace__diagnostics")
+            .QuerySelectorAll("button")
+            .Single(button => button.TextContent.Trim() == "Enable")
+            .Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Enable connection?", _dialogProvider.Markup, StringComparison.Ordinal));
+        _dialogProvider.FindAll("button").Single(button => button.TextContent.Trim() == "Enable").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("Connection changed elsewhere", _dialogProvider.Markup, StringComparison.Ordinal);
+            var snackbar = Assert.Single(Services.GetRequiredService<ISnackbar>().ShownSnackbars);
+            Assert.Contains("preferred", snackbar.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("clear", snackbar.Message, StringComparison.OrdinalIgnoreCase);
         });
     }
 
@@ -542,9 +980,9 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         _api.Adapters = [CreateAdapter(includeSecret: true)];
 
         var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
-        cut.WaitForAssertion(() => Assert.Contains("Create full Studio override", cut.Markup, StringComparison.Ordinal));
+        cut.WaitForAssertion(() => Assert.Contains("Create full Database override", cut.Markup, StringComparison.Ordinal));
 
-        cut.FindAll("button").Single(x => x.TextContent.Contains("Create full Studio override", StringComparison.Ordinal)).Click();
+        cut.FindAll("button").Single(x => x.TextContent.Contains("Create full Database override", StringComparison.Ordinal)).Click();
         Assert.True(cut.FindComponent<Microsoft.AspNetCore.Components.Routing.NavigationLock>().Instance.ConfirmExternalNavigation);
         cut.FindAll("button").Single(x => x.TextContent.Contains("Save changes", StringComparison.Ordinal)).Click();
         cut.WaitForAssertion(() => Assert.NotNull(_api.CreatedRequest));
@@ -591,16 +1029,16 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             if (expectedAction)
-                Assert.Contains("Make this Studio record effective", cut.Markup, StringComparison.Ordinal);
+                Assert.Contains("Make this Database record effective", cut.Markup, StringComparison.Ordinal);
             else
-                Assert.DoesNotContain("Make this Studio record effective", cut.Markup, StringComparison.Ordinal);
+                Assert.DoesNotContain("Make this Database record effective", cut.Markup, StringComparison.Ordinal);
         });
 
         if (!expectedAction)
             return;
 
-        cut.FindAll("button").Single(button => button.TextContent.Contains("Make this Studio record effective", StringComparison.Ordinal)).Click();
-        _dialogProvider.WaitForAssertion(() => Assert.Contains("Make this Studio record effective?", _dialogProvider.Markup, StringComparison.Ordinal));
+        cut.FindAll("button").Single(button => button.TextContent.Contains("Make this Database record effective", StringComparison.Ordinal)).Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Make this Database record effective?", _dialogProvider.Markup, StringComparison.Ordinal));
         Assert.Null(_api.UpdatedRequest);
 
         _dialogProvider.FindAll("button").Single(button => button.TextContent.Contains("Make record effective", StringComparison.Ordinal)).Click();
@@ -631,7 +1069,11 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Legacy custom editor", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Make this Studio record effective", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Make this Database record effective", cut.Markup, StringComparison.Ordinal);
+            Assert.Equal(
+                ["General", "Provisioning", "Diagnostics"],
+                cut.FindComponents<MudTabPanel>().Select(panel => panel.Instance.Text));
+            Assert.DoesNotContain("Provider", cut.FindComponents<MudTabPanel>().Select(panel => panel.Instance.Text));
         });
 
         var tabs = cut.FindComponent<MudTabs>();
@@ -664,27 +1106,20 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task Diagnostics_ShowsTheBackendManagementContractAndBuild()
+    public async Task Diagnostics_OmitsBackendBuildMetadataAndDoesNotLoadIt()
     {
         var connection = CreateConnection();
         _api.GetResult = connection;
         _api.Adapters = [CreateAdapter()];
-        _api.Runtime = new ExternalAuthenticationRuntimeDescriptor
-        {
-            ManagementContractVersion = 1,
-            ProductVersion = "3.8.0",
-            InformationalVersion = "3.8.0+abcdef"
-        };
-
         var cut = Render<ConnectionEdit>(parameters => parameters.Add(component => component.ConnectionId, connection.Id));
         var tabs = cut.FindComponent<MudTabs>();
-        await cut.InvokeAsync(() => tabs.Instance.ActivatePanelAsync(2));
+        await cut.InvokeAsync(() => tabs.Instance.ActivatePanelAsync(3));
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Management contract v1", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Backend 3.8.0", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("3.8.0+abcdef", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Management contract", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Backend test", cut.Markup, StringComparison.Ordinal);
+            Assert.Equal(0, _api.RuntimeRequests);
         });
     }
 
@@ -705,8 +1140,8 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             Assert.Contains("Effective: Deployment", header.TextContent, StringComparison.Ordinal);
             Assert.Contains("Stored: Disabled", header.TextContent, StringComparison.Ordinal);
             Assert.Contains("Stored: Not validated", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("Stored record not tested", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("Stored record validity", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("Stored record not tested", header.TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("At a glance", cut.Markup, StringComparison.Ordinal);
         });
     }
 
@@ -738,13 +1173,13 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("deployment-defined connection is shadowed by an effective Studio override", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("deployment-defined connection is read-only and shadowed by an effective Database override", cut.Markup, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("persisted record is shadowed by deployment configuration", cut.Markup, StringComparison.OrdinalIgnoreCase);
             var header = cut.Find(".connection-workspace__header");
-            Assert.Contains("Effective: Studio", header.TextContent, StringComparison.Ordinal);
+            Assert.Contains("Effective: Database", header.TextContent, StringComparison.Ordinal);
             Assert.Contains("Deployment: Enabled", header.TextContent, StringComparison.Ordinal);
             Assert.Contains("Deployment: Valid", header.TextContent, StringComparison.Ordinal);
-            Assert.Contains("Deployment record validity", cut.Find(".connection-workspace__configuration").TextContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("At a glance", cut.Markup, StringComparison.Ordinal);
         });
     }
 
@@ -799,6 +1234,10 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         Assert.Contains("Managed secret", cut.Markup, StringComparison.Ordinal);
         Assert.DoesNotContain("External binding", cut.Markup, StringComparison.Ordinal);
+        Assert.All(cut.FindComponents<MudTextField<string>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
+        Assert.All(cut.FindComponents<MudSelect<string>>(), field =>
+            AssertOutlinedDense(field.Instance.Variant, field.Instance.Margin));
         var password = cut.Find("input[type=password]");
         password.Change("top-secret-value");
         cut.FindAll("button").Single(x => x.TextContent.Contains("Replace managed secret", StringComparison.Ordinal)).Click();
@@ -1039,6 +1478,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         Assert.False(ConnectionActionAvailability.CanEnableOrDisable(database, true));
         Assert.Equal("\"17\"", ConnectionConcurrency.ToIfMatch(17));
         Assert.True(ConnectionConcurrency.IsConflict(System.Net.HttpStatusCode.PreconditionFailed));
+        Assert.False(ConnectionConcurrency.IsConflict(System.Net.HttpStatusCode.Conflict));
         var changedElsewhere = new ManagementApiException("changed", 412, CreateConnection());
         Assert.True(ConnectionConflictRecovery.TryGetCurrent(changedElsewhere, out var recovered));
         Assert.Equal("connection-1", recovered.Id);
@@ -1132,21 +1572,82 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     {
         _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [CreateConnection()], NextCursor = "cursor-2" });
         _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [new ConnectionSummary { Id = "connection-2", Key = "next", DisplayName = "Next", AdapterType = "custom" }], NextCursor = null });
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [CreateConnection()], NextCursor = "cursor-2" });
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [new ConnectionSummary { Id = "connection-2", Key = "next", DisplayName = "Next", AdapterType = "custom" }], NextCursor = null });
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [CreateConnection()], NextCursor = "cursor-2" });
 
         var cut = Render<ConnectionIndex>();
         cut.WaitForAssertion(() => Assert.Contains("Contoso", cut.Markup));
-        Assert.Contains("Page 1", cut.Markup, StringComparison.Ordinal);
-        var previousPage = cut.FindAll("button").Single(button => button.TextContent.Contains("Previous page", StringComparison.Ordinal));
+        var pager = cut.Find(".mud-table-pagination");
+        Assert.Contains("Rows Per Page", pager.TextContent, StringComparison.Ordinal);
+        Assert.Contains("Page 1", pager.TextContent, StringComparison.Ordinal);
+        var firstPage = pager.QuerySelector("button[aria-label=\"First page\"]")!;
+        var previousPage = pager.QuerySelector("button[aria-label=\"Previous page\"]")!;
+        var nextPage = pager.QuerySelector("button[aria-label=\"Next page\"]")!;
+        Assert.True(firstPage.HasAttribute("disabled"));
         Assert.True(previousPage.HasAttribute("disabled"));
-        cut.FindAll("button").Single(button => button.TextContent.Contains("Next page", StringComparison.Ordinal)).Click();
+        Assert.False(nextPage.HasAttribute("disabled"));
+        nextPage.Click();
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Next", cut.Markup);
-            Assert.Contains("Page 2", cut.Markup, StringComparison.Ordinal);
-            Assert.False(cut.FindAll("button").Single(button => button.TextContent.Contains("Previous page", StringComparison.Ordinal)).HasAttribute("disabled"));
+            var nextPager = cut.Find(".mud-table-pagination");
+            Assert.Contains("Page 2", nextPager.TextContent, StringComparison.Ordinal);
+            Assert.False(nextPager.QuerySelector("button[aria-label=\"First page\"]")!.HasAttribute("disabled"));
+            Assert.False(nextPager.QuerySelector("button[aria-label=\"Previous page\"]")!.HasAttribute("disabled"));
+            Assert.True(nextPager.QuerySelector("button[aria-label=\"Next page\"]")!.HasAttribute("disabled"));
+            Assert.Null(nextPager.QuerySelector("button[aria-label=\"Last page\"]"));
         });
 
-        Assert.Equal([null, "cursor-2"], _api.Cursors);
+        cut.Find("button[aria-label=\"Previous page\"]").Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Contoso", cut.Markup, StringComparison.Ordinal);
+            var previousPager = cut.Find(".mud-table-pagination");
+            Assert.Contains("Page 1", previousPager.TextContent, StringComparison.Ordinal);
+            Assert.True(previousPager.QuerySelector("button[aria-label=\"Previous page\"]")!.HasAttribute("disabled"));
+        });
+
+        cut.Find("button[aria-label=\"Next page\"]").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Page 2", cut.Find(".mud-table-pagination").TextContent, StringComparison.Ordinal));
+        cut.Find("button[aria-label=\"First page\"]").Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Contoso", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Page 1", cut.Find(".mud-table-pagination").TextContent, StringComparison.Ordinal);
+        });
+
+        Assert.Equal([null, "cursor-2", null, "cursor-2", null], _api.Cursors);
+    }
+
+    [Fact]
+    public async Task ConnectionList_ChangingPageSizeResetsTheCursorChain()
+    {
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [CreateConnection()], NextCursor = "cursor-2" });
+        _api.ListResults.Enqueue(new ListConnectionsResponse
+        {
+            Items = [new ConnectionSummary { Id = "connection-2", Key = "next", DisplayName = "Next", AdapterType = "custom" }],
+            NextCursor = "cursor-3"
+        });
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [CreateConnection()], NextCursor = null });
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains("Contoso", cut.Markup, StringComparison.Ordinal));
+        cut.Find("button[aria-label=\"Next page\"]").Click();
+        cut.WaitForAssertion(() => Assert.Contains("Next", cut.Markup, StringComparison.Ordinal));
+
+        var pageSize = cut.FindComponent<MudSelect<int>>().Instance;
+        Assert.Equal([10, 25, 50, 100], cut.FindComponents<MudSelectItem<int>>().Select(item => item.Instance.Value));
+        await cut.InvokeAsync(() => pageSize.ValueChanged.InvokeAsync(25));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Contoso", cut.Markup, StringComparison.Ordinal);
+            Assert.True(cut.Find("button[aria-label=\"First page\"]").HasAttribute("disabled"));
+            Assert.Equal(
+                [(null, 10), ("cursor-2", 10), (null, 25)],
+                _api.ListRequests.Select(request => (request.Cursor, request.PageSize)));
+        });
     }
 
     [Fact]
@@ -1158,6 +1659,14 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         connection.Validity = "valid";
         connection.OverridesConfigurationConnection = true;
         connection.IsPreferred = true;
+        _api.Adapters =
+        [
+            new AdapterDescriptor
+            {
+                Type = connection.AdapterType,
+                Capabilities = new AdapterCapabilities { SupportsTest = true, SupportsPreview = true }
+            }
+        ];
         _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
 
         var cut = Render<ConnectionIndex>();
@@ -1169,7 +1678,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             Assert.Contains("Include archived", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Ownership", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Availability", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("Studio", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Database", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Overrides deployment", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Available", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Enabled · Valid", cut.Markup, StringComparison.Ordinal);
@@ -1186,8 +1695,112 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         _popoverProvider.WaitForAssertion(() =>
         {
             Assert.Contains("Manage", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.Contains("Test connection", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.Contains("Preview sign-in", _popoverProvider.Markup, StringComparison.Ordinal);
             Assert.Contains("Disable", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.Contains("Archive", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.Equal(2, _popoverProvider.FindAll(".mud-divider").Count);
         });
+    }
+
+    [Fact]
+    public void ConnectionList_NamesAndLinksBothSidesOfAShadowRelationship()
+    {
+        var deployment = CreateConnection("configuration");
+        deployment.Id = "deployment-keycloak";
+        deployment.DisplayName = "Keycloak General";
+        deployment.Shadowed = true;
+        deployment.ShadowedBy = new ConnectionReference
+        {
+            Id = "database-keycloak",
+            DisplayName = "Keycloak",
+            Source = "database"
+        };
+        var database = CreateConnection();
+        database.Id = "database-keycloak";
+        database.DisplayName = "Keycloak";
+        database.OverridesConfigurationConnection = true;
+        database.Shadows =
+        [
+            new ConnectionReference
+            {
+                Id = deployment.Id,
+                DisplayName = deployment.DisplayName,
+                Source = "configuration"
+            }
+        ];
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [database, deployment] });
+
+        var cut = Render<ConnectionIndex>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Shadowed by", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Overrides", cut.Markup, StringComparison.Ordinal);
+            var shadowingLink = cut.Find("a[aria-label=\"Manage shadowing connection Keycloak\"]");
+            Assert.EndsWith(
+                "security/external-authentication/connections/database-keycloak",
+                shadowingLink.GetAttribute("href"),
+                StringComparison.Ordinal);
+            var shadowedLink = cut.Find("a[aria-label=\"Manage shadowed connection Keycloak General\"]");
+            Assert.Contains("Overrides Keycloak General", shadowedLink.ParentElement!.ParentElement!.TextContent, StringComparison.Ordinal);
+            Assert.EndsWith(
+                "security/external-authentication/connections/deployment-keycloak",
+                shadowedLink.GetAttribute("href"),
+                StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_DoesNotPresentAnActiveShadowRelationshipWhenTheServerOmitsIt()
+    {
+        var deployment = CreateConnection("configuration");
+        deployment.Id = "deployment-keycloak";
+        deployment.DisplayName = "Keycloak General";
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [deployment] });
+
+        var cut = Render<ConnectionIndex>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(deployment.DisplayName, cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Shadows", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Shadowed by", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_ClickingARowOpensTheManageScreen()
+    {
+        var connection = CreateConnection();
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        var manageLink = cut.Find($"a[aria-label=\"Manage {connection.DisplayName}\"]");
+        Assert.Equal($"security/external-authentication/connections/{connection.Id}", manageLink.GetAttribute("href"));
+        cut.Find("tbody tr").Click();
+
+        Assert.EndsWith(
+            $"/security/external-authentication/connections/{connection.Id}",
+            Services.GetRequiredService<NavigationManager>().Uri,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConnectionList_ActionsMenuDoesNotTriggerTheRowAction()
+    {
+        var connection = CreateConnection();
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        var initialUri = navigation.Uri;
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+
+        _popoverProvider.WaitForAssertion(() => Assert.Contains("Manage", _popoverProvider.Markup, StringComparison.Ordinal));
+        Assert.Equal(initialUri, navigation.Uri);
     }
 
     [Fact]
@@ -1228,11 +1841,182 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         });
     }
 
+    [Fact]
+    public void ConnectionList_TestConnectionRecordsTheObservationAndShowsTheRedactedSuccessMessage()
+    {
+        var connection = CreateConnection();
+        _api.Adapters =
+        [
+            new AdapterDescriptor
+            {
+                Type = connection.AdapterType,
+                Capabilities = new AdapterCapabilities { SupportsTest = true }
+            }
+        ];
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+        _popoverProvider.WaitForElements(".mud-menu-item")
+            .Single(item => item.TextContent.Contains("Test connection", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(connection.Id, _operations.TestedConnectionId);
+            Assert.Equal("\"7\"", _operations.TestedIfMatch);
+            Assert.Contains("Provider metadata was resolved.", cut.Markup, StringComparison.Ordinal);
+            Assert.Equal(
+                "Connection test completed. The result contains only redacted diagnostics.",
+                Assert.Single(Services.GetRequiredService<ISnackbar>().ShownSnackbars).Message);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_FailedTestUsesTheSameRedactedOperationalMessageAsTheDiagnosticsPage()
+    {
+        var connection = CreateConnection();
+        _api.Adapters =
+        [
+            new AdapterDescriptor
+            {
+                Type = connection.AdapterType,
+                Capabilities = new AdapterCapabilities { SupportsTest = true }
+            }
+        ];
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+        _operations.TestException = new InvalidOperationException("provider-access-token");
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+        _popoverProvider.WaitForElements(".mud-menu-item")
+            .Single(item => item.TextContent.Contains("Test connection", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var message = Assert.Single(Services.GetRequiredService<ISnackbar>().ShownSnackbars).Message;
+            Assert.Equal(ConnectionOperationActions.TestFailedMessage, message);
+            Assert.DoesNotContain("provider-access-token", message, StringComparison.Ordinal);
+            Assert.Contains("Not tested", cut.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_ArchiveRequiresConfirmationAndReloadsTheList()
+    {
+        var connection = CreateConnection();
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+        _api.ListResults.Enqueue(new ListConnectionsResponse());
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+        _popoverProvider.WaitForElements(".mud-menu-item")
+            .Single(item => item.TextContent.Contains("Archive", StringComparison.Ordinal))
+            .Click();
+        _dialogProvider.WaitForAssertion(() =>
+            Assert.Contains("preserves its identity links", _dialogProvider.Markup, StringComparison.Ordinal));
+        _dialogProvider.FindAll("button")
+            .Single(button => button.TextContent.Trim() == "Archive")
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(connection.Id, _api.ArchivedConnectionId);
+            Assert.Equal("\"7\"", _api.ArchivedIfMatch);
+            Assert.Equal(2, _api.ListRequests.Count);
+            Assert.DoesNotContain(connection.DisplayName, cut.Markup, StringComparison.Ordinal);
+            Assert.Equal(
+                "Connection archived.",
+                Assert.Single(Services.GetRequiredService<ISnackbar>().ShownSnackbars).Message);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_PreviewSignInPreservesTheOneTimeResultFlowInADialog()
+    {
+        var connection = CreateConnection();
+        _api.Adapters =
+        [
+            new AdapterDescriptor
+            {
+                Type = connection.AdapterType,
+                Capabilities = new AdapterCapabilities { SupportsPreview = true }
+            }
+        ];
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+        _popoverProvider.WaitForElements(".mud-menu-item")
+            .Single(item => item.TextContent.Contains("Preview sign-in", StringComparison.Ordinal))
+            .Click();
+
+        _dialogProvider.WaitForAssertion(() =>
+        {
+            Assert.Equal(connection.Id, _operations.PreviewedConnectionId);
+            Assert.Equal("\"7\"", _operations.PreviewedIfMatch);
+            Assert.Contains("Open preview sign-in", _dialogProvider.Markup, StringComparison.Ordinal);
+            Assert.Contains(
+                "https://elsa.example.test/external-authentication/previews/preview-handle/authorize",
+                _dialogProvider.Markup,
+                StringComparison.Ordinal);
+        });
+
+        _dialogProvider.FindAll("button")
+            .Single(button => button.TextContent.Contains("Get one-time preview result", StringComparison.Ordinal))
+            .Click();
+        _dialogProvider.WaitForAssertion(() =>
+        {
+            Assert.Equal("preview-handle", _operations.PreviewHandle);
+            Assert.Contains("https://issuer.example.test", _dialogProvider.Markup, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ConnectionList_HidesUnavailableActionsWithoutLeavingEmptyDividers()
+    {
+        _permissions.AllowedPermissions = new HashSet<string>([ExternalAuthenticationPermissions.Read], StringComparer.Ordinal);
+        var connection = CreateConnection();
+        connection.Validity = "valid";
+        _api.Adapters =
+        [
+            new AdapterDescriptor
+            {
+                Type = connection.AdapterType,
+                Capabilities = new AdapterCapabilities { SupportsTest = true, SupportsPreview = true }
+            }
+        ];
+        _api.ListResults.Enqueue(new ListConnectionsResponse { Items = [connection] });
+
+        var cut = Render<ConnectionIndex>();
+        cut.WaitForAssertion(() => Assert.Contains(connection.DisplayName, cut.Markup, StringComparison.Ordinal));
+
+        cut.Find($"button[aria-label=\"Actions for {connection.DisplayName}\"]").Click();
+        _popoverProvider.WaitForAssertion(() =>
+        {
+            Assert.Contains("Manage", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Test connection", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Preview sign-in", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Enable", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Archive", _popoverProvider.Markup, StringComparison.Ordinal);
+            Assert.Empty(_popoverProvider.FindAll(".mud-divider"));
+        });
+    }
+
     [Theory]
-    [InlineData("database", false, true, "Studio", "Overrides deployment")]
-    [InlineData("configuration", true, false, "Deployment", "Shadowed by Studio")]
-    [InlineData("database", true, false, "Studio", "Shadowed by deployment")]
-    [InlineData("database", false, false, "Studio", null)]
+    [InlineData("database", false, true, "Database", "Overrides deployment")]
+    [InlineData("configuration", true, false, "Deployment", "Shadowed by Database")]
+    [InlineData("database", true, false, "Database", "Shadowed by deployment")]
+    [InlineData("database", false, false, "Database", null)]
     public void ConnectionListPresentation_DescribesOwnershipRelationships(
         string source,
         bool shadowed,
@@ -1246,6 +2030,21 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         Assert.Equal(expectedOwnership, ConnectionListPresentation.OwnershipLabel(connection));
         Assert.Equal(expectedRelationship, ConnectionListPresentation.OwnershipRelationship(connection));
+    }
+
+    [Fact]
+    public void ConnectionListPresentation_RejectsIncompleteAndSelfReferentialRelationshipMetadata()
+    {
+        var connection = CreateConnection();
+        connection.ShadowedBy = new ConnectionReference { Id = connection.Id, DisplayName = "Self" };
+        connection.Shadows =
+        [
+            new ConnectionReference { Id = "missing-name" },
+            new ConnectionReference { Id = "deployment", DisplayName = "Deployment connection" }
+        ];
+
+        Assert.Null(ConnectionListPresentation.GetShadowingConnection(connection));
+        Assert.Equal("deployment", Assert.Single(ConnectionListPresentation.GetShadowedConnections(connection)).Id);
     }
 
     [Theory]
@@ -1319,15 +2118,16 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         var cut = Render<ConnectionIndex>();
         cut.WaitForAssertion(() => Assert.Single(_api.ListRequests));
-        cut.FindAll("button").Single(button => button.TextContent.Contains("Next page", StringComparison.Ordinal)).Click();
+        cut.Find("button[aria-label=\"Next page\"]").Click();
         cut.WaitForAssertion(() => Assert.Equal(2, _api.ListRequests.Count));
-        Assert.Contains("Page 2", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Page 2", cut.Find(".mud-table-pagination").TextContent, StringComparison.Ordinal);
 
         var source = cut.FindComponent<MudSelect<string>>().Instance;
         await cut.InvokeAsync(() => source.ValueChanged.InvokeAsync("database"));
         cut.WaitForAssertion(() => Assert.Equal("database", _api.ListRequests[2].Source));
         Assert.Null(_api.ListRequests[2].Cursor);
-        Assert.Contains("Page 1", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("Page 1", cut.Find(".mud-table-pagination").TextContent, StringComparison.Ordinal);
+        Assert.True(cut.Find("button[aria-label=\"First page\"]").HasAttribute("disabled"));
 
         var includeArchived = cut.FindComponent<MudCheckBox<bool>>().Instance;
         await cut.InvokeAsync(() => includeArchived.ValueChanged.InvokeAsync(true));
@@ -1355,11 +2155,11 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Studio", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Database", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Shadowed by deployment", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Shadowed", cut.Markup, StringComparison.Ordinal);
             Assert.Contains("Stored: Enabled · Valid", cut.Markup, StringComparison.Ordinal);
-            Assert.Contains("create or promote a Studio record", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("create or promote a Database record", cut.Markup, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("can only be changed through deployment configuration", cut.Markup, StringComparison.OrdinalIgnoreCase);
         });
     }
@@ -1389,11 +2189,11 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Contains("Manage existing Studio record", cut.Markup, StringComparison.Ordinal);
-            Assert.DoesNotContain("Create full Studio override", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("Manage existing Database record", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Create full Database override", cut.Markup, StringComparison.Ordinal);
         });
 
-        cut.FindAll("button").Single(button => button.TextContent.Contains("Manage existing Studio record", StringComparison.Ordinal)).Click();
+        cut.FindAll("button").Single(button => button.TextContent.Contains("Manage existing Database record", StringComparison.Ordinal)).Click();
         Assert.EndsWith("/security/external-authentication/connections/stored-override", Services.GetRequiredService<NavigationManager>().Uri, StringComparison.Ordinal);
     }
 
@@ -1427,9 +2227,9 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             Assert.Null(_api.ListRequests.Single().Archived);
-            Assert.Contains("archived Studio record already exists", cut.Markup, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("Review and restore Studio record", cut.Markup, StringComparison.Ordinal);
-            Assert.DoesNotContain("Create full Studio override", cut.Markup, StringComparison.Ordinal);
+            Assert.Contains("archived Database record already exists", cut.Markup, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Review and restore Database record", cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain("Create full Database override", cut.Markup, StringComparison.Ordinal);
         });
     }
 
@@ -1476,7 +2276,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     {
         var menu = new ExternalAuthenticationSecurityMenuContributor(
             new FeatureProvider(true),
-            new PermissionSetService(ExternalAuthenticationPermissions.Read));
+            new PermissionService(ExternalAuthenticationPermissions.Read));
 
         var item = Assert.Single(await menu.GetMenuItemsAsync());
         Assert.Equal("security/external-authentication", item.Href);
@@ -1492,7 +2292,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     {
         var menu = new ExternalAuthenticationSecurityMenuContributor(
             new FeatureProvider(true),
-            new PermissionSetService(
+            new PermissionService(
                 ExternalAuthenticationPermissions.Read,
                 ExternalAuthenticationPermissions.ManageLinks,
                 ExternalAuthenticationPermissions.SessionsRead));
@@ -1505,7 +2305,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
 
         var sessionsOnly = await new ExternalAuthenticationSecurityMenuContributor(
                 new FeatureProvider(true),
-                new PermissionSetService(ExternalAuthenticationPermissions.SessionsRead))
+                new PermissionService(ExternalAuthenticationPermissions.SessionsRead))
             .GetMenuItemsAsync();
         Assert.Equal("Authentication sessions", Assert.Single(sessionsOnly).Text);
     }
@@ -1543,6 +2343,25 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         return await Refit.ApiException.Create(request, HttpMethod.Post, response, new Refit.RefitSettings());
     }
 
+    private (IRenderedComponent<DescriptorField> Component, Dictionary<string, JsonElement> Settings) RenderTagsArrayField()
+    {
+        var settings = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["scopes"] = JsonSerializer.SerializeToElement(Array.Empty<string>())
+        };
+        var component = Render<DescriptorField>(parameters => parameters
+            .Add(field => field.Field, new ConnectionFieldDescriptor
+            {
+                Name = "scopes",
+                DisplayName = "Scopes",
+                ValueType = "string-array",
+                UiHint = "tags"
+            })
+            .Add(field => field.Settings, settings));
+
+        return (component, settings);
+    }
+
     private static ConnectionDetail CreateConnection(string source = "database") => new()
     {
         Id = "connection-1",
@@ -1577,30 +2396,38 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         DisplayName = "Contoso"
     };
 
+    private static void AssertOutlinedDense(Variant variant, Margin margin)
+    {
+        Assert.Equal(Variant.Outlined, variant);
+        Assert.Equal(Margin.Dense, margin);
+    }
+
     private sealed class FeatureProvider(bool enabled) : IRemoteFeatureProvider
     {
         public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default) => Task.FromResult(enabled && featureName == Feature.RemoteFeatureName);
         public Task<IEnumerable<FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<FeatureDescriptor>>([]);
     }
 
-    private sealed class PermissionService(bool allowed) : IExternalAuthenticationPermissionService
+    private sealed class PermissionService : IExternalAuthenticationPermissionService
     {
-        public bool Allowed { get; set; } = allowed;
+        public PermissionService(bool allowed) => Allowed = allowed;
 
-        public ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default) => ValueTask.FromResult(Allowed);
-        public ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult<IReadOnlySet<string>>(Allowed ? new HashSet<string>(["*"], StringComparer.Ordinal) : new HashSet<string>(StringComparer.Ordinal));
-    }
+        public PermissionService(params string[] permissions)
+        {
+            Allowed = true;
+            AllowedPermissions = permissions.ToHashSet(StringComparer.Ordinal);
+        }
 
-    private sealed class PermissionSetService(params string[] permissions) : IExternalAuthenticationPermissionService
-    {
-        private readonly IReadOnlySet<string> _permissions = permissions.ToHashSet(StringComparer.Ordinal);
+        public bool Allowed { get; set; }
+        public IReadOnlySet<string>? AllowedPermissions { get; set; }
 
         public ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult(_permissions.Contains(permission));
-
+            ValueTask.FromResult(Allowed && (AllowedPermissions is null || AllowedPermissions.Contains(permission)));
         public ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult(_permissions);
+            ValueTask.FromResult<IReadOnlySet<string>>(
+                Allowed
+                    ? AllowedPermissions ?? new HashSet<string>(["*"], StringComparer.Ordinal)
+                    : new HashSet<string>(StringComparer.Ordinal));
     }
 
     private sealed class CustomEditorRegistration(string key, int contractVersion, Type componentType) : ICustomConnectionEditorRegistration
@@ -1673,6 +2500,12 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     private sealed class TestOperationsApi : IExternalAuthenticationOperationsApi
     {
         public bool? RevokeActiveSessions { get; private set; }
+        public string? TestedConnectionId { get; private set; }
+        public string? TestedIfMatch { get; private set; }
+        public string? PreviewedConnectionId { get; private set; }
+        public string? PreviewedIfMatch { get; private set; }
+        public string? PreviewHandle { get; private set; }
+        public Exception? TestException { get; set; }
 
         public Task DisableWithRecoveryOverrideAsync(
             string connectionId,
@@ -1685,9 +2518,40 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             return Task.CompletedTask;
         }
 
-        public Task<ConnectionTestResult> TestAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task<PreviewInitiation> InitiatePreviewAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task<PreviewResultDocument> GetPreviewResultAsync(string previewHandle, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ConnectionTestResult> TestAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default)
+        {
+            TestedConnectionId = connectionId;
+            TestedIfMatch = ifMatch;
+            if (TestException is not null)
+                throw TestException;
+            return Task.FromResult(new ConnectionTestResult
+            {
+                Status = "succeeded",
+                Summary = "Provider metadata was resolved.",
+                TestedMaterialRevision = "material-7"
+            });
+        }
+        public Task<PreviewInitiation> InitiatePreviewAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default)
+        {
+            PreviewedConnectionId = connectionId;
+            PreviewedIfMatch = ifMatch;
+            return Task.FromResult(new PreviewInitiation
+            {
+                NavigationUrl = "/external-authentication/previews/preview-handle/authorize",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+            });
+        }
+
+        public Task<PreviewResultDocument> GetPreviewResultAsync(string previewHandle, CancellationToken cancellationToken = default)
+        {
+            PreviewHandle = previewHandle;
+            return Task.FromResult(new PreviewResultDocument
+            {
+                Issuer = "https://issuer.example.test",
+                MaskedSubject = "sub•••123",
+                PolicyDecision = "would-link"
+            });
+        }
         public Task<ListExternalAuthenticationSessionsResponse> ListSessionsAsync(string? userId = null, string? connectionId = null, string? status = null, string? cursor = null, int pageSize = 25, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task RevokeSessionAsync(string sessionId, RevokeExternalAuthenticationSessionRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
@@ -1696,6 +2560,8 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
     {
         public Queue<ListConnectionsResponse> ListResults { get; } = new();
         public Queue<Task<ListConnectionsResponse>> PendingListResults { get; } = new();
+        public Queue<ConnectionDetail> GetResults { get; } = new();
+        public List<string> GetRequests { get; } = [];
         public List<ListRequest> ListRequests { get; } = [];
         public List<string?> Cursors { get; } = [];
         public ConnectionDetail? GetResult { get; set; }
@@ -1710,28 +2576,40 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
         public ICollection<IdentityRoleOption> Roles { get; set; } = [];
         public ICollection<ManagedSecretResolverDescriptor> ManagedSecretResolvers { get; set; } =
             [new() { Type = "elsa-secrets", DisplayName = "Elsa Secrets" }];
+        public int RuntimeRequests { get; private set; }
         public ConnectionValidationResult ValidationResult { get; set; } = new() { Valid = true };
         public Exception? CreateException { get; set; }
         public ConnectionMutation? CreatedRequest { get; private set; }
         public string? UpdatedConnectionId { get; private set; }
         public ConnectionMutation? UpdatedRequest { get; private set; }
         public string? UpdatedIfMatch { get; private set; }
+        public string? ArchivedConnectionId { get; private set; }
+        public string? ArchivedIfMatch { get; private set; }
+        public string? ValidatedConnectionId { get; private set; }
+        public Exception? EnableException { get; set; }
 
         public Task<ListConnectionsResponse> ListAsync(string? search = null, string? source = null, string? scope = null, string? adapterType = null, bool? enabled = null, bool? valid = null, bool? shadowed = null, bool? archived = null, string? cursor = null, int pageSize = 25, CancellationToken cancellationToken = default)
         {
             Cursors.Add(cursor);
-            ListRequests.Add(new ListRequest(search, source, archived, cursor));
+            ListRequests.Add(new ListRequest(search, source, archived, cursor, pageSize));
             if (PendingListResults.TryDequeue(out var pending))
                 return pending;
 
             return Task.FromResult(ListResults.Dequeue());
         }
 
-        public sealed record ListRequest(string? Search, string? Source, bool? Archived, string? Cursor);
+        public sealed record ListRequest(string? Search, string? Source, bool? Archived, string? Cursor, int PageSize);
 
-        public Task<ConnectionDetail> GetAsync(string connectionId, CancellationToken cancellationToken = default) => Task.FromResult(GetResult ?? throw new NotSupportedException());
-        public Task<ExternalAuthenticationRuntimeDescriptor> GetRuntimeAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(Runtime ?? throw new NotSupportedException());
+        public Task<ConnectionDetail> GetAsync(string connectionId, CancellationToken cancellationToken = default)
+        {
+            GetRequests.Add(connectionId);
+            return Task.FromResult(GetResults.TryDequeue(out var result) ? result : GetResult ?? throw new NotSupportedException());
+        }
+        public Task<ExternalAuthenticationRuntimeDescriptor> GetRuntimeAsync(CancellationToken cancellationToken = default)
+        {
+            RuntimeRequests++;
+            return Task.FromResult(Runtime ?? throw new NotSupportedException());
+        }
         public Task<ICollection<AdapterDescriptor>> GetAdaptersAsync(CancellationToken cancellationToken = default) => Task.FromResult(Adapters);
         public Task<ICollection<PermissionGrantSourceDescriptor>> GetPermissionSourcesAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<ICollection<UnlinkedIdentityPolicyDescriptor>> GetPoliciesAsync(CancellationToken cancellationToken = default) => Task.FromResult(Policies);
@@ -1758,11 +2636,21 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             GetResult.Shadowed = false;
             return Task.FromResult(GetResult);
         }
-        public Task EnableAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task EnableAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) =>
+            EnableException is null ? Task.CompletedTask : Task.FromException(EnableException);
         public Task DisableAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task ArchiveAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task ArchiveAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default)
+        {
+            ArchivedConnectionId = connectionId;
+            ArchivedIfMatch = ifMatch;
+            return Task.CompletedTask;
+        }
         public Task RestoreAsync(string connectionId, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task<ConnectionValidationResult> ValidateAsync(string connectionId, CancellationToken cancellationToken = default) => Task.FromResult(ValidationResult);
+        public Task<ConnectionValidationResult> ValidateAsync(string connectionId, CancellationToken cancellationToken = default)
+        {
+            ValidatedConnectionId = connectionId;
+            return Task.FromResult(ValidationResult);
+        }
         public Task<ConnectionDetail> ReplaceManagedSecretAsync(string connectionId, string fieldName, ManagedSecretMutation request, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task RemoveSecretBindingAsync(string connectionId, string fieldName, string ifMatch, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         Task<IdentityRoleOptionsResponse> IIdentityRolesApi.ListAsync(CancellationToken cancellationToken) =>

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionEditorTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/ConnectionEditorTests.cs
@@ -2279,7 +2279,7 @@ public sealed class ConnectionEditorTests : BunitContext, IAsyncLifetime
             new PermissionService(ExternalAuthenticationPermissions.Read));
 
         var item = Assert.Single(await menu.GetMenuItemsAsync());
-        Assert.Equal("security/external-authentication", item.Href);
+        Assert.Equal("security/external-authentication/connections", item.Href);
         Assert.Equal("Identity provider connections", item.Text);
         Assert.Equal(100, item.Order);
 

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/CursorTablePagerTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Connections/CursorTablePagerTests.cs
@@ -1,0 +1,34 @@
+using Bunit;
+using Elsa.Studio.ExternalAuthentication.Components.Pagination;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.ExternalAuthentication.Tests.Connections;
+
+public sealed class CursorTablePagerTests : BunitContext, IAsyncLifetime
+{
+    public CursorTablePagerTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        JSInterop.Setup<int>("mudpopoverHelper.countProviders").SetResult(1);
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void PageSizeSelect_IsGroupedInMudBlazorsNonGrowingPaginationDisplay()
+    {
+        var cut = Render<CursorTablePager>();
+
+        var display = cut.Find(".mud-table-pagination-display");
+        var pageSizeSelect = display.QuerySelector(".mud-table-pagination-select");
+
+        Assert.NotNull(pageSizeSelect);
+    }
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Links/ExternalIdentityLinksTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Links/ExternalIdentityLinksTests.cs
@@ -338,7 +338,7 @@ public sealed class ExternalIdentityLinksTests : BunitContext, IAsyncLifetime
 
         var item = Assert.Single(await menu.GetMenuItemsAsync());
 
-        Assert.Equal("security/external-authentication", item.Href);
+        Assert.Equal("security/external-authentication/connections", item.Href);
         Assert.Equal("Identity provider connections", item.Text);
     }
 

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionEditor.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionEditor.razor
@@ -2,107 +2,68 @@
 
 <MudForm @ref="_form">
     <MudStack Spacing="3">
-        <MudAlert Severity="Severity.Info" Dense="true">
-            Upstream Client Registration settings belong to this provider connection. Elsa Authentication Client settings remain deployment-owned and are not editable here.
-        </MudAlert>
-        @if (Connection.IsConfigurationOwned)
+        @if (ShowContext)
         {
-            <MudAlert Severity="Severity.Warning" Dense="true">
-                This connection is configuration-owned and read-only in Studio.
-                @if (CanCreateOverride)
-                {
-                    <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="@(() => FullOverrideRequested.InvokeAsync())">
-                        Create full Studio override
-                    </MudButton>
-                }
-                else if (!HasExistingStudioOverride)
-                {
-                    <div>A Studio override is unavailable because deployment policy or your permissions do not allow it.</div>
-                }
-                else
-                {
-                    <div>@(ExistingStudioOverrideArchived
-                        ? "An archived Studio record already exists for this connection."
-                        : "A Studio record already exists for this connection.")</div>
-                    <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="@(() => ExistingStudioOverrideRequested.InvokeAsync())">
-                        @(ExistingStudioOverrideArchived ? "Review and restore Studio record" : "Manage existing Studio record")
-                    </MudButton>
-                }
+            <MudAlert Severity="Severity.Info" Dense="true">
+                Upstream Client Registration settings belong to this provider connection. Elsa Authentication Client settings remain deployment-owned and are not editable here.
             </MudAlert>
-        }
-        <MudTextField T="string" Value="@Model.DisplayName" ValueChanged="SetDisplayNameAsync" Label="Display name" Required="true" ReadOnly="@ReadOnly" />
-        <MudTextField T="string" Value="@Model.Key" ValueChanged="SetKeyAsync" Label="Connection key" Required="true" ReadOnly="@(ReadOnly || !string.IsNullOrWhiteSpace(Connection.Id))" HelperText="Immutable after creation." />
-        @if (!string.IsNullOrWhiteSpace(Connection.CallbackUri))
-        {
-            <MudTextField Value="@Connection.CallbackUri"
-                          Label="Provider callback URI"
-                          ReadOnly="true"
-                          HelperText="Derived by Elsa from deployment configuration. Register this exact URI with the identity provider." />
-        }
-        @if (!string.IsNullOrWhiteSpace(Connection.PreviewCallbackUri))
-        {
-            <MudTextField Value="@Connection.PreviewCallbackUri"
-                          Label="Provider preview callback URI"
-                          ReadOnly="true"
-                          HelperText="Register this exact URI with the identity provider to enable administrator previews." />
-        }
-        <MudNumericField T="int" Value="@Model.Order" ValueChanged="SetOrderAsync" Label="Display order" ReadOnly="@ReadOnly" />
-        <MudCheckBox T="bool" Value="@Model.IsPreferred" ValueChanged="SetPreferredAsync" Label="Mark as the preferred sign-in method" Disabled="@ReadOnly" />
-        <MudSelect T="string" Value="@Model.UpstreamLogoutMode" ValueChanged="SetUpstreamLogoutModeAsync" Label="Upstream sign-out" Disabled="@ReadOnly">
-            <MudSelectItem T="string" Value="@("disabled")">Disabled</MudSelectItem>
-            <MudSelectItem T="string" Value="@("userChoice")">Let the user choose</MudSelectItem>
-            <MudSelectItem T="string" Value="@("always")">Always sign out upstream</MudSelectItem>
-        </MudSelect>
-
-        <MudDivider />
-        <MudText Typo="Typo.h6">@Adapter.DisplayName settings</MudText>
-        @foreach (var field in Adapter.Fields.Where(field => !field.IsSecretBinding && DescriptorEditorState.IsVisible(field, Model.AdapterSettings)))
-        {
-            <DescriptorField Field="field" Settings="Model.AdapterSettings" ReadOnly="@ReadOnly" Changed="@OnAdapterSettingsChangedAsync" />
-            @if (DescriptorEditorState.IsUnsafeSettingActive(field, Model.AdapterSettings))
+            @if (Connection.IsConfigurationOwned)
             {
-                <MudAlert Severity="Severity.Warning" Dense="true">This provider trust setting can weaken authentication safety. It requires explicit confirmation and the provider-trust permission.</MudAlert>
+                <MudAlert Severity="Severity.Warning" Dense="true">
+                    This connection is configuration-owned and read-only in Elsa Studio.
+                    @if (CanCreateOverride)
+                    {
+                        <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="@(() => FullOverrideRequested.InvokeAsync())">
+                            Create full Database override
+                        </MudButton>
+                    }
+                    else if (!HasExistingStudioOverride)
+                    {
+                        <div>A Database override is unavailable because deployment policy or your permissions do not allow it.</div>
+                    }
+                    else
+                    {
+                        <div>@(ExistingStudioOverrideArchived
+                            ? "An archived Database record already exists for this connection."
+                            : "A Database record already exists for this connection.")</div>
+                        <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="@(() => ExistingStudioOverrideRequested.InvokeAsync())">
+                            @(ExistingStudioOverrideArchived ? "Review and restore Database record" : "Manage existing Database record")
+                        </MudButton>
+                    }
+                </MudAlert>
             }
         }
 
-        @if (HasActiveUnsafeSettings)
+        @if (IncludesGeneral)
         {
-            <MudCheckBox T="bool"
-                         Value="@Model.ConfirmUnsafeSettings"
-                         ValueChanged="SetUnsafeSettingsConfirmationAsync"
-                         Disabled="@(ReadOnly || !CanConfigureUnsafeSettings)"
-                         Label="I understand and explicitly confirm unsafe provider trust settings" />
-            @if (!CanConfigureUnsafeSettings)
-            {
-                <MudText Typo="Typo.caption" Color="Color.Warning">You do not have permission to configure unsafe provider trust settings.</MudText>
-            }
+            <ConnectionGeneralFields Connection="Connection"
+                                     Model="Model"
+                                     ReadOnly="ReadOnly"
+                                     Changed="NotifyChangedAsync" />
         }
 
-        <MudDivider />
-        <div class="connection-editor__secrets">
-            <MudText Typo="Typo.h6">Secret bindings</MudText>
-            <MudText Typo="Typo.caption">Secret values are write-only and never displayed or returned to Studio. Deployment-managed external references remain read-only.</MudText>
-            @foreach (var field in Adapter.Fields.Where(field => field.IsSecretBinding && DescriptorEditorState.IsVisible(field, Model.AdapterSettings)))
-            {
-                <SecretBindingField Field="field"
-                                    Binding="@(Connection.SecretBindings.GetValueOrDefault(field.Name))"
-                                    ReadOnly="@ReadOnly"
-                                    CanManage="@CanManageSecrets"
-                                    CanRemove="@(!Connection.EnabledIntent || !field.IsRequired)"
-                                    ManagedSecretResolvers="ManagedSecretResolvers"
-                                    ManagedSecretResolverError="@ManagedSecretResolverError"
-                                    OnManagedReplace="@((secret) => ManagedSecretChanged.InvokeAsync((field.Name, secret)))"
-                                    OnRemove="@(() => SecretBindingRemoved.InvokeAsync(field.Name))" />
-            }
-        </div>
+        @if (IncludesProvider)
+        {
+            <ConnectionProviderFields Connection="Connection"
+                                      Adapter="Adapter"
+                                      Model="Model"
+                                      ReadOnly="ReadOnly"
+                                      CanConfigureUnsafeSettings="CanConfigureUnsafeSettings"
+                                      CanManageSecrets="CanManageSecrets"
+                                      ManagedSecretResolvers="ManagedSecretResolvers"
+                                      ManagedSecretResolverError="@ManagedSecretResolverError"
+                                      ManagedSecretChanged="ManagedSecretChanged"
+                                      SecretBindingRemoved="SecretBindingRemoved"
+                                      Changed="NotifyChangedAsync" />
+        }
 
-        @if (!ReadOnly)
+        @if (ShowActions && !ReadOnly)
         {
             <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync">Save changes</MudButton>
         }
         @if (_validationErrors.Count > 0)
         {
-            <MudAlert Severity="Severity.Error">
+            <MudAlert Severity="Severity.Error" Class="connection-editor__validation" aria-live="polite">
                 @foreach (var error in _validationErrors)
                 {
                     <div>@error</div>
@@ -132,67 +93,40 @@
     [Parameter] public EventCallback Changed { get; set; }
     [Parameter] public bool CanManageSecrets { get; set; } = true;
     [Parameter] public EventCallback ExistingStudioOverrideRequested { get; set; }
+    [Parameter] public ConnectionEditorSection Section { get; set; } = ConnectionEditorSection.All;
+    [Parameter] public bool ShowActions { get; set; } = true;
+    [Parameter] public bool ShowContext { get; set; } = true;
 
     private readonly List<string> _validationErrors = [];
+    private bool IncludesGeneral => Section is ConnectionEditorSection.All or ConnectionEditorSection.General;
+    private bool IncludesProvider => Section is ConnectionEditorSection.All or ConnectionEditorSection.Provider;
     private bool HasActiveUnsafeSettings => Adapter.Fields.Any(descriptor => DescriptorEditorState.IsUnsafeSettingActive(descriptor, Model.AdapterSettings));
 
-    private Task OnAdapterSettingsChangedAsync()
+    public async Task<bool> ValidateAsync()
     {
-        if (!HasActiveUnsafeSettings)
-            Model.ConfirmUnsafeSettings = false;
-        return NotifyChangedAsync();
-    }
+        await _form.Validate();
+        _validationErrors.Clear();
+        if (IncludesProvider)
+        {
+            _validationErrors.AddRange(Adapter.Fields.SelectMany(field => DescriptorEditorState.Validate(field, Model.AdapterSettings)));
+            if (HasActiveUnsafeSettings && (!CanConfigureUnsafeSettings || !Model.ConfirmUnsafeSettings))
+                _validationErrors.Add("Unsafe provider trust settings require the dedicated permission and explicit confirmation.");
+        }
 
-    private async Task SetDisplayNameAsync(string value)
-    {
-        Model.DisplayName = value;
-        await NotifyChangedAsync();
-    }
-
-    private async Task SetKeyAsync(string value)
-    {
-        Model.Key = value;
-        await NotifyChangedAsync();
-    }
-
-    private async Task SetOrderAsync(int value)
-    {
-        Model.Order = value;
-        await NotifyChangedAsync();
-    }
-
-    private async Task SetPreferredAsync(bool value)
-    {
-        Model.IsPreferred = value;
-        await NotifyChangedAsync();
-    }
-
-    private async Task SetUpstreamLogoutModeAsync(string value)
-    {
-        Model.UpstreamLogoutMode = value;
-        await NotifyChangedAsync();
-    }
-
-    private async Task SetUnsafeSettingsConfirmationAsync(bool value)
-    {
-        Model.ConfirmUnsafeSettings = value;
-        await NotifyChangedAsync();
+        await InvokeAsync(StateHasChanged);
+        return _form.IsValid && _validationErrors.Count == 0;
     }
 
     private async Task NotifyChangedAsync()
     {
+        _validationErrors.Clear();
         await Changed.InvokeAsync();
         await InvokeAsync(StateHasChanged);
     }
 
     private async Task SaveAsync()
     {
-        await _form.Validate();
-        _validationErrors.Clear();
-        _validationErrors.AddRange(Adapter.Fields.SelectMany(field => DescriptorEditorState.Validate(field, Model.AdapterSettings)));
-        if (HasActiveUnsafeSettings && (!CanConfigureUnsafeSettings || !Model.ConfirmUnsafeSettings))
-            _validationErrors.Add("Unsafe provider trust settings require the dedicated permission and explicit confirmation.");
-        if (_form.IsValid && _validationErrors.Count == 0)
+        if (await ValidateAsync())
             await Saved.InvokeAsync(Model);
     }
 }

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionEditorSection.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionEditorSection.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Studio.ExternalAuthentication.Components.ConnectionEditor;
+
+public enum ConnectionEditorSection
+{
+    All,
+    General,
+    Provider
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionGeneralFields.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionGeneralFields.razor
@@ -1,0 +1,114 @@
+<MudGrid Spacing="4" Class="connection-editor__general-fields">
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Value="@Model.DisplayName"
+                      ValueChanged="SetDisplayNameAsync"
+                      Label="Display name"
+                      HelperText="A friendly name for this connection."
+                      Required="true"
+                      ReadOnly="@ReadOnly"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudTextField T="string"
+                      Value="@Model.Key"
+                      ValueChanged="SetKeyAsync"
+                      Label="Connection key"
+                      Required="true"
+                      ReadOnly="@(ReadOnly || !string.IsNullOrWhiteSpace(Connection.Id))"
+                      HelperText="Immutable after creation."
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense" />
+    </MudItem>
+    @if (!string.IsNullOrWhiteSpace(Connection.CallbackUri))
+    {
+        <MudItem xs="12">
+            <MudTextField Value="@Connection.CallbackUri"
+                          Label="Provider callback URI"
+                          ReadOnly="true"
+                          HelperText="Derived by Elsa from deployment configuration. Register this exact URI with the identity provider."
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense" />
+        </MudItem>
+    }
+    @if (!string.IsNullOrWhiteSpace(Connection.PreviewCallbackUri))
+    {
+        <MudItem xs="12">
+            <MudTextField Value="@Connection.PreviewCallbackUri"
+                          Label="Provider preview callback URI"
+                          ReadOnly="true"
+                          HelperText="Register this exact URI with the identity provider to enable administrator previews."
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense" />
+        </MudItem>
+    }
+    <MudItem xs="12" md="6">
+        <MudNumericField T="int"
+                         Value="@Model.Order"
+                         ValueChanged="SetOrderAsync"
+                         Label="Display order"
+                         HelperText="Controls the order in which this provider appears."
+                         ReadOnly="@ReadOnly"
+                         Variant="Variant.Outlined"
+                         Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudSelect T="string"
+                   Value="@Model.UpstreamLogoutMode"
+                   ValueChanged="SetUpstreamLogoutModeAsync"
+                   Label="Upstream sign-out"
+                   HelperText="Controls whether Elsa also signs the user out at the provider."
+                   Disabled="@ReadOnly"
+                   Variant="Variant.Outlined"
+                   Margin="Margin.Dense">
+            <MudSelectItem T="string" Value="@("disabled")">Disabled</MudSelectItem>
+            <MudSelectItem T="string" Value="@("userChoice")">Let the user choose</MudSelectItem>
+            <MudSelectItem T="string" Value="@("always")">Always sign out upstream</MudSelectItem>
+        </MudSelect>
+    </MudItem>
+    <MudItem xs="12">
+        <MudCheckBox T="bool"
+                     Value="@Model.IsPreferred"
+                     ValueChanged="SetPreferredAsync"
+                     Label="Mark as the preferred sign-in method"
+                     Disabled="@ReadOnly" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    [Parameter, EditorRequired] public ConnectionDetail Connection { get; set; } = default!;
+    [Parameter, EditorRequired] public ConnectionMutation Model { get; set; } = default!;
+    [Parameter] public bool ReadOnly { get; set; }
+    [Parameter] public EventCallback Changed { get; set; }
+
+    private async Task SetDisplayNameAsync(string value)
+    {
+        Model.DisplayName = value;
+        await Changed.InvokeAsync();
+    }
+
+    private async Task SetKeyAsync(string value)
+    {
+        Model.Key = value;
+        await Changed.InvokeAsync();
+    }
+
+    private async Task SetOrderAsync(int value)
+    {
+        Model.Order = value;
+        await Changed.InvokeAsync();
+    }
+
+    private async Task SetPreferredAsync(bool value)
+    {
+        Model.IsPreferred = value;
+        await Changed.InvokeAsync();
+    }
+
+    private async Task SetUpstreamLogoutModeAsync(string value)
+    {
+        Model.UpstreamLogoutMode = value;
+        await Changed.InvokeAsync();
+    }
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionPolicyEditor.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionPolicyEditor.razor
@@ -10,7 +10,9 @@
                Value="@SelectedType"
                ValueChanged="SelectAsync"
                Label="Unlinked identity policy"
-               Disabled="@ReadOnly">
+               Disabled="@ReadOnly"
+               Variant="Variant.Outlined"
+               Margin="Margin.Dense">
         <MudSelectItem T="string" Value="@("inherit")">Use deployment default</MudSelectItem>
         @foreach (var descriptor in AvailableDescriptors)
         {
@@ -35,7 +37,9 @@
                            ValueChanged="SelectMatcherAsync"
                            Label="User matcher"
                            Required="true"
-                           Disabled="@ReadOnly">
+                           Disabled="@ReadOnly"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
                     @foreach (var matcher in Matchers)
                     {
                         <MudSelectItem T="string" Value="@matcher.Type">@matcher.DisplayName</MudSelectItem>
@@ -66,7 +70,9 @@
                            Value="@(GetStringSetting("noMatchAction"))"
                            ValueChanged="SetNoMatchActionAsync"
                            Label="When no user matches"
-                           Disabled="@ReadOnly">
+                           Disabled="@ReadOnly"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
                     <MudSelectItem T="string" Value="@("reject")">Reject sign-in</MudSelectItem>
                     <MudSelectItem T="string" Value="@("create-user")">Create an Elsa user</MudSelectItem>
                 </MudSelect>
@@ -83,7 +89,9 @@
                            MultiSelection="true"
                            SelectedValues="@GetSelectedRoleIds()"
                            SelectedValuesChanged="SetSelectedRoleIdsAsync"
-                           Disabled="@(ReadOnly || !CanSelectRoles || !string.IsNullOrWhiteSpace(RoleOptionsError))">
+                           Disabled="@(ReadOnly || !CanSelectRoles || !string.IsNullOrWhiteSpace(RoleOptionsError))"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
                     @foreach (var role in Roles)
                     {
                         <MudSelectItem T="string" Value="@role.Id">@role.Name</MudSelectItem>

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionProviderFields.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/ConnectionProviderFields.razor
@@ -1,0 +1,123 @@
+@using Elsa.Studio.ExternalAuthentication.Services
+
+<MudStack Spacing="3" Class="connection-editor__provider-fields">
+    <div>
+        <MudText Typo="Typo.h6" HtmlTag="h2">@Adapter.DisplayName settings</MudText>
+        @if (!string.IsNullOrWhiteSpace(Adapter.Description))
+        {
+            <MudText Typo="Typo.caption">@Adapter.Description</MudText>
+        }
+    </div>
+
+    <MudGrid Spacing="4">
+        @foreach (var descriptor in VisibleProviderFields)
+        {
+            <MudItem xs="12" md="@GetColumnSpan(descriptor)">
+                <MudStack Spacing="1">
+                    <DescriptorField Field="descriptor" Settings="Model.AdapterSettings" ReadOnly="@ReadOnly" Changed="@OnAdapterSettingsChangedAsync" />
+                    @if (DescriptorEditorState.IsUnsafeSettingActive(descriptor, Model.AdapterSettings))
+                    {
+                        <MudAlert Severity="Severity.Warning" Dense="true">This provider trust setting can weaken authentication safety. It requires explicit confirmation and the provider-trust permission.</MudAlert>
+                    }
+                </MudStack>
+            </MudItem>
+        }
+    </MudGrid>
+
+    @if (HasActiveUnsafeSettings)
+    {
+        <MudCheckBox T="bool"
+                     Value="@Model.ConfirmUnsafeSettings"
+                     ValueChanged="SetUnsafeSettingsConfirmationAsync"
+                     Disabled="@(ReadOnly || !CanConfigureUnsafeSettings)"
+                     Label="I understand and explicitly confirm unsafe provider trust settings" />
+        @if (!CanConfigureUnsafeSettings)
+        {
+            <MudText Typo="Typo.caption" Color="Color.Warning">You do not have permission to configure unsafe provider trust settings.</MudText>
+        }
+    }
+
+    @if (VisibleSecretFields.Count > 0)
+    {
+        <MudDivider />
+        <div class="connection-editor__secrets">
+            <MudStack Spacing="2">
+                <div>
+                    <MudText Typo="Typo.h6" HtmlTag="h2">Secret bindings</MudText>
+                    <MudText Typo="Typo.caption">Secret values are write-only and never displayed or returned to Elsa Studio. Deployment-managed external references remain read-only.</MudText>
+                </div>
+                @if (!ReadOnly && !CanManageSecrets)
+                {
+                    <MudAlert Severity="Severity.Info" Dense="true">Save the connection draft before configuring secrets.</MudAlert>
+                }
+                else
+                {
+                    <MudGrid Spacing="4">
+                        @foreach (var descriptor in VisibleSecretFields)
+                        {
+                            <MudItem xs="12" md="6">
+                                <SecretBindingField Field="descriptor"
+                                                    Binding="@(Connection.SecretBindings.GetValueOrDefault(descriptor.Name))"
+                                                    ReadOnly="@ReadOnly"
+                                                    CanManage="@CanManageSecrets"
+                                                    CanRemove="@(!Connection.EnabledIntent || !descriptor.IsRequired)"
+                                                    ManagedSecretResolvers="ManagedSecretResolvers"
+                                                    ManagedSecretResolverError="@ManagedSecretResolverError"
+                                                    OnManagedReplace="@((secret) => ManagedSecretChanged.InvokeAsync((descriptor.Name, secret)))"
+                                                    OnRemove="@(() => SecretBindingRemoved.InvokeAsync(descriptor.Name))" />
+                            </MudItem>
+                        }
+                    </MudGrid>
+                }
+            </MudStack>
+        </div>
+    }
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public ConnectionDetail Connection { get; set; } = default!;
+    [Parameter, EditorRequired] public AdapterDescriptor Adapter { get; set; } = default!;
+    [Parameter, EditorRequired] public ConnectionMutation Model { get; set; } = default!;
+    [Parameter] public bool ReadOnly { get; set; }
+    [Parameter] public bool CanConfigureUnsafeSettings { get; set; }
+    [Parameter] public bool CanManageSecrets { get; set; } = true;
+    [Parameter] public ICollection<ManagedSecretResolverDescriptor> ManagedSecretResolvers { get; set; } = [];
+    [Parameter] public string? ManagedSecretResolverError { get; set; }
+    [Parameter] public EventCallback<(string Field, ManagedSecretMutation Secret)> ManagedSecretChanged { get; set; }
+    [Parameter] public EventCallback<string> SecretBindingRemoved { get; set; }
+    [Parameter] public EventCallback Changed { get; set; }
+
+    private IReadOnlyList<ConnectionFieldDescriptor> VisibleProviderFields => Adapter.Fields
+        .Where(descriptor => !descriptor.IsSecretBinding && DescriptorEditorState.IsVisible(descriptor, Model.AdapterSettings))
+        .ToArray();
+    private IReadOnlyList<ConnectionFieldDescriptor> VisibleSecretFields => Adapter.Fields
+        .Where(descriptor => descriptor.IsSecretBinding && DescriptorEditorState.IsVisible(descriptor, Model.AdapterSettings))
+        .ToArray();
+    private bool HasActiveUnsafeSettings => Adapter.Fields.Any(descriptor => DescriptorEditorState.IsUnsafeSettingActive(descriptor, Model.AdapterSettings));
+
+    private async Task OnAdapterSettingsChangedAsync()
+    {
+        if (!HasActiveUnsafeSettings)
+            Model.ConfirmUnsafeSettings = false;
+        await Changed.InvokeAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task SetUnsafeSettingsConfirmationAsync(bool value)
+    {
+        Model.ConfirmUnsafeSettings = value;
+        await Changed.InvokeAsync();
+    }
+
+    private static int GetColumnSpan(ConnectionFieldDescriptor field) =>
+        IsWideField(field) ? 12 : 6;
+
+    private static bool IsWideField(ConnectionFieldDescriptor field) =>
+        field.Name.Contains("url", StringComparison.OrdinalIgnoreCase) ||
+        field.Name.Contains("uri", StringComparison.OrdinalIgnoreCase) ||
+        field.Name.Contains("endpoint", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(field.ValueType, "uri", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(field.ValueType, "string-array", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(field.UiHint, "textarea", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(field.UiHint, "multiline", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/DescriptorField.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/DescriptorField.razor
@@ -4,11 +4,11 @@
 {
     @if (IsFixedPkce)
     {
-        <MudPaper Outlined="true" Class="pa-3 connection-editor__fixed-pkce">
-            <MudText Typo="Typo.subtitle2">@Field.DisplayName</MudText>
-            <MudText Typo="Typo.body2">S256</MudText>
-            <MudText Typo="Typo.caption">S256 PKCE is always required for the authorization-code flow and cannot be changed.</MudText>
-        </MudPaper>
+        <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" AlignItems="AlignItems.Baseline" Class="connection-editor__fixed-pkce">
+            <MudText Typo="Typo.subtitle2">@Field.DisplayName:</MudText>
+            <MudText Typo="Typo.body2">S256 required</MudText>
+            <MudText Typo="Typo.caption">The authorization-code flow always uses S256 and this value cannot be changed.</MudText>
+        </MudStack>
     }
     else if (IsStringArray && Field.AllowedValues.Count > 0)
     {
@@ -18,7 +18,9 @@
                    MultiSelection="true"
                    SelectedValues="@GetStringArray()"
                    SelectedValuesChanged="SetStringArrayAsync"
-                   Disabled="@IsReadOnly">
+                   Disabled="@IsReadOnly"
+                   Variant="Variant.Outlined"
+                   Margin="Margin.Dense">
             @foreach (var allowedValue in Field.AllowedValues)
             {
                 <MudSelectItem T="string" Value="@allowedValue">@DescriptorValuePresentation.GetDisplayName(Field, allowedValue)</MudSelectItem>
@@ -28,16 +30,20 @@
     else if (IsTagsField)
     {
         <MudStack Spacing="1">
-            <MudStack Row="true" AlignItems="AlignItems.End">
+            <MudStack Row="true" AlignItems="AlignItems.Start">
                 <MudTextField T="string"
                               Value="@_pendingArrayValue"
                               ValueChanged="@SetPendingArrayValue"
+                              OnKeyDown="@OnPendingArrayValueKeyDownAsync"
                               Label="@Field.DisplayName"
                               HelperText="@TagsHelpText"
                               ReadOnly="@IsReadOnly"
-                              Immediate="true" />
+                              Immediate="true"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
                 <MudButton Variant="Variant.Outlined"
                            StartIcon="@Icons.Material.Filled.Add"
+                           Class="mt-1"
                            Disabled="@(IsReadOnly || string.IsNullOrWhiteSpace(_pendingArrayValue))"
                            OnClick="AddStringArrayValueAsync">
                     Add
@@ -62,11 +68,11 @@
     }
     else if (IsStringArray)
     {
-        <MudTextField T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetTextAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Lines="@Lines" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))" />
+        <MudTextField T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetTextAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Lines="@Lines" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))" Variant="Variant.Outlined" Margin="Margin.Dense" />
     }
     else if (Field.AllowedValues.Count > 0)
     {
-        <MudSelect T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetAllowedValueAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" Disabled="@IsReadOnly" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))">
+        <MudSelect T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetAllowedValueAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" Disabled="@IsReadOnly" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))" Variant="Variant.Outlined" Margin="Margin.Dense">
             @foreach (var allowedValue in Field.AllowedValues)
             {
                 <MudSelectItem T="string" Value="@allowedValue">@DescriptorValuePresentation.GetDisplayName(Field, allowedValue)</MudSelectItem>
@@ -79,15 +85,15 @@
     }
     else if (string.Equals(Field.ValueType, "integer", StringComparison.OrdinalIgnoreCase) || string.Equals(Field.ValueType, "int", StringComparison.OrdinalIgnoreCase))
     {
-        <MudNumericField T="int?" Value="@DescriptorEditorState.GetInteger(Settings, Field.Name)" ValueChanged="@SetIntegerAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Validation="@(new Func<int?, IEnumerable<string>>(ValidateInteger))" />
+        <MudNumericField T="int?" Value="@DescriptorEditorState.GetInteger(Settings, Field.Name)" ValueChanged="@SetIntegerAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Validation="@(new Func<int?, IEnumerable<string>>(ValidateInteger))" Variant="Variant.Outlined" Margin="Margin.Dense" />
     }
     else if (string.Equals(Field.ValueType, "number", StringComparison.OrdinalIgnoreCase) || string.Equals(Field.ValueType, "decimal", StringComparison.OrdinalIgnoreCase))
     {
-        <MudNumericField T="decimal?" Value="@DescriptorEditorState.GetNumber(Settings, Field.Name)" ValueChanged="@SetNumberAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Validation="@(new Func<decimal?, IEnumerable<string>>(ValidateNumber))" />
+        <MudNumericField T="decimal?" Value="@DescriptorEditorState.GetNumber(Settings, Field.Name)" ValueChanged="@SetNumberAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" Validation="@(new Func<decimal?, IEnumerable<string>>(ValidateNumber))" Variant="Variant.Outlined" Margin="Margin.Dense" />
     }
     else
     {
-        <MudTextField T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetTextAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" InputType="@InputType" Lines="@Lines" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))" />
+        <MudTextField T="string" Value="@DescriptorEditorState.ToDisplayString(GetValue())" ValueChanged="@SetTextAsync" Label="@Field.DisplayName" HelperText="@HelpText" Required="@Field.IsRequired" ReadOnly="@IsReadOnly" InputType="@InputType" Lines="@Lines" Validation="@(new Func<string?, IEnumerable<string>>(ValidateString))" Variant="Variant.Outlined" Margin="Margin.Dense" />
     }
 }
 
@@ -98,7 +104,7 @@
     [Parameter] public EventCallback Changed { get; set; }
 
     private string? HelpText => Field.HelpText ?? Field.Description;
-    private string TagsHelpText => string.IsNullOrWhiteSpace(HelpText) ? "Enter a value, then select Add." : $"{HelpText} Enter a value, then select Add.";
+    private string TagsHelpText => string.IsNullOrWhiteSpace(HelpText) ? "Enter a value, then press Enter or select Add." : $"{HelpText} Enter a value, then press Enter or select Add.";
     private string? _inputError;
     private string _pendingArrayValue = string.Empty;
     private bool IsReadOnly => ReadOnly || Field.IsReadOnly;
@@ -164,6 +170,9 @@
     }
 
     private void SetPendingArrayValue(string value) => _pendingArrayValue = value;
+
+    private Task OnPendingArrayValueKeyDownAsync(KeyboardEventArgs args) =>
+        args.Key == "Enter" ? AddStringArrayValueAsync() : Task.CompletedTask;
 
     private async Task AddStringArrayValueAsync()
     {

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/SecretBindingField.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/ConnectionEditor/SecretBindingField.razor
@@ -13,7 +13,7 @@
                 @if (ManagedSecretResolvers.Count > 0)
                 {
                     <MudText Typo="Typo.subtitle2">Managed secret</MudText>
-                    <MudSelect T="string" @bind-Value="_managedResolverType" Label="Secret store" Required="true">
+                    <MudSelect T="string" @bind-Value="_managedResolverType" Label="Secret store" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense">
                         @foreach (var resolver in ManagedSecretResolvers)
                         {
                             <MudSelectItem T="string" Value="@resolver.Type">@resolver.DisplayName</MudSelectItem>
@@ -23,7 +23,9 @@
                                   Label="Secret value"
                                   InputType="InputType.Password"
                                   autocomplete="new-password"
-                                  HelperText="Write-only. Elsa stores the value and never returns it to Studio." />
+                                  HelperText="Write-only. Elsa stores the value and never returns it to Elsa Studio."
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense" />
                     <MudButton Size="Size.Small"
                                Variant="Variant.Outlined"
                                Disabled="@(string.IsNullOrWhiteSpace(_managedResolverType) || string.IsNullOrWhiteSpace(_managedValue))"

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/Operations/ConnectionOperations.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/Operations/ConnectionOperations.razor
@@ -2,16 +2,15 @@
 @inject Elsa.Studio.ExternalAuthentication.Services.IExternalAuthenticationPermissionService Permissions
 @inject ISnackbar Snackbar
 @using Elsa.Studio.ExternalAuthentication.Services
-@using ApiException = Refit.ApiException
 
 <MudStack Spacing="2">
-    <MudText Typo="Typo.h6">Operations</MudText>
-    <MudText Typo="Typo.caption">Tests and previews use the current revision. Results are redacted and never reveal provider tokens, secrets, or unrestricted claims.</MudText>
+    <MudText Typo="Typo.h6">Provider connectivity</MudText>
+    <MudText Typo="Typo.caption">Tests provider reachability for the current revision. A successful test does not verify complete connection configuration or client authentication. Results are redacted.</MudText>
 
     @if (Observation is { } observation)
     {
         <MudAlert Severity="@ConnectionObservationPresentation.StatusSeverity(observation.Status)" Dense="true">
-            <strong>Latest test: @observation.Status</strong> — @observation.Summary
+            <strong>Connectivity test: @observation.Status</strong> — @observation.Summary
             @if (observation.IsStale)
             {
                 <br /><span>This observation is stale because the connection has materially changed since it was tested.</span>
@@ -37,7 +36,7 @@
         }
         @if (Adapter.Capabilities.SupportsPreview)
         {
-            <MudButton Variant="Variant.Outlined" Disabled="@(!_canPreview || IsReadOnly || _startingPreview)" OnClick="StartPreviewAsync">
+            <MudButton Variant="Variant.Outlined" Disabled="@(!CanPreview || _startingPreview)" OnClick="StartPreviewAsync">
                 @(_startingPreview ? "Preparing preview…" : "Preview sign-in")
             </MudButton>
         }
@@ -71,9 +70,10 @@
 </MudStack>
 
 @code {
-    [Parameter, EditorRequired] public ConnectionDetail Connection { get; set; } = default!;
+    [Parameter, EditorRequired] public ConnectionSummary Connection { get; set; } = default!;
     [Parameter, EditorRequired] public AdapterDescriptor Adapter { get; set; } = default!;
     [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public bool StartPreviewOnLoad { get; set; }
     [Parameter] public EventCallback<ConnectionObservation> ObservationRecorded { get; set; }
 
     private bool _canTest;
@@ -86,13 +86,20 @@
     private string? _previewHandle;
     private PreviewResultDocument? _previewResult;
     private string? _operationError;
+    private bool _previewStartRequested;
 
     private ConnectionObservation? Observation => _testing ? null : Connection.LatestObservation;
+    private bool CanPreview => _canPreview && !IsReadOnly && Adapter.Capabilities.SupportsPreview;
 
     protected override async Task OnParametersSetAsync()
     {
         _canTest = await Permissions.HasAsync(ExternalAuthenticationPermissions.Test);
         _canPreview = await Permissions.HasAsync(ExternalAuthenticationPermissions.Preview);
+        if (StartPreviewOnLoad && !_previewStartRequested && CanPreview)
+        {
+            _previewStartRequested = true;
+            await StartPreviewAsync();
+        }
     }
 
     private async Task TestAsync()
@@ -101,18 +108,16 @@
         _operationError = null;
         try
         {
-            var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationOperationsApi>();
-            var result = await api.TestAsync(Connection.Id, ConnectionConcurrency.ToIfMatch(Connection.Revision));
-            var observation = result.ToObservation();
+            var observation = await ConnectionOperationActions.TestConnectionAsync(ApiClientProvider, Connection);
             Connection.LatestObservation = observation;
             await ObservationRecorded.InvokeAsync(observation);
-            Snackbar.Add("Connection test completed. The result contains only redacted diagnostics.", Severity.Success);
+            Snackbar.Add(ConnectionOperationActions.TestCompletedMessage, Severity.Success);
         }
         catch (Exception exception)
         {
-            _operationError = PresentOperationError(
+            _operationError = ConnectionOperationActions.PresentError(
                 exception,
-                "The connection test failed before a diagnostic observation was recorded. Check the connection requirements and server logs, then try again.");
+                ConnectionOperationActions.TestFailedMessage);
             Snackbar.Add(_operationError, Severity.Error);
         }
         finally
@@ -123,6 +128,9 @@
 
     private async Task StartPreviewAsync()
     {
+        if (!CanPreview)
+            return;
+
         _startingPreview = true;
         _previewResult = null;
         _operationError = null;
@@ -140,7 +148,7 @@
         }
         catch (Exception exception)
         {
-            _operationError = PresentOperationError(
+            _operationError = ConnectionOperationActions.PresentError(
                 exception,
                 "Preview could not be prepared. Validate the connection and confirm the provider preview callback URI, then try again.");
             Snackbar.Add(_operationError, Severity.Error);
@@ -169,7 +177,7 @@
         }
         catch (Exception exception)
         {
-            _operationError = PresentOperationError(
+            _operationError = ConnectionOperationActions.PresentError(
                 exception,
                 "The one-time preview result is unavailable or has expired. Start a new preview and complete provider sign-in before retrieving it.");
             Snackbar.Add(_operationError, Severity.Error);
@@ -213,10 +221,4 @@
         string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase) &&
         left.Port == right.Port;
 
-    private static string PresentOperationError(Exception exception, string fallbackMessage) =>
-        exception is ApiException apiException
-            ? ConnectionManagementError
-                .Parse(apiException.StatusCode, apiException.Content, fallbackMessage)
-                .OperationalDisplayMessage
-            : fallbackMessage;
 }

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/Operations/PreviewSignInDialog.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/Operations/PreviewSignInDialog.razor
@@ -1,0 +1,19 @@
+<MudDialog>
+    <DialogContent>
+        <ConnectionOperations
+            Connection="Connection"
+            Adapter="Adapter"
+            StartPreviewOnLoad="true" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter, EditorRequired] public ConnectionSummary Connection { get; set; } = default!;
+    [Parameter, EditorRequired] public AdapterDescriptor Adapter { get; set; } = default!;
+
+    private void Close() => MudDialog.Close();
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Components/Pagination/CursorTablePager.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Components/Pagination/CursorTablePager.razor
@@ -1,0 +1,56 @@
+<div class="mud-table-pagination">
+    <MudToolBar Gutters="false" Class="mud-table-pagination-toolbar">
+        <MudSpacer />
+        <div class="mud-table-pagination-display">
+            <MudText Typo="Typo.caption" Class="mud-table-pagination-caption">Rows Per Page</MudText>
+            <MudSelect
+                T="int"
+                Value="PageSize"
+                ValueChanged="PageSizeChanged"
+                Disabled="Loading"
+                Dense="true"
+                Variant="Variant.Text"
+                Class="mud-table-pagination-select"
+                aria-label="Rows per page">
+                @foreach (var option in PageSizeOptions)
+                {
+                    <MudSelectItem T="int" Value="option">@option</MudSelectItem>
+                }
+            </MudSelect>
+        </div>
+        <MudText Typo="Typo.caption" Class="mud-table-pagination-information">Page @PageNumber</MudText>
+        <div class="mud-table-pagination-actions">
+            <MudIconButton
+                Icon="@Icons.Material.Filled.FirstPage"
+                Disabled="@(!HasPrevious || Loading)"
+                OnClick="FirstPage"
+                aria-label="First page"
+                title="First page" />
+            <MudIconButton
+                Icon="@Icons.Material.Filled.NavigateBefore"
+                Disabled="@(!HasPrevious || Loading)"
+                OnClick="PreviousPage"
+                aria-label="Previous page"
+                title="Previous page" />
+            <MudIconButton
+                Icon="@Icons.Material.Filled.NavigateNext"
+                Disabled="@(!HasNext || Loading)"
+                OnClick="NextPage"
+                aria-label="Next page"
+                title="Next page" />
+        </div>
+    </MudToolBar>
+</div>
+
+@code {
+    [Parameter] public int PageNumber { get; set; } = 1;
+    [Parameter] public int PageSize { get; set; } = 10;
+    [Parameter] public IReadOnlyList<int> PageSizeOptions { get; set; } = [10, 25, 50, 100];
+    [Parameter] public bool HasPrevious { get; set; }
+    [Parameter] public bool HasNext { get; set; }
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public EventCallback<int> PageSizeChanged { get; set; }
+    [Parameter] public EventCallback FirstPage { get; set; }
+    [Parameter] public EventCallback PreviousPage { get; set; }
+    [Parameter] public EventCallback NextPage { get; set; }
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Menu/ExternalAuthenticationSecurityMenuContributor.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Menu/ExternalAuthenticationSecurityMenuContributor.cs
@@ -23,7 +23,7 @@ public sealed class ExternalAuthenticationSecurityMenuContributor(
             items.Add(new()
             {
                 Icon = Icons.Material.Filled.AdminPanelSettings,
-                Href = "security/external-authentication",
+                Href = "security/external-authentication/connections",
                 Text = "Identity provider connections",
                 Order = 100
             });

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Models/ConnectionModels.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Models/ConnectionModels.cs
@@ -318,5 +318,5 @@ public sealed class ManagementApiException(string message, int statusCode, Conne
 {
     public int StatusCode { get; } = statusCode;
     public ConnectionDetail? Current { get; } = current;
-    public bool IsConcurrencyConflict => StatusCode is 409 or 412;
+    public bool IsConcurrencyConflict => StatusCode == 412;
 }

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Edit.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Edit.razor
@@ -14,7 +14,7 @@
 <PageTitle>@(IsNew ? "Create identity provider connection" : "Manage identity provider connection")</PageTitle>
 <NavigationLock ConfirmExternalNavigation="@_isDirty" OnBeforeInternalNavigation="ConfirmNavigationAsync" />
 
-<MudContainer MaxWidth="MaxWidth.Large">
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="connection-workspace">
     <MudStack Spacing="3" Class="py-4">
         <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Outlined.ArrowBack" Class="align-self-start" OnClick="Back">Identity provider connections</MudButton>
         @if (_loading)
@@ -60,7 +60,13 @@
                 <MudAlert Severity="Severity.Warning" Dense="true" aria-live="polite">
                     @if (_connection.IsConfigurationOwned)
                     {
-                        <span>This deployment-defined connection is shadowed by an effective Studio override.</span>
+                        <span>This deployment-defined connection is read-only and shadowed by an effective Database override.</span>
+                        @if (!string.IsNullOrWhiteSpace(_existingStudioOverrideId))
+                        {
+                            <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="ManageExistingStudioOverride">
+                                @(_existingStudioOverrideArchived ? "Review and restore Database record" : "Manage existing Database record")
+                            </MudButton>
+                        }
                     }
                     else
                     {
@@ -68,10 +74,38 @@
                         @if (CanPromoteCurrentConnection)
                         {
                             <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="PromoteToConfigurationOverrideAsync">
-                                Make this Studio record effective
+                                Make this Database record effective
                             </MudButton>
                         }
                     }
+                </MudAlert>
+            }
+            else if (_connection.IsConfigurationOwned)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" aria-live="polite" Class="connection-workspace__ownership">
+                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudText Typo="Typo.body2">This deployment-owned connection is read-only in Elsa Studio.</MudText>
+                        <MudSpacer />
+                        @if (CanCreateFullOverride)
+                        {
+                            <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="StartFullOverride">Create full Database override</MudButton>
+                        }
+                        else if (!string.IsNullOrWhiteSpace(_existingStudioOverrideId))
+                        {
+                            <MudText Typo="Typo.caption">
+                                @(_existingStudioOverrideArchived
+                                    ? "An archived Database record already exists for this connection."
+                                    : "A Database record already exists for this connection.")
+                            </MudText>
+                            <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="ManageExistingStudioOverride">
+                                @(_existingStudioOverrideArchived ? "Review and restore Database record" : "Manage existing Database record")
+                            </MudButton>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.caption">A Database override is unavailable under the current policy or permissions.</MudText>
+                        }
+                    </MudStack>
                 </MudAlert>
             }
             <MudPaper Outlined="true">
@@ -82,109 +116,66 @@
                          AlwaysShowScrollButtons="false"
                          MinimumTabWidth="100"
                          TabPanelsClass="pa-4 pa-sm-6">
-                    <MudTabPanel Text="Settings">
-                        <div class="connection-workspace__configuration">
-                            <MudGrid Spacing="3">
-                                <MudItem xs="12" md="@(IsNew ? 12 : 8)">
-                                    <MudStack Spacing="3">
-                                        @if (IsNew)
-                                        {
-                                            <MudSelect T="string" Value="_adapter.Type" ValueChanged="SelectAdapterAsync" Label="Provider protocol" Required="true">
-                                                @foreach (var adapter in _adapters)
-                                                {
-                                                    <MudSelectItem T="string" Value="@adapter.Type">@adapter.DisplayName</MudSelectItem>
-                                                }
-                                            </MudSelect>
-                                        }
-                                        @if (CustomEditors.TryResolve(_adapter.CustomEditor, out var customEditorType))
-                                        {
-                                            @if (!string.IsNullOrWhiteSpace(_existingStudioOverrideId))
-                                            {
-                                                <MudAlert Severity="Severity.Info" Dense="true">
-                                                    @(_existingStudioOverrideArchived
-                                                        ? "An archived Studio record already exists for this connection."
-                                                        : "A Studio record already exists for this connection.")
-                                                    <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="ManageExistingStudioOverride">
-                                                        @(_existingStudioOverrideArchived ? "Review and restore Studio record" : "Manage existing Studio record")
-                                                    </MudButton>
-                                                </MudAlert>
-                                            }
-                                            <DynamicComponent Type="customEditorType" Parameters="GetCustomEditorParameters(customEditorType)" />
-                                        }
-                                        else
-                                        {
-                                            <ConnectionEditor Connection="_connection"
-                                                              Adapter="_adapter"
-                                                              Model="_model"
-                                                              ReadOnly="@(IsNew ? !_canCreate : !_canUpdate || _connection.IsConfigurationOwned)"
-                                                              CanConfigureUnsafeSettings="_canConfigureUnsafeSettings"
-                                                              CanCreateOverride="@CanCreateFullOverride"
-                                                              HasExistingStudioOverride="@(!string.IsNullOrWhiteSpace(_existingStudioOverrideId))"
-                                                              ExistingStudioOverrideArchived="_existingStudioOverrideArchived"
-                                                              ManagedSecretResolvers="_managedSecretResolvers"
-                                                              ManagedSecretResolverError="@ManagedSecretResolverError"
-                                                              Saved="SaveAsync"
-                                                              Changed="MarkDirty"
-                                                              CanManageSecrets="@(!IsNew)"
-                                                              ManagedSecretChanged="ReplaceManagedSecretAsync"
-                                                              SecretBindingRemoved="RemoveBindingAsync"
-                                                              FullOverrideRequested="StartFullOverride"
-                                                              ExistingStudioOverrideRequested="ManageExistingStudioOverride" />
-                                        }
-                                    </MudStack>
-                                </MudItem>
-                                @if (!IsNew)
+                    <MudTabPanel Text="General">
+                        <div class="connection-workspace__general">
+                            <MudStack Spacing="3">
+                                @if (IsNew)
                                 {
-                                    <MudItem xs="12" md="4">
-                                        <MudStack Spacing="2">
-                                            <MudPaper Outlined="true" Class="pa-4">
-                                                <MudStack Spacing="2">
-                                                    <MudText Typo="Typo.h6">At a glance</MudText>
-                                                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" Justify="Justify.SpaceBetween">
-                                                        <MudText Typo="Typo.caption">Effective source</MudText>
-                                                        <MudText Typo="Typo.body2">@EffectiveSourceLabel</MudText>
-                                                    </MudStack>
-                                                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" Justify="Justify.SpaceBetween">
-                                                        <MudText Typo="Typo.caption">Record source</MudText>
-                                                        <MudText Typo="Typo.body2">@RecordSourceLabel</MudText>
-                                                    </MudStack>
-                                                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" Justify="Justify.SpaceBetween">
-                                                        <MudText Typo="Typo.caption">@ValidityHeading</MudText>
-                                                        <MudText Typo="Typo.body2">@ConnectionStatusPresentation.ValidityLabel(_connection.Validity)</MudText>
-                                                    </MudStack>
-                                                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" Justify="Justify.SpaceBetween">
-                                                        <MudText Typo="Typo.caption">Provisioning policy</MudText>
-                                                        <MudText Typo="Typo.body2">@ProvisioningPolicyLabel</MudText>
-                                                    </MudStack>
-                                                    <MudDivider />
-                                                    <MudText Typo="Typo.caption">@LatestTestLabel</MudText>
-                                                </MudStack>
-                                            </MudPaper>
-                                            <MudAlert Severity="Severity.Info" Dense="true">
-                                                <MudStack Spacing="1" AlignItems="AlignItems.Start">
-                                                    @if (_connection.IsConfigurationOwned)
-                                                    {
-                                                        <MudText Typo="Typo.body2">Tests and previews are available under Diagnostics.</MudText>
-                                                    }
-                                                    else
-                                                    {
-                                                        <MudText Typo="Typo.body2">Tests, previews and lifecycle actions are available under Diagnostics.</MudText>
-                                                    }
-                                                    <MudButton Variant="Variant.Text"
-                                                               Size="Size.Small"
-                                                               StartIcon="@Icons.Material.Outlined.ArrowForward"
-                                                               Class="px-0"
-                                                               OnClick="@(() => _activeWorkspaceTab = 2)">
-                                                        Open Diagnostics
-                                                    </MudButton>
-                                                </MudStack>
-                                            </MudAlert>
-                                        </MudStack>
-                                    </MudItem>
+                                    <MudSelect T="string"
+                                               Value="_adapter.Type"
+                                               ValueChanged="SelectAdapterAsync"
+                                               Label="Provider protocol"
+                                               Required="true"
+                                               Variant="Variant.Outlined"
+                                               Margin="Margin.Dense">
+                                        @foreach (var adapter in _adapters)
+                                        {
+                                            <MudSelectItem T="string" Value="@adapter.Type">@adapter.DisplayName</MudSelectItem>
+                                        }
+                                    </MudSelect>
                                 }
-                            </MudGrid>
+                                @if (_customEditorType is not null)
+                                {
+                                    <DynamicComponent Type="_customEditorType" Parameters="GetCustomEditorParameters(_customEditorType)" />
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.caption">Provider protocol, scopes and secret bindings are managed under Provider.</MudText>
+                                    <ConnectionEditor @ref="_generalEditor"
+                                                      Connection="_connection"
+                                                      Adapter="_adapter"
+                                                      Model="_model"
+                                                      Section="ConnectionEditorSection.General"
+                                                      ShowActions="false"
+                                                      ShowContext="false"
+                                                      ReadOnly="@EditorReadOnly"
+                                                      Changed="MarkDirty" />
+                                }
+                            </MudStack>
                         </div>
                     </MudTabPanel>
+                    @if (_customEditorType is null)
+                    {
+                        <MudTabPanel Text="Provider">
+                            <div class="connection-workspace__provider">
+                                <ConnectionEditor @ref="_providerEditor"
+                                                  Connection="_connection"
+                                                  Adapter="_adapter"
+                                                  Model="_model"
+                                                  Section="ConnectionEditorSection.Provider"
+                                                  ShowActions="false"
+                                                  ShowContext="false"
+                                                  ReadOnly="@EditorReadOnly"
+                                                  CanConfigureUnsafeSettings="_canConfigureUnsafeSettings"
+                                                  ManagedSecretResolvers="_managedSecretResolvers"
+                                                  ManagedSecretResolverError="@ManagedSecretResolverError"
+                                                  Changed="MarkDirty"
+                                                  CanManageSecrets="@(!IsNew)"
+                                                  ManagedSecretChanged="ReplaceManagedSecretAsync"
+                                                  SecretBindingRemoved="RemoveBindingAsync" />
+                            </div>
+                        </MudTabPanel>
+                    }
                     <MudTabPanel Text="Provisioning">
                         <div class="connection-workspace__provisioning">
                             <MudStack Spacing="3">
@@ -196,14 +187,6 @@
                                                         CanSelectRoles="_canReadRoles"
                                                         RoleOptionsError="@RoleOptionsError"
                                                         ReadOnly="@(!_canManagePolicies || _connection.IsConfigurationOwned)" />
-                                @if (CanSaveConnection)
-                                {
-                                    <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2" AlignItems="AlignItems.Center">
-                                        <MudText Typo="Typo.caption">Connection and provisioning changes are saved together.</MudText>
-                                        <MudSpacer />
-                                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => _activeWorkspaceTab = 0)">Review configuration</MudButton>
-                                    </MudStack>
-                                }
                             </MudStack>
                         </div>
                     </MudTabPanel>
@@ -214,34 +197,63 @@
                                 <MudGrid Spacing="3">
                                     <MudItem xs="12" md="@(_connection.IsConfigurationOwned ? 12 : 8)">
                                         <MudStack Spacing="3">
-                                            @if (_runtimeDescriptor is not null)
-                                            {
-                                                <MudPaper Outlined="true" Class="pa-3">
-                                                    <MudText Typo="Typo.body2">
-                                                        Management contract v@_runtimeDescriptor.ManagementContractVersion · Backend @_runtimeDescriptor.ProductVersion
-                                                    </MudText>
-                                                    <MudText Typo="Typo.caption">@_runtimeDescriptor.InformationalVersion</MudText>
-                                                </MudPaper>
-                                            }
-                                            else if (_runtimeDescriptorUnavailable)
-                                            {
-                                                <MudAlert Severity="Severity.Warning" Dense="true" aria-live="polite">
-                                                    Backend runtime details are unavailable. If Studio was just upgraded, restart the backend and verify that both applications use compatible builds.
-                                                </MudAlert>
-                                            }
                                             <ConnectionOperations Connection="_connection"
                                                                   Adapter="_adapter"
                                                                   ObservationRecorded="OnObservationRecordedAsync" />
-                                            @if (_validation is not null)
-                                            {
-                                                <MudAlert Severity="@(_validation.Valid ? Severity.Success : Severity.Error)">
-                                                    @(_validation.Valid ? "The current revision is structurally valid." : "The current revision has validation errors.")
-                                                    @foreach (var error in _validation.Errors)
+                                            <MudStack Spacing="2">
+                                                <MudText Typo="Typo.h6">Configuration validation</MudText>
+                                                <MudAlert Severity="@CurrentValiditySeverity" Dense="true" aria-live="polite">
+                                                    <MudText Typo="Typo.body2">@CurrentValiditySummary</MudText>
+                                                    @if (CurrentValidationErrors.Count > 0)
                                                     {
-                                                        <div>@error.Field: @error.Message</div>
+                                                        <ul class="ma-0 mt-2 pl-4">
+                                                            @foreach (var error in CurrentValidationErrors)
+                                                            {
+                                                                <li>
+                                                                    @if (ValidationMessageIncludesField(error))
+                                                                    {
+                                                                        @error.Message
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        <strong>@GetValidationFieldLabel(error.Field):</strong> @error.Message
+                                                                    }
+                                                                </li>
+                                                            }
+                                                        </ul>
+                                                    }
+                                                    else if (CurrentRevisionIsInvalid)
+                                                    {
+                                                        <MudText Typo="Typo.caption" Class="mt-2">
+                                                            @(_validation is null
+                                                                ? "Select Validate to refresh the diagnostic details for this revision."
+                                                                : "The backend did not return validation details for this revision.")
+                                                        </MudText>
+                                                    }
+                                                    @if (CanReviewProviderSettings)
+                                                    {
+                                                        <MudButton Variant="Variant.Outlined"
+                                                                   Color="Color.Error"
+                                                                   Size="Size.Small"
+                                                                   Class="mt-2"
+                                                                   OnClick="ReviewProviderSettings">
+                                                            @ProviderRepairActionLabel
+                                                        </MudButton>
                                                     }
                                                 </MudAlert>
-                                            }
+                                                @if (CurrentValidationWarnings.Count > 0)
+                                                {
+                                                    <MudAlert Severity="Severity.Warning" Dense="true">
+                                                        <MudText Typo="Typo.body2">Validation warnings</MudText>
+                                                        <ul class="ma-0 mt-2 pl-4">
+                                                            @foreach (var warning in CurrentValidationWarnings)
+                                                            {
+                                                                <li>@warning</li>
+                                                            }
+                                                        </ul>
+                                                    </MudAlert>
+                                                }
+                                            </MudStack>
                                         </MudStack>
                                     </MudItem>
                                     @if (!_connection.IsConfigurationOwned)
@@ -254,7 +266,7 @@
                                                     @if (_connection.OverridesConfigurationConnection)
                                                     {
                                                         <MudAlert Severity="Severity.Info" Dense="true">
-                                                            This complete Studio override keeps shadowing deployment configuration while disabled.
+                                                            This complete Database override keeps shadowing deployment configuration while disabled.
                                                             Archiving it reveals the configuration-owned connection; restoring it resumes shadowing in a disabled state.
                                                         </MudAlert>
                                                     }
@@ -284,6 +296,19 @@
                         </MudTabPanel>
                     }
                 </MudTabs>
+                @if (CanSaveConnection && _customEditorType is null)
+                {
+                    <div class="connection-workspace__actions pa-4 pa-sm-6" role="group" aria-label="Connection form actions">
+                        <MudStack Row="true" Spacing="2" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center">
+                            <MudButton OnClick="Back">Cancel</MudButton>
+                            <MudButton Color="Color.Primary"
+                                       Disabled="@(!_isDirty || !WorkspaceIsValid)"
+                                       OnClick="SaveWorkspaceAsync">
+                                Save changes
+                            </MudButton>
+                        </MudStack>
+                    </div>
+                }
             </MudPaper>
         }
     </MudStack>
@@ -299,8 +324,6 @@
     private ICollection<ExternalUserMatcherDescriptor> _matcherDescriptors = [];
     private ICollection<IdentityRoleOption> _roleOptions = [];
     private ICollection<ManagedSecretResolverDescriptor> _managedSecretResolvers = [];
-    private ExternalAuthenticationRuntimeDescriptor? _runtimeDescriptor;
-    private bool _runtimeDescriptorUnavailable;
     private string? _roleOptionsError;
     private string? _managedSecretResolverError;
     private ConnectionMutation? _model;
@@ -315,40 +338,91 @@
     private bool _canReadRoles;
     private int _activeWorkspaceTab;
     private bool _isDirty;
+    private ConnectionEditor? _generalEditor;
+    private ConnectionEditor? _providerEditor;
+    private Type? _customEditorType;
     private string? _loadedConnectionId;
     private string? RoleOptionsError => _roleOptionsError;
     private string? ManagedSecretResolverError => _managedSecretResolverError;
     private string ConnectionMetadata => IsNew
         ? _adapter?.DisplayName ?? "Select a provider protocol"
-        : $"{_connection?.Key} · {_adapter?.DisplayName} · {LatestTestLabel}";
+        : $"{_connection?.Key} · {_adapter?.DisplayName}";
     private string ConnectionTitle => IsNew
         ? "Create identity provider connection"
         : string.IsNullOrWhiteSpace(_connection?.DisplayName)
             ? string.IsNullOrWhiteSpace(_model?.DisplayName) ? "Identity provider connection" : _model.DisplayName
             : _connection.DisplayName;
-    private string LatestTestLabel => _connection?.LatestObservation is { } observation
-        ? $"{ShadowedRecordLabel("test", "Last test")}: {observation.Status} · {observation.ObservedAt.ToLocalTime():g}"
-        : _connection?.Shadowed == true ? ShadowedRecordLabel("not tested", "Not tested") : "Not tested";
     private string EffectiveSourceLabel => _connection?.Shadowed == true
-        ? _connection.IsConfigurationOwned ? "Studio" : "Deployment"
-        : _connection?.IsConfigurationOwned == true ? "Deployment" : "Studio";
-    private string RecordSourceLabel => _connection?.IsConfigurationOwned == true ? "Deployment configuration" : "Studio database";
+        ? _connection.IsConfigurationOwned ? "Database" : "Deployment"
+        : _connection?.IsConfigurationOwned == true ? "Deployment" : "Database";
     private string LifecycleStatusLabel => ConnectionStatusPresentation.LifecycleDisplayLabel(_connection!);
     private string ValidityStatusLabel => ConnectionStatusPresentation.ValidityDisplayLabel(_connection!);
-    private string ValidityHeading => _connection?.Shadowed == true
-        ? _connection.IsConfigurationOwned ? "Deployment record validity" : "Stored record validity"
-        : "Validity";
-    private string ShadowedRecordLabel(string suffix, string fallback) =>
-        _connection?.Shadowed != true
-            ? fallback
-            : $"{(_connection.IsConfigurationOwned ? "Deployment record" : "Stored record")} {suffix}";
-    private string ProvisioningPolicyLabel =>
-        _model?.UnlinkedPolicy is { } selection
-            ? _policyDescriptors.FirstOrDefault(descriptor => string.Equals(descriptor.Type, selection.Type, StringComparison.Ordinal))?.DisplayName ?? selection.Type
-            : "Not configured";
-
     private bool IsNew => string.IsNullOrWhiteSpace(ConnectionId);
     private bool CanSaveConnection => _connection?.IsConfigurationOwned != true && (IsNew ? _canCreate : _canUpdate);
+    private bool EditorReadOnly => IsNew ? !_canCreate : !_canUpdate || _connection?.IsConfigurationOwned == true;
+    private bool WorkspaceIsValid =>
+        _model is not null &&
+        _adapter is not null &&
+        !string.IsNullOrWhiteSpace(_model.DisplayName) &&
+        !string.IsNullOrWhiteSpace(_model.Key) &&
+        !_adapter.Fields.SelectMany(descriptor => DescriptorEditorState.Validate(descriptor, _model.AdapterSettings)).Any() &&
+        (!_adapter.Fields.Any(descriptor => DescriptorEditorState.IsUnsafeSettingActive(descriptor, _model.AdapterSettings)) ||
+         _canConfigureUnsafeSettings && _model.ConfirmUnsafeSettings);
+    private bool CurrentRevisionIsValid => string.Equals(_connection?.Validity, "valid", StringComparison.OrdinalIgnoreCase);
+    private bool CurrentRevisionIsInvalid => string.Equals(_connection?.Validity, "invalid", StringComparison.OrdinalIgnoreCase);
+    private IReadOnlyCollection<ConnectionValidationMessage> CurrentValidationErrors =>
+        (_connection?.ValidationErrors ?? [])
+        .Concat(CurrentRevisionIsValid ? [] : _validation?.Errors ?? [])
+        .GroupBy(error => (error.Field, error.Code, error.Message))
+        .Select(group => group.First())
+        .ToArray();
+    private IReadOnlyCollection<string> CurrentValidationWarnings =>
+        (_connection?.ValidationWarnings ?? [])
+        .Concat(_validation?.Warnings ?? [])
+        .Where(warning => !string.IsNullOrWhiteSpace(warning))
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+    private Severity CurrentValiditySeverity => CurrentRevisionIsInvalid
+        ? Severity.Error
+        : CurrentRevisionIsValid
+            ? Severity.Success
+            : CurrentValidationErrors.Count > 0
+                ? Severity.Error
+                : Severity.Info;
+    private string CurrentValiditySummary => CurrentRevisionIsInvalid
+        ? "The current revision is invalid."
+        : CurrentRevisionIsValid
+            ? "The current revision is valid."
+            : CurrentValidationErrors.Count > 0
+                ? "Validation found issues, but the current revision status could not be confirmed."
+                : "The current revision has not been validated.";
+    private string GetValidationFieldLabel(string field)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+            return "Connection";
+
+        var fieldName = field.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? field;
+        return fieldName switch
+        {
+            "displayName" => "Display name",
+            "key" => "Connection key",
+            _ => _adapter?.Fields.FirstOrDefault(descriptor => string.Equals(descriptor.Name, fieldName, StringComparison.Ordinal))?.DisplayName ?? field
+        };
+    }
+    private bool ValidationMessageIncludesField(ConnectionValidationMessage error) =>
+        error.Message.StartsWith(GetValidationFieldLabel(error.Field), StringComparison.OrdinalIgnoreCase);
+    private bool CanReviewProviderSettings =>
+        _customEditorType is null && CurrentValidationErrors.Any(IsProviderValidationError);
+    private string ProviderRepairActionLabel =>
+        CurrentValidationErrors.Any(error => error.Field.StartsWith("secretBindings.", StringComparison.Ordinal))
+            ? "Review secret binding"
+            : "Review provider settings";
+    private static bool IsProviderValidationError(ConnectionValidationMessage error) =>
+        error.Field.StartsWith("secretBindings.", StringComparison.Ordinal) ||
+        error.Field.StartsWith("adapterSettings.", StringComparison.Ordinal) ||
+        string.Equals(error.Field, "adapterType", StringComparison.Ordinal);
+    private void ReviewProviderSettings() => _activeWorkspaceTab = 1;
+    private int DiagnosticsTabIndex => _customEditorType is null ? 3 : 2;
     private bool CanToggleEnabled => _connection is not null && ConnectionActionAvailability.CanEnableOrDisable(_connection, _canUpdate);
     private string CurrentConnectionId => ConnectionId ?? _connection?.Id ?? string.Empty;
     private bool CanPromoteCurrentConnection =>
@@ -362,6 +436,14 @@
             OverridesConfigurationConnection: false,
             CanPromoteToConfigurationOverride: true
         };
+
+    private void ResolveCustomEditor()
+    {
+        _customEditorType = null;
+        if (_adapter is not null && CustomEditors.TryResolve(_adapter.CustomEditor, out var customEditorType))
+            _customEditorType = customEditorType;
+    }
+
     private IDictionary<string, object> GetCustomEditorParameters(Type customEditorType)
     {
         var parameters = new Dictionary<string, object>
@@ -398,7 +480,6 @@
         try
         {
             var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
-            await LoadRuntimeDescriptorAsync(api);
             _adapters = await api.GetAdaptersAsync();
             _policyDescriptors = await api.GetPoliciesAsync();
             _matcherDescriptors = await api.GetUserMatchersAsync();
@@ -410,6 +491,7 @@
                 if (_adapter is null)
                     return;
 
+                ResolveCustomEditor();
                 _connection = new ConnectionDetail { AdapterType = _adapter.Type, Scope = new ConnectionScope() };
                 _model = new ConnectionMutation { AdapterType = _adapter.Type, AdapterSettingsVersion = _adapter.SettingsVersion, Scope = new ConnectionScope() };
                 ConnectionAdapterSelection.ApplyDefaults(_model, _adapter);
@@ -418,6 +500,7 @@
 
             _connection = await api.GetAsync(ConnectionId!);
             _adapter = _adapters.FirstOrDefault(adapter => string.Equals(adapter.Type, _connection.AdapterType, StringComparison.Ordinal));
+            ResolveCustomEditor();
             _model = ToMutation(_connection);
             _loadedConnectionId = ConnectionId;
             await FindExistingStudioOverrideAsync(api);
@@ -446,6 +529,7 @@
             var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
             _connection = await api.GetAsync(ConnectionId!);
             _adapter = _adapters.FirstOrDefault(adapter => string.Equals(adapter.Type, _connection.AdapterType, StringComparison.Ordinal));
+            ResolveCustomEditor();
             _model = ToMutation(_connection);
             _validation = null;
             _isDirty = false;
@@ -488,20 +572,6 @@
     private void ManageExistingStudioOverride() =>
         Navigation.NavigateTo($"security/external-authentication/connections/{Uri.EscapeDataString(_existingStudioOverrideId!)}");
 
-    private async Task LoadRuntimeDescriptorAsync(IExternalAuthenticationConnectionsApi api)
-    {
-        try
-        {
-            _runtimeDescriptor = await api.GetRuntimeAsync();
-            _runtimeDescriptorUnavailable = false;
-        }
-        catch
-        {
-            _runtimeDescriptor = null;
-            _runtimeDescriptorUnavailable = true;
-        }
-    }
-
     private async Task LoadRoleOptionsAsync()
     {
         if (!_canReadRoles)
@@ -542,6 +612,26 @@
         {
             _managedSecretResolverError = "Managed secret storage capability could not be loaded. Contact the server administrator.";
         }
+    }
+
+    private async Task SaveWorkspaceAsync()
+    {
+        if (_model is null || _generalEditor is null || _providerEditor is null || !CanSaveConnection)
+            return;
+
+        if (!await _generalEditor.ValidateAsync())
+        {
+            _activeWorkspaceTab = 0;
+            return;
+        }
+
+        if (!await _providerEditor.ValidateAsync())
+        {
+            _activeWorkspaceTab = 1;
+            return;
+        }
+
+        await SaveAsync(_model);
     }
 
     private async Task SaveAsync(ConnectionMutation mutation)
@@ -626,6 +716,7 @@
             return Task.CompletedTask;
 
         _adapter = adapter;
+        ResolveCustomEditor();
         ConnectionAdapterSelection.Apply(_connection, _model, adapter);
         _isDirty = true;
         return Task.CompletedTask;
@@ -646,7 +737,7 @@
                 ConnectionConcurrency.ToIfMatch(_connection.Revision));
             _model = ToMutation(_connection);
             _isDirty = false;
-            Snackbar.Add("Managed secret replaced. Its value was not returned to Studio.", Severity.Success);
+            Snackbar.Add("Managed secret replaced. Its value was not returned to Elsa Studio.", Severity.Success);
         }
         catch (ManagementApiException exception) when (exception.IsConcurrencyConflict)
         {
@@ -658,11 +749,11 @@
         }
         catch (ApiException exception)
         {
-            ShowManagementError(exception, "The managed secret could not be replaced. The value was not retained by Studio.");
+            ShowManagementError(exception, "The managed secret could not be replaced. The value was not retained by Elsa Studio.");
         }
         catch
         {
-            Snackbar.Add("The managed secret could not be replaced. The value was not retained by Studio.", Severity.Error);
+            Snackbar.Add("The managed secret could not be replaced. The value was not retained by Elsa Studio.", Severity.Error);
         }
     }
 
@@ -844,8 +935,22 @@
         try
         {
             var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
-            _validation = await api.ValidateAsync(CurrentConnectionId);
-            _activeWorkspaceTab = 2;
+            _validation = null;
+            _connection.Validity = "unknown";
+            _connection.ValidationErrors = [];
+            _connection.ValidationWarnings = [];
+            var validation = await api.ValidateAsync(CurrentConnectionId);
+            _activeWorkspaceTab = DiagnosticsTabIndex;
+            var refreshed = await api.GetAsync(CurrentConnectionId);
+            if (refreshed.Revision != _connection.Revision)
+            {
+                Snackbar.Add("The connection changed while it was being validated. Reload it before validating again.", Severity.Warning);
+                return;
+            }
+            _validation = validation;
+            _connection.Validity = refreshed.Validity;
+            _connection.ValidationErrors = refreshed.ValidationErrors;
+            _connection.ValidationWarnings = refreshed.ValidationWarnings;
         }
         catch (ApiException exception)
         {
@@ -979,7 +1084,7 @@
         };
         ConnectionId = null;
         _isDirty = true;
-        Snackbar.Add("A complete database-owned copy is ready. Review every field and reconfigure its secrets after saving the draft.", Severity.Info);
+        Snackbar.Add("A complete Database-owned copy is ready. Review every field and reconfigure its secrets after saving the draft.", Severity.Info);
     }
 
     private async Task PromoteToConfigurationOverrideAsync()
@@ -988,8 +1093,8 @@
             return;
 
         var confirmed = await Dialogs.ShowMessageBoxAsync(
-            "Make this Studio record effective?",
-            "This makes the existing Studio record override deployment configuration. Its configured secret bindings are preserved. While disabled, it still shadows deployment configuration; archiving it reveals the deployment connection again.",
+            "Make this Database record effective?",
+            "This makes the existing Database record override deployment configuration. Its configured secret bindings are preserved. While disabled, it still shadows deployment configuration; archiving it reveals the deployment connection again.",
             yesText: "Make record effective",
             cancelText: "Cancel") == true;
         if (!confirmed)
@@ -997,7 +1102,7 @@
 
         var mutation = ToMutation(_connection);
         mutation.OverridesConfigurationConnection = true;
-        await UpdateExistingConnectionAsync(mutation, "This Studio record now overrides deployment configuration.");
+        await UpdateExistingConnectionAsync(mutation, "This Database record now overrides deployment configuration.");
     }
 
     private void Back() => Navigation.NavigateTo("security/external-authentication/connections");

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Edit.razor.css
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Edit.razor.css
@@ -1,0 +1,7 @@
+.connection-workspace__actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    border-top: 1px solid var(--mud-palette-lines-default, #d7dde5);
+    background: var(--mud-palette-surface, #fff);
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Index.razor
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Pages/Connections/Index.razor
@@ -1,4 +1,5 @@
 @page "/security/external-authentication/connections"
+@using Elsa.Studio.ExternalAuthentication.Components.Pagination
 @using Elsa.Studio.ExternalAuthentication.Services
 @inject Elsa.Studio.Contracts.IBackendApiClientProvider ApiClientProvider
 @inject Elsa.Studio.ExternalAuthentication.Services.IExternalAuthenticationPermissionService Permissions
@@ -46,7 +47,16 @@
         }
         else
         {
-            <MudTable T="ConnectionSummary" Items="_items" Dense="true" Hover="true" Elevation="0" Breakpoint="Breakpoint.Md" Class="connection-list__table">
+            <MudTable
+                T="ConnectionSummary"
+                Items="_items"
+                Dense="true"
+                Hover="true"
+                Elevation="0"
+                Breakpoint="Breakpoint.Md"
+                RowStyle="cursor: pointer;"
+                OnRowClick="OnRowClick"
+                Class="connection-list__table">
                 <HeaderContent>
                     <MudTh>Connection</MudTh>
                     <MudTh>Ownership</MudTh>
@@ -56,7 +66,16 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Connection">
-                        <MudText Typo="Typo.body2" Class="font-weight-medium">@context.DisplayName</MudText>
+                        <span @onclick:stopPropagation="true">
+                            <MudLink
+                                Href="@ConnectionUrl(context)"
+                                Color="Color.Inherit"
+                                Underline="Underline.Hover"
+                                Class="font-weight-medium"
+                                aria-label="@($"Manage {context.DisplayName}")">
+                                @context.DisplayName
+                            </MudLink>
+                        </span>
                         <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Spacing="1">
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Key · @context.AdapterType</MudText>
                             @if (context.IsPreferred)
@@ -75,7 +94,43 @@
                                 Color="@(context.IsConfigurationOwned ? Color.Info : Color.Default)">
                                 @ConnectionListPresentation.OwnershipLabel(context)
                             </MudChip>
-                            @if (ConnectionListPresentation.OwnershipRelationship(context) is { } relationship)
+                            @if (ConnectionListPresentation.GetShadowingConnection(context) is { } shadowingConnection)
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    Shadowed by
+                                    <span @onclick:stopPropagation="true">
+                                        <MudLink
+                                            Href="@ConnectionUrl(shadowingConnection.Id)"
+                                            Underline="Underline.Hover"
+                                            aria-label="@($"Manage shadowing connection {shadowingConnection.DisplayName}")">
+                                            @shadowingConnection.DisplayName
+                                        </MudLink>
+                                    </span>
+                                </MudText>
+                            }
+                            else if (ConnectionListPresentation.GetShadowedConnections(context) is { Count: > 0 } shadowedConnections)
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @($"{ConnectionListPresentation.ShadowedConnectionsRelationship(context)} ")
+                                    @for (var index = 0; index < shadowedConnections.Count; index++)
+                                    {
+                                        if (index > 0)
+                                        {
+                                            <span>, </span>
+                                        }
+                                        var shadowedConnection = shadowedConnections[index];
+                                        <span @onclick:stopPropagation="true">
+                                            <MudLink
+                                                Href="@ConnectionUrl(shadowedConnection.Id)"
+                                                Underline="Underline.Hover"
+                                                aria-label="@($"Manage shadowed connection {shadowedConnection.DisplayName}")">
+                                                @shadowedConnection.DisplayName
+                                            </MudLink>
+                                        </span>
+                                    }
+                                </MudText>
+                            }
+                            else if (ConnectionListPresentation.OwnershipRelationship(context) is { } relationship)
                             {
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">@relationship</MudText>
                             }
@@ -120,42 +175,83 @@
                         }
                     </MudTd>
                     <MudTd DataLabel="Actions" Style="text-align: right;">
-                        <MudMenu
-                            Icon="@Icons.Material.Filled.MoreVert"
-                            Size="Size.Small"
-                            Dense="true"
-                            AriaLabel="@($"Actions for {context.DisplayName}")">
-                            <MudMenuItem
-                                Icon="@(context.IsConfigurationOwned ? Icons.Material.Outlined.Pageview : Icons.Material.Outlined.Edit)"
-                                OnClick="@(() => OpenAsync(context))">
-                                @(context.IsConfigurationOwned ? "View" : "Manage")
-                            </MudMenuItem>
-                            @if (ConnectionActionAvailability.CanEnableOrDisable(context, _canUpdate))
-                            {
+                        <div @onclick:stopPropagation="true">
+                            <MudMenu
+                                Icon="@Icons.Material.Filled.MoreVert"
+                                Size="Size.Small"
+                                Dense="true"
+                                AriaLabel="@($"Actions for {context.DisplayName}")">
                                 <MudMenuItem
-                                    Icon="@(context.EnabledIntent ? Icons.Material.Outlined.ToggleOff : Icons.Material.Outlined.ToggleOn)"
-                                    OnClick="@(() => ToggleEnabledAsync(context))">
-                                    @(context.EnabledIntent ? "Disable" : "Enable")
+                                    Icon="@(context.IsConfigurationOwned ? Icons.Material.Outlined.Pageview : Icons.Material.Outlined.Edit)"
+                                    OnClick="@(() => OpenAsync(context))">
+                                    @(context.IsConfigurationOwned ? "View" : "Manage")
                                 </MudMenuItem>
-                            }
-                        </MudMenu>
+                                @if (HasDiagnosticsActions(context) || HasLifecycleActions(context))
+                                {
+                                    <MudDivider />
+                                }
+                                @if (CanTestConnection(context))
+                                {
+                                    <MudMenuItem
+                                        Icon="@Icons.Material.Outlined.CheckCircle"
+                                        OnClick="@(() => TestConnectionAsync(context))">
+                                        Test connection
+                                    </MudMenuItem>
+                                }
+                                @if (CanPreviewSignIn(context))
+                                {
+                                    <MudMenuItem
+                                        Icon="@Icons.Material.Outlined.Login"
+                                        OnClick="@(() => PreviewSignInAsync(context))">
+                                        Preview sign-in
+                                    </MudMenuItem>
+                                }
+                                @if (HasDiagnosticsActions(context) && HasLifecycleActions(context))
+                                {
+                                    <MudDivider />
+                                }
+                                @if (ConnectionActionAvailability.CanEnableOrDisable(context, _canUpdate))
+                                {
+                                    <MudMenuItem
+                                        Icon="@(context.EnabledIntent ? Icons.Material.Outlined.ToggleOff : Icons.Material.Outlined.ToggleOn)"
+                                        OnClick="@(() => ToggleEnabledAsync(context))">
+                                        @(context.EnabledIntent ? "Disable" : "Enable")
+                                    </MudMenuItem>
+                                }
+                                @if (CanArchiveConnection(context))
+                                {
+                                    <MudMenuItem
+                                        Icon="@Icons.Material.Outlined.Archive"
+                                        OnClick="@(() => ArchiveAsync(context))">
+                                        Archive
+                                    </MudMenuItem>
+                                }
+                            </MudMenu>
+                        </div>
                     </MudTd>
                 </RowTemplate>
                 <NoRecordsContent><MudText>No connections match the current filters.</MudText></NoRecordsContent>
             </MudTable>
-            <MudStack Row="true" Wrap="Wrap.Wrap" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center" Spacing="2" Class="pa-3 connection-list__footer" aria-label="Connection pages">
-                <MudText Typo="Typo.caption">Page @_paging.PageNumber</MudText>
-                <MudButton Variant="Variant.Outlined" Disabled="@(!_paging.HasPrevious || _loading)" OnClick="PreviousPageAsync">Previous page</MudButton>
-                <MudButton Variant="Variant.Outlined" Disabled="@(!_paging.HasNext || _loading)" OnClick="NextPageAsync">Next page</MudButton>
-            </MudStack>
+            <CursorTablePager
+                PageNumber="_paging.PageNumber"
+                PageSize="_pageSize"
+                HasPrevious="_paging.HasPrevious"
+                HasNext="_paging.HasNext"
+                Loading="_loading"
+                PageSizeChanged="SetPageSizeAsync"
+                FirstPage="ReloadAsync"
+                PreviousPage="PreviousPageAsync"
+                NextPage="NextPageAsync" />
         }
     </MudPaper>
 </MudContainer>
 
 @code {
     private readonly List<ConnectionSummary> _items = [];
+    private readonly Dictionary<string, AdapterDescriptor> _adapters = new(StringComparer.OrdinalIgnoreCase);
     private string? _search;
     private string? _source;
+    private int _pageSize = 10;
     private readonly Elsa.Studio.ExternalAuthentication.Services.ConnectionListPagingState _paging = new();
     private readonly Elsa.Studio.ExternalAuthentication.Services.ConnectionListRequestState _requests = new();
     private bool _includeArchived;
@@ -163,20 +259,46 @@
     private bool _canRead;
     private bool _canCreate;
     private bool _canUpdate;
+    private bool _canArchive;
+    private bool _canTest;
+    private bool _canPreview;
     private bool _canRevokeSessions;
     private bool _configurationOverridesAllowed;
 
     private string ConfigurationGuidance => _configurationOverridesAllowed
-        ? "Deployment-owned connections are read-only. Authorized administrators can create or promote a Studio record to override them. Enabled, valid Studio connections become login methods without a restart."
-        : "Deployment-owned connections are read-only and must be changed in deployment configuration. Enabled, valid Studio connections become login methods without a restart.";
+        ? "Deployment-owned connections are read-only. Authorized administrators can create or promote a Database record to override them. Enabled, valid Database connections become login methods without a restart."
+        : "Deployment-owned connections are read-only and must be changed in deployment configuration. Enabled, valid Database connections become login methods without a restart.";
 
     protected override async Task OnInitializedAsync()
     {
         _canRead = await Permissions.HasAsync(ExternalAuthenticationPermissions.Read);
         _canCreate = await Permissions.HasAsync(ExternalAuthenticationPermissions.Create);
         _canUpdate = await Permissions.HasAsync(ExternalAuthenticationPermissions.Update);
+        _canArchive = await Permissions.HasAsync(ExternalAuthenticationPermissions.Archive);
+        _canTest = await Permissions.HasAsync(ExternalAuthenticationPermissions.Test);
+        _canPreview = await Permissions.HasAsync(ExternalAuthenticationPermissions.Preview);
         _canRevokeSessions = await Permissions.HasAsync(ExternalAuthenticationPermissions.SessionsRevoke);
+        await LoadAdaptersAsync();
         await ReloadAsync();
+    }
+
+    private async Task LoadAdaptersAsync()
+    {
+        if (!_canRead || (!_canTest && !_canPreview))
+            return;
+
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
+            var adapters = await api.GetAdaptersAsync();
+            _adapters.Clear();
+            foreach (var adapter in adapters)
+                _adapters[adapter.Type] = adapter;
+        }
+        catch (Exception exception)
+        {
+            Snackbar.Add(exception.Message, Severity.Error);
+        }
     }
 
     private async Task ReloadAsync()
@@ -200,6 +322,15 @@
     private async Task SetIncludeArchivedAsync(bool includeArchived)
     {
         _includeArchived = includeArchived;
+        await ReloadAsync();
+    }
+
+    private async Task SetPageSizeAsync(int pageSize)
+    {
+        if (_pageSize == pageSize)
+            return;
+
+        _pageSize = pageSize;
         await ReloadAsync();
     }
 
@@ -232,7 +363,7 @@
         try
         {
             var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
-            var response = await api.ListAsync(search, source, archived: includeArchived ? null : false, cursor: cursor, pageSize: 25);
+            var response = await api.ListAsync(search, source, archived: includeArchived ? null : false, cursor: cursor, pageSize: _pageSize);
             if (!_requests.IsCurrent(request))
                 return;
 
@@ -255,7 +386,94 @@
     }
 
     private void CreateAsync() => Navigation.NavigateTo("security/external-authentication/connections/new");
-    private void OpenAsync(ConnectionSummary connection) => Navigation.NavigateTo($"security/external-authentication/connections/{Uri.EscapeDataString(connection.Id)}");
+    private static string ConnectionUrl(ConnectionSummary connection) => ConnectionUrl(connection.Id);
+    private static string ConnectionUrl(string connectionId) => $"security/external-authentication/connections/{Uri.EscapeDataString(connectionId)}";
+    private void OpenAsync(ConnectionSummary connection) => Navigation.NavigateTo(ConnectionUrl(connection));
+    private void OnRowClick(TableRowClickEventArgs<ConnectionSummary> args)
+    {
+        if (args.Item is not null)
+            OpenAsync(args.Item);
+    }
+
+    private bool CanTestConnection(ConnectionSummary connection) =>
+        _canTest &&
+        _adapters.TryGetValue(connection.AdapterType, out var adapter) &&
+        adapter.Capabilities.SupportsTest;
+    private bool CanPreviewSignIn(ConnectionSummary connection) =>
+        _canPreview &&
+        _adapters.TryGetValue(connection.AdapterType, out var adapter) &&
+        adapter.Capabilities.SupportsPreview;
+    private bool CanArchiveConnection(ConnectionSummary connection) =>
+        !connection.Archived &&
+        ConnectionActionAvailability.CanArchiveOrRestore(connection, _canArchive);
+    private bool HasDiagnosticsActions(ConnectionSummary connection) =>
+        CanTestConnection(connection) || CanPreviewSignIn(connection);
+    private bool HasLifecycleActions(ConnectionSummary connection) =>
+        ConnectionActionAvailability.CanEnableOrDisable(connection, _canUpdate) || CanArchiveConnection(connection);
+
+    private async Task TestConnectionAsync(ConnectionSummary connection)
+    {
+        if (!CanTestConnection(connection))
+            return;
+
+        try
+        {
+            connection.LatestObservation = await ConnectionOperationActions.TestConnectionAsync(ApiClientProvider, connection);
+            Snackbar.Add(ConnectionOperationActions.TestCompletedMessage, Severity.Success);
+        }
+        catch (Exception exception)
+        {
+            Snackbar.Add(
+                ConnectionOperationActions.PresentError(exception, ConnectionOperationActions.TestFailedMessage),
+                Severity.Error);
+        }
+    }
+
+    private async Task PreviewSignInAsync(ConnectionSummary connection)
+    {
+        if (!CanPreviewSignIn(connection) || !_adapters.TryGetValue(connection.AdapterType, out var adapter))
+            return;
+
+        var parameters = new DialogParameters<PreviewSignInDialog>
+        {
+            { component => component.Connection, connection },
+            { component => component.Adapter, adapter }
+        };
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            CloseOnEscapeKey = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Medium
+        };
+        await Dialogs.ShowAsync<PreviewSignInDialog>("Preview sign-in", parameters, options);
+    }
+
+    private async Task ArchiveAsync(ConnectionSummary connection)
+    {
+        if (!CanArchiveConnection(connection))
+            return;
+
+        if (await Dialogs.ShowMessageBoxAsync(
+                "Archive connection?",
+                "Archiving removes this connection from login discovery but preserves its identity links. You can restore it later as disabled.",
+                yesText: "Archive",
+                cancelText: "Cancel") != true)
+            return;
+
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IExternalAuthenticationConnectionsApi>();
+            await api.ArchiveAsync(connection.Id, ConnectionConcurrency.ToIfMatch(connection.Revision));
+            Snackbar.Add("Connection archived.", Severity.Success);
+            await ReloadAsync();
+        }
+        catch (Exception exception)
+        {
+            Snackbar.Add(exception.Message, Severity.Error);
+        }
+    }
+
     private async Task ToggleEnabledAsync(ConnectionSummary connection)
     {
         if (!ConnectionActionAvailability.CanEnableOrDisable(connection, _canUpdate))

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Services/ConnectionManagementUiState.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Services/ConnectionManagementUiState.cs
@@ -226,14 +226,25 @@ public static class ConnectionStatusPresentation
 public static class ConnectionListPresentation
 {
     public static string OwnershipLabel(ConnectionSummary connection) =>
-        connection.IsConfigurationOwned ? "Deployment" : "Studio";
+        connection.IsConfigurationOwned ? "Deployment" : "Database";
 
     public static string? OwnershipRelationship(ConnectionSummary connection) =>
         connection.OverridesConfigurationConnection
             ? "Overrides deployment"
             : connection.Shadowed
-                ? connection.IsConfigurationOwned ? "Shadowed by Studio" : "Shadowed by deployment"
+                ? connection.IsConfigurationOwned ? "Shadowed by Database" : "Shadowed by deployment"
                 : null;
+
+    public static ConnectionReference? GetShadowingConnection(ConnectionSummary connection) =>
+        IsValidRelationshipReference(connection, connection.ShadowedBy) ? connection.ShadowedBy : null;
+
+    public static IReadOnlyList<ConnectionReference> GetShadowedConnections(ConnectionSummary connection) =>
+        connection.Shadows
+            .Where(reference => IsValidRelationshipReference(connection, reference))
+            .ToArray();
+
+    public static string ShadowedConnectionsRelationship(ConnectionSummary connection) =>
+        connection.OverridesConfigurationConnection ? "Overrides" : "Shadows";
 
     public static string AvailabilityLabel(ConnectionSummary connection) =>
         connection.Archived
@@ -276,6 +287,12 @@ public static class ConnectionListPresentation
                         : connection.EnabledIntent
                             ? Icons.Material.Outlined.WarningAmber
                             : Icons.Material.Outlined.PauseCircle;
+
+    private static bool IsValidRelationshipReference(ConnectionSummary connection, ConnectionReference? reference) =>
+        reference is not null &&
+        !string.IsNullOrWhiteSpace(reference.Id) &&
+        !string.IsNullOrWhiteSpace(reference.DisplayName) &&
+        !string.Equals(connection.Id, reference.Id, StringComparison.Ordinal);
 }
 
 public static class ConnectionObservationPresentation
@@ -369,7 +386,7 @@ public static class ConnectionDisableConfirmation
 public static class ConnectionConcurrency
 {
     public static string ToIfMatch(long revision) => $"\"{revision}\"";
-    public static bool IsConflict(System.Net.HttpStatusCode statusCode) => statusCode is System.Net.HttpStatusCode.Conflict or System.Net.HttpStatusCode.PreconditionFailed;
+    public static bool IsConflict(System.Net.HttpStatusCode statusCode) => statusCode == System.Net.HttpStatusCode.PreconditionFailed;
 }
 
 public static class ConnectionConflictRecovery
@@ -519,10 +536,16 @@ public sealed record ConnectionManagementErrorInfo(
     {
         get
         {
+            var message = ConflictCode switch
+            {
+                "configuration_preferred_connection" => "A configuration-owned connection is already the preferred sign-in method. Clear Preferred on this connection before enabling it, or override the existing preferred connection instead.",
+                "default_connection_conflict" => "Another database connection is already the preferred sign-in method. Clear Preferred on one of the connections before enabling this one.",
+                _ => Message
+            };
             var details = Errors.Select(error => $"{error.Field}: {error.Message}")
                 .Concat(Warnings.Select(warning => $"Warning: {warning}"))
                 .ToArray();
-            return details.Length == 0 ? Message : $"{Message} {string.Join(" ", details)}";
+            return details.Length == 0 ? message : $"{message} {string.Join(" ", details)}";
         }
     }
 

--- a/src/modules/Elsa.Studio.ExternalAuthentication/Services/ConnectionOperationActions.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication/Services/ConnectionOperationActions.cs
@@ -1,0 +1,32 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.ExternalAuthentication.Client;
+using Elsa.Studio.ExternalAuthentication.Models;
+using Refit;
+
+namespace Elsa.Studio.ExternalAuthentication.Services;
+
+public static class ConnectionOperationActions
+{
+    public const string TestCompletedMessage = "Connection test completed. The result contains only redacted diagnostics.";
+    public const string TestFailedMessage = "The connection test failed before a diagnostic observation was recorded. Check the connection requirements and server logs, then try again.";
+
+    public static async Task<ConnectionObservation> TestConnectionAsync(
+        IBackendApiClientProvider apiClientProvider,
+        ConnectionSummary connection,
+        CancellationToken cancellationToken = default)
+    {
+        var api = await apiClientProvider.GetApiAsync<IExternalAuthenticationOperationsApi>(cancellationToken);
+        var result = await api.TestAsync(
+            connection.Id,
+            ConnectionConcurrency.ToIfMatch(connection.Revision),
+            cancellationToken);
+        return result.ToObservation();
+    }
+
+    public static string PresentError(Exception exception, string fallbackMessage) =>
+        exception is ApiException apiException
+            ? ConnectionManagementError
+                .Parse(apiException.StatusCode, apiException.Content, fallbackMessage)
+                .OperationalDisplayMessage
+            : fallbackMessage;
+}


### PR DESCRIPTION
Extracted from [#924](https://github.com/elsa-workflows/elsa-studio/pull/924) as the connection workspace and editor slice.

## Summary
- redesigns the connection list, editor, operations, and policy surfaces
- adds theme-aware fields, row actions, validation, preview, and diagnostics UX
- expands connection workspace regression coverage

## Stack
4 of 7. Previous: [#927](https://github.com/elsa-workflows/elsa-studio/pull/927). Next: [#929](https://github.com/elsa-workflows/elsa-studio/pull/929).

## Validation
- Elsa.Studio.ExternalAuthentication.Tests (net10 Release): 209 passed
- canonical connection route and menu boundary covered
- self-review loop: clean
