### PR TITLE
Fix Http Polly package downgrades

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.24" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="8.0.24" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.18" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -61,7 +61,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.18" />
     <PackageVersion Include="Microsoft.JSInterop" Version="9.0.13" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.18" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
     <PackageVersion Include="Refit" Version="9.0.2" />
   </ItemGroup>
@@ -80,7 +80,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
     <PackageVersion Include="Refit" Version="10.0.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- align central Http Polly package pins with Elsa.Api.Client requirements
- remove NU1605 restore failures for the OpenID Connect Blazor Server module across net8.0, net9.0, and net10.0

## Verification
- dotnet restore Elsa.Studio.sln --force-evaluate
- dotnet build Elsa.Studio.sln --no-restore -warnaserror --verbosity minimal
- dotnet test Elsa.Studio.sln --no-restore --no-build --verbosity minimal