### PR TITLE
[5/7] Theme the workflow designer and add output converters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview1" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview.5397" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
@@ -41,9 +41,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.24" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.18" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -60,9 +60,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.18" />
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.18" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -79,9 +79,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
     <PackageVersion Include="Refit" Version="10.0.1" />
   </ItemGroup>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IOutputConverterService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IOutputConverterService.cs
@@ -1,0 +1,17 @@
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Provides output converter descriptors that are compatible with declared binding types.
+/// </summary>
+public interface IOutputConverterService
+{
+    /// <summary>
+    /// Gets the output converters compatible with the specified declared types.
+    /// </summary>
+    Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(
+        string sourceType,
+        string destinationType,
+        CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteOutputConverterService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteOutputConverterService.cs
@@ -1,0 +1,29 @@
+using Elsa.Api.Client.Resources.OutputConverters.Contracts;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Requests;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <summary>
+/// Retrieves output converter descriptors from the connected Elsa server.
+/// </summary>
+public class RemoteOutputConverterService(IBackendApiClientProvider backendApiClientProvider) : IOutputConverterService
+{
+    /// <inheritdoc />
+    public async Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(
+        string sourceType,
+        string destinationType,
+        CancellationToken cancellationToken = default)
+    {
+        var api = await backendApiClientProvider.GetApiAsync<IOutputConvertersApi>(cancellationToken);
+        var response = await api.ListAsync(new ListOutputConvertersRequest
+        {
+            SourceType = sourceType,
+            DestinationType = destinationType
+        }, cancellationToken);
+
+        return response.Items;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IStorageDriverService, RemoteStorageDriverService>()
             .AddScoped<IServerInformationProvider, RemoteServerInformationProvider>()
             .AddScoped<IVariableTypeService, RemoteVariableTypeService>()
+            .AddScoped<IOutputConverterService, RemoteOutputConverterService>()
             .AddScoped<IWorkflowActivationStrategyService, RemoteWorkflowActivationStrategyService>()
             .AddScoped<ILogPersistenceStrategyService, RemoteLogPersistenceStrategyService>()
             .AddScoped<IIncidentStrategiesProvider, RemoteIncidentStrategiesProvider>()

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/DesignerThemeTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/DesignerThemeTests.cs
@@ -1,0 +1,112 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.Designer.Services;
+using MudBlazor;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+public class DesignerThemeTests
+{
+    [Fact]
+    public void FromPalette_ShouldMapEveryX6ColorFromTheActiveMudPalette()
+    {
+        var palette = new PaletteDark
+        {
+            Surface = "#18212b",
+            BackgroundGray = "#233041",
+            LinesDefault = "#405064",
+            TextPrimary = "#f4f7fa",
+            TextSecondary = "#aab6c4",
+            Primary = "#66a9ff",
+            Secondary = "#45c7b8",
+            Success = "#65c98a"
+        };
+
+        var theme = X6DesignerTheme.FromPalette(palette);
+
+        Assert.Equal("#405064ff", theme.Grid);
+        Assert.Equal("#405064ff", theme.Edge);
+        Assert.Equal("#18212bff", theme.PortSurface);
+        Assert.Equal("#66a9ffff", theme.PortStroke);
+        Assert.Equal("#aab6c4ff", theme.PortText);
+        Assert.Equal("#66a9ffff", theme.Selection);
+        Assert.Equal("#45c7b8ff", theme.ConnectionHighlight);
+        Assert.Equal("#65c98aff", theme.EmbeddingHighlight);
+    }
+
+    [Fact]
+    public void GridColor_ShouldDefaultToTheActiveTheme()
+    {
+        var gridArgs = new X6GridArgs();
+
+        Assert.Null(gridArgs.Color);
+    }
+
+    [Fact]
+    public void ThemeSubscription_ShouldHandleBothThemeEventsAndUnsubscribe()
+    {
+        var themeService = new StubThemeService();
+        var applyCount = 0;
+        var subscription = new X6DesignerThemeSubscription(
+            themeService,
+            _ =>
+            {
+                applyCount++;
+                return Task.CompletedTask;
+            });
+
+        themeService.RaiseCurrentThemeChanged();
+        themeService.RaiseIsDarkModeChanged();
+
+        Assert.Equal(2, applyCount);
+
+        subscription.Dispose();
+        themeService.RaiseCurrentThemeChanged();
+
+        Assert.Equal(2, applyCount);
+    }
+
+    [Fact]
+    public void V2NodeAssets_ShouldUseThemeTokensInsteadOfAWhiteInlineSurface()
+    {
+        var css = ReadAsset("designer.v2.css");
+        var wrapper = ReadAsset("ActivityWrapper.razor");
+
+        Assert.Contains("--elsa-designer-node-surface: var(--mud-palette-surface)", css);
+        Assert.Contains("background-color: var(--elsa-designer-node-surface)", css);
+        Assert.Contains("color: var(--elsa-designer-node-text)", css);
+        Assert.Contains("color: var(--elsa-designer-node-muted)", css);
+        Assert.Contains("--elsa-activity-accent", wrapper);
+        Assert.DoesNotContain("const string white", wrapper);
+        Assert.DoesNotContain("background-color: {backgroundColor}", wrapper);
+    }
+
+    [Fact]
+    public void V1NodeAssets_ShouldAlsoRemainReadableInDarkMode()
+    {
+        var css = ReadAsset("designer.v1.css");
+        var wrapper = ReadAsset("ActivityWrapperV1.razor");
+
+        Assert.Contains("background-color: var(--mud-palette-surface)", css);
+        Assert.Contains("color: var(--mud-palette-text-primary)", css);
+        Assert.Contains("--elsa-activity-accent", wrapper);
+        Assert.DoesNotContain("const string white", wrapper);
+        Assert.DoesNotContain("background-color: {Color}", wrapper);
+    }
+
+    private static string ReadAsset(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "DesignerAssets", name));
+
+    private sealed class StubThemeService : IThemeService
+    {
+        public event Action CurrentThemeChanged = delegate { };
+        public event Action IsDarkModeChanged = delegate { };
+        public MudTheme CurrentTheme { get; set; } = new();
+        public bool IsDarkMode { get; set; }
+
+        public void RaiseCurrentThemeChanged() => CurrentThemeChanged();
+        public void RaiseIsDarkModeChanged() => IsDarkModeChanged();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
@@ -17,4 +17,31 @@
         <ProjectReference Include="..\Elsa.Studio.Workflows.Designer\Elsa.Studio.Workflows.Designer.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\css\designer.v2.css"
+              Link="DesignerAssets\designer.v2.css"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\css\designer.v1.css"
+              Link="DesignerAssets\designer.v1.css"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\Components\ActivityWrappers\V2\ActivityWrapper.razor"
+              Link="DesignerAssets\ActivityWrapper.razor"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\Components\ActivityWrappers\V1\ActivityWrapper.razor"
+              Link="DesignerAssets\ActivityWrapperV1.razor"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\internal\init.ts"
+              Link="DesignerAssets\init.ts"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\api\create-graph.ts"
+              Link="DesignerAssets\create-graph.ts"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\api\calculate-activity-size.ts"
+              Link="DesignerAssets\calculate-activity-size.ts"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\api\update-activity-size.ts"
+              Link="DesignerAssets\update-activity-size.ts"
+              CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6ActivitySizingContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6ActivitySizingContractTests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+public sealed class X6ActivitySizingContractTests
+{
+    [Fact]
+    public void DetachedActivityMeasurements_UseTheLiveDesignerLayoutContext()
+    {
+        var calculation = ReadAsset("calculate-activity-size.ts");
+        var update = ReadAsset("update-activity-size.ts");
+        var graphCreation = ReadAsset("create-graph.ts");
+
+        Assert.Contains("getActivityMeasurementScopeClass", calculation, StringComparison.Ordinal);
+        Assert.Contains("wrapper.className = item.measurementScopeClass", calculation, StringComparison.Ordinal);
+        Assert.Contains("calculateActivitySize(activity, portCount, measurementScopeClass)", update, StringComparison.Ordinal);
+        Assert.Contains("enforceMinimumNodeSize(node, measurementScopeClass)", graphCreation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActivitySizeCache_DistinguishesEffectiveLabelsAndDesignerLayouts()
+    {
+        var calculation = ReadAsset("calculate-activity-size.ts");
+
+        Assert.Contains("activity.name", calculation, StringComparison.Ordinal);
+        Assert.Contains("measurementScopeClass", calculation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManualResize_EnforcesAndPersistsSizeOnlyAfterTheGestureCompletes()
+    {
+        var graphCreation = ReadAsset("create-graph.ts");
+
+        Assert.Contains("graph.on('node:resized', onNodeResizeCompleted)", graphCreation, StringComparison.Ordinal);
+        Assert.DoesNotContain("graph.on('node:change:size'", graphCreation, StringComparison.Ordinal);
+    }
+
+    private static string ReadAsset(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "DesignerAssets", name));
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6PortInteractionContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6PortInteractionContractTests.cs
@@ -1,0 +1,60 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+public sealed class X6PortInteractionContractTests
+{
+    [Fact]
+    public void ActivityPorts_UseLargerMagneticHitTargetsAndHoverExpansion()
+    {
+        var portRegistration = ReadAsset("init.ts");
+        var graphCreation = ReadAsset("create-graph.ts");
+        var designerStyles = ReadAsset("designer.v2.css");
+
+        // A transparent circle makes the magnetic target substantially easier to acquire without
+        // changing the normal, compact port appearance.
+        Assert.Contains("selector: \"hitArea\"", portRegistration, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex("hitArea:\\s*\\{[^}]*r:\\s*(?:1[2-9]|[2-9]\\d)", RegexOptions.CultureInvariant),
+            portRegistration);
+        Assert.Contains("selector: \"port\"", portRegistration, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex("port:\\s*\\{[^}]*magnet:\\s*true", RegexOptions.CultureInvariant),
+            portRegistration);
+        Assert.Contains("selector: \"dock\"", portRegistration, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex("dock:\\s*\\{[^}]*width:\\s*14[^}]*height:\\s*24", RegexOptions.CultureInvariant),
+            portRegistration);
+        Assert.Contains("selector: \"circle\"", portRegistration, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex("circle:\\s*\\{[^}]*r:\\s*[5-9]", RegexOptions.CultureInvariant),
+            portRegistration);
+
+        // Native hover styling keeps the visual feedback transient and avoids persisting a
+        // graph-model mutation or introducing event-handler lifecycle bookkeeping.
+        Assert.Contains(".x6-port:hover .elsa-designer-port-circle", designerStyles, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex("\\.x6-port:hover \\.elsa-designer-port-circle\\s*\\{[^}]*r:\\s*(?:[6-9]|1\\d)px", RegexOptions.CultureInvariant),
+            designerStyles);
+        Assert.Contains(".x6-port:hover .elsa-designer-port-dock", designerStyles, StringComparison.Ordinal);
+
+        // A source port must remain connectable and accept another outgoing edge after one has
+        // already been created from it.
+        Assert.Contains("magnetConnectable: () => !readOnly && !isSequenceMode", graphCreation, StringComparison.Ordinal);
+        Assert.Contains("allowMulti: true", graphCreation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActivityNodes_UseDockedPortsWithoutAHandleLikeAccentBar()
+    {
+        var designerStyles = ReadAsset("designer.v2.css");
+
+        Assert.DoesNotContain(".elsa-activity::before", designerStyles, StringComparison.Ordinal);
+        Assert.Contains(".elsa-activity.is-starting-point", designerStyles, StringComparison.Ordinal);
+        Assert.Contains("border-color: var(--elsa-activity-accent", designerStyles, StringComparison.Ordinal);
+    }
+
+    private static string ReadAsset(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "DesignerAssets", name));
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v1.css
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v1.css
@@ -16,11 +16,23 @@
 }
 
 .elsa-flowchart-diagram-designer-v1 .elsa-activity {
-    border-left: solid 6px var(--mud-palette-info);
-    filter: drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06));
+    color: var(--mud-palette-text-primary);
+    background-color: var(--mud-palette-surface);
+    border-color: var(--mud-palette-lines-default);
+    border-left: solid 4px var(--elsa-activity-accent, var(--mud-palette-info));
     height: 100%;
 }
 
+.elsa-flowchart-diagram-designer-v1 .elsa-activity.is-starting-point {
+    background-color: var(--mud-palette-surface);
+    background-color: color-mix(
+        in srgb,
+        var(--elsa-activity-accent, var(--mud-palette-primary)) 8%,
+        var(--mud-palette-surface)
+    );
+}
+
 .elsa-flowchart-diagram-designer-v1 .elsa-activity-wrapper-badge.has-retries .mud-badge-wrapper .mud-badge {
-    background-color: #FFEB3B !important;
+    color: var(--mud-palette-warning-text) !important;
+    background-color: var(--mud-palette-warning) !important;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v2.css
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.v2.css
@@ -1,14 +1,32 @@
+.elsa-flowchart-diagram-designer-v2 {
+    --elsa-designer-canvas: var(--mud-palette-surface);
+    --elsa-designer-grid: var(--mud-palette-lines-default);
+    --elsa-designer-node-surface: var(--mud-palette-surface);
+    --elsa-designer-node-border: var(--mud-palette-lines-default);
+    --elsa-designer-node-text: var(--mud-palette-text-primary);
+    --elsa-designer-node-muted: var(--mud-palette-text-secondary);
+    --elsa-designer-accent-foreground: var(--mud-palette-primary-text);
+    --elsa-designer-edge: var(--mud-palette-lines-default);
+    --elsa-designer-selection: var(--mud-palette-primary);
+    --elsa-designer-port-surface: var(--mud-palette-surface);
+    --elsa-designer-port-stroke: var(--mud-palette-primary);
+    --elsa-designer-port-text: var(--mud-palette-text-secondary);
+    --elsa-designer-connection-highlight: var(--mud-palette-secondary);
+    --elsa-designer-embedding-highlight: var(--mud-palette-success);
+}
+
 .elsa-flowchart-diagram-designer-v2 .x6-graph-background {
-    background-color: var(--mud-palette-surface);
+    background-color: var(--elsa-designer-canvas);
 }
 
 .elsa-flowchart-diagram-designer-v2 .x6-widget-selection-box {
-    border: dashed 2px var(--mud-palette-gray-light);
+    border: solid 2px var(--elsa-designer-selection);
+    border-radius: 4px;
     box-shadow: none;
 }
 
 .elsa-flowchart-diagram-designer-v2 .x6-widget-selection-inner {
-    border: dashed 2px var(--mud-palette-gray-light);
+    border: dashed 1px var(--elsa-designer-selection);
     box-shadow: none;
 }
 
@@ -16,67 +34,95 @@
     border: none;
 }
 
-.elsa-flowchart-diagram-designer-v2 .elsa-snapline .x6-widget-snapline-horizontal,
-.elsa-flowchart-diagram-designer-v2 .elsa-snapline .x6-widget-snapline-vertical {
-    stroke: var(--mud-palette-secondary);
+.elsa-flowchart-diagram-designer-v2 .x6-widget-transform-resize {
+    width: 8px;
+    height: 8px;
+    background-color: var(--elsa-designer-node-surface);
+    border: 2px solid var(--elsa-designer-selection);
+    border-radius: 50%;
 }
 
-.elsa-flowchart-diagram-designer-v2 .elsa-activity-wrapper-badge {
-    
+.elsa-flowchart-diagram-designer-v2 .elsa-snapline .x6-widget-snapline-horizontal,
+.elsa-flowchart-diagram-designer-v2 .elsa-snapline .x6-widget-snapline-vertical {
+    stroke: var(--elsa-designer-connection-highlight);
 }
 
 .elsa-flowchart-diagram-designer-v2 .elsa-activity-wrapper-badge.has-retries .mud-badge-wrapper .mud-badge {
-    background-color: #FFEB3B !important;
+    color: var(--mud-palette-warning-text) !important;
+    background-color: var(--mud-palette-warning) !important;
 }
 
 .elsa-flowchart-diagram-designer-v2 .elsa-activity {
     height: 100%;
-}
-
-/* Use equal 16px padding all around */
-.elsa-flowchart-diagram-designer-v2 .activity-grid {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    column-gap: 12px;
-    padding: 16px; /* top/right/bottom/left = 16px */
-    border-radius: 8px;
-}
-
-/* Icon container */
-.elsa-flowchart-diagram-designer-v2 .activity-icon {
-    background-color: #1976d2;
-    width: 42px;
-    height: 42px;
-    min-width: 42px;     /* enforce at least 42px */
-    min-height: 42px;
-    flex: none;          /* don’t let flex or grid shrink it */
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    box-sizing: border-box;
+    position: relative;
+    overflow: hidden;
+    color: var(--elsa-designer-node-text);
+    background-color: var(--elsa-designer-node-surface);
+    border-color: var(--elsa-designer-node-border);
     border-radius: 4px;
 }
 
-/* Middle content (label, type, ports, description) */
+.elsa-flowchart-diagram-designer-v2 .elsa-activity.is-starting-point {
+    background-color: var(--elsa-designer-node-surface);
+    background-color: color-mix(
+        in srgb,
+        var(--elsa-activity-accent, var(--mud-palette-primary)) 8%,
+        var(--elsa-designer-node-surface)
+    );
+    border-color: var(--elsa-activity-accent, var(--mud-palette-primary));
+    box-shadow: inset 0 0 0 1px color-mix(
+        in srgb,
+        var(--elsa-activity-accent, var(--mud-palette-primary)) 56%,
+        transparent
+    );
+}
+
+.elsa-flowchart-diagram-designer-v2 .activity-icon {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--elsa-designer-accent-foreground);
+    background-color: var(--elsa-activity-accent, var(--mud-palette-primary));
+    border-radius: 4px;
+}
+
+.elsa-flowchart-diagram-designer-v2 .activity-icon .mud-icon-root {
+    color: inherit;
+}
+
 .elsa-flowchart-diagram-designer-v2 .activity-content {
     display: flex;
     flex-direction: column;
     justify-content: center;
+    min-width: 0;
 }
 
-/* First line: activity label stays default color */
 .elsa-flowchart-diagram-designer-v2 .activity-label {
+    color: var(--elsa-designer-node-text);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.25rem;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Second line: lighter grey to mimic original */
 .elsa-flowchart-diagram-designer-v2 .activity-type {
-    color: var(--mud-palette-gray-light);
-    font-size: 0.75rem; /* slightly smaller */
+    color: var(--elsa-designer-node-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1rem;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Embedded ports row */
 .elsa-flowchart-diagram-designer-v2 .activity-ports {
     display: flex;
     flex-wrap: wrap;
@@ -88,16 +134,55 @@
     border-style: dashed !important;
 }
 
-/* Optional description below */
+.elsa-flowchart-diagram-designer-v2 .activity-ports .mud-input,
+.elsa-flowchart-diagram-designer-v2 .embedded-port {
+    color: var(--elsa-designer-node-text);
+    background-color: var(--elsa-designer-node-surface) !important;
+}
+
 .elsa-flowchart-diagram-designer-v2 .activity-description {
     margin-top: 4px;
     font-size: 0.75rem;
-    color: #666;
+    color: var(--elsa-designer-node-muted);
 }
 
-/* Menu on the right: vertically center */
 .elsa-flowchart-diagram-designer-v2 .activity-menu {
     align-self: center;
+    color: var(--elsa-designer-node-text);
+}
+
+.elsa-flowchart-diagram-designer-v2 .x6-port-label {
+    fill: var(--elsa-designer-port-text);
+}
+
+.elsa-flowchart-diagram-designer-v2 .elsa-designer-port-dock {
+    transform-box: fill-box;
+    transform-origin: center;
+    transition:
+        transform 120ms ease-out,
+        fill 120ms ease-out,
+        stroke 120ms ease-out;
+}
+
+.elsa-flowchart-diagram-designer-v2 .elsa-designer-port-circle {
+    transition:
+        r 120ms ease-out,
+        fill 120ms ease-out,
+        stroke 120ms ease-out;
+}
+
+.elsa-flowchart-diagram-designer-v2 .x6-port:hover .elsa-designer-port-dock {
+    fill: color-mix(
+        in srgb,
+        var(--elsa-designer-port-stroke) 10%,
+        var(--elsa-designer-node-surface)
+    );
+    stroke: var(--elsa-designer-port-stroke);
+    transform: scale(1.08);
+}
+
+.elsa-flowchart-diagram-designer-v2 .x6-port:hover .elsa-designer-port-circle {
+    r: 8px;
 }
 
 .elsa-sequence-diagram-designer .x6-port {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/apply-graph-theme.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/apply-graph-theme.ts
@@ -1,0 +1,34 @@
+import {graphBindings} from "./graph-bindings";
+
+export interface X6DesignerTheme {
+    grid: string;
+    edge: string;
+    portSurface: string;
+    portStroke: string;
+    portText: string;
+    selection: string;
+    connectionHighlight: string;
+    embeddingHighlight: string;
+}
+
+export function applyGraphTheme(graphId: string, theme: X6DesignerTheme) {
+    const {graph} = graphBindings[graphId];
+    applyDesignerThemeVariables(graph.container, theme);
+    graph.grid.update({color: theme.grid});
+}
+
+export function applyDesignerThemeVariables(element: HTMLElement, theme: X6DesignerTheme) {
+    const variables: Record<string, string> = {
+        "--elsa-designer-grid": theme.grid,
+        "--elsa-designer-edge": theme.edge,
+        "--elsa-designer-port-surface": theme.portSurface,
+        "--elsa-designer-port-stroke": theme.portStroke,
+        "--elsa-designer-port-text": theme.portText,
+        "--elsa-designer-selection": theme.selection,
+        "--elsa-designer-connection-highlight": theme.connectionHighlight,
+        "--elsa-designer-embedding-highlight": theme.embeddingHighlight,
+    };
+
+    for (const [name, value] of Object.entries(variables))
+        element.style.setProperty(name, value);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/calculate-activity-size.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/calculate-activity-size.ts
@@ -1,27 +1,41 @@
 import {activityTagName, createActivityElement} from "../internal/create-activity-element";
 import {Activity, Size} from "../models";
 
-// Cache for storing calculated activity sizes
-// Key format: "activityType:showsDescription:hasIcon:portCount:displayTextLength:descriptionLength"
+// Cache for storing calculated activity sizes.
 const sizeCache = new Map<string, Size>();
 
 // Queue for batching size calculations
-let calculationQueue: Array<{activity: Activity, portCount?: number, resolve: (size: Size) => void, reject: (error: any) => void}> = [];
+let calculationQueue: Array<{
+    activity: Activity,
+    portCount?: number,
+    measurementScopeClass: string,
+    resolve: (size: Size) => void,
+    reject: (error: any) => void
+}> = [];
 let batchTimer: number | null = null;
 
-function getCacheKey(activity: Activity, portCount?: number): string {
+function getCacheKey(activity: Activity, portCount: number | undefined, measurementScopeClass: string): string {
     const type = activity.type || 'unknown';
+    const name = activity.name || '';
     const displayText = activity.metadata?.displayText || '';
     const description = activity.metadata?.description || '';
     const hasDescription = !!description;
     const showDescription = activity.metadata?.showDescription === true;
     const hasIcon = !!activity.metadata?.icon;
     const ports = portCount ?? 0;
-    // Include display text and description lengths to differentiate activities with different text content
-    // Using length is more efficient than hashing the full text, while still catching size-affecting changes
-    const displayTextKey = displayText.length;
-    const descriptionKey = hasDescription && showDescription ? description.length : 0;
-    return `${type}:${hasDescription && showDescription}:${hasIcon}:${ports}:${displayTextKey}:${descriptionKey}`;
+    const visibleDescription = hasDescription && showDescription ? description : '';
+
+    // The effective label and designer layout both affect the rendered dimensions. Using the
+    // complete values avoids collisions between different same-length labels.
+    return JSON.stringify([measurementScopeClass, type, name, displayText, visibleDescription, hasIcon, ports]);
+}
+
+export function getActivityMeasurementScopeClass(element: Element | null): string {
+    const designerScope = element?.closest<HTMLElement>(
+        '.elsa-flowchart-diagram-designer, .elsa-flowchart-diagram-designer-v1, .elsa-flowchart-diagram-designer-v2'
+    );
+
+    return designerScope?.className ?? '';
 }
 
 function processBatch() {
@@ -43,11 +57,18 @@ function processBatch() {
     const bodyElement = document.getElementsByTagName('body')[0];
     bodyElement.appendChild(container);
 
-    const measurements: Array<{wrapper: HTMLElement, activity: Activity, portCount?: number, resolve: (size: Size) => void, reject: (error: any) => void}> = [];
+    const measurements: Array<{
+        wrapper: HTMLElement,
+        activity: Activity,
+        portCount?: number,
+        measurementScopeClass: string,
+        resolve: (size: Size) => void,
+        reject: (error: any) => void
+    }> = [];
 
     // Create all elements at once
     for (const item of batch) {
-        const cacheKey = getCacheKey(item.activity, item.portCount);
+        const cacheKey = getCacheKey(item.activity, item.portCount, item.measurementScopeClass);
         
         // Check cache first
         const cachedSize = sizeCache.get(cacheKey);
@@ -58,6 +79,7 @@ function processBatch() {
         }
 
         const wrapper = document.createElement('div');
+        wrapper.className = item.measurementScopeClass;
         wrapper.style.display = 'inline-block';
         const dummyActivityElement = createActivityElement(item.activity, true);
         wrapper.appendChild(dummyActivityElement);
@@ -67,6 +89,7 @@ function processBatch() {
             wrapper,
             activity: item.activity,
             portCount: item.portCount,
+            measurementScopeClass: item.measurementScopeClass,
             resolve: item.resolve,
             reject: item.reject
         });
@@ -120,7 +143,11 @@ function processBatch() {
                 };
                 
                 // Cache the size
-                const cacheKey = getCacheKey(measurement.activity, measurement.portCount);
+                const cacheKey = getCacheKey(
+                    measurement.activity,
+                    measurement.portCount,
+                    measurement.measurementScopeClass
+                );
                 sizeCache.set(cacheKey, size);
                 
                 // Return a shallow copy to prevent mutation
@@ -138,9 +165,9 @@ function processBatch() {
     checkAllSizes();
 }
 
-export function calculateActivitySize(activity: Activity, portCount?: number): Promise<Size> {
+export function calculateActivitySize(activity: Activity, portCount?: number, measurementScopeClass = ''): Promise<Size> {
     // Check cache first
-    const cacheKey = getCacheKey(activity, portCount);
+    const cacheKey = getCacheKey(activity, portCount, measurementScopeClass);
     const cachedSize = sizeCache.get(cacheKey);
     
     if (cachedSize) {
@@ -150,7 +177,7 @@ export function calculateActivitySize(activity: Activity, portCount?: number): P
 
     // Add to batch queue
     return new Promise((resolve, reject) => {
-        calculationQueue.push({activity, portCount, resolve, reject});
+        calculationQueue.push({activity, portCount, measurementScopeClass, resolve, reject});
 
         // Schedule batch processing
         if (batchTimer === null) {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -9,7 +9,9 @@ import {DotNetComponentRef, graphBindings} from "./graph-bindings";
 import {DotNetFlowchartDesigner} from "./dotnet-flowchart-designer";
 import {Activity} from "../models";
 import {enforceMinimumNodeSize} from "./update-activity-size";
+import {getActivityMeasurementScopeClass} from "./calculate-activity-size";
 import {arrangeSequenceGraph, moveSelectedSequenceNode, normalizeSequenceOrientation, withSuppressedGraphUpdated} from "./sequence-mode";
+import {applyDesignerThemeVariables, X6DesignerTheme} from "./apply-graph-theme";
 
 export async function createGraph(containerId: string, componentRef: DotNetComponentRef, readOnly: boolean, settings?: any): Promise<string> {
     const containerElement = document.getElementById(containerId);
@@ -18,6 +20,13 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
     const graphId = containerId;
     const mode = settings?.mode === 'sequence' ? 'sequence' : 'flowchart';
     const isSequenceMode = mode === 'sequence';
+    const theme: X6DesignerTheme | undefined = settings?.theme;
+    const measurementScopeClass = getActivityMeasurementScopeClass(containerElement);
+
+    if (!theme)
+        throw new Error("An X6 designer theme is required.");
+
+    applyDesignerThemeVariables(containerElement, theme);
 
     const graph = new Graph({
         container: containerElement,
@@ -26,10 +35,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
             type: settings?.grid?.type || 'dot',
             visible: settings?.grid?.visible || true,
             size: settings?.grid?.size || 10,
-            args: settings?.grid?.args || {
-                color: '#334154',
-                thickness: 1,
-            }
+            args: resolveGridArgs(settings?.grid?.args, theme.grid),
         },
         magnetThreshold: settings?.magnetThreshold || 0,
         panning: settings?.panning || {
@@ -55,6 +61,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         },
         connecting: {
             router: 'manhattan',
+            allowMulti: true,
             connector: {
                 name: 'rounded',
                 args: {
@@ -100,8 +107,8 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                 name: 'stroke',
                 args: {
                     attrs: {
-                        fill: '#fff',
-                        stroke: '#31d0c6',
+                        fill: 'var(--elsa-designer-port-surface)',
+                        stroke: 'var(--elsa-designer-connection-highlight)',
                         strokeWidth: 4,
                     },
                 },
@@ -111,7 +118,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
                 args: {
                     padding: -1,
                     attrs: {
-                        stroke: '#73d13d',
+                        stroke: 'var(--elsa-designer-embedding-highlight)',
                     },
                 },
             },
@@ -409,31 +416,16 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         return false;
     };
 
-    // Track if we're currently enforcing minimum size to prevent infinite loops
-    let isEnforcingMinSize = false;
-    
-    const onNodeSizeChanged = async (e: any) => {
-        // Prevent infinite loop when we programmatically resize after enforcing minimum
-        if (isEnforcingMinSize) {
-            return false;
-        }
-        
-        // Skip graph update when size was changed programmatically (e.g., from updateActivitySize during initial render).
-        // This prevents unwanted auto-saves when the server returns different sizes than what the Studio calculated.
+    const onNodeResizeCompleted = async (e: any) => {
+        // Honor graph-level suppression during internal graph mutations.
         const binding = graphBindings[graphId];
         if (binding?.suppressGraphUpdated > 0) {
             return false;
         }
         
         const node = e.node || e.cell;
-        if (node) {
-            isEnforcingMinSize = true;
-            try {
-                await enforceMinimumNodeSize(node);
-            } finally {
-                isEnforcingMinSize = false;
-            }
-        }
+        if (node)
+            await enforceMinimumNodeSize(node, measurementScopeClass);
         
         await interop.raiseGraphUpdated();
         return false;
@@ -475,7 +467,10 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
         await interop.raiseGraphUpdated();
         return false;
     });
-    graph.on('node:change:size', onNodeSizeChanged);
+    // The Transform plugin emits `node:change:size` for every pointer movement. Waiting for
+    // `node:resized` avoids racing X6's active gesture with asynchronous minimum-size
+    // enforcement and Blazor graph updates.
+    graph.on('node:resized', onNodeResizeCompleted);
     graph.on('edge:removed', onGraphUpdated);
     graph.on('edge:connected', onGraphUpdated);
     graph.on('edge:vertexs:added', onGraphUpdated);
@@ -490,4 +485,11 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
     };
 
     return graphId;
+}
+
+function resolveGridArgs(args: any, themeColor: string) {
+    if (Array.isArray(args))
+        return args.map(item => ({...item, color: item?.color || themeColor}));
+
+    return {...(args || {}), color: args?.color || themeColor};
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
@@ -1,4 +1,5 @@
 export * from './add-activity-node';
+export * from './apply-graph-theme';
 export * from './calculate-activity-size';
 export * from './center-content';
 export * from './create-graph';
@@ -10,7 +11,6 @@ export * from './read-graph';
 export * from './raise-activity-selected';
 export * from './raise-activity-embedded-port-selected';
 export * from './select-activity';
-export * from './set-grid-color';
 export * from './sequence-commands';
 export * from './update-activity';
 export * from './update-activity-size';

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/set-grid-color.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/set-grid-color.ts
@@ -1,6 +1,0 @@
-import {graphBindings} from "./graph-bindings";
-
-export function setGridColor(graphId: string, color: string) {
-    const {graph} = graphBindings[graphId];
-    graph.grid.update({color: color});
-}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-size.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/update-activity-size.ts
@@ -1,4 +1,4 @@
-import {calculateActivitySize} from "./calculate-activity-size";
+import {calculateActivitySize, getActivityMeasurementScopeClass} from "./calculate-activity-size";
 import {Activity, Size} from "../models";
 import {graphBindings} from "./graph-bindings";
 import {Node} from "@antv/x6";
@@ -14,6 +14,7 @@ export async function updateActivitySize(elementId: string, activityModel: Activ
 
     // Get container element.
     const container = wrapper.closest('.graph-container');
+    const measurementScopeClass = getActivityMeasurementScopeClass(wrapper);
 
     // Get graph ID.
     const graphId = container.id;
@@ -26,7 +27,7 @@ export async function updateActivitySize(elementId: string, activityModel: Activ
     const activity = typeof activityModel === 'string' ? JSON.parse(activityModel) : activityModel;
 
     // Calculate the size of the activity.
-    const rect = await calculateActivitySize(activity, portCount);
+    const rect = await calculateActivitySize(activity, portCount, measurementScopeClass);
     let width = rect.width;
     let height = rect.height;
 
@@ -68,7 +69,7 @@ export async function updateActivitySize(elementId: string, activityModel: Activ
  * @param node The X6 node to enforce minimum size on
  * @returns true if the size was adjusted, false otherwise
  */
-export async function enforceMinimumNodeSize(node: Node): Promise<boolean> {
+export async function enforceMinimumNodeSize(node: Node, measurementScopeClass = ''): Promise<boolean> {
     const activity: Activity = node.data;
     
     if (!activity) {
@@ -79,7 +80,7 @@ export async function enforceMinimumNodeSize(node: Node): Promise<boolean> {
     const portCount = node.ports?.items?.length ?? 0;
 
     // Calculate the minimum size based on content and port count
-    const minSize = await calculateActivitySize(activity, portCount);
+    const minSize = await calculateActivitySize(activity, portCount, measurementScopeClass);
     const currentSize = node.size();
     
     let needsResize = false;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
@@ -3,6 +3,18 @@ import {createActivityElement} from "./create-activity-element";
 import {Activity} from "../models";
 
 export function initialize() {
+    const createPortInteractionAttrs = () => ({
+        port: {
+            magnet: true,
+        },
+        hitArea: {
+            r: 12,
+            fill: "transparent",
+            stroke: "transparent",
+            pointerEvents: "all",
+            cursor: "crosshair",
+        },
+    });
 
     Shape.HTML.register({
         shape: "elsa-activity",
@@ -13,21 +25,57 @@ export function initialize() {
             const activityStats = cell.prop('activityStats');
             return createActivityElement(activity, false, selectedPort, activityStats);
         },
+        portMarkup: [
+            {
+                tagName: "g",
+                selector: "port",
+                children: [
+                    {
+                        tagName: "circle",
+                        selector: "hitArea",
+                        className: "elsa-designer-port-hit-area",
+                    },
+                    {
+                        tagName: "rect",
+                        selector: "dock",
+                        className: "elsa-designer-port-dock",
+                    },
+                    {
+                        tagName: "circle",
+                        selector: "circle",
+                        className: "elsa-designer-port-circle",
+                    },
+                ],
+            },
+        ],
         ports: {
             groups: {
                 in: {
                     position: "left",
                     attrs: {
+                        ...createPortInteractionAttrs(),
+                        dock: {
+                            x: -7,
+                            y: -12,
+                            width: 14,
+                            height: 24,
+                            rx: 7,
+                            ry: 7,
+                            fill: "var(--elsa-designer-node-surface)",
+                            stroke: "var(--elsa-designer-node-border)",
+                            strokeWidth: 1,
+                            pointerEvents: "none",
+                        },
                         circle: {
                             r: 5,
-                            magnet: true,
-                            stroke: "#0ea5e9",
+                            stroke: "var(--elsa-designer-port-stroke)",
                             strokeWidth: 2,
-                            fill: "#fff",
+                            fill: "var(--elsa-designer-port-surface)",
+                            pointerEvents: "none",
                         },
                         text: {
                             fontSize: 12,
-                            fill: "#888",
+                            fill: "var(--elsa-designer-port-text)",
                         },
                     },
                     label: {
@@ -39,16 +87,29 @@ export function initialize() {
                 out: {
                     position: "right",
                     attrs: {
+                        ...createPortInteractionAttrs(),
+                        dock: {
+                            x: -7,
+                            y: -12,
+                            width: 14,
+                            height: 24,
+                            rx: 7,
+                            ry: 7,
+                            fill: "var(--elsa-designer-node-surface)",
+                            stroke: "var(--elsa-designer-node-border)",
+                            strokeWidth: 1,
+                            pointerEvents: "none",
+                        },
                         circle: {
                             r: 5,
-                            magnet: true,
-                            stroke: "#fff",
+                            stroke: "var(--elsa-designer-port-surface)",
                             strokeWidth: 2,
-                            fill: "#0ea5e9",
+                            fill: "var(--elsa-designer-port-stroke)",
+                            pointerEvents: "none",
                         },
                         text: {
                             fontSize: 12,
-                            fill: "#888",
+                            fill: "var(--elsa-designer-port-text)",
                         },
                     },
                     label: {
@@ -67,7 +128,7 @@ export function initialize() {
             inherit: 'edge',
             attrs: {
                 line: {
-                    stroke: '#C2C8D5',
+                    stroke: 'var(--elsa-designer-edge)',
                     strokeWidth: 1,
                     targetMarker: 'classic',
                     size: 6,
@@ -83,7 +144,7 @@ export function initialize() {
             inherit: 'edge',
             attrs: {
                 line: {
-                    stroke: '#94a3b8',
+                    stroke: 'var(--elsa-designer-edge)',
                     strokeWidth: 2,
                     targetMarker: 'classic',
                     size: 6,

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V1/ActivityWrapper.razor
@@ -6,8 +6,8 @@
 @inherits ActivityWrapperBase
 @inject ILocalizer Localizer
 @{
-    const string white = "#ffffff";
-    var colorStyle = CanStartWorkflow ? $"color: {white};" : "";
+    var activityClass = CanStartWorkflow ? "elsa-activity pa-3 is-starting-point" : "elsa-activity pa-3";
+    var activityStyle = $"--elsa-activity-accent: {Color};";
     var metadata = Stats?.Metadata;
     var hasRetryAttempts = metadata != null && metadata.TryGetValue("HasRetryAttempts", out var hasRetryAttemptsValue) && hasRetryAttemptsValue is JsonElement { ValueKind: JsonValueKind.True }; 
     var color = Stats == null ? MudBlazor.Color.Transparent : Stats.Faulted ? MudBlazor.Color.Error :  Stats.Blocked ? MudBlazor.Color.Warning : Stats.Uncompleted > Stats.Completed ? MudBlazor.Color.Info : Stats.Completed > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default;
@@ -18,16 +18,16 @@
 
     <MudBadge Color="color" Content="content" Overlap="true" Icon="@icon" Style="width: 100%; height: 100%;" Visible="showBadge" class="@cssClass">
         <MudPaper
-            Class="elsa-activity pa-3"
-            Style="@($"border-left-color: {Color}; {(CanStartWorkflow ? $"background-color: {Color}" : "")};")"
+            Class="@activityClass"
+            Style="@activityStyle"
             Outlined="true">
             <MudStack Row="true" AlignItems="AlignItems.Center" Style="height:100%">
                 @if (Icon != null)
                 {
-                    <MudIcon Icon="@Icon" Style="@colorStyle"></MudIcon>
+                    <MudIcon Icon="@Icon"></MudIcon>
                 }
                 <MudStack Style="height:100%" Justify="Justify.Center">
-                    <MudText Typo="Typo.body1" Style="@colorStyle">@Localizer[Label]</MudText>
+                    <MudText Typo="Typo.body1">@Localizer[Label]</MudText>
                     @{
                         var visiblePorts = Ports.Where(x => x is { Type: PortType.Embedded, IsBrowsable: true }).ToList();
                     }
@@ -61,7 +61,7 @@
 
                     @if (!string.IsNullOrWhiteSpace(Description) && ShowDescription)
                     {
-                        <MudText Typo="Typo.caption" Style="@colorStyle">@Description</MudText>
+                        <MudText Typo="Typo.caption">@Description</MudText>
                     }
                 </MudStack>
             </MudStack>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V2/ActivityWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/V2/ActivityWrapper.razor
@@ -6,13 +6,8 @@
 @inject ILocalizer Localizer
 
 @{
-    const string white = "#ffffff";
-    const string transparent = "rgba(0,0,0,0)";
-    var colorStyle = CanStartWorkflow ? $"color: {white};" : "";
-    var backgroundColor = CanStartWorkflow ? Color : white;
-    var iconBgColor = CanStartWorkflow ? transparent : Color;
-    var iconColor = white;
-    var menuIconColor = CanStartWorkflow ? white : "var(--mud-palette-text-primary)";
+    var activityClass = CanStartWorkflow ? "elsa-activity pa-2 is-starting-point" : "elsa-activity pa-2";
+    var activityStyle = $"--elsa-activity-accent: {Color};";
     var metadata = Stats?.Metadata;
     var hasRetryAttempts = metadata != null && metadata.TryGetValue("HasRetryAttempts", out var hasRetryAttemptsValue) && hasRetryAttemptsValue is JsonElement { ValueKind: JsonValueKind.True };
     var color = Stats == null ? MudBlazor.Color.Transparent : Stats.Faulted ? MudBlazor.Color.Error : Stats.Blocked ? MudBlazor.Color.Warning : Stats.Uncompleted > Stats.Completed ? MudBlazor.Color.Info : Stats.Completed > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default;
@@ -28,8 +23,8 @@
 <MudBadge Color="color" Content="content" Overlap="true" Icon="@icon" Style="width: 100%; height: 100%;"
           Visible="showBadge" Class="@cssClass">
     <MudPaper
-        Class="elsa-activity pa-2"
-        Style="@($"background-color: {backgroundColor};")"
+        Class="@activityClass"
+        Style="@activityStyle"
         Outlined="true">
 
         <MudStack>
@@ -38,23 +33,23 @@
                 <!-- Icon -->
                 @if (Icon != null)
                 {
-                    <div class="activity-icon" style="@($"background-color: {iconBgColor};")">
-                        <MudIcon Icon="@Icon" Size="Size.Small" Style="@($"color: {iconColor};")"/>
+                    <div class="activity-icon">
+                        <MudIcon Icon="@Icon" Size="Size.Small"/>
                     </div>
                 }
 
                 <!-- Labels + Embedded ports + Description -->
                 <div class="activity-content">
-                    <MudText Typo="Typo.subtitle1" Class="activity-label" Style="@colorStyle">@Localizer[Label]</MudText>
-                    <MudText Typo="Typo.subtitle2" Class="activity-type" Style="@colorStyle">@Localizer[TypeName]</MudText>
+                    <MudText Typo="Typo.subtitle1" Class="activity-label">@Localizer[Label]</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="activity-type">@Localizer[TypeName]</MudText>
                 </div>
 
                 <!-- Menu -->
                 <div class="activity-menu">
                     <!-- hidden until we have better integration between X6 node handling and events. -->
-                    <MudMenu Icon="@Icons.Material.Filled.MoreVert" Style="@($"color: {menuIconColor}; visibility: hidden;")">
+                    <MudMenu Icon="@Icons.Material.Filled.MoreVert" Style="visibility: hidden;">
                         <ActivatorContent>
-                            <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" Style="@($"color: {menuIconColor};")"></MudIconButton>
+                            <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small"></MudIconButton>
                         </ActivatorContent>
                         <ChildContent>
                             <MudMenuItem Icon="@Icons.Material.Outlined.Check" IconColor="MudBlazor.Color.Primary" Label="@toggleCanStartText"/>
@@ -97,7 +92,7 @@
             @if (!string.IsNullOrWhiteSpace(Description) && ShowDescription)
             {
                 <div>
-                    <MudText Typo="Typo.caption" Class="activity-description" Style="@colorStyle">@Description</MudText>
+                    <MudText Typo="Typo.caption" Class="activity-description">@Description</MudText>
                 </div>
             }
         </MudStack>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
-using MudBlazor.Utilities;
 using ThrottleDebounce;
 
 namespace Elsa.Studio.Workflows.Designer.Components;
@@ -34,6 +33,7 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     private IFlowchartMapper? _flowchartMapper;
     private IActivityMapper? _activityMapper;
     private X6GraphApi _graphApi = null!;
+    private IDisposable? _themeSubscription;
     private readonly PendingActionsQueue _pendingGraphActions;
     private readonly RateLimitedFunc<Task> _rateLimitedLoadFlowchartAction;
     private IDictionary<string, ActivityStats>? _activityStats;
@@ -358,7 +358,9 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        ThemeService.IsDarkModeChanged += OnDarkModeChanged;
+        _themeSubscription = new X6DesignerThemeSubscription(
+            ThemeService,
+            theme => ScheduleGraphActionAsync(() => _graphApi.ApplyThemeAsync(theme)));
         _flowchart = Flowchart;
     }
 
@@ -391,7 +393,6 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
 
     private async Task<IFlowchartMapper> GetFlowchartMapperAsync() => _flowchartMapper ??= await MapperFactory.CreateFlowchartMapperAsync();
     private async Task<IActivityMapper> GetActivityMapperAsync() => _activityMapper ??= await MapperFactory.CreateActivityMapperAsync();
-    private async Task SetGridColorAsync(string color) => await ScheduleGraphActionAsync(() => _graphApi.SetGridColorAsync(color));
     private async Task ScheduleGraphActionAsync(Func<Task> action) => await _pendingGraphActions.EnqueueAsync(action);
     private async Task<T> ScheduleGraphActionAsync<T>(Func<Task<T>> action) => await _pendingGraphActions.EnqueueAsync(action);
 
@@ -452,13 +453,6 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
         }
     }
 
-    private async void OnDarkModeChanged()
-    {
-        var palette = ThemeService.CurrentPalette;
-        var gridColor = palette.BackgroundGray;
-        await SetGridColorAsync(gridColor.ToString(MudColorOutputFormats.HexA));
-    }
-
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
         if (_graphApi != null!)
@@ -469,7 +463,7 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
 
     void IDisposable.Dispose()
     {
-        ThemeService.IsDarkModeChanged -= OnDarkModeChanged;
+        _themeSubscription?.Dispose();
         _componentRef?.Dispose();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/SequenceDesigner.razor.cs
@@ -19,7 +19,6 @@ using Humanizer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
-using MudBlazor.Utilities;
 using ThrottleDebounce;
 
 namespace Elsa.Studio.Workflows.Designer.Components;
@@ -37,6 +36,7 @@ public partial class SequenceDesigner : IDisposable, IAsyncDisposable
     private JsonObject? _sequence;
     private IDictionary<string, ActivityStats>? _activityStats;
     private X6GraphApi _graphApi = null!;
+    private IDisposable? _themeSubscription;
 
     public SequenceDesigner()
     {
@@ -194,7 +194,9 @@ public partial class SequenceDesigner : IDisposable, IAsyncDisposable
 
     protected override void OnInitialized()
     {
-        ThemeService.IsDarkModeChanged += OnDarkModeChanged;
+        _themeSubscription = new X6DesignerThemeSubscription(
+            ThemeService,
+            theme => ScheduleGraphActionAsync(() => _graphApi.ApplyThemeAsync(theme)));
         _sequence = Sequence;
     }
 
@@ -276,13 +278,6 @@ public partial class SequenceDesigner : IDisposable, IAsyncDisposable
         }
     }
 
-    private async void OnDarkModeChanged()
-    {
-        var palette = ThemeService.CurrentPalette;
-        var gridColor = palette.BackgroundGray;
-        await ScheduleGraphActionAsync(() => _graphApi.SetGridColorAsync(gridColor.ToString(MudColorOutputFormats.HexA)));
-    }
-
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
         if (_graphApi != null!)
@@ -293,7 +288,7 @@ public partial class SequenceDesigner : IDisposable, IAsyncDisposable
 
     void IDisposable.Dispose()
     {
-        ThemeService.IsDarkModeChanged -= OnDarkModeChanged;
+        _themeSubscription?.Dispose();
         _componentRef?.Dispose();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
 using Microsoft.Extensions.Options;
@@ -12,7 +14,11 @@ namespace Elsa.Studio.Workflows.Designer.Interop;
 /// <summary>
 /// Provides access to the designer JavaScript module.
 /// </summary>
-public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> options, IServiceProvider serviceProvider) : JsInteropBase(jsRuntime)
+public class DesignerJsInterop(
+    IJSRuntime jsRuntime,
+    IOptions<DesignerOptions> options,
+    IServiceProvider serviceProvider,
+    IThemeService themeService) : JsInteropBase(jsRuntime)
 {
     /// <summary>
     /// Provides the string.
@@ -45,7 +51,8 @@ public class DesignerJsInterop(IJSRuntime jsRuntime, IOptions<DesignerOptions> o
                 graphSettings.Panning,
                 graphSettings.Mousewheel,
                 graphSettings.ResizingEnabled,
-                Mode = mode
+                Mode = mode,
+                Theme = X6DesignerTheme.FromPalette(themeService.CurrentPalette)
             };
 
             await module.InvokeAsync<string>("createGraph", containerId, componentRef, isReadOnly, settings);

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
@@ -38,10 +38,10 @@ public class X6GraphApi
     public async Task DisposeGraphAsync() => await TryInvokeAsync(module => module.InvokeVoidAsync("disposeGraph", _containerId));
 
     /// <summary>
-    /// Sets the grid color.
+    /// Applies the active Elsa theme to the X6 graph.
     /// </summary>
-    /// <param name="color">The color.</param>
-    public async Task SetGridColorAsync(string color) => await InvokeAsync(module => module.InvokeVoidAsync("setGridColor", _containerId, color));
+    public async Task ApplyThemeAsync(X6DesignerTheme theme) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("applyGraphTheme", _containerId, theme));
 
     /// <summary>
     /// Adds a node to the graph.

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/X6DesignerTheme.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/X6DesignerTheme.cs
@@ -1,0 +1,34 @@
+using MudBlazor;
+using MudBlazor.Utilities;
+
+namespace Elsa.Studio.Workflows.Designer.Models;
+
+/// <summary>
+/// Theme colors used by X6-rendered workflow designer chrome.
+/// </summary>
+public sealed record X6DesignerTheme(
+    string Grid,
+    string Edge,
+    string PortSurface,
+    string PortStroke,
+    string PortText,
+    string Selection,
+    string ConnectionHighlight,
+    string EmbeddingHighlight)
+{
+    /// <summary>
+    /// Creates an X6 theme from the active MudBlazor palette.
+    /// </summary>
+    public static X6DesignerTheme FromPalette(Palette palette) =>
+        new(
+            ToHex(palette.LinesDefault),
+            ToHex(palette.LinesDefault),
+            ToHex(palette.Surface),
+            ToHex(palette.Primary),
+            ToHex(palette.TextSecondary),
+            ToHex(palette.Primary),
+            ToHex(palette.Secondary),
+            ToHex(palette.Success));
+
+    private static string ToHex(MudColor color) => color.ToString(MudColorOutputFormats.HexA);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GridArgs.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Options/X6GridArgs.cs
@@ -8,7 +8,7 @@ public class X6GridArgs
     /// <summary>
     /// Gets or sets the color.
     /// </summary>
-    public string Color { get; set; } = "#334154"; //f1f1f1 for V1
+    public string? Color { get; set; }
     /// <summary>
     /// Gets or sets the thickness.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Services/X6DesignerThemeSubscription.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Services/X6DesignerThemeSubscription.cs
@@ -1,0 +1,27 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Designer.Models;
+
+namespace Elsa.Studio.Workflows.Designer.Services;
+
+internal sealed class X6DesignerThemeSubscription : IDisposable
+{
+    private readonly IThemeService _themeService;
+    private readonly Func<X6DesignerTheme, Task> _applyTheme;
+
+    public X6DesignerThemeSubscription(IThemeService themeService, Func<X6DesignerTheme, Task> applyTheme)
+    {
+        _themeService = themeService;
+        _applyTheme = applyTheme;
+        _themeService.CurrentThemeChanged += OnThemeChanged;
+        _themeService.IsDarkModeChanged += OnThemeChanged;
+    }
+
+    public void Dispose()
+    {
+        _themeService.CurrentThemeChanged -= OnThemeChanged;
+        _themeService.IsDarkModeChanged -= OnThemeChanged;
+    }
+
+    private async void OnThemeChanged() =>
+        await _applyTheme(X6DesignerTheme.FromPalette(_themeService.CurrentPalette));
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ActivityPickers/TreeviewActivityPickerTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ActivityPickers/TreeviewActivityPickerTests.cs
@@ -1,0 +1,85 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.ActivityPickers.Treeview;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Elsa.Studio.Workflows.UI.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.ActivityPickers;
+
+public sealed class TreeviewActivityPickerTests : BunitContext, IAsyncLifetime
+{
+    public TreeviewActivityPickerTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub(
+        [
+            new ActivityDescriptor
+            {
+                Name = "WriteLine",
+                DisplayName = "Write Line",
+                TypeName = "Elsa.WriteLine",
+                Category = "Flow",
+                IsBrowsable = true
+            }
+        ]));
+        Services.AddSingleton<IActivityDisplaySettingsRegistry>(new ActivityDisplaySettingsRegistryStub());
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void ClickingCategoryLabel_TogglesItsExpansion()
+    {
+        Render<MudPopoverProvider>();
+        var cut = Render<ActivityPicker>();
+        var category = cut.FindComponents<MudTreeViewItem<string>>().Single(item => item.Instance.Text == "Flow");
+
+#pragma warning disable MUD0012 // The component is the system under test; Expanded is its observable state.
+        Assert.False(category.Instance.Expanded);
+
+        category.Find(".mud-treeview-item-label").Click();
+
+        Assert.True(category.Instance.Expanded);
+
+        category.Find(".mud-treeview-item-label").Click();
+
+        Assert.False(category.Instance.Expanded);
+#pragma warning restore MUD0012
+    }
+
+    private sealed class ActivityRegistryStub(IEnumerable<ActivityDescriptor> activities) : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => activities;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => activities.FirstOrDefault(x => x.TypeName == activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => activities.Where(x => x.TypeName == activityType);
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class ActivityDisplaySettingsRegistryStub : IActivityDisplaySettingsRegistry
+    {
+        public ActivityDisplaySettings GetSettings(string activityType) => new("#0EA5E9");
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ActivityPickers/TreeviewActivityPickerTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ActivityPickers/TreeviewActivityPickerTests.cs
@@ -49,11 +49,11 @@ public sealed class TreeviewActivityPickerTests : BunitContext, IAsyncLifetime
 
         category.Find(".mud-treeview-item-label").Click();
 
-        Assert.True(category.Instance.Expanded);
+        cut.WaitForAssertion(() => Assert.True(cut.FindComponents<MudTreeViewItem<string>>().Single(item => item.Instance.Text == "Flow").Instance.Expanded));
 
-        category.Find(".mud-treeview-item-label").Click();
+        cut.FindComponents<MudTreeViewItem<string>>().Single(item => item.Instance.Text == "Flow").Find(".mud-treeview-item-label").Click();
 
-        Assert.False(category.Instance.Expanded);
+        cut.WaitForAssertion(() => Assert.False(cut.FindComponents<MudTreeViewItem<string>>().Single(item => item.Instance.Text == "Flow").Instance.Expanded));
 #pragma warning restore MUD0012
     }
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
@@ -8,6 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" />
+        <PackageReference Include="bunit" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
@@ -15,6 +17,18 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\..\hosts\Elsa.Studio.Host.Server\Pages\_Host.cshtml"
+              Link="HostAssets\ServerHost.cshtml"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\..\hosts\Elsa.Studio.Host.Wasm\wwwroot\index.html"
+              Link="HostAssets\WasmHost.html"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\..\hosts\Elsa.Studio.Host.HostedWasm\Pages\_Host.cshtml"
+              Link="HostAssets\HostedWasmHost.cshtml"
+              CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
@@ -87,6 +87,26 @@ public sealed class OutputConverterSettingsEditorTests : BunitContext, IAsyncLif
         Assert.Contains("Enter a valid integer.", cut.Markup);
     }
 
+    [Fact]
+    public void SchemaDefaultsAreNotDisplayedBeforeTheyArePersisted()
+    {
+        JsonObject? changed = null;
+        using var document = JsonDocument.Parse("""
+            {"type":"object","properties":{"format":{"type":"string","default":"compact"}}}
+            """);
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.SettingsSchema, document.RootElement.Clone())
+            .Add(x => x.Settings, new JsonObject())
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        Assert.True(string.IsNullOrEmpty(cut.Find("input").GetAttribute("value")));
+        Assert.Null(changed);
+    }
+
     private sealed class TestLocalizer : ILocalizer
     {
         public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputConverterSettingsEditorTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public sealed class OutputConverterSettingsEditorTests : BunitContext, IAsyncLifetime
+{
+    public OutputConverterSettingsEditorTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task RawSettingsRejectANonObjectWithoutChangingTheBinding()
+    {
+        JsonObject? changed = null;
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.Settings, new JsonObject { ["format"] = "compact" })
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("[]"));
+
+        Assert.Null(changed);
+        Assert.Contains("Converter settings must be a valid JSON object.", cut.Markup);
+    }
+
+    [Fact]
+    public async Task SupportedObjectSchemaEditsTypedSettings()
+    {
+        JsonObject? changed = null;
+        using var document = JsonDocument.Parse("""
+            {"type":"object","properties":{"format":{"type":"string","title":"Format","default":"compact"}}}
+            """);
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.SettingsSchema, document.RootElement.Clone())
+            .Add(x => x.Settings, new JsonObject { ["format"] = "compact" })
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("indented"));
+
+        Assert.Equal("indented", changed!["format"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task TypedSettingsShowValidationErrorsWithoutChangingTheBinding()
+    {
+        JsonObject? changed = null;
+        using var document = JsonDocument.Parse("""
+            {"type":"object","properties":{"precision":{"type":"integer"}}}
+            """);
+        var cut = Render<OutputConverterSettingsEditor>(parameters => parameters
+            .Add(x => x.SettingsSchema, document.RootElement.Clone())
+            .Add(x => x.SettingsChanged, value =>
+            {
+                changed = value;
+                return Task.CompletedTask;
+            }));
+
+        var field = cut.FindComponent<MudTextField<string>>();
+        await cut.InvokeAsync(() => field.Instance.ValueChanged.InvokeAsync("not-an-integer"));
+
+        Assert.Null(changed);
+        Assert.Contains("Enter a valid integer.", cut.Markup);
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.VariableTypes.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
+{
+    private readonly OutputConverterServiceStub _converterService = new();
+    private readonly JsonObject _activity = new()
+    {
+        ["result"] = new JsonObject
+        {
+            ["typeName"] = "Source",
+            ["memoryReference"] = new JsonObject { ["id"] = "result" }
+        }
+    };
+
+    public OutputsTabConverterTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IVariableTypeService>(new VariableTypeServiceStub());
+        Services.AddSingleton<IOutputConverterService>(_converterService);
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void LoadsCompatibleConvertersUsingTheDeclaredBindingTypes()
+    {
+        var cut = RenderOutputsTab();
+
+        Assert.Equal(("Source", "String"), _converterService.Requests.Single());
+        cut.WaitForAssertion(() => Assert.Contains(
+            cut.FindComponents<MudSelectItem<string>>(),
+            item => item.Instance.Value == "sample.to-text"));
+    }
+
+    [Fact]
+    public async Task SelectingAndClearingAConverterRoundTripsOnlyConverterJson()
+    {
+        var cut = RenderOutputsTab();
+        cut.WaitForState(() => cut.FindComponents<MudSelect<string>>().Count == 1);
+        var converter = cut.FindComponents<MudSelect<string>>().Single();
+
+        await cut.InvokeAsync(() => converter.Instance.ValueChanged.InvokeAsync("sample.to-text"));
+
+        var binding = _activity["result"]!.AsObject();
+        Assert.Equal("Source", binding["typeName"]!.GetValue<string>());
+        Assert.Equal("result", binding["memoryReference"]!["id"]!.GetValue<string>());
+        Assert.Equal("sample.to-text", binding["converter"]!["id"]!.GetValue<string>());
+
+        await cut.InvokeAsync(() => converter.Instance.ValueChanged.InvokeAsync(string.Empty));
+
+        Assert.Null(_activity["result"]!["converter"]);
+    }
+
+    [Fact]
+    public void UnavailableDiscoveryDoesNotDiscardPersistedConverterConfiguration()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject
+        {
+            ["id"] = "unavailable.converter",
+            ["settings"] = new JsonObject { ["format"] = "compact" }
+        };
+        _converterService.Exception = new InvalidOperationException();
+
+        var cut = RenderOutputsTab();
+
+        Assert.DoesNotContain("Converter", cut.Markup);
+        Assert.Equal("unavailable.converter", _activity["result"]!["converter"]!["id"]!.GetValue<string>());
+        Assert.Equal("compact", _activity["result"]!["converter"]!["settings"]!["format"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ChangingDestinationClearsAnIncompatibleConverter()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject { ["id"] = "sample.to-text" };
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables =
+            [
+                new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                new Variable { Id = "count", Name = "Count", TypeName = "Integer" }
+            ]
+        });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        await cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(new BindingTargetOption("Count", "count", "Integer", false)));
+
+        Assert.Null(_activity["result"]!["converter"]);
+    }
+
+    [Fact]
+    public void ReadOnlyWorkspaceDisablesConverterSelection()
+    {
+        var cut = RenderOutputsTab(readOnly: true);
+
+        Assert.All(cut.FindComponents<MudSelect<string>>(), select => Assert.True(select.Instance.Disabled));
+    }
+
+    private IRenderedComponent<OutputsTab> RenderOutputsTab(WorkflowDefinition? workflowDefinition = null, bool readOnly = false) => Render<OutputsTab>(parameters => parameters
+        .AddCascadingValue<IWorkspace>(new WorkspaceStub(readOnly))
+        .Add(x => x.WorkflowDefinition, workflowDefinition ?? new WorkflowDefinition
+        {
+            Variables = [new Variable { Id = "result", Name = "Result", TypeName = "String" }]
+        })
+        .Add(x => x.Activity, _activity)
+        .Add(x => x.ActivityDescriptor, new ActivityDescriptor
+        {
+            Outputs = [new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" }]
+        })
+        .Add(x => x.OnActivityUpdated, (Func<JsonObject, Task>)(_ => Task.CompletedTask)));
+
+    private sealed class VariableTypeServiceStub : IVariableTypeService
+    {
+        public Task<IEnumerable<VariableTypeDescriptor>> GetVariableTypesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<VariableTypeDescriptor>>([new("Source", "Source", "Tests", null)]);
+    }
+
+    private sealed class OutputConverterServiceStub : IOutputConverterService
+    {
+        public ICollection<(string SourceType, string DestinationType)> Requests { get; } = [];
+        public Exception? Exception { get; set; }
+
+        public Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(string sourceType, string destinationType, CancellationToken cancellationToken = default)
+        {
+            Requests.Add((sourceType, destinationType));
+            if (Exception != null)
+                throw Exception;
+
+            if (destinationType == "Integer")
+                return Task.FromResult<ICollection<OutputConverterDescriptor>>([]);
+
+            return Task.FromResult<ICollection<OutputConverterDescriptor>>(
+            [
+                new OutputConverterDescriptor
+                {
+                    Id = "sample.to-text",
+                    SourceTypeName = sourceType,
+                    ResultTypeName = destinationType,
+                    DisplayName = "Convert to text",
+                    Description = "Formats the value as text."
+                }
+            ]);
+        }
+    }
+
+    private sealed class WorkspaceStub(bool isReadOnly) : IWorkspace
+    {
+        public bool IsReadOnly { get; } = isReadOnly;
+        public bool HasWorkflowEditPermission => !IsReadOnly;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Bunit;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
@@ -67,6 +68,7 @@ public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
         Assert.Equal("Source", binding["typeName"]!.GetValue<string>());
         Assert.Equal("result", binding["memoryReference"]!["id"]!.GetValue<string>());
         Assert.Equal("sample.to-text", binding["converter"]!["id"]!.GetValue<string>());
+        Assert.Empty(binding["converter"]!["settings"]!.AsObject());
 
         await cut.InvokeAsync(() => converter.Instance.ValueChanged.InvokeAsync(string.Empty));
 
@@ -117,7 +119,177 @@ public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
         Assert.All(cut.FindComponents<MudSelect<string>>(), select => Assert.True(select.Instance.Disabled));
     }
 
-    private IRenderedComponent<OutputsTab> RenderOutputsTab(WorkflowDefinition? workflowDefinition = null, bool readOnly = false) => Render<OutputsTab>(parameters => parameters
+    [Fact]
+    public void OutputsWithTheSameTypePairShareOneRequest()
+    {
+        _activity["summary"] = new JsonObject
+        {
+            ["typeName"] = "Source",
+            ["memoryReference"] = new JsonObject { ["id"] = "result" }
+        };
+
+        RenderOutputsTab(outputs:
+        [
+            new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" },
+            new OutputDescriptor { Name = "Summary", TypeName = "Source", DisplayName = "Summary" }
+        ]);
+
+        Assert.Equal([("Source", "String")], _converterService.Requests);
+    }
+
+    [Fact]
+    public async Task DistinctTypePairsStartConcurrently()
+    {
+        var allRequestsStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRequests = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _converterService.Handler = async (_, _, _) =>
+        {
+            if (_converterService.Requests.Count == 2)
+                allRequestsStarted.TrySetResult();
+
+            await releaseRequests.Task;
+            return [];
+        };
+        _activity["summary"] = new JsonObject
+        {
+            ["typeName"] = "OtherSource",
+            ["memoryReference"] = new JsonObject { ["id"] = "result" }
+        };
+
+        var cut = RenderOutputsTab(outputs:
+        [
+            new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" },
+            new OutputDescriptor { Name = "Summary", TypeName = "OtherSource", DisplayName = "Summary" }
+        ]);
+
+        await allRequestsStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(2, _converterService.Requests.Count);
+        releaseRequests.SetResult();
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindComponents<MudSelect<string>>().Count));
+    }
+
+    [Fact]
+    public void UnchangedParametersReuseTheSuccessfulRequest()
+    {
+        var cut = RenderOutputsTab();
+        cut.WaitForAssertion(() => Assert.Single(_converterService.Requests));
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, cut.Instance.WorkflowDefinition)
+            .Add(x => x.Activity, cut.Instance.Activity)
+            .Add(x => x.ActivityDescriptor, cut.Instance.ActivityDescriptor)
+            .Add(x => x.OnActivityUpdated, cut.Instance.OnActivityUpdated));
+
+        Assert.Single(_converterService.Requests);
+    }
+
+    [Fact]
+    public async Task SwitchingTargetsWithTheSameDeclaredTypeReusesTheRequest()
+    {
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables =
+            [
+                new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                new Variable { Id = "summary", Name = "Summary", TypeName = "String" }
+            ]
+        });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        await cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(new BindingTargetOption("Summary", "summary", "String", false)));
+
+        Assert.Single(_converterService.Requests);
+    }
+
+    [Fact]
+    public void FailedRequestsAreRetried()
+    {
+        _converterService.Exception = new InvalidOperationException();
+        var cut = RenderOutputsTab();
+        Assert.Single(_converterService.Requests);
+
+        _converterService.Exception = null;
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, cut.Instance.WorkflowDefinition)
+            .Add(x => x.Activity, cut.Instance.Activity)
+            .Add(x => x.ActivityDescriptor, cut.Instance.ActivityDescriptor)
+            .Add(x => x.OnActivityUpdated, cut.Instance.OnActivityUpdated));
+
+        cut.WaitForAssertion(() => Assert.Equal(2, _converterService.Requests.Count));
+    }
+
+    [Fact]
+    public void EmptyResultsAreCached()
+    {
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables = [new Variable { Id = "result", Name = "Result", TypeName = "Integer" }]
+        });
+        cut.WaitForAssertion(() => Assert.Single(_converterService.Requests));
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, cut.Instance.WorkflowDefinition)
+            .Add(x => x.Activity, cut.Instance.Activity)
+            .Add(x => x.ActivityDescriptor, cut.Instance.ActivityDescriptor)
+            .Add(x => x.OnActivityUpdated, cut.Instance.OnActivityUpdated));
+
+        Assert.Single(_converterService.Requests);
+    }
+
+    [Fact]
+    public async Task SelectingAConverterPersistsTopLevelSchemaDefaults()
+    {
+        using var schema = JsonDocument.Parse("""
+            {"type":"object","properties":{"format":{"type":"string","default":"compact"},"precision":{"type":"integer","default":2},"enabled":{"type":"boolean","default":true}}}
+            """);
+        _converterService.Descriptors =
+        [
+            new OutputConverterDescriptor
+            {
+                Id = "sample.to-text",
+                SourceTypeName = "Source",
+                ResultTypeName = "String",
+                SettingsSchema = schema.RootElement.Clone()
+            }
+        ];
+        var updates = 0;
+        var cut = RenderOutputsTab(onActivityUpdated: _ =>
+        {
+            updates++;
+            return Task.CompletedTask;
+        });
+        cut.WaitForState(() => cut.FindComponents<MudSelect<string>>().Count == 1);
+
+        await cut.InvokeAsync(() => cut.FindComponent<MudSelect<string>>().Instance.ValueChanged.InvokeAsync("sample.to-text"));
+
+        var settings = _activity["result"]!["converter"]!["settings"]!.AsObject();
+        Assert.Equal("compact", settings["format"]!.GetValue<string>());
+        Assert.Equal(2, settings["precision"]!.GetValue<int>());
+        Assert.True(settings["enabled"]!.GetValue<bool>());
+        Assert.Equal(1, updates);
+    }
+
+    [Fact]
+    public async Task ReselectingAConverterPreservesItsSettings()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject
+        {
+            ["id"] = "sample.to-text",
+            ["settings"] = new JsonObject { ["format"] = "custom" }
+        };
+        var cut = RenderOutputsTab();
+        cut.WaitForState(() => cut.FindComponents<MudSelect<string>>().Count == 1);
+
+        await cut.InvokeAsync(() => cut.FindComponent<MudSelect<string>>().Instance.ValueChanged.InvokeAsync("sample.to-text"));
+
+        Assert.Equal("custom", _activity["result"]!["converter"]!["settings"]!["format"]!.GetValue<string>());
+    }
+
+    private IRenderedComponent<OutputsTab> RenderOutputsTab(
+        WorkflowDefinition? workflowDefinition = null,
+        bool readOnly = false,
+        IReadOnlyCollection<OutputDescriptor>? outputs = null,
+        Func<JsonObject, Task>? onActivityUpdated = null) => Render<OutputsTab>(parameters => parameters
         .AddCascadingValue<IWorkspace>(new WorkspaceStub(readOnly))
         .Add(x => x.WorkflowDefinition, workflowDefinition ?? new WorkflowDefinition
         {
@@ -126,9 +298,9 @@ public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
         .Add(x => x.Activity, _activity)
         .Add(x => x.ActivityDescriptor, new ActivityDescriptor
         {
-            Outputs = [new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" }]
+            Outputs = outputs ?? [new OutputDescriptor { Name = "Result", TypeName = "Source", DisplayName = "Result" }]
         })
-        .Add(x => x.OnActivityUpdated, (Func<JsonObject, Task>)(_ => Task.CompletedTask)));
+        .Add(x => x.OnActivityUpdated, onActivityUpdated ?? (_ => Task.CompletedTask)));
 
     private sealed class VariableTypeServiceStub : IVariableTypeService
     {
@@ -140,18 +312,24 @@ public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
     {
         public ICollection<(string SourceType, string DestinationType)> Requests { get; } = [];
         public Exception? Exception { get; set; }
+        public Func<string, string, CancellationToken, Task<ICollection<OutputConverterDescriptor>>>? Handler { get; set; }
+        public ICollection<OutputConverterDescriptor>? Descriptors { get; set; }
 
         public Task<ICollection<OutputConverterDescriptor>> GetOutputConvertersAsync(string sourceType, string destinationType, CancellationToken cancellationToken = default)
         {
             Requests.Add((sourceType, destinationType));
+            if (Handler != null)
+                return Handler(sourceType, destinationType, cancellationToken);
+
             if (Exception != null)
                 throw Exception;
 
             if (destinationType == "Integer")
                 return Task.FromResult<ICollection<OutputConverterDescriptor>>([]);
 
-            return Task.FromResult<ICollection<OutputConverterDescriptor>>(
-            [
+            return Task.FromResult(Descriptors ??
+                (ICollection<OutputConverterDescriptor>)
+                [
                 new OutputConverterDescriptor
                 {
                     Id = "sample.to-text",

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/OutputsTabConverterTests.cs
@@ -285,6 +285,156 @@ public sealed class OutputsTabConverterTests : BunitContext, IAsyncLifetime
         Assert.Equal("custom", _activity["result"]!["converter"]!["settings"]!["format"]!.GetValue<string>());
     }
 
+    [Fact]
+    public async Task CompletionAfterDisposalDoesNotMutateTheActivity()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject
+        {
+            ["id"] = "sample.to-text",
+            ["settings"] = new JsonObject { ["format"] = "custom" }
+        };
+        var releaseRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken requestCancellationToken = default;
+        _converterService.Handler = async (sourceType, destinationType, cancellationToken) =>
+        {
+            if (destinationType == "String")
+                return [CreateDescriptor("sample.to-text", sourceType, destinationType)];
+
+            requestCancellationToken = cancellationToken;
+            await releaseRequest.Task;
+            return [];
+        };
+        var updates = 0;
+        var cut = RenderOutputsTab(
+            workflowDefinition: new WorkflowDefinition
+            {
+                Variables =
+                [
+                    new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                    new Variable { Id = "count", Name = "Count", TypeName = "Integer" }
+                ]
+            },
+            onActivityUpdated: _ =>
+            {
+                updates++;
+                return Task.CompletedTask;
+            });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        var destinationChange = cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(
+            new BindingTargetOption("Count", "count", "Integer", false)));
+        cut.WaitForAssertion(() => Assert.Equal(2, _converterService.Requests.Count));
+        cut.Instance.Dispose();
+
+        Assert.True(requestCancellationToken.IsCancellationRequested);
+        releaseRequest.SetResult();
+        await destinationChange;
+        Assert.Equal("sample.to-text", _activity["result"]!["converter"]!["id"]!.GetValue<string>());
+        Assert.Equal(1, updates);
+    }
+
+    [Fact]
+    public async Task ChangingTypePairsHidesStaleDescriptorsWhileLoading()
+    {
+        var newPairStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseNewPair = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _converterService.Handler = async (sourceType, destinationType, _) =>
+        {
+            if (destinationType == "String")
+                return [CreateDescriptor("sample.to-text", sourceType, destinationType)];
+
+            newPairStarted.TrySetResult();
+            await releaseNewPair.Task;
+            return [CreateDescriptor("sample.to-number", sourceType, destinationType)];
+        };
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables =
+            [
+                new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                new Variable { Id = "count", Name = "Count", TypeName = "Integer" }
+            ]
+        });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        var destinationChange = cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(
+            new BindingTargetOption("Count", "count", "Integer", false)));
+        await newPairStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Empty(cut.FindComponents<MudSelect<string>>());
+        releaseNewPair.SetResult();
+        await destinationChange;
+        cut.WaitForAssertion(() =>
+        {
+            var option = Assert.Single(cut.FindComponents<MudSelectItem<string>>(), item => item.Instance.Value == "sample.to-number");
+            Assert.NotNull(option);
+            Assert.DoesNotContain(cut.FindComponents<MudSelectItem<string>>(), item => item.Instance.Value == "sample.to-text");
+        });
+    }
+
+    [Fact]
+    public async Task FailedTypePairRequestKeepsPersistedConverterButHidesStaleDescriptors()
+    {
+        _activity["result"]!.AsObject()["converter"] = new JsonObject { ["id"] = "sample.to-text" };
+        _converterService.Handler = (sourceType, destinationType, _) => destinationType == "String"
+            ? Task.FromResult<ICollection<OutputConverterDescriptor>>([CreateDescriptor("sample.to-text", sourceType, destinationType)])
+            : Task.FromException<ICollection<OutputConverterDescriptor>>(new InvalidOperationException());
+        var cut = RenderOutputsTab(workflowDefinition: new WorkflowDefinition
+        {
+            Variables =
+            [
+                new Variable { Id = "result", Name = "Result", TypeName = "String" },
+                new Variable { Id = "count", Name = "Count", TypeName = "Integer" }
+            ]
+        });
+        var bindingTarget = cut.FindComponent<MudSelect<BindingTargetOption>>();
+
+        await cut.InvokeAsync(() => bindingTarget.Instance.ValueChanged.InvokeAsync(
+            new BindingTargetOption("Count", "count", "Integer", false)));
+
+        Assert.Empty(cut.FindComponents<MudSelect<string>>());
+        Assert.Equal("sample.to-text", _activity["result"]!["converter"]!["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task SwitchingConvertersDiscardsOldSettingsAndUsesNewDefaults()
+    {
+        using var schema = JsonDocument.Parse("""
+            {"type":"object","properties":{"format":{"type":"string","default":"new-default"}}}
+            """);
+        _activity["result"]!.AsObject()["converter"] = new JsonObject
+        {
+            ["id"] = "sample.first",
+            ["settings"] = new JsonObject { ["obsolete"] = true }
+        };
+        _converterService.Descriptors =
+        [
+            CreateDescriptor("sample.first", "Source", "String"),
+            CreateDescriptor("sample.second", "Source", "String", schema.RootElement.Clone())
+        ];
+        var cut = RenderOutputsTab();
+        cut.WaitForState(() => cut.FindComponents<MudSelect<string>>().Count == 1);
+
+        await cut.InvokeAsync(() => cut.FindComponent<MudSelect<string>>().Instance.ValueChanged.InvokeAsync("sample.second"));
+
+        var settings = _activity["result"]!["converter"]!["settings"]!.AsObject();
+        Assert.Equal("new-default", settings["format"]!.GetValue<string>());
+        Assert.False(settings.ContainsKey("obsolete"));
+    }
+
+    private static OutputConverterDescriptor CreateDescriptor(
+        string id,
+        string sourceType,
+        string destinationType,
+        JsonElement? settingsSchema = null) => new()
+    {
+        Id = id,
+        SourceTypeName = sourceType,
+        ResultTypeName = destinationType,
+        DisplayName = id,
+        SettingsSchema = settingsSchema
+    };
+
     private IRenderedComponent<OutputsTab> RenderOutputsTab(
         WorkflowDefinition? workflowDefinition = null,
         bool readOnly = false,

--- a/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/RemoteOutputConverterServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/OutputConverters/RemoteOutputConverterServiceTests.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics.CodeAnalysis;
+using Elsa.Api.Client.Resources.OutputConverters.Contracts;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Requests;
+using Elsa.Api.Client.Resources.OutputConverters.Responses;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Domain.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.OutputConverters;
+
+public class RemoteOutputConverterServiceTests
+{
+    [Fact]
+    public async Task GetOutputConvertersAsyncForwardsDeclaredTypesToTheBackend()
+    {
+        var api = new OutputConvertersApiStub();
+        var service = new RemoteOutputConverterService(new BackendApiClientProviderStub(api));
+
+        var converters = await service.GetOutputConvertersAsync("Source", "String");
+
+        Assert.Equal("Source", api.Request!.SourceType);
+        Assert.Equal("String", api.Request.DestinationType);
+        Assert.Single(converters);
+        Assert.Equal("sample.to-text", converters.Single().Id);
+    }
+
+    private sealed class OutputConvertersApiStub : IOutputConvertersApi
+    {
+        public ListOutputConvertersRequest? Request { get; private set; }
+
+        public Task<ListOutputConvertersResponse> ListAsync(ListOutputConvertersRequest request, CancellationToken cancellationToken = default)
+        {
+            Request = request;
+            return Task.FromResult(new ListOutputConvertersResponse(
+            [
+                new OutputConverterDescriptor
+                {
+                    Id = "sample.to-text",
+                    SourceTypeName = "Source",
+                    ResultTypeName = "String",
+                    DisplayName = "Convert to text"
+                }
+            ]));
+        }
+    }
+
+    private sealed class BackendApiClientProviderStub(IOutputConvertersApi api) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://studio.test");
+
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class =>
+            typeof(T) == typeof(IOutputConvertersApi)
+                ? ValueTask.FromResult((T)api)
+                : throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor
@@ -42,6 +42,7 @@
                                  Items="@_treeItemData"
                                  FilterFunc="@(x => MatchesName((ActivityTreeItem)x))"
                                  SelectionMode="SelectionMode.SingleSelection"
+                                 ExpandOnClick="true"
                                  Dense="true">
                         <ItemTemplate>
                             @{
@@ -51,7 +52,6 @@
                                              Icon="@(item.IconWithColor)"
                                              Visible="@item.Visible"
                                              Items="@item.Children"
-                                             OnDoubleClick="@(() => OnItemDoubleClick(item))"
                                              title="@(item.ActivityDescriptor?.Description is { } description ? Localizer[description] : "")"
                                              @bind-Expanded="@item.Expanded"
                                              draggable="@(item.ActivityDescriptor is not null ? "true" : "false")"

--- a/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs
@@ -116,14 +116,6 @@ public partial class ActivityPicker
         _expanded = !_expanded;
     }
 
-    private void OnItemDoubleClick(ActivityTreeItem item)
-    {
-        if (item.Children?.Any() == true)
-        {
-            item.Expanded = !item.Expanded;
-        }
-    }
-
     private Task<bool> MatchesName(ActivityTreeItem item)
     {
         if (string.IsNullOrEmpty(item.CategoryPath) && string.IsNullOrEmpty(item.Text))

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor
@@ -1,0 +1,40 @@
+@using System.Text.Json
+@using System.Text.Json.Nodes
+@using Elsa.Studio.Localization
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+@if (_fields.Count > 0)
+{
+    <MudStack Spacing="2" Class="ml-4">
+        @foreach (var field in _fields)
+        {
+            @if (field.Options.Count > 0)
+            {
+                <MudSelect T="string" Label="@Localizer[field.Label]" HelperText="@Localizer[field.Description]" Value="@GetTextValue(field.Name)" ValueChanged="@(value => UpdateEnumAsync(field, value))" Required="@field.IsRequired" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Dense="true" Variant="Variant.Outlined">
+                    @foreach (var option in field.Options)
+                    {
+                        <MudSelectItem Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+            else if (field.Type == "boolean")
+            {
+                <MudCheckBox T="bool" Label="@Localizer[field.Label]" Value="@GetBooleanValue(field.Name)" ValueChanged="@(value => UpdateBooleanAsync(field.Name, value))" ReadOnly="IsReadOnly" Disabled="IsReadOnly" />
+            }
+            else
+            {
+                <MudTextField T="string" Label="@Localizer[field.Label]" HelperText="@Localizer[field.Description]" Value="@GetTextValue(field.Name)" ValueChanged="@(value => UpdateTextAsync(field, value))" Required="@field.IsRequired" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Variant="Variant.Outlined" />
+            }
+        }
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true">@_error</MudAlert>
+        }
+    </MudStack>
+}
+else
+{
+    <MudTextField T="string" Label="@Localizer["Converter settings"]" HelperText="@Localizer["Enter a JSON object."]" Value="@_rawSettings" ValueChanged="OnRawSettingsChangedAsync" Error="@(!string.IsNullOrEmpty(_error))" ErrorText="@_error" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Lines="6" Variant="Variant.Outlined" Class="ml-4" />
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
@@ -1,0 +1,190 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Components;
+
+/// <summary>
+/// Edits JSON settings for a selected output converter.
+/// </summary>
+public partial class OutputConverterSettingsEditor
+{
+    private readonly List<SettingsField> _fields = [];
+    private JsonObject _settings = [];
+    private string _rawSettings = "{}";
+    private string? _error;
+    private string? _settingsSignature;
+
+    /// <summary>
+    /// The optional JSON schema provided by the selected converter descriptor.
+    /// </summary>
+    [Parameter] public JsonElement? SettingsSchema { get; set; }
+
+    /// <summary>
+    /// The current converter settings.
+    /// </summary>
+    [Parameter] public JsonObject? Settings { get; set; }
+
+    /// <summary>
+    /// Raised when valid converter settings change.
+    /// </summary>
+    [Parameter] public EventCallback<JsonObject> SettingsChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether settings are read-only.
+    /// </summary>
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        var schemaSignature = SettingsSchema?.GetRawText() ?? string.Empty;
+        var settingsSignature = $"{schemaSignature}\n{Settings?.ToJsonString() ?? "{}"}";
+        if (settingsSignature == _settingsSignature)
+            return;
+
+        _settingsSignature = settingsSignature;
+        _settings = Settings?.DeepClone().AsObject() ?? [];
+        _rawSettings = _settings.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        _error = null;
+        BuildFields();
+    }
+
+    private void BuildFields()
+    {
+        _fields.Clear();
+        if (SettingsSchema is not { ValueKind: JsonValueKind.Object } schema ||
+            !schema.TryGetProperty("type", out var type) || type.GetString() != "object" ||
+            !schema.TryGetProperty("properties", out var properties) || properties.ValueKind != JsonValueKind.Object)
+            return;
+
+        var required = schema.TryGetProperty("required", out var requiredElement) && requiredElement.ValueKind == JsonValueKind.Array
+            ? requiredElement.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()).ToHashSet()
+            : [];
+
+        foreach (var property in properties.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.Object)
+            {
+                _fields.Clear();
+                return;
+            }
+
+            var propertySchema = property.Value;
+            var fieldType = propertySchema.TryGetProperty("type", out var fieldTypeElement) ? fieldTypeElement.GetString() : null;
+            var options = propertySchema.TryGetProperty("enum", out var enumElement) && enumElement.ValueKind == JsonValueKind.Array
+                ? enumElement.EnumerateArray().Where(x => x.ValueKind is JsonValueKind.String or JsonValueKind.Number).Select(x => x.ToString()).ToList()
+                : [];
+
+            if (fieldType == null && propertySchema.TryGetProperty("enum", out enumElement) && enumElement.ValueKind == JsonValueKind.Array)
+                fieldType = enumElement.EnumerateArray().All(x => x.ValueKind == JsonValueKind.Number) ? "number" : "string";
+
+            if (fieldType is not ("string" or "number" or "integer" or "boolean") && options.Count == 0)
+            {
+                _fields.Clear();
+                return;
+            }
+
+            if (options.Count > 0 && fieldType is not (null or "string" or "number" or "integer"))
+            {
+                _fields.Clear();
+                return;
+            }
+
+            var label = propertySchema.TryGetProperty("title", out var title) ? title.GetString() : null;
+            var description = propertySchema.TryGetProperty("description", out var descriptionElement) ? descriptionElement.GetString() : null;
+            var field = new SettingsField(property.Name, label ?? property.Name, description ?? string.Empty, fieldType ?? "string", options, required.Contains(property.Name));
+            _fields.Add(field);
+
+            if (!_settings.ContainsKey(property.Name) && propertySchema.TryGetProperty("default", out var defaultValue))
+                _settings[property.Name] = JsonNode.Parse(defaultValue.GetRawText());
+        }
+    }
+
+    private string? GetTextValue(string name) => _settings[name]?.ToString();
+
+    private bool GetBooleanValue(string name) =>
+        _settings[name] is JsonValue value && value.TryGetValue<bool>(out var boolean) && boolean;
+
+    private async Task UpdateEnumAsync(SettingsField field, string value)
+    {
+        await UpdateTextAsync(field, value);
+    }
+
+    private async Task UpdateTextAsync(SettingsField field, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (field.IsRequired)
+            {
+                _error = Localizer["This setting is required."];
+                return;
+            }
+
+            _settings.Remove(field.Name);
+        }
+        else if (field.Type == "number")
+        {
+            if (!decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var number))
+            {
+                _error = Localizer["Enter a valid number."];
+                return;
+            }
+
+            _settings[field.Name] = number;
+        }
+        else if (field.Type == "integer")
+        {
+            if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integer))
+            {
+                _error = Localizer["Enter a valid integer."];
+                return;
+            }
+
+            _settings[field.Name] = integer;
+        }
+        else
+        {
+            _settings[field.Name] = value;
+        }
+
+        _error = null;
+        await RaiseSettingsChangedAsync();
+    }
+
+    private async Task UpdateBooleanAsync(string name, bool value)
+    {
+        _settings[name] = value;
+        _error = null;
+        await RaiseSettingsChangedAsync();
+    }
+
+    private async Task OnRawSettingsChangedAsync(string value)
+    {
+        _rawSettings = value;
+
+        try
+        {
+            var settings = JsonNode.Parse(value) as JsonObject;
+            if (settings == null)
+                throw new JsonException();
+
+            _settings = settings;
+            _error = null;
+            await RaiseSettingsChangedAsync();
+        }
+        catch (JsonException)
+        {
+            _error = Localizer["Converter settings must be a valid JSON object."];
+        }
+    }
+
+    private Task RaiseSettingsChangedAsync()
+    {
+        _settingsSignature = _settings.ToJsonString();
+        return SettingsChanged.InvokeAsync(_settings.DeepClone().AsObject());
+    }
+
+    private sealed record SettingsField(string Name, string Label, string Description, string Type, ICollection<string> Options, bool IsRequired);
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputConverterSettingsEditor.razor.cs
@@ -96,9 +96,6 @@ public partial class OutputConverterSettingsEditor
             var description = propertySchema.TryGetProperty("description", out var descriptionElement) ? descriptionElement.GetString() : null;
             var field = new SettingsField(property.Name, label ?? property.Name, description ?? string.Empty, fieldType ?? "string", options, required.Contains(property.Name));
             _fields.Add(field);
-
-            if (!_settings.ContainsKey(property.Name) && propertySchema.TryGetProperty("default", out var defaultValue))
-                _settings[property.Name] = JsonNode.Parse(defaultValue.GetRawText());
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor
@@ -2,9 +2,10 @@
 @using Variant = MudBlazor.Variant
 @using Elsa.Api.Client.Extensions
 @using Elsa.Api.Client.Shared.Models
+@using Elsa.Studio.Localization
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs.Outputs.Models
 @inherits StudioComponentBase
-@using Microsoft.Extensions.Localization
+@implements IDisposable
 @inject ILocalizer Localizer
 
 <MudForm ReadOnly="IsReadOnly">
@@ -12,17 +13,20 @@
         @foreach (var outputDescriptor in OutputDescriptors)
         {
             var activity = Activity;
-            var displayName = string.IsNullOrWhiteSpace(outputDescriptor.DisplayName) ? outputDescriptor.Name : outputDescriptor.DisplayName;
+            var displayName = string.IsNullOrWhiteSpace(outputDescriptor.DisplayName) ? outputDescriptor.Name : outputDescriptor.DisplayName!;
             var propertyName = outputDescriptor.Name.Camelize();
             var propertyValue = activity.GetProperty<ActivityOutput>(propertyName);
             var propertyType = _variableTypes.TryGetValue(outputDescriptor.TypeName, out var type) ? type : default;
             var propertyTypeName = propertyType?.DisplayName ?? outputDescriptor.TypeName;
             var selectedValue = _bindingTargetOptions.FirstOrDefault(x => x.Value == propertyValue?.MemoryReference?.Id);
+            var converterState = GetConverterState(outputDescriptor);
+            var converterId = GetConverterId(propertyName);
+            var selectedConverter = converterState.Descriptors.FirstOrDefault(x => x.Id == converterId);
 
             <MudSelect
                 T="BindingTargetOption"
                 Label="@Localizer[displayName]"
-                HelperText="@Localizer[outputDescriptor.Description]"
+                HelperText="@(outputDescriptor.Description is { Length: > 0 } outputDescription ? Localizer[outputDescription].Value : null)"
                 Value="@selectedValue"
                 Dense="false"
                 Variant="Variant.Outlined"
@@ -44,6 +48,30 @@
                     }
                 }
             </MudSelect>
+
+            @if (selectedValue != null && converterState.IsAvailable)
+            {
+                <MudSelect T="string" Label="@Localizer["Converter"]" HelperText="@(selectedConverter?.Description is { Length: > 0 } description ? Localizer[description].Value : null)" Value="@converterId" Dense="true" Variant="Variant.Outlined" Margin="Margin.Dense" ToStringFunc="@(id => GetConverterDisplayName(id, converterState))" ValueChanged="@(id => OnConverterChanged(id, outputDescriptor))" ReadOnly="IsReadOnly" Disabled="IsReadOnly" Class="ml-4">
+                    <MudSelectItem T="string" Value="@string.Empty">@Localizer["None"]</MudSelectItem>
+                    @if (!string.IsNullOrWhiteSpace(converterId) && selectedConverter == null)
+                    {
+                        <MudSelectItem T="string" Value="@converterId">@converterId</MudSelectItem>
+                    }
+                    @foreach (var converter in converterState.Descriptors)
+                    {
+                        <MudSelectItem T="string" Value="@converter.Id">@Localizer[string.IsNullOrWhiteSpace(converter.DisplayName) ? converter.Id : converter.DisplayName]</MudSelectItem>
+                    }
+                </MudSelect>
+
+                @if (!string.IsNullOrWhiteSpace(converterId) && selectedConverter == null)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="ml-4">@Localizer["The configured converter is unavailable."]</MudAlert>
+                }
+                else if (selectedConverter != null)
+                {
+                    <OutputConverterSettingsEditor SettingsSchema="selectedConverter.SettingsSchema" Settings="GetConverterSettings(propertyName)" SettingsChanged="@(settings => OnConverterSettingsChanged(settings, outputDescriptor))" IsReadOnly="IsReadOnly" />
+                }
+            }
         }
     </MudStack>
 </MudForm>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
@@ -23,6 +24,10 @@ public partial class OutputsTab
     private ICollection<BindingTargetOption> _bindingTargetOptions = new List<BindingTargetOption>();
     private IDictionary<string, VariableTypeDescriptor> _variableTypes = new Dictionary<string, VariableTypeDescriptor>();
     private readonly IDictionary<string, OutputConverterState> _converterStates = new Dictionary<string, OutputConverterState>();
+    private readonly Dictionary<ConverterRequestKey, IReadOnlyCollection<OutputConverterDescriptor>> _converterCache = [];
+    private readonly Dictionary<ConverterRequestKey, Task<IReadOnlyCollection<OutputConverterDescriptor>>> _converterRequests = [];
+    private readonly object _converterCacheLock = new();
+    private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
 
     /// <summary>
     /// The workflow definition.
@@ -86,13 +91,15 @@ public partial class OutputsTab
         _bindingTargetGroups = bindingTargetGroups;
         _bindingTargetOptions = variableBindingTargets.Concat(outputBindingTargets).ToList();
 
-        foreach (var outputDescriptor in OutputDescriptors)
+        var converterLoads = OutputDescriptors.Select(outputDescriptor =>
         {
             var propertyName = outputDescriptor.Name.Camelize();
             var binding = Activity.GetProperty<ActivityOutput>(propertyName);
             var target = _bindingTargetOptions.FirstOrDefault(x => x.Value == binding?.MemoryReference?.Id);
-            await LoadConvertersAsync(outputDescriptor, target, clearIncompatibleConverter: false);
-        }
+            return LoadConvertersAsync(outputDescriptor, target, clearIncompatibleConverter: false);
+        });
+
+        await Task.WhenAll(converterLoads);
     }
 
     private async Task OnBindingChanged(BindingTargetOption? bindingTargetOption, OutputDescriptor outputDescriptor)
@@ -136,9 +143,10 @@ public partial class OutputsTab
         else
         {
             var existingConverter = binding["converter"] as JsonObject;
-            var settings = existingConverter?["id"]?.GetValue<string>() == converterId
-                ? existingConverter["settings"]?.DeepClone()
-                : new JsonObject();
+            var isSameConverter = existingConverter?["id"]?.GetValue<string>() == converterId;
+            var settings = isSameConverter
+                ? existingConverter!["settings"]?.DeepClone()
+                : CreateDefaultSettings(GetConverterState(outputDescriptor).Descriptors.FirstOrDefault(x => x.Id == converterId)?.SettingsSchema);
             binding["converter"] = new JsonObject
             {
                 ["id"] = converterId,
@@ -165,8 +173,7 @@ public partial class OutputsTab
     private async Task LoadConvertersAsync(OutputDescriptor outputDescriptor, BindingTargetOption? target, bool clearIncompatibleConverter)
     {
         var state = GetConverterState(outputDescriptor);
-        var cancellationToken = state.BeginRequest();
-        var requestVersion = state.RequestVersion;
+        var requestVersion = state.BeginRequest();
 
         if (target == null)
         {
@@ -174,28 +181,28 @@ public partial class OutputsTab
             return;
         }
 
+        var requestKey = new ConverterRequestKey(outputDescriptor.TypeName, target.DeclaredTypeName);
+        if (state.LoadedKey == requestKey && state.IsAvailable)
+        {
+            if (clearIncompatibleConverter)
+                await ClearIncompatibleConverterAsync(outputDescriptor, state);
+            return;
+        }
+
         try
         {
-            var descriptors = await OutputConverterService.GetOutputConvertersAsync(outputDescriptor.TypeName, target.DeclaredTypeName, cancellationToken);
+            var descriptors = await GetConvertersAsync(requestKey);
             if (requestVersion != state.RequestVersion)
                 return;
 
             state.Descriptors = descriptors;
             state.IsAvailable = true;
+            state.LoadedKey = requestKey;
 
-            if (clearIncompatibleConverter && !IsCurrentConverterCompatible(outputDescriptor, state))
-            {
-                var propertyName = outputDescriptor.Name.Camelize();
-                var binding = Activity.GetProperty<JsonObject>(propertyName);
-                binding?.Remove("converter");
-                if (binding != null)
-                {
-                    Activity.SetProperty(binding, propertyName);
-                    await RaiseActivityUpdatedAsync(Activity);
-                }
-            }
+            if (clearIncompatibleConverter)
+                await ClearIncompatibleConverterAsync(outputDescriptor, state);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (_disposeCancellationTokenSource.IsCancellationRequested)
         {
         }
         catch (Exception)
@@ -210,8 +217,99 @@ public partial class OutputsTab
     /// <inheritdoc />
     public void Dispose()
     {
-        foreach (var state in _converterStates.Values)
-            state.Dispose();
+        _disposeCancellationTokenSource.Cancel();
+        _disposeCancellationTokenSource.Dispose();
+    }
+
+    private Task<IReadOnlyCollection<OutputConverterDescriptor>> GetConvertersAsync(ConverterRequestKey requestKey)
+    {
+        TaskCompletionSource<IReadOnlyCollection<OutputConverterDescriptor>> completion;
+        Task<IReadOnlyCollection<OutputConverterDescriptor>> request;
+        lock (_converterCacheLock)
+        {
+            if (_converterCache.TryGetValue(requestKey, out var cachedDescriptors))
+                return Task.FromResult(cachedDescriptors);
+
+            if (_converterRequests.TryGetValue(requestKey, out var existingRequest))
+                return existingRequest;
+
+            completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            request = completion.Task;
+            _converterRequests[requestKey] = request;
+        }
+
+        _ = CompleteConverterRequestAsync(requestKey, request, completion);
+        return request;
+    }
+
+    private async Task CompleteConverterRequestAsync(
+        ConverterRequestKey requestKey,
+        Task<IReadOnlyCollection<OutputConverterDescriptor>> request,
+        TaskCompletionSource<IReadOnlyCollection<OutputConverterDescriptor>> completion)
+    {
+        try
+        {
+            var descriptors = (await OutputConverterService.GetOutputConvertersAsync(
+                requestKey.SourceType,
+                requestKey.DestinationType,
+                _disposeCancellationTokenSource.Token)).ToArray();
+
+            lock (_converterCacheLock)
+                _converterCache[requestKey] = descriptors;
+
+            completion.TrySetResult(descriptors);
+        }
+        catch (OperationCanceledException exception)
+        {
+            completion.TrySetCanceled(exception.CancellationToken);
+        }
+        catch (Exception exception)
+        {
+            completion.TrySetException(exception);
+        }
+        finally
+        {
+            lock (_converterCacheLock)
+            {
+                if (_converterRequests.TryGetValue(requestKey, out var currentRequest) && currentRequest == request)
+                    _converterRequests.Remove(requestKey);
+            }
+        }
+    }
+
+    private async Task ClearIncompatibleConverterAsync(OutputDescriptor outputDescriptor, OutputConverterState state)
+    {
+        if (IsCurrentConverterCompatible(outputDescriptor, state))
+            return;
+
+        var propertyName = outputDescriptor.Name.Camelize();
+        var binding = Activity.GetProperty<JsonObject>(propertyName);
+        binding?.Remove("converter");
+        if (binding != null)
+        {
+            Activity.SetProperty(binding, propertyName);
+            await RaiseActivityUpdatedAsync(Activity);
+        }
+    }
+
+    private static JsonObject CreateDefaultSettings(JsonElement? settingsSchema)
+    {
+        var settings = new JsonObject();
+        if (settingsSchema is not { ValueKind: JsonValueKind.Object } schema ||
+            !schema.TryGetProperty("type", out var type) || type.GetString() != "object" ||
+            !schema.TryGetProperty("properties", out var properties) || properties.ValueKind != JsonValueKind.Object)
+            return settings;
+
+        foreach (var property in properties.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.Object)
+                return new JsonObject();
+
+            if (property.Value.TryGetProperty("default", out var defaultValue))
+                settings[property.Name] = JsonNode.Parse(defaultValue.GetRawText());
+        }
+
+        return settings;
     }
 
     private OutputConverterState GetConverterState(OutputDescriptor outputDescriptor)
@@ -251,33 +349,26 @@ public partial class OutputsTab
             await OnActivityUpdated(activity);
     }
 
-    private sealed class OutputConverterState : IDisposable
-    {
-        private CancellationTokenSource? _cancellationTokenSource;
+    private readonly record struct ConverterRequestKey(string SourceType, string DestinationType);
 
-        public ICollection<OutputConverterDescriptor> Descriptors { get; set; } = [];
+    private sealed class OutputConverterState
+    {
+        public IReadOnlyCollection<OutputConverterDescriptor> Descriptors { get; set; } = [];
         public bool IsAvailable { get; set; }
         public int RequestVersion { get; set; }
+        public ConverterRequestKey? LoadedKey { get; set; }
 
-        public CancellationToken BeginRequest()
+        public int BeginRequest()
         {
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
-            _cancellationTokenSource = new();
             RequestVersion++;
-            return _cancellationTokenSource.Token;
+            return RequestVersion;
         }
 
         public void Reset()
         {
             Descriptors = [];
             IsAvailable = false;
-        }
-
-        public void Dispose()
-        {
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
+            LoadedKey = null;
         }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.OutputConverters.Models;
 using Elsa.Api.Client.Resources.VariableTypes.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
@@ -21,6 +22,7 @@ public partial class OutputsTab
     private ICollection<BindingTargetGroup> _bindingTargetGroups = new List<BindingTargetGroup>();
     private ICollection<BindingTargetOption> _bindingTargetOptions = new List<BindingTargetOption>();
     private IDictionary<string, VariableTypeDescriptor> _variableTypes = new Dictionary<string, VariableTypeDescriptor>();
+    private readonly IDictionary<string, OutputConverterState> _converterStates = new Dictionary<string, OutputConverterState>();
 
     /// <summary>
     /// The workflow definition.
@@ -48,6 +50,7 @@ public partial class OutputsTab
     [CascadingParameter] public IWorkspace? Workspace { get; set; }
 
     [Inject] IVariableTypeService VariableTypeService { get; set; } = default!;
+    [Inject] IOutputConverterService OutputConverterService { get; set; } = default!;
 
     private IReadOnlyCollection<OutputDescriptor> OutputDescriptors => ActivityDescriptor.Outputs;
     private bool IsReadOnly => Workspace?.IsReadOnly == true;
@@ -62,18 +65,18 @@ public partial class OutputsTab
     }
 
     /// <inheritdoc />
-    protected override Task OnParametersSetAsync()
+    protected override async Task OnParametersSetAsync()
     {
         var bindingTargetGroups = new List<BindingTargetGroup>();
         var variables = WorkflowDefinition.Variables;
         var outputDefinitions = WorkflowDefinition.Outputs;
 
         var variableBindingTargets = variables
-            .Select(variable => new BindingTargetOption(variable.Name, variable.Id))
+            .Select(variable => new BindingTargetOption(variable.Name, variable.Id, variable.TypeName, variable.IsArray))
             .ToList();
 
         var outputBindingTargets = outputDefinitions
-            .Select(outputDefinition => new BindingTargetOption(outputDefinition.DisplayName, outputDefinition.Name))
+            .Select(outputDefinition => new BindingTargetOption(outputDefinition.DisplayName, outputDefinition.Name, outputDefinition.Type, outputDefinition.IsArray))
             .ToList();
 
         if (variableBindingTargets.Any()) bindingTargetGroups.Add(new BindingTargetGroup("Variables", BindingKind.Variable, variableBindingTargets));
@@ -82,7 +85,14 @@ public partial class OutputsTab
 
         _bindingTargetGroups = bindingTargetGroups;
         _bindingTargetOptions = variableBindingTargets.Concat(outputBindingTargets).ToList();
-        return Task.CompletedTask;
+
+        foreach (var outputDescriptor in OutputDescriptors)
+        {
+            var propertyName = outputDescriptor.Name.Camelize();
+            var binding = Activity.GetProperty<ActivityOutput>(propertyName);
+            var target = _bindingTargetOptions.FirstOrDefault(x => x.Value == binding?.MemoryReference?.Id);
+            await LoadConvertersAsync(outputDescriptor, target, clearIncompatibleConverter: false);
+        }
     }
 
     private async Task OnBindingChanged(BindingTargetOption? bindingTargetOption, OutputDescriptor outputDescriptor)
@@ -90,20 +100,184 @@ public partial class OutputsTab
         var activity = Activity;
         var propertyName = outputDescriptor.Name.Camelize();
 
-        var activityOutput = bindingTargetOption == null
-            ? default
-            : new ActivityOutput
+        if (bindingTargetOption == null)
+        {
+            activity.SetProperty(default(JsonNode), propertyName);
+            await RaiseActivityUpdatedAsync(activity);
+            return;
+        }
+
+        var currentBinding = activity.GetProperty<JsonObject>(propertyName);
+        var activityOutput = new JsonObject
+        {
+            ["typeName"] = outputDescriptor.TypeName,
+            ["memoryReference"] = new JsonObject { ["id"] = bindingTargetOption.Value }
+        };
+
+        if (currentBinding?["converter"] is JsonObject converter)
+            activityOutput["converter"] = converter.DeepClone();
+
+        activity.SetProperty(activityOutput, propertyName);
+        await RaiseActivityUpdatedAsync(activity);
+        await LoadConvertersAsync(outputDescriptor, bindingTargetOption, clearIncompatibleConverter: true);
+    }
+
+    private async Task OnConverterChanged(string? converterId, OutputDescriptor outputDescriptor)
+    {
+        var propertyName = outputDescriptor.Name.Camelize();
+        var binding = Activity.GetProperty<JsonObject>(propertyName);
+        if (binding == null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(converterId))
+        {
+            binding.Remove("converter");
+        }
+        else
+        {
+            var existingConverter = binding["converter"] as JsonObject;
+            var settings = existingConverter?["id"]?.GetValue<string>() == converterId
+                ? existingConverter["settings"]?.DeepClone()
+                : new JsonObject();
+            binding["converter"] = new JsonObject
             {
-                TypeName = outputDescriptor.TypeName,
-                MemoryReference = new MemoryReference
-                {
-                    Id = bindingTargetOption.Value
-                }
+                ["id"] = converterId,
+                ["settings"] = settings
             };
+        }
 
-        activity.SetProperty(activityOutput!.SerializeToNode(), propertyName);
+        Activity.SetProperty(binding, propertyName);
+        await RaiseActivityUpdatedAsync(Activity);
+    }
 
+    private async Task OnConverterSettingsChanged(JsonObject settings, OutputDescriptor outputDescriptor)
+    {
+        var propertyName = outputDescriptor.Name.Camelize();
+        var binding = Activity.GetProperty<JsonObject>(propertyName);
+        if (binding?["converter"] is not JsonObject converter)
+            return;
+
+        converter["settings"] = settings.DeepClone();
+        Activity.SetProperty(binding, propertyName);
+        await RaiseActivityUpdatedAsync(Activity);
+    }
+
+    private async Task LoadConvertersAsync(OutputDescriptor outputDescriptor, BindingTargetOption? target, bool clearIncompatibleConverter)
+    {
+        var state = GetConverterState(outputDescriptor);
+        var cancellationToken = state.BeginRequest();
+        var requestVersion = state.RequestVersion;
+
+        if (target == null)
+        {
+            state.Reset();
+            return;
+        }
+
+        try
+        {
+            var descriptors = await OutputConverterService.GetOutputConvertersAsync(outputDescriptor.TypeName, target.DeclaredTypeName, cancellationToken);
+            if (requestVersion != state.RequestVersion)
+                return;
+
+            state.Descriptors = descriptors;
+            state.IsAvailable = true;
+
+            if (clearIncompatibleConverter && !IsCurrentConverterCompatible(outputDescriptor, state))
+            {
+                var propertyName = outputDescriptor.Name.Camelize();
+                var binding = Activity.GetProperty<JsonObject>(propertyName);
+                binding?.Remove("converter");
+                if (binding != null)
+                {
+                    Activity.SetProperty(binding, propertyName);
+                    await RaiseActivityUpdatedAsync(Activity);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception)
+        {
+            if (requestVersion != state.RequestVersion)
+                return;
+
+            state.Reset();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var state in _converterStates.Values)
+            state.Dispose();
+    }
+
+    private OutputConverterState GetConverterState(OutputDescriptor outputDescriptor)
+    {
+        if (_converterStates.TryGetValue(outputDescriptor.Name, out var state))
+            return state;
+
+        state = new OutputConverterState();
+        _converterStates[outputDescriptor.Name] = state;
+        return state;
+    }
+
+    private string GetConverterDisplayName(string? converterId, OutputConverterState state)
+    {
+        if (string.IsNullOrWhiteSpace(converterId))
+            return Localizer["None"];
+
+        var descriptor = state.Descriptors.FirstOrDefault(x => x.Id == converterId);
+        return Localizer[descriptor == null || string.IsNullOrWhiteSpace(descriptor.DisplayName) ? converterId : descriptor.DisplayName];
+    }
+
+    private string? GetConverterId(string propertyName) =>
+        (Activity.GetProperty<JsonObject>(propertyName)?["converter"] as JsonObject)?["id"]?.GetValue<string>();
+
+    private JsonObject? GetConverterSettings(string propertyName) =>
+        (Activity.GetProperty<JsonObject>(propertyName)?["converter"] as JsonObject)?["settings"] as JsonObject;
+
+    private bool IsCurrentConverterCompatible(OutputDescriptor outputDescriptor, OutputConverterState state)
+    {
+        var converterId = GetConverterId(outputDescriptor.Name.Camelize());
+        return string.IsNullOrWhiteSpace(converterId) || state.Descriptors.Any(x => x.Id == converterId);
+    }
+
+    private async Task RaiseActivityUpdatedAsync(JsonObject activity)
+    {
         if (OnActivityUpdated != null)
             await OnActivityUpdated(activity);
+    }
+
+    private sealed class OutputConverterState : IDisposable
+    {
+        private CancellationTokenSource? _cancellationTokenSource;
+
+        public ICollection<OutputConverterDescriptor> Descriptors { get; set; } = [];
+        public bool IsAvailable { get; set; }
+        public int RequestVersion { get; set; }
+
+        public CancellationToken BeginRequest()
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = new();
+            RequestVersion++;
+            return _cancellationTokenSource.Token;
+        }
+
+        public void Reset()
+        {
+            Descriptors = [];
+            IsAvailable = false;
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+        }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
@@ -28,6 +28,7 @@ public partial class OutputsTab
     private readonly Dictionary<ConverterRequestKey, Task<IReadOnlyCollection<OutputConverterDescriptor>>> _converterRequests = [];
     private readonly object _converterCacheLock = new();
     private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
+    private volatile bool _disposed;
 
     /// <summary>
     /// The workflow definition.
@@ -172,6 +173,9 @@ public partial class OutputsTab
 
     private async Task LoadConvertersAsync(OutputDescriptor outputDescriptor, BindingTargetOption? target, bool clearIncompatibleConverter)
     {
+        if (_disposed)
+            return;
+
         var state = GetConverterState(outputDescriptor);
         var requestVersion = state.BeginRequest();
 
@@ -189,10 +193,13 @@ public partial class OutputsTab
             return;
         }
 
+        if (state.LoadedKey != requestKey)
+            state.Reset();
+
         try
         {
             var descriptors = await GetConvertersAsync(requestKey);
-            if (requestVersion != state.RequestVersion)
+            if (_disposed || requestVersion != state.RequestVersion)
                 return;
 
             state.Descriptors = descriptors;
@@ -217,6 +224,10 @@ public partial class OutputsTab
     /// <inheritdoc />
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _disposeCancellationTokenSource.Cancel();
         _disposeCancellationTokenSource.Dispose();
     }
@@ -254,8 +265,11 @@ public partial class OutputsTab
                 requestKey.DestinationType,
                 _disposeCancellationTokenSource.Token)).ToArray();
 
-            lock (_converterCacheLock)
-                _converterCache[requestKey] = descriptors;
+            if (!_disposed)
+            {
+                lock (_converterCacheLock)
+                    _converterCache[requestKey] = descriptors;
+            }
 
             completion.TrySetResult(descriptors);
         }
@@ -279,7 +293,7 @@ public partial class OutputsTab
 
     private async Task ClearIncompatibleConverterAsync(OutputDescriptor outputDescriptor, OutputConverterState state)
     {
-        if (IsCurrentConverterCompatible(outputDescriptor, state))
+        if (_disposed || IsCurrentConverterCompatible(outputDescriptor, state))
             return;
 
         var propertyName = outputDescriptor.Name.Camelize();
@@ -345,7 +359,7 @@ public partial class OutputsTab
 
     private async Task RaiseActivityUpdatedAsync(JsonObject activity)
     {
-        if (OnActivityUpdated != null)
+        if (!_disposed && OnActivityUpdated != null)
             await OnActivityUpdated(activity);
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Components/OutputsTab.razor.cs
@@ -214,7 +214,7 @@ public partial class OutputsTab
         }
         catch (Exception)
         {
-            if (requestVersion != state.RequestVersion)
+            if (_disposed || requestVersion != state.RequestVersion)
                 return;
 
             state.Reset();
@@ -224,10 +224,14 @@ public partial class OutputsTab
     /// <inheritdoc />
     public void Dispose()
     {
-        if (_disposed)
-            return;
+        lock (_converterCacheLock)
+        {
+            if (_disposed)
+                return;
 
-        _disposed = true;
+            _disposed = true;
+        }
+
         _disposeCancellationTokenSource.Cancel();
         _disposeCancellationTokenSource.Dispose();
     }
@@ -238,6 +242,9 @@ public partial class OutputsTab
         Task<IReadOnlyCollection<OutputConverterDescriptor>> request;
         lock (_converterCacheLock)
         {
+            if (_disposed)
+                return Task.FromCanceled<IReadOnlyCollection<OutputConverterDescriptor>>(new CancellationToken(true));
+
             if (_converterCache.TryGetValue(requestKey, out var cachedDescriptors))
                 return Task.FromResult(cachedDescriptors);
 
@@ -265,9 +272,9 @@ public partial class OutputsTab
                 requestKey.DestinationType,
                 _disposeCancellationTokenSource.Token)).ToArray();
 
-            if (!_disposed)
+            lock (_converterCacheLock)
             {
-                lock (_converterCacheLock)
+                if (!_disposed)
                     _converterCache[requestKey] = descriptors;
             }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/ActivityProperties/Tabs/Outputs/Models/BindingTargetOption.cs
@@ -3,4 +3,10 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.A
 /// <summary>
 /// Represents the binding target option record.
 /// </summary>
-public record BindingTargetOption(string Text, string Value);
+public record BindingTargetOption(string Text, string Value, string TypeName, bool IsArray)
+{
+    /// <summary>
+    /// Gets the declared type name, including the array suffix when applicable.
+    /// </summary>
+    public string DeclaredTypeName => IsArray ? $"{TypeName}[]" : TypeName;
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -424,7 +424,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
             if (response.ConsumingWorkflowCount > 0)
             {
-                UserMessageService.ShowSnackbarTextMessage(Localizer["{0} consuming workflow(s) updated", response.ConsumingWorkflowCount], Severity.Success, options => options.VisibleStateDuration = 3000);
+                UserMessageService.ShowSnackbarTextMessage(Localizer["{0} consuming workflow(s) updated", response.ConsumingWorkflowCount], Severity.Success);
             }
         }));
     }
@@ -542,7 +542,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         {
             snackbarOptions.SnackbarVariant = Variant.Filled;
             snackbarOptions.CloseAfterNavigation = failedImports.Count > 0;
-            snackbarOptions.VisibleStateDuration = failedImports.Count > 0 ? 10000 : 3000;
+            snackbarOptions.VisibleStateDuration = failedImports.Count > 0 ? 10000 : 5000;
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor
@@ -12,10 +12,17 @@
                 <MudTextField Label="@Localizer["Name"]" @bind-Value="_metadataModel.Name" For="@(() => _metadataModel.Name)" HelperText="@Localizer["The name of the new workflow."]" Variant="Variant.Outlined" Margin="Margin.Dense" />
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.subtitle2">@Localizer["Workflow type"]</MudText>
-                    <MudStack Spacing="1">
+                    <MudStack Spacing="2" role="radiogroup" aria-label="@Localizer["Workflow type"]">
                         @foreach (var template in _rootActivityTemplates)
                         {
-                            <MudPaper Outlined="true" Elevation="0" Class="@GetRootActivityTemplateClass(template)" @onclick="@(() => SelectRootActivityTemplate(template.Key))">
+                            <MudPaper Outlined="true"
+                                      Elevation="0"
+                                      Class="@GetRootActivityTemplateClass(template)"
+                                      role="radio"
+                                      aria-checked="@(IsRootActivityTemplateSelected(template) ? "true" : "false")"
+                                      tabindex="0"
+                                      @onclick="@(() => SelectRootActivityTemplate(template.Key))"
+                                      @onkeydown="@((KeyboardEventArgs args) => OnRootActivityTemplateKeyDown(args, template.Key))">
                                 <MudStack Row="true" AlignItems="MudBlazor.AlignItems.Center" Spacing="2">
                                     <MudIcon Icon="@template.Icon" Style="@GetRootActivityTemplateIconStyle(template)" />
                                     <MudStack Spacing="0" Class="flex-grow-1">

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.cs
@@ -6,6 +6,7 @@ using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.Validators;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
@@ -63,6 +64,12 @@ public partial class CreateWorkflowDialog
     private void SelectRootActivityTemplate(string key)
     {
         _selectedRootActivityTemplateKey = key;
+    }
+
+    private void OnRootActivityTemplateKeyDown(KeyboardEventArgs args, string key)
+    {
+        if (args.Key is "Enter" or " " || args.Code == "Space")
+            SelectRootActivityTemplate(key);
     }
 
     private bool IsRootActivityTemplateSelected(WorkflowRootActivityTemplate template)

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/CreateWorkflowDialog.razor.css
@@ -1,12 +1,21 @@
 .workflow-root-template {
     cursor: pointer;
-    padding: 10px 12px;
+    padding: 12px 16px;
     transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.workflow-root-template ::deep * {
+    cursor: pointer;
 }
 
 .workflow-root-template:hover {
     border-color: var(--mud-palette-primary);
     background-color: var(--mud-palette-action-default-hover);
+}
+
+.workflow-root-template:focus-visible {
+    outline: 2px solid var(--mud-palette-primary);
+    outline-offset: 2px;
 }
 
 .workflow-root-template-selected {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -323,7 +323,6 @@ public partial class WorkflowDefinitionList
             UserMessageService.ShowSnackbarTextMessage(message, Severity.Info, options =>
             {
                 options.SnackbarVariant = Variant.Filled;
-                options.VisibleStateDuration = 3000;
             });
         }
 
@@ -410,7 +409,7 @@ public partial class WorkflowDefinitionList
         {
             options.SnackbarVariant = Variant.Filled;
             options.CloseAfterNavigation = failedResultCount > 0;
-            options.VisibleStateDuration = failedResultCount > 0 ? 10000 : 3000;
+            options.VisibleStateDuration = failedResultCount > 0 ? 10000 : 5000;
         });
         Reload();
     }
@@ -444,7 +443,6 @@ public partial class WorkflowDefinitionList
             UserMessageService.ShowSnackbarTextMessage(message, Severity.Info, options =>
             {
                 options.SnackbarVariant = Variant.Filled;
-                options.VisibleStateDuration = 3000;
             });
         }
 


### PR DESCRIPTION
Extracted from [#924](https://github.com/elsa-workflows/elsa-studio/pull/924) as the workflow-designer slice.

## Summary
- refreshes workflow designer theming and activity-picker behavior
- adds bound-output converter discovery and configuration
- includes converter contracts and workflow UI regression coverage

## Stack
5 of 7. Previous: [#928](https://github.com/elsa-workflows/elsa-studio/pull/928). Next: [#930](https://github.com/elsa-workflows/elsa-studio/pull/930).

## Validation
- Elsa.Studio.Workflows.Tests (net10 Release): 45 passed
- tree expansion regression: 25/25 isolated process runs passed
- converter deduplication, concurrency, retry, disposal, stale-state, and schema-default behavior covered
- self-review loop: clean after 3 passes
