### PR TITLE
Add user and role management

### DIFF
--- a/specs/012-user-role-management/design.md
+++ b/specs/012-user-role-management/design.md
@@ -1,0 +1,75 @@
+# User and Role Management UX
+
+## Context
+
+Elsa Server exposes CRUD endpoints for users and roles under `/identity/users` and
+`/identity/roles`. Elsa Studio currently contains route shells for both resources,
+but no client contracts, navigation entries, or management experience.
+
+The design follows the Administration navigation introduced in feature 011 and
+uses the same full-page resource pattern as External Authentication. Secrets is a
+useful reference for credential handling, but its create dialog is too narrow for
+role assignment and permission editing.
+
+## Recommended design
+
+### Navigation
+
+- Add **Users** and **Roles** as the first two children of **Identity & access**.
+- Show each item only when the matching remote Identity feature and read permission
+  are available.
+- Keep identity provider connections, external identity links, and authentication
+  sessions after these core identity resources.
+
+### List pages
+
+- `/security/users` shows name, assigned roles, and tenant scope.
+- `/security/roles` shows name, permissions, and tenant scope.
+- Both pages provide local search, explicit loading and error states, a meaningful
+  empty state, row navigation, keyboard-accessible edit actions, and permission-
+  gated create/delete affordances.
+- The server endpoints return complete collections without paging or search, so the
+  pages load once and filter locally rather than presenting misleading pagination.
+
+### Create and edit pages
+
+- `/security/users/new` and `/security/users/{id}` share one user editor.
+- `/security/roles/new` and `/security/roles/{id}` share one role editor.
+- Editors use a compact overview card with a single clear primary save action,
+  cancel/back navigation, inline validation, and an outlined danger section for
+  existing records.
+- User names are immutable after creation because the API only updates password and
+  roles. The edit page therefore presents the user name as read-only identity.
+- Available roles come from the roles endpoint and are selected with a multi-select.
+- New passwords are optional. Leaving the create password blank asks the server to
+  generate one; Studio shows it exactly once in a dedicated success dialog and never
+  logs it. On edit, a blank password means "leave unchanged".
+- Role names and permission strings are editable. Because the server has no
+  permission-catalog endpoint, permissions use an explicit add/remove token editor
+  with examples rather than an incomplete hard-coded checklist.
+
+### Deletion
+
+- Delete actions always require confirmation and are permission-gated.
+- Conflict responses are surfaced as actionable errors rather than silently
+  removing the row.
+- Advanced cross-module role-remediation endpoints are intentionally out of scope
+  for the first management UX; a blocked delete remains non-destructive and explains
+  that dependencies must be resolved.
+
+## API and state design
+
+- Add narrow Refit contracts and local DTOs in the Security module.
+- Resolve clients through `IBackendApiClientProvider`, matching existing Studio
+  modules.
+- Centralize permission-claim lookup for the Security pages and menu contributor.
+- Never retain hashed password fields returned by older server contracts; deserialize
+  only the fields the UI needs.
+
+## Verification
+
+- bUnit tests cover routes, menu permission gates, list rendering/filtering,
+  create/update payloads, generated-password disclosure, and deletion confirmation.
+- Build and test the affected solution projects.
+- Test-drive navigation, list, create, edit, validation, responsive layout, and
+  keyboard interaction in the running Studio with Computer Use.

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -151,7 +151,7 @@ if (selectedAuthProvider != StudioAuthenticationProvider.ElsaLogin)
 }
 builder.Services.AddRemoteBackend(backendApiConfig);
 builder.Services.AddSettingsModule();
-builder.Services.AddSecurityModule();
+builder.Services.AddSecurityModule(backendApiConfig);
 
 // Management UI remains backend-feature-gated. Broker sign-in is active only when selected above.
 builder.Services.AddExternalAuthenticationModule(backendApiConfig);

--- a/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
@@ -123,7 +123,7 @@ if (selectedAuthProvider != StudioAuthenticationProvider.ElsaLogin)
 }
 services.AddRemoteBackend(backendApiConfig);
 services.AddSettingsModule();
-services.AddSecurityModule();
+services.AddSecurityModule(backendApiConfig);
 
 // Management UI remains feature-gated by the Elsa backend; broker login is activated only by the provider above.
 services.AddExternalAuthenticationModule(backendApiConfig);

--- a/src/modules/Elsa.Studio.Administration.Tests/AdministrationNavigationTests.cs
+++ b/src/modules/Elsa.Studio.Administration.Tests/AdministrationNavigationTests.cs
@@ -6,6 +6,8 @@ using Elsa.Studio.Models;
 using Elsa.Studio.Secrets.Menu;
 using Elsa.Studio.Security.Contracts;
 using Elsa.Studio.Security.Menu;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
 using Elsa.Studio.Services;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
@@ -57,6 +59,32 @@ public class AdministrationNavigationTests
         Assert.Equal(100, item.Order);
     }
 
+    [Fact]
+    public async Task IdentityMenu_UsesReadPermissionsAndCoreIdentityOrdering()
+    {
+        Assert.Equal("Elsa.Identity.ShellFeatures.Identity", Elsa.Studio.Security.Feature.RemoteFeatureName);
+
+        var contributor = new IdentitySecurityMenuContributor(
+            new EnabledRemoteFeatureProvider(),
+            new TestIdentityPermissionService(IdentityPermissions.ReadUser, IdentityPermissions.ReadRole));
+
+        var items = (await contributor.GetMenuItemsAsync()).ToList();
+
+        Assert.Collection(items,
+            user =>
+            {
+                Assert.Equal("Users", user.Text);
+                Assert.Equal("security/users", user.Href);
+                Assert.Equal(10, user.Order);
+            },
+            role =>
+            {
+                Assert.Equal("Roles", role.Text);
+                Assert.Equal("security/roles", role.Href);
+                Assert.Equal(20, role.Order);
+            });
+    }
+
     private sealed class TestLocalizer : ILocalizer
     {
         public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
@@ -74,5 +102,16 @@ public class AdministrationNavigationTests
         public ValueTask<IEnumerable<MenuItem>> GetMenuItemsAsync(CancellationToken cancellationToken = default) => new([
             new MenuItem { Href = "security/test", Text = "Test" }
         ]);
+    }
+
+    private sealed class TestIdentityPermissionService(params string[] permissions) : IIdentityPermissionService
+    {
+        private readonly IReadOnlySet<string> _permissions = permissions.ToHashSet(StringComparer.Ordinal);
+
+        public ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default) =>
+            new(_permissions.Contains(permission));
+
+        public ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default) =>
+            new(_permissions);
     }
 }

--- a/src/modules/Elsa.Studio.Administration.Tests/Elsa.Studio.Administration.Tests.csproj
+++ b/src/modules/Elsa.Studio.Administration.Tests/Elsa.Studio.Administration.Tests.csproj
@@ -8,9 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" />
+        <PackageReference Include="bunit" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/Elsa.Studio.Administration.Tests/IdentityManagementTests.cs
+++ b/src/modules/Elsa.Studio.Administration.Tests/IdentityManagementTests.cs
@@ -1,0 +1,479 @@
+using System.Diagnostics.CodeAnalysis;
+using Bunit;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+using RoleEditor = Elsa.Studio.Security.Pages.Role;
+using RolesPage = Elsa.Studio.Security.Pages.Roles;
+using UserEditor = Elsa.Studio.Security.Pages.User;
+using UsersPage = Elsa.Studio.Security.Pages.Users;
+
+namespace Elsa.Studio.Administration.Tests;
+
+public sealed class IdentityManagementTests : BunitContext, IAsyncLifetime
+{
+    private readonly UsersApi _users = new();
+    private readonly RolesApi _roles = new();
+    private readonly PermissionService _permissionService = new("*");
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public IdentityManagementTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<IBackendApiClientProvider>(new ApiProvider(_users, _roles));
+        Services.AddSingleton<IIdentityPermissionService>(_permissionService);
+        Services.AddSingleton<IClipboard>(new Clipboard());
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void UserList_RendersRolesAndFiltersLocally()
+    {
+        _users.Users =
+        [
+            new() { Id = "user-1", Name = "alice", Roles = ["admin"], TenantId = null },
+            new() { Id = "user-2", Name = "bob", Roles = ["operator"], TenantId = "tenant-a" }
+        ];
+
+        var cut = Render<UsersPage>();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("alice", cut.Markup);
+            Assert.Contains("operator", cut.Markup);
+            Assert.Contains("tenant-a", cut.Markup);
+            Assert.Contains("Open user alice", cut.Markup);
+            Assert.Equal(Breakpoint.Md, cut.FindComponent<MudTable<UserSummary>>().Instance.Breakpoint);
+        });
+
+        cut.Find("input[placeholder='Search users']").Input("operator");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("alice", cut.Markup);
+            Assert.Contains("bob", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void RoleList_RendersPermissionPreviewAndEmptyPermissionState()
+    {
+        _roles.Roles =
+        [
+            new() { Id = "admin", Name = "admin", Permissions = ["read:user", "update:user"] },
+            new() { Id = "role-2", Name = "observer", Permissions = [] }
+        ];
+
+        var cut = Render<RolesPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("read:user", cut.Markup);
+            Assert.Contains("No permissions", cut.Markup);
+            Assert.Contains("Edit role admin", cut.Markup);
+            Assert.Contains("Open role admin", cut.Markup);
+            Assert.Equal(Breakpoint.Md, cut.FindComponent<MudTable<RoleSummary>>().Instance.Breakpoint);
+            Assert.Empty(cut.FindAll("td[data-label='Name']")[0].QuerySelectorAll(".mud-typography-caption"));
+        });
+    }
+
+    [Fact]
+    public async Task CreateUser_UsesRoleIdsAndShowsGeneratedPasswordOnce()
+    {
+        _roles.Roles = [new() { Id = "power-user", Name = "Power User" }];
+        _users.CreateResult = new() { Id = "user-3", Name = "carol", Password = "once-only", Roles = [] };
+        var cut = Render<UserEditor>();
+        cut.WaitForAssertion(() => Assert.Contains("Create an Elsa account", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.FindComponent<MudSelect<string>>().Instance.SelectedValuesChanged.InvokeAsync(["power-user"]));
+        cut.Find("input[type='text']").Change("carol");
+        cut.FindAll("button").Single(x => x.TextContent.Trim() == "Create user").Click();
+
+        _dialogProvider.WaitForAssertion(() =>
+        {
+            Assert.Equal("carol", _users.CreateRequest?.Name);
+            Assert.Null(_users.CreateRequest?.Password);
+            Assert.Equal(["power-user"], _users.CreateRequest?.Roles);
+            Assert.Contains("once-only", _dialogProvider.Markup);
+            Assert.Contains("shown once", _dialogProvider.Markup, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public async Task PasswordOnlyUserUpdate_DoesNotResubmitUnchangedRoles()
+    {
+        _users.Users = [new() { Id = "user-1", Name = "alice", Roles = ["admin-role"] }];
+        _roles.Roles = [new() { Id = "admin-role", Name = "Administrators" }];
+        var cut = Render<UserEditor>(parameters => parameters.Add(component => component.Id, "user-1"));
+        cut.WaitForAssertion(() => Assert.Contains("alice", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.FindAll("input[type='password']")[0].Change("replacement-password"));
+        await cut.InvokeAsync(() => cut.FindAll("input[type='password']")[1].Change("replacement-password"));
+        await cut.InvokeAsync(() => cut.FindAll("button").Single(x => x.TextContent.Trim() == "Save changes").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("user-1", _users.UpdateId);
+            Assert.Equal("replacement-password", _users.UpdateRequest?.Password);
+            Assert.Null(_users.UpdateRequest?.Roles);
+        });
+    }
+
+    [Fact]
+    public async Task UserEditor_ReloadsAndClearsPasswordsWhenRouteIdChangesAfterCreate()
+    {
+        _users.CreateResult = new() { Id = "user-3", Name = "server-carol", Roles = [] };
+        _users.Users = [new() { Id = "user-3", Name = "server-carol", Roles = [] }];
+        var cut = Render<UserEditor>();
+        cut.WaitForAssertion(() => Assert.Contains("Create an Elsa account", cut.Markup));
+
+        await cut.InvokeAsync(() => cut.Find("input[type='text']").Change("carol"));
+        await cut.InvokeAsync(() => cut.FindAll("input[type='password']")[0].Change("supplied-password"));
+        await cut.InvokeAsync(() => cut.FindAll("input[type='password']")[1].Change("supplied-password"));
+        await cut.InvokeAsync(() => cut.FindAll("button").Single(x => x.TextContent.Trim() == "Create user").Click());
+        cut.WaitForAssertion(() => Assert.Equal("carol", _users.CreateRequest?.Name));
+
+        cut.Render(parameters => parameters.Add(component => component.Id, "user-3"));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("input[readonly][value='server-carol']"));
+            Assert.All(cut.FindAll("input[type='password']"), input => Assert.True(string.IsNullOrEmpty(input.GetAttribute("value"))));
+        });
+    }
+
+    [Fact]
+    public void UserEditor_IgnoresAStaleLoadAfterTheRouteChanges()
+    {
+        var firstLoad = new TaskCompletionSource<ListUsersResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondLoad = new TaskCompletionSource<ListUsersResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _users.ListResults.Enqueue(firstLoad.Task);
+        _users.ListResults.Enqueue(secondLoad.Task);
+        var cut = Render<UserEditor>(parameters => parameters.Add(component => component.Id, "user-a"));
+        cut.WaitForState(() => _users.ListCallCount == 1);
+
+        cut.Render(parameters => parameters.Add(component => component.Id, "user-b"));
+        cut.WaitForState(() => _users.ListCallCount == 2);
+        secondLoad.SetResult(new() { Users = [new() { Id = "user-b", Name = "bob" }] });
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find("input[readonly][value='bob']")));
+
+        firstLoad.SetResult(new() { Users = [new() { Id = "user-a", Name = "alice" }] });
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("input[readonly][value='bob']"));
+            Assert.DoesNotContain("alice", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void CreateRole_SendsAddedPermissionTokens()
+    {
+        _roles.CreateResult = new() { Id = "role-3", Name = "auditor", Permissions = ["read:user"] };
+        _roles.Roles = [_roles.CreateResult];
+        var cut = Render<RoleEditor>();
+        cut.WaitForAssertion(() => Assert.Contains("Create a reusable set", cut.Markup));
+
+        var inputs = cut.FindAll("input");
+        inputs[0].Change("auditor");
+        inputs[1].Input("read:user");
+        cut.FindAll("button").Single(x => x.TextContent.Trim() == "Add").Click();
+        cut.FindAll("button").Single(x => x.TextContent.Trim() == "Create role").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("auditor", _roles.CreateRequest?.Name);
+            Assert.Equal(["read:user"], _roles.CreateRequest?.Permissions);
+        });
+
+        cut.Render(parameters => parameters.Add(component => component.Id, "role-3"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("input[value='auditor']"));
+            Assert.Contains("read:user", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void RoleEditor_IgnoresAStaleLoadAfterTheRouteChanges()
+    {
+        var firstLoad = new TaskCompletionSource<ListRolesResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondLoad = new TaskCompletionSource<ListRolesResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _roles.ListResults.Enqueue(firstLoad.Task);
+        _roles.ListResults.Enqueue(secondLoad.Task);
+        var cut = Render<RoleEditor>(parameters => parameters.Add(component => component.Id, "role-a"));
+        cut.WaitForState(() => _roles.ListCallCount == 1);
+
+        cut.Render(parameters => parameters.Add(component => component.Id, "role-b"));
+        cut.WaitForState(() => _roles.ListCallCount == 2);
+        secondLoad.SetResult(new() { Roles = [new() { Id = "role-b", Name = "Operators", Permissions = ["read:user"] }] });
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find("input[value='Operators']")));
+
+        firstLoad.SetResult(new() { Roles = [new() { Id = "role-a", Name = "Administrators", Permissions = ["*"] }] });
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("input[value='Operators']"));
+            Assert.DoesNotContain("Administrators", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void ReadOnlyLists_UseViewAffordancesAndHideMutations()
+    {
+        _permissionService.Set(IdentityPermissions.ReadUser, IdentityPermissions.ReadRole);
+        _users.Users = [new() { Id = "user-1", Name = "alice" }];
+        _roles.Roles = [new() { Id = "role-1", Name = "auditor" }];
+
+        var users = Render<UsersPage>();
+        var roles = Render<RolesPage>();
+
+        users.WaitForAssertion(() =>
+        {
+            Assert.Contains("View user alice", users.Markup);
+            Assert.DoesNotContain("Edit user alice", users.Markup);
+            Assert.DoesNotContain("Create user", users.Markup);
+            Assert.DoesNotContain("Delete user alice", users.Markup);
+        });
+        roles.WaitForAssertion(() =>
+        {
+            Assert.Contains("View role auditor", roles.Markup);
+            Assert.DoesNotContain("Edit role auditor", roles.Markup);
+            Assert.DoesNotContain("Create role", roles.Markup);
+            Assert.DoesNotContain("Delete role auditor", roles.Markup);
+        });
+    }
+
+    [Fact]
+    public void UserDeletion_RequiresConfirmation()
+    {
+        _users.Users = [new() { Id = "user-1", Name = "alice" }];
+        var cut = Render<UsersPage>();
+        cut.WaitForAssertion(() => Assert.Contains("Delete user alice", cut.Markup));
+
+        cut.Find("button[aria-label='Delete user alice']").Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Delete user?", _dialogProvider.Markup));
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel").Click();
+
+        Assert.Empty(_users.DeletedIds);
+    }
+
+    [Fact]
+    public async Task UserListDeletion_DisablesTheRowActionWhileTheRequestIsPending()
+    {
+        var deleteCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _users.DeleteHandler = _ => deleteCompletion.Task;
+        _users.Users = [new() { Id = "user-1", Name = "alice" }];
+        var cut = Render<UsersPage>();
+        cut.WaitForAssertion(() => Assert.Contains("Delete user alice", cut.Markup));
+
+        cut.Find("button[aria-label='Delete user alice']").Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Delete user?", _dialogProvider.Markup));
+        var confirmTask = _dialogProvider.InvokeAsync(() =>
+            _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Delete").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(1, _users.DeleteCallCount);
+            Assert.True(cut.Find("button[aria-label='Delete user alice']").HasAttribute("disabled"));
+        });
+        cut.Find("button[aria-label='Delete user alice']").Click();
+        Assert.Equal(1, _users.DeleteCallCount);
+
+        deleteCompletion.SetResult();
+        await confirmTask;
+    }
+
+    [Fact]
+    public void UserDeletion_IsCancelledWhenTheRouteChangesDuringConfirmation()
+    {
+        _users.Users =
+        [
+            new() { Id = "user-a", Name = "alice" },
+            new() { Id = "user-b", Name = "bob" }
+        ];
+        var cut = Render<UserEditor>(parameters => parameters.Add(component => component.Id, "user-a"));
+        cut.WaitForAssertion(() => Assert.Contains("alice", cut.Markup));
+
+        cut.FindAll("button").Single(x => x.TextContent.Trim() == "Delete user").Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Delete alice?", _dialogProvider.Markup));
+        cut.Render(parameters => parameters.Add(component => component.Id, "user-b"));
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find("input[readonly][value='bob']")));
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Delete").Click();
+
+        Assert.Empty(_users.DeletedIds);
+    }
+
+    [Fact]
+    public async Task UserDeletion_DisablesTheEditorWhileTheRequestIsPending()
+    {
+        var deleteCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _users.DeleteHandler = _ => deleteCompletion.Task;
+        _users.Users = [new() { Id = "user-a", Name = "alice" }];
+        var cut = Render<UserEditor>(parameters => parameters.Add(component => component.Id, "user-a"));
+        cut.WaitForAssertion(() => Assert.Contains("alice", cut.Markup));
+
+        cut.FindAll("button").Single(x => x.TextContent.Trim() == "Delete user").Click();
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("Delete alice?", _dialogProvider.Markup));
+        var confirmTask = _dialogProvider.InvokeAsync(() =>
+            _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Delete").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(1, _users.DeleteCallCount);
+            Assert.True(cut.FindAll("button").Single(x => x.TextContent.Trim() == "Delete user").HasAttribute("disabled"));
+        });
+        deleteCompletion.SetResult();
+        await confirmTask;
+        Assert.Equal(["user-a"], _users.DeletedIds);
+    }
+
+    [Fact]
+    public async Task GeneratedPasswordCompletion_DoesNotNavigateAfterEditorDisposal()
+    {
+        _users.CreateResult = new() { Id = "user-3", Name = "carol", Password = "once-only" };
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        var cut = Render<UserEditor>();
+        cut.WaitForAssertion(() => Assert.Contains("Create an Elsa account", cut.Markup));
+        await cut.InvokeAsync(() => cut.Find("input[type='text']").Change("carol"));
+        var createTask = cut.InvokeAsync(() => cut.FindAll("button").Single(x => x.TextContent.Trim() == "Create user").Click());
+        _dialogProvider.WaitForAssertion(() => Assert.Contains("once-only", _dialogProvider.Markup));
+        var uriBeforeDisposal = navigation.Uri;
+
+        Assert.IsAssignableFrom<IDisposable>(cut.Instance).Dispose();
+        await _dialogProvider.InvokeAsync(() =>
+            _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "I have saved it").Click());
+        await createTask;
+        cut.Dispose();
+
+        Assert.Equal(uriBeforeDisposal, navigation.Uri);
+    }
+
+    [Fact]
+    public async Task RoleSaveCompletion_DoesNotOverwriteANewRoute()
+    {
+        _roles.Roles =
+        [
+            new() { Id = "role-a", Name = "Administrators", Permissions = ["*"] },
+            new() { Id = "role-b", Name = "Operators", Permissions = ["read:user"] }
+        ];
+        var updateCompletion = new TaskCompletionSource<RoleSummary>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _roles.UpdateHandler = (_, _) => updateCompletion.Task;
+        var cut = Render<RoleEditor>(parameters => parameters.Add(component => component.Id, "role-a"));
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find("input[value='Administrators']")));
+        await cut.InvokeAsync(() => cut.Find("input[value='Administrators']").Change("Admins"));
+
+        var saveTask = cut.InvokeAsync(() => cut.FindAll("button").Single(x => x.TextContent.Trim() == "Save changes").Click());
+        cut.WaitForState(() => _roles.UpdateId == "role-a");
+        cut.Render(parameters => parameters.Add(component => component.Id, "role-b"));
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Find("input[value='Operators']")));
+        updateCompletion.SetResult(new() { Id = "role-a", Name = "Admins", Permissions = ["*"] });
+        await saveTask;
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("input[value='Operators']"));
+            Assert.DoesNotContain("Admins", cut.Markup);
+        });
+    }
+
+    private sealed class ApiProvider(UsersApi users, RolesApi roles) : IBackendApiClientProvider
+    {
+        public Uri Url => new("https://elsa.example.test");
+
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
+        {
+            object api = typeof(T) == typeof(IUsersApi) ? users : roles;
+            return new((T)api);
+        }
+    }
+
+    private sealed class PermissionService(params string[] permissions) : IIdentityPermissionService
+    {
+        private IReadOnlySet<string> _permissions = permissions.ToHashSet(StringComparer.Ordinal);
+        public void Set(params string[] values) => _permissions = values.ToHashSet(StringComparer.Ordinal);
+        public ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default) => new(_permissions.Contains("*") || _permissions.Contains(permission));
+        public ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default) => new(_permissions);
+    }
+
+    private sealed class Clipboard : IClipboard
+    {
+        public Task CopyText(string text, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class UsersApi : IUsersApi
+    {
+        public ICollection<UserSummary> Users { get; set; } = [];
+        public Queue<Task<ListUsersResponse>> ListResults { get; } = [];
+        public int ListCallCount { get; private set; }
+        public CreateUserRequest? CreateRequest { get; private set; }
+        public CreateUserResponse CreateResult { get; set; } = new();
+        public string? UpdateId { get; private set; }
+        public UpdateUserRequest? UpdateRequest { get; private set; }
+        public ICollection<string> DeletedIds { get; } = [];
+        public int DeleteCallCount { get; private set; }
+        public Func<string, Task>? DeleteHandler { get; set; }
+
+        public Task<ListUsersResponse> ListAsync(CancellationToken cancellationToken = default)
+        {
+            ListCallCount++;
+            return ListResults.Count > 0 ? ListResults.Dequeue() : Task.FromResult(new ListUsersResponse { Users = Users });
+        }
+        public Task<CreateUserResponse> CreateAsync(CreateUserRequest request, CancellationToken cancellationToken = default)
+        {
+            CreateRequest = request;
+            return Task.FromResult(CreateResult);
+        }
+        public Task<UserSummary> UpdateAsync(string id, UpdateUserRequest request, CancellationToken cancellationToken = default)
+        {
+            UpdateId = id;
+            UpdateRequest = request;
+            return Task.FromResult(Users.Single(user => user.Id == id));
+        }
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            DeleteCallCount++;
+            DeletedIds.Add(id);
+            return DeleteHandler?.Invoke(id) ?? Task.CompletedTask;
+        }
+    }
+
+    private sealed class RolesApi : IRolesApi
+    {
+        public ICollection<RoleSummary> Roles { get; set; } = [];
+        public Queue<Task<ListRolesResponse>> ListResults { get; } = [];
+        public int ListCallCount { get; private set; }
+        public CreateRoleRequest? CreateRequest { get; private set; }
+        public RoleSummary CreateResult { get; set; } = new();
+        public string? UpdateId { get; private set; }
+        public UpdateRoleRequest? UpdateRequest { get; private set; }
+        public Func<string, UpdateRoleRequest, Task<RoleSummary>>? UpdateHandler { get; set; }
+
+        public Task<ListRolesResponse> ListAsync(CancellationToken cancellationToken = default)
+        {
+            ListCallCount++;
+            return ListResults.Count > 0 ? ListResults.Dequeue() : Task.FromResult(new ListRolesResponse { Roles = Roles });
+        }
+        public Task<RoleSummary> CreateAsync(CreateRoleRequest request, CancellationToken cancellationToken = default)
+        {
+            CreateRequest = request;
+            return Task.FromResult(CreateResult);
+        }
+        public Task<RoleSummary> UpdateAsync(string id, UpdateRoleRequest request, CancellationToken cancellationToken = default)
+        {
+            UpdateId = id;
+            UpdateRequest = request;
+            return UpdateHandler?.Invoke(id, request) ?? Task.FromResult(Roles.Single(role => role.Id == id));
+        }
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Client/IRolesApi.cs
+++ b/src/modules/Elsa.Studio.Security/Client/IRolesApi.cs
@@ -1,0 +1,19 @@
+using Elsa.Studio.Security.Models;
+using Refit;
+
+namespace Elsa.Studio.Security.Client;
+
+public interface IRolesApi
+{
+    [Get("/identity/roles")]
+    Task<ListRolesResponse> ListAsync(CancellationToken cancellationToken = default);
+
+    [Post("/identity/roles")]
+    Task<RoleSummary> CreateAsync([Body] CreateRoleRequest request, CancellationToken cancellationToken = default);
+
+    [Put("/identity/roles/{id}")]
+    Task<RoleSummary> UpdateAsync(string id, [Body] UpdateRoleRequest request, CancellationToken cancellationToken = default);
+
+    [Delete("/identity/roles/{id}")]
+    Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Security/Client/IUsersApi.cs
+++ b/src/modules/Elsa.Studio.Security/Client/IUsersApi.cs
@@ -1,0 +1,19 @@
+using Elsa.Studio.Security.Models;
+using Refit;
+
+namespace Elsa.Studio.Security.Client;
+
+public interface IUsersApi
+{
+    [Get("/identity/users")]
+    Task<ListUsersResponse> ListAsync(CancellationToken cancellationToken = default);
+
+    [Post("/identity/users")]
+    Task<CreateUserResponse> CreateAsync([Body] CreateUserRequest request, CancellationToken cancellationToken = default);
+
+    [Put("/identity/users/{id}")]
+    Task<UserSummary> UpdateAsync(string id, [Body] UpdateUserRequest request, CancellationToken cancellationToken = default);
+
+    [Delete("/identity/users/{id}")]
+    Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Security/Components/GeneratedPasswordDialog.razor
+++ b/src/modules/Elsa.Studio.Security/Components/GeneratedPasswordDialog.razor
@@ -1,0 +1,49 @@
+@using Elsa.Studio.DomInterop.Contracts
+@inject IClipboard Clipboard
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                This generated password is shown once. Copy it now and deliver it through an approved secure channel.
+            </MudAlert>
+            <MudTextField T="string"
+                          Value="@Password"
+                          Label="Generated password"
+                          ReadOnly="true"
+                          Variant="Variant.Outlined"
+                          InputType="InputType.Text"
+                          Class="generated-password" />
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.ContentCopy"
+                       OnClick="CopyAsync">
+                Copy password
+            </MudButton>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Done">I have saved it</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Parameter, EditorRequired] public string Password { get; set; } = string.Empty;
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    private async Task CopyAsync()
+    {
+        try
+        {
+            await Clipboard.CopyText(Password);
+            Snackbar.Add("Password copied.", Severity.Success);
+        }
+        catch
+        {
+            Snackbar.Add("Unable to copy. Select the password and copy it manually.", Severity.Warning);
+        }
+    }
+
+    private void Done() => MudDialog.Close();
+}

--- a/src/modules/Elsa.Studio.Security/Components/GeneratedPasswordDialog.razor.css
+++ b/src/modules/Elsa.Studio.Security/Components/GeneratedPasswordDialog.razor.css
@@ -1,0 +1,3 @@
+.generated-password ::deep input {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}

--- a/src/modules/Elsa.Studio.Security/Components/PermissionTokenEditor.razor
+++ b/src/modules/Elsa.Studio.Security/Components/PermissionTokenEditor.razor
@@ -1,0 +1,71 @@
+<MudStack Spacing="2">
+    <MudText Typo="Typo.subtitle2" HtmlTag="h2">Permissions</MudText>
+    <MudText Typo="Typo.caption">
+        Add exact Elsa permission names, for example <code>read:workflow-definitions</code>. Use <code>*</code> only for unrestricted access.
+    </MudText>
+
+    <MudStack Row="true" AlignItems="AlignItems.Start" Spacing="2">
+        <MudTextField @bind-Value="_permission"
+                      Label="Permission name"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      Immediate="true"
+                      Disabled="@Disabled"
+                      OnKeyDown="OnKeyDown"
+                      Class="flex-grow-1" />
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Add"
+                   Disabled="@(Disabled || string.IsNullOrWhiteSpace(_permission))"
+                   OnClick="AddAsync">
+            Add
+        </MudButton>
+    </MudStack>
+
+    @if (Permissions.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true">This role currently grants no permissions.</MudAlert>
+    }
+    else
+    {
+        <MudChipSet T="string" AllClosable="@(!Disabled)" OnClose="RemoveAsync" aria-label="Assigned permissions">
+            @foreach (var permission in Permissions.OrderBy(x => x, StringComparer.Ordinal))
+            {
+                <MudChip T="string" Value="@permission" Variant="Variant.Outlined" Size="Size.Small">@permission</MudChip>
+            }
+        </MudChipSet>
+    }
+</MudStack>
+
+@code {
+    private string? _permission;
+
+    [Parameter, EditorRequired] public HashSet<string> Permissions { get; set; } = new(StringComparer.Ordinal);
+    [Parameter] public EventCallback PermissionsChanged { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+
+    private async Task OnKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+            await AddAsync();
+    }
+
+    private async Task AddAsync()
+    {
+        var value = _permission?.Trim();
+        if (Disabled || string.IsNullOrWhiteSpace(value))
+            return;
+
+        if (Permissions.Add(value))
+            await PermissionsChanged.InvokeAsync();
+        _permission = string.Empty;
+    }
+
+    private async Task RemoveAsync(MudChip<string> chip)
+    {
+        if (Disabled || chip.Value == null || !Permissions.Remove(chip.Value))
+            return;
+
+        await PermissionsChanged.InvokeAsync();
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Security/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,11 @@
 using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Extensions;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Security.Client;
 using Elsa.Studio.Security.Menu;
+using Elsa.Studio.Security.Contracts;
+using Elsa.Studio.Security.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Studio.Security.Extensions;
@@ -14,10 +20,22 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The service collection for method chaining.</returns>
-    public static IServiceCollection AddSecurityModule(this IServiceCollection services)
+    public static IServiceCollection AddSecurityModule(this IServiceCollection services, BackendApiConfig? backendApiConfig = null)
     {
-        return services
+        services
             .AddScoped<IFeature, Feature>()
-            .AddScoped<IMenuProvider, SecurityMenu>();
+            .AddScoped<IMenuProvider, SecurityMenu>()
+            .AddScoped<ISecurityMenuContributor, IdentitySecurityMenuContributor>()
+            .AddScoped<IIdentityPermissionService, IdentityPermissionService>()
+            .AddClipboardInterop();
+
+        if (backendApiConfig != null)
+        {
+            services
+                .AddRemoteApi<IUsersApi>(backendApiConfig)
+                .AddRemoteApi<IRolesApi>(backendApiConfig);
+        }
+
+        return services;
     }
 }

--- a/src/modules/Elsa.Studio.Security/Menu/IdentitySecurityMenuContributor.cs
+++ b/src/modules/Elsa.Studio.Security/Menu/IdentitySecurityMenuContributor.cs
@@ -1,0 +1,45 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Security.Contracts;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using MudBlazor;
+
+namespace Elsa.Studio.Security.Menu;
+
+public sealed class IdentitySecurityMenuContributor(
+    IRemoteFeatureProvider remoteFeatures,
+    IIdentityPermissionService permissions) : ISecurityMenuContributor
+{
+    public async ValueTask<IEnumerable<MenuItem>> GetMenuItemsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await remoteFeatures.IsEnabledOrDefaultAsync(Feature.RemoteFeatureName, cancellationToken))
+            return [];
+
+        var items = new List<MenuItem>();
+        if (await permissions.HasAsync(IdentityPermissions.ReadUser, cancellationToken))
+        {
+            items.Add(new()
+            {
+                Icon = Icons.Material.Filled.People,
+                Href = "security/users",
+                Text = "Users",
+                Order = 10
+            });
+        }
+
+        if (await permissions.HasAsync(IdentityPermissions.ReadRole, cancellationToken))
+        {
+            items.Add(new()
+            {
+                Icon = Icons.Material.Filled.Badge,
+                Href = "security/roles",
+                Text = "Roles",
+                Order = 20
+            });
+        }
+
+        return items;
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Models/IdentityModels.cs
+++ b/src/modules/Elsa.Studio.Security/Models/IdentityModels.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Refit;
+
+namespace Elsa.Studio.Security.Models;
+
+public static class IdentityPermissions
+{
+    public const string ReadUser = "read:user";
+    public const string CreateUser = "create:user";
+    public const string UpdateUser = "update:user";
+    public const string DeleteUser = "delete:user";
+    public const string ReadRole = "read:role";
+    public const string CreateRole = "create:role";
+    public const string UpdateRole = "update:role";
+    public const string DeleteRole = "delete:role";
+}
+
+public class UserSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public ICollection<string> Roles { get; set; } = [];
+    public string? TenantId { get; set; }
+}
+
+public sealed class ListUsersResponse
+{
+    public ICollection<UserSummary> Users { get; set; } = [];
+}
+
+public sealed class CreateUserRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Password { get; set; }
+    public ICollection<string> Roles { get; set; } = [];
+}
+
+public sealed class CreateUserResponse : UserSummary
+{
+    public string Password { get; set; } = string.Empty;
+}
+
+public sealed class UpdateUserRequest
+{
+    public string? Password { get; set; }
+    public ICollection<string>? Roles { get; set; }
+}
+
+public sealed class RoleSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public ICollection<string> Permissions { get; set; } = [];
+    public string? TenantId { get; set; }
+}
+
+public sealed class ListRolesResponse
+{
+    public ICollection<RoleSummary> Roles { get; set; } = [];
+}
+
+public sealed class CreateRoleRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public ICollection<string> Permissions { get; set; } = [];
+}
+
+public sealed class UpdateRoleRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public ICollection<string> Permissions { get; set; } = [];
+}
+
+public static class IdentityApiErrors
+{
+    public static string ToDisplayMessage(Exception exception, string fallback)
+    {
+        if (exception is not ApiException { Content: { Length: > 0 } content })
+            return string.IsNullOrWhiteSpace(exception.Message) ? fallback : exception.Message;
+
+        try
+        {
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+            if (root.TryGetProperty("message", out var message) && !string.IsNullOrWhiteSpace(message.GetString()))
+                return message.GetString()!;
+
+            if (root.TryGetProperty("title", out var title) && !string.IsNullOrWhiteSpace(title.GetString()))
+                return title.GetString()!;
+        }
+        catch (JsonException)
+        {
+            // The API returned a non-JSON error body. Use the stable fallback below.
+        }
+
+        return fallback;
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Module.cs
+++ b/src/modules/Elsa.Studio.Security/Module.cs
@@ -1,11 +1,13 @@
 using Elsa.Studio.Abstractions;
+using Elsa.Studio.Attributes;
 
 namespace Elsa.Studio.Security;
 
 /// <summary>
 /// Represents the security feature module for the Elsa Studio application.
 /// </summary>
+[RemoteFeature(RemoteFeatureName)]
 public class Feature : FeatureBase
 {
-
+    public const string RemoteFeatureName = "Elsa.Identity.ShellFeatures.Identity";
 }

--- a/src/modules/Elsa.Studio.Security/Pages/Role.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/Role.razor
@@ -1,0 +1,106 @@
+@page "/security/roles/new"
+@page "/security/roles/{Id}"
+@inherits StudioComponentBase
+@using Elsa.Studio.Security.Components
+
+<PageTitle>@PageTitleText</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large">
+    <MudStack Spacing="3" Class="py-4">
+        <MudButton Variant="Variant.Text"
+                   StartIcon="@Icons.Material.Outlined.ArrowBack"
+                   Class="align-self-start"
+                   Href="security/roles">
+            Roles
+        </MudButton>
+
+        @if (_loading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading role" />
+        }
+        else if (!string.IsNullOrWhiteSpace(_loadError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_loadError</MudAlert>
+        }
+        else
+        {
+            <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+                <div>
+                    <MudText Typo="Typo.h4" HtmlTag="h1">@PageTitleText</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@PageDescription</MudText>
+                </div>
+                <MudStack Row="true" Spacing="1">
+                    <MudButton Variant="Variant.Text" Href="security/roles" Disabled="@_saving">Cancel</MudButton>
+                    @if (CanSave)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Save"
+                                   OnClick="SaveAsync"
+                                   Disabled="@_saving">
+                            @(_saving ? "Saving..." : SaveLabel)
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudStack>
+
+            @if (!CanSave)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">You can view this role, but you do not have permission to save changes.</MudAlert>
+            }
+
+            <MudPaper Outlined="true" Class="pa-4 pa-sm-6">
+                <MudForm @ref="_form">
+                    <MudStack Spacing="4">
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">Role details</MudText>
+                            <MudText Typo="Typo.caption">Use a concise name that describes the access this role grants.</MudText>
+                        </div>
+
+                        <MudTextField @bind-Value="_name"
+                                      Label="Role name"
+                                      Required="true"
+                                      RequiredError="Enter a role name."
+                                      Disabled="@(_saving || !CanSave)"
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense" />
+
+                        @if (!IsNew)
+                        {
+                            <MudTextField Value="@Id"
+                                          Label="Role ID"
+                                          ReadOnly="true"
+                                          Variant="Variant.Outlined"
+                                          Margin="Margin.Dense" />
+                        }
+
+                        <MudDivider />
+
+                        <PermissionTokenEditor Permissions="_rolePermissions"
+                                               PermissionsChanged="OnPermissionsChanged"
+                                               Disabled="@(_saving || !CanSave)" />
+                    </MudStack>
+                </MudForm>
+            </MudPaper>
+
+            @if (!IsNew && CanDelete)
+            {
+                <MudPaper Outlined="true" Class="pa-4">
+                    <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">Delete role</MudText>
+                            <MudText Typo="Typo.caption">Deletion is blocked while users or policies still depend on this role.</MudText>
+                        </div>
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Error"
+                                   StartIcon="@Icons.Material.Outlined.Delete"
+                                   Disabled="@_saving"
+                                   OnClick="DeleteAsync">
+                            Delete role
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+            }
+        }
+    </MudStack>
+</MudContainer>

--- a/src/modules/Elsa.Studio.Security/Pages/Role.razor.cs
+++ b/src/modules/Elsa.Studio.Security/Pages/Role.razor.cs
@@ -1,0 +1,206 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Security.Pages;
+
+public partial class Role : IDisposable
+{
+    private readonly HashSet<string> _rolePermissions = new(StringComparer.Ordinal);
+    private IReadOnlySet<string> _permissions = new HashSet<string>();
+    private MudForm _form = default!;
+    private bool _loading = true;
+    private bool _saving;
+    private string? _loadError;
+    private string? _name;
+    private string? _loadedId;
+    private bool _hasLoadedParameters;
+    private long _loadVersion;
+    private bool _disposed;
+
+    [Parameter] public string? Id { get; set; }
+    [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = default!;
+    [Inject] private IIdentityPermissionService PermissionService { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    protected bool IsNew => string.IsNullOrWhiteSpace(Id);
+    protected bool CanSave => IsNew ? Has(IdentityPermissions.CreateRole) : Has(IdentityPermissions.UpdateRole);
+    protected bool CanDelete => Has(IdentityPermissions.DeleteRole);
+    protected string PageTitleText => IsNew ? "Create role" : _name ?? "Role";
+    protected string PageDescription => IsNew ? "Create a reusable set of Elsa permissions." : "Manage the permissions granted by this role.";
+    protected string SaveLabel => IsNew ? "Create role" : "Save changes";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_hasLoadedParameters && string.Equals(_loadedId, Id, StringComparison.Ordinal))
+            return;
+
+        _hasLoadedParameters = true;
+        _loadedId = Id;
+        var loadVersion = ++_loadVersion;
+        var requestedId = Id;
+        var isNew = string.IsNullOrWhiteSpace(requestedId);
+        ResetEditorState();
+
+        try
+        {
+            var permissions = await PermissionService.ListAsync();
+            if (!IsCurrentLoad(loadVersion))
+                return;
+            _permissions = permissions;
+
+            if (isNew && !Has(IdentityPermissions.CreateRole))
+            {
+                _loadError = "You do not have permission to create roles.";
+                return;
+            }
+
+            if (!isNew && !Has(IdentityPermissions.ReadRole))
+            {
+                _loadError = "You do not have permission to view roles.";
+                return;
+            }
+
+            if (!isNew)
+            {
+                var api = await ApiClientProvider.GetApiAsync<IRolesApi>();
+                if (!IsCurrentLoad(loadVersion))
+                    return;
+                var roles = await api.ListAsync();
+                if (!IsCurrentLoad(loadVersion))
+                    return;
+                var role = roles.Roles.FirstOrDefault(x => string.Equals(x.Id, requestedId, StringComparison.Ordinal));
+                if (role == null)
+                {
+                    _loadError = "The role was not found.";
+                    return;
+                }
+
+                _name = role.Name;
+                _rolePermissions.UnionWith(role.Permissions);
+            }
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(loadVersion))
+                _loadError = IdentityApiErrors.ToDisplayMessage(exception, "The role editor could not be loaded.");
+        }
+        finally
+        {
+            if (IsCurrentLoad(loadVersion))
+                _loading = false;
+        }
+    }
+
+    protected async Task SaveAsync()
+    {
+        var operationVersion = _loadVersion;
+        var operationId = Id;
+        var isNew = string.IsNullOrWhiteSpace(operationId);
+        await _form.Validate();
+        if (!IsCurrentLoad(operationVersion) || !_form.IsValid || !CanSave)
+            return;
+
+        var name = _name!.Trim();
+        var permissions = _rolePermissions.OrderBy(x => x, StringComparer.Ordinal).ToArray();
+        _saving = true;
+        StateHasChanged();
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>();
+            if (!IsCurrentLoad(operationVersion))
+                return;
+
+            if (isNew)
+            {
+                var created = await api.CreateAsync(new() { Name = name, Permissions = permissions });
+                if (!IsCurrentLoad(operationVersion))
+                    return;
+                Snackbar.Add("Role created.", Severity.Success);
+                NavigationManager.NavigateTo($"security/roles/{Uri.EscapeDataString(created.Id)}");
+            }
+            else
+            {
+                var updated = await api.UpdateAsync(operationId!, new() { Name = name, Permissions = permissions });
+                if (!IsCurrentLoad(operationVersion))
+                    return;
+                _name = updated.Name;
+                Snackbar.Add("Role updated.", Severity.Success);
+            }
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(operationVersion))
+                Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, isNew ? "The role could not be created." : "The role could not be updated."), Severity.Error);
+        }
+        finally
+        {
+            if (IsCurrentLoad(operationVersion))
+                _saving = false;
+        }
+    }
+
+    protected async Task DeleteAsync()
+    {
+        var operationVersion = _loadVersion;
+        var operationId = Id;
+        var operationName = _name;
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete role?",
+            $"Delete {operationName}? Users and policies may depend on it.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+        if (confirmed != true || !IsCurrentLoad(operationVersion))
+            return;
+
+        _saving = true;
+        StateHasChanged();
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>();
+            if (!IsCurrentLoad(operationVersion))
+                return;
+            await api.DeleteAsync(operationId!);
+            if (!IsCurrentLoad(operationVersion))
+                return;
+            Snackbar.Add("Role deleted.", Severity.Success);
+            NavigationManager.NavigateTo("security/roles");
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(operationVersion))
+                Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, "The role could not be deleted because it may still be in use."), Severity.Error);
+        }
+        finally
+        {
+            if (IsCurrentLoad(operationVersion))
+                _saving = false;
+        }
+    }
+
+    protected async Task OnPermissionsChanged() => await _form.Validate();
+
+    private void ResetEditorState()
+    {
+        _loading = true;
+        _saving = false;
+        _loadError = null;
+        _name = null;
+        _permissions = new HashSet<string>();
+        _rolePermissions.Clear();
+    }
+
+    private bool Has(string permission) => _permissions.Contains("*") || _permissions.Contains(permission);
+    private bool IsCurrentLoad(long version) => !_disposed && version == _loadVersion;
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _loadVersion++;
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Pages/Roles.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/Roles.razor
@@ -4,5 +4,126 @@
 <PageTitle>Roles</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.False">
-    <PageHeading Text="Roles"></PageHeading>
+    <MudStack Spacing="3" Class="py-4">
+        <PageHeading Text="Roles" />
+
+        @if (!_permissionsLoaded)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading role permissions" />
+        }
+        else if (!CanRead)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">You do not have permission to view roles.</MudAlert>
+        }
+        else
+        {
+            @if (!string.IsNullOrWhiteSpace(_loadError))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText>@_loadError</MudText>
+                        <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="LoadAsync">Retry</MudButton>
+                    </MudStack>
+                </MudAlert>
+            }
+
+            <MudTable T="RoleSummary"
+                      Items="@FilteredRoles"
+                      Loading="@_loading"
+                      Dense="true"
+                      Hover="true"
+                      Elevation="0"
+                      Breakpoint="Breakpoint.Md"
+                      RowStyle="cursor: pointer;"
+                      OnRowClick="OpenRole">
+                <ToolBarContent>
+                    <MudTextField T="string"
+                                  @bind-Value="_search"
+                                  Placeholder="Search roles"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Outlined.Search"
+                                  Clearable="true"
+                                  Immediate="true"
+                                  Class="flex-grow-1" />
+                    <MudSpacer />
+                    @if (CanCreate)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   Href="security/roles/new">
+                            Create role
+                        </MudButton>
+                    }
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>Name</MudTh>
+                    <MudTh>Permissions</MudTh>
+                    <MudTh>Scope</MudTh>
+                    <MudTh><span class="mud-sr-only">Actions</span></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">
+                        <span @onclick:stopPropagation="true">
+                            <MudLink Href="@RoleUrl(context.Id)"
+                                     Color="Color.Inherit"
+                                     Underline="Underline.Hover"
+                                     Class="font-weight-medium"
+                                     aria-label="@($"Open role {context.Name}")">
+                                @context.Name
+                            </MudLink>
+                        </span>
+                        @if (!string.Equals(context.Id, context.Name, StringComparison.Ordinal))
+                        {
+                            <MudText Typo="Typo.caption">@context.Id</MudText>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Permissions">
+                        @if (context.Permissions.Count == 0)
+                        {
+                            <MudText Typo="Typo.caption">No permissions</MudText>
+                        }
+                        else
+                        {
+                            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
+                                @foreach (var permission in Preview(context.Permissions))
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@permission</MudChip>
+                                }
+                                @if (context.Permissions.Count > PreviewLimit)
+                                {
+                                    <MudChip T="string" Size="Size.Small">+@(context.Permissions.Count - PreviewLimit) more</MudChip>
+                                }
+                            </MudStack>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Scope">@Scope(context.TenantId)</MudTd>
+                    <MudTd DataLabel="Actions">
+                        <div @onclick:stopPropagation="true">
+                            <MudIconButton Icon="@(CanUpdate ? Icons.Material.Outlined.Edit : Icons.Material.Outlined.Visibility)"
+                                           Href="@RoleUrl(context.Id)"
+                                           aria-label="@(CanUpdate ? $"Edit role {context.Name}" : $"View role {context.Name}")" />
+                            @if (CanDelete)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Outlined.Delete"
+                                               Color="Color.Error"
+                                               Disabled="@IsDeleting(context.Id)"
+                                               OnClick="@(() => DeleteAsync(context))"
+                                               aria-label="@($"Delete role {context.Name}")" />
+                            }
+                        </div>
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-8">
+                        <MudIcon Icon="@Icons.Material.Outlined.Badge" Size="Size.Large" Color="Color.Secondary" />
+                        <MudText Typo="Typo.h6">@EmptyTitle</MudText>
+                        <MudText Typo="Typo.body2">@EmptyDescription</MudText>
+                    </MudStack>
+                </NoRecordsContent>
+            </MudTable>
+        }
+    </MudStack>
 </MudContainer>

--- a/src/modules/Elsa.Studio.Security/Pages/Roles.razor.cs
+++ b/src/modules/Elsa.Studio.Security/Pages/Roles.razor.cs
@@ -1,0 +1,121 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Security.Pages;
+
+public partial class Roles
+{
+    protected const int PreviewLimit = 3;
+    private readonly HashSet<string> _deletingIds = new(StringComparer.Ordinal);
+    private readonly List<RoleSummary> _roles = [];
+    private IReadOnlySet<string> _permissions = new HashSet<string>();
+    private bool _permissionsLoaded;
+    private bool _loading;
+    private string? _loadError;
+    private string? _search;
+
+    [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = default!;
+    [Inject] private IIdentityPermissionService PermissionService { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    protected bool CanRead => Has(IdentityPermissions.ReadRole);
+    protected bool CanCreate => Has(IdentityPermissions.CreateRole);
+    protected bool CanUpdate => Has(IdentityPermissions.UpdateRole);
+    protected bool CanDelete => Has(IdentityPermissions.DeleteRole);
+    protected IEnumerable<RoleSummary> FilteredRoles => string.IsNullOrWhiteSpace(_search)
+        ? _roles
+        : _roles.Where(MatchesSearch);
+    protected string EmptyTitle => string.IsNullOrWhiteSpace(_search) ? "No roles yet" : "No matching roles";
+    protected string EmptyDescription => string.IsNullOrWhiteSpace(_search)
+        ? "Create a role to group permissions for users."
+        : "Try a different name, permission, or tenant.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _permissions = await PermissionService.ListAsync();
+        _permissionsLoaded = true;
+        if (CanRead)
+            await LoadAsync();
+    }
+
+    protected async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>();
+            var response = await api.ListAsync();
+            _roles.Clear();
+            _roles.AddRange(response.Roles.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase));
+        }
+        catch (Exception exception)
+        {
+            _loadError = IdentityApiErrors.ToDisplayMessage(exception, "Roles could not be loaded.");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    protected void OpenRole(TableRowClickEventArgs<RoleSummary> args)
+    {
+        if (args.Item != null)
+            NavigationManager.NavigateTo(RoleUrl(args.Item.Id));
+    }
+
+    protected async Task DeleteAsync(RoleSummary role)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete role?",
+            $"Delete {role.Name}? Users and policies may depend on it.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+        if (confirmed != true)
+            return;
+
+        if (!_deletingIds.Add(role.Id))
+            return;
+        StateHasChanged();
+
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>();
+            await api.DeleteAsync(role.Id);
+            _roles.Remove(role);
+            Snackbar.Add("Role deleted.", Severity.Success);
+        }
+        catch (Exception exception)
+        {
+            Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, "The role could not be deleted because it may still be in use."), Severity.Error);
+        }
+        finally
+        {
+            _deletingIds.Remove(role.Id);
+        }
+    }
+
+    protected static IEnumerable<string> Preview(ICollection<string> values) =>
+        values.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).Take(PreviewLimit);
+    protected static string Scope(string? tenantId) => string.IsNullOrWhiteSpace(tenantId) ? "Host" : tenantId;
+    protected static string RoleUrl(string id) => $"security/roles/{Uri.EscapeDataString(id)}";
+    protected bool IsDeleting(string id) => _deletingIds.Contains(id);
+
+    private bool MatchesSearch(RoleSummary role)
+    {
+        var search = _search!.Trim();
+        return role.Name.Contains(search, StringComparison.OrdinalIgnoreCase)
+               || role.Id.Contains(search, StringComparison.OrdinalIgnoreCase)
+               || role.Permissions.Any(x => x.Contains(search, StringComparison.OrdinalIgnoreCase))
+               || (role.TenantId?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private bool Has(string permission) => _permissions.Contains("*") || _permissions.Contains(permission);
+}

--- a/src/modules/Elsa.Studio.Security/Pages/User.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/User.razor
@@ -1,0 +1,154 @@
+@page "/security/users/new"
+@page "/security/users/{Id}"
+@inherits StudioComponentBase
+
+<PageTitle>@PageTitleText</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large">
+    <MudStack Spacing="3" Class="py-4">
+        <MudButton Variant="Variant.Text"
+                   StartIcon="@Icons.Material.Outlined.ArrowBack"
+                   Class="align-self-start"
+                   Href="security/users">
+            Users
+        </MudButton>
+
+        @if (_loading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading user" />
+        }
+        else if (!string.IsNullOrWhiteSpace(_loadError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_loadError</MudAlert>
+        }
+        else
+        {
+            <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+                <div>
+                    <MudText Typo="Typo.h4" HtmlTag="h1">@PageTitleText</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@PageDescription</MudText>
+                </div>
+                <MudStack Row="true" Spacing="1">
+                    <MudButton Variant="Variant.Text" Href="security/users" Disabled="@_saving">Cancel</MudButton>
+                    @if (CanSave)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Save"
+                                   OnClick="SaveAsync"
+                                   Disabled="@_saving">
+                            @(_saving ? "Saving..." : SaveLabel)
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudStack>
+
+            @if (!CanSave)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">You can view this user, but you do not have permission to save changes.</MudAlert>
+            }
+
+            <MudPaper Outlined="true" Class="pa-4 pa-sm-6">
+                <MudForm @ref="_form">
+                    <MudStack Spacing="4">
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">Account</MudText>
+                            <MudText Typo="Typo.caption">The username is the stable identity used to sign in to Elsa.</MudText>
+                        </div>
+
+                        <MudTextField @bind-Value="_name"
+                                      Label="Username"
+                                      Required="true"
+                                      RequiredError="Enter a username."
+                                      ReadOnly="@(!IsNew)"
+                                      Disabled="@(_saving || !CanSave)"
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense" />
+
+                        @if (!IsNew)
+                        {
+                            <MudTextField Value="@Id"
+                                          Label="User ID"
+                                          ReadOnly="true"
+                                          Variant="Variant.Outlined"
+                                          Margin="Margin.Dense" />
+                        }
+
+                        <MudDivider />
+
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">Roles</MudText>
+                            <MudText Typo="Typo.caption">Roles group the permissions this user receives.</MudText>
+                        </div>
+
+                        <MudSelect T="string"
+                                   Label="Assigned roles"
+                                   MultiSelection="true"
+                                   SelectedValues="_selectedRoles"
+                                   SelectedValuesChanged="OnSelectedRolesChanged"
+                                   Disabled="@(_saving || !CanSave || !CanReadRoles)"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense">
+                            @foreach (var role in _roleOptions)
+                            {
+                                <MudSelectItem T="string" Value="@role.Id">@role.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                        @if (!CanReadRoles)
+                        {
+                            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true">
+                                Role assignment is unavailable because you do not have permission to view roles.
+                            </MudAlert>
+                        }
+
+                        <MudDivider />
+
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">@PasswordHeading</MudText>
+                            <MudText Typo="Typo.caption">@CredentialGuidance</MudText>
+                        </div>
+
+                        <MudGrid Spacing="2">
+                            <MudItem xs="12" sm="6">
+                                <MudTextField @bind-Value="_password"
+                                              Label="@PasswordLabel"
+                                              InputType="InputType.Password"
+                                              Disabled="@(_saving || !CanSave)"
+                                              Variant="Variant.Outlined"
+                                              Margin="Margin.Dense" />
+                            </MudItem>
+                            <MudItem xs="12" sm="6">
+                                <MudTextField @bind-Value="_passwordConfirmation"
+                                              Label="Confirm password"
+                                              InputType="InputType.Password"
+                                              Validation="@((string? value) => ValidatePasswordConfirmation(value))"
+                                              Disabled="@(_saving || !CanSave)"
+                                              Variant="Variant.Outlined"
+                                              Margin="Margin.Dense" />
+                            </MudItem>
+                        </MudGrid>
+                    </MudStack>
+                </MudForm>
+            </MudPaper>
+
+            @if (!IsNew && CanDelete)
+            {
+                <MudPaper Outlined="true" Class="pa-4">
+                    <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
+                        <div>
+                            <MudText Typo="Typo.h6" HtmlTag="h2">Delete user</MudText>
+                            <MudText Typo="Typo.caption">Permanently removes this user when no installed module still references it.</MudText>
+                        </div>
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Error"
+                                   StartIcon="@Icons.Material.Outlined.Delete"
+                                   Disabled="@_saving"
+                                   OnClick="DeleteAsync">
+                            Delete user
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+            }
+        }
+    </MudStack>
+</MudContainer>

--- a/src/modules/Elsa.Studio.Security/Pages/User.razor.cs
+++ b/src/modules/Elsa.Studio.Security/Pages/User.razor.cs
@@ -1,0 +1,286 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Components;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Security.Pages;
+
+public partial class User : IDisposable
+{
+    private readonly List<RoleSummary> _roleOptions = [];
+    private readonly HashSet<string> _originalRoles = new(StringComparer.Ordinal);
+    private IReadOnlySet<string> _permissions = new HashSet<string>();
+    private IReadOnlyCollection<string> _selectedRoles = [];
+    private MudForm _form = default!;
+    private bool _loading = true;
+    private bool _saving;
+    private string? _loadError;
+    private string? _name;
+    private string? _password;
+    private string? _passwordConfirmation;
+    private string? _loadedId;
+    private bool _hasLoadedParameters;
+    private bool _rolesChanged;
+    private long _loadVersion;
+    private bool _disposed;
+
+    [Parameter] public string? Id { get; set; }
+    [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = default!;
+    [Inject] private IIdentityPermissionService PermissionService { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    protected bool IsNew => string.IsNullOrWhiteSpace(Id);
+    protected bool CanReadRoles => Has(IdentityPermissions.ReadRole);
+    protected bool CanSave => IsNew ? Has(IdentityPermissions.CreateUser) : Has(IdentityPermissions.UpdateUser);
+    protected bool CanDelete => Has(IdentityPermissions.DeleteUser);
+    protected string PageTitleText => IsNew ? "Create user" : _name ?? "User";
+    protected string PageDescription => IsNew ? "Create an Elsa account and assign its roles." : "Manage role assignments and account credentials.";
+    protected string SaveLabel => IsNew ? "Create user" : "Save changes";
+    protected string PasswordHeading => IsNew ? "Password" : "Change password";
+    protected string PasswordLabel => IsNew ? "Password (optional)" : "New password (optional)";
+    protected string CredentialGuidance => IsNew
+        ? "Leave blank to let Elsa generate a one-time password."
+        : "Leave both fields blank to keep the current password.";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_hasLoadedParameters && string.Equals(_loadedId, Id, StringComparison.Ordinal))
+            return;
+
+        _hasLoadedParameters = true;
+        _loadedId = Id;
+        var loadVersion = ++_loadVersion;
+        var requestedId = Id;
+        var isNew = string.IsNullOrWhiteSpace(requestedId);
+        ResetEditorState();
+
+        try
+        {
+            var permissions = await PermissionService.ListAsync();
+            if (!IsCurrentLoad(loadVersion))
+                return;
+            _permissions = permissions;
+
+            if (isNew && !Has(IdentityPermissions.CreateUser))
+            {
+                _loadError = "You do not have permission to create users.";
+                return;
+            }
+
+            if (!isNew && !Has(IdentityPermissions.ReadUser))
+            {
+                _loadError = "You do not have permission to view users.";
+                return;
+            }
+
+            var usersApi = await ApiClientProvider.GetApiAsync<IUsersApi>();
+            if (!IsCurrentLoad(loadVersion))
+                return;
+            var rolesApi = CanReadRoles ? await ApiClientProvider.GetApiAsync<IRolesApi>() : null;
+            if (!IsCurrentLoad(loadVersion))
+                return;
+            var rolesTask = rolesApi?.ListAsync();
+
+            if (!isNew)
+            {
+                var users = await usersApi.ListAsync();
+                if (!IsCurrentLoad(loadVersion))
+                    return;
+                var user = users.Users.FirstOrDefault(x => string.Equals(x.Id, requestedId, StringComparison.Ordinal));
+                if (user == null)
+                {
+                    _loadError = "The user was not found.";
+                    return;
+                }
+
+                _name = user.Name;
+                _originalRoles.UnionWith(user.Roles);
+                _selectedRoles = _originalRoles.ToHashSet(StringComparer.Ordinal);
+            }
+
+            if (rolesTask != null)
+            {
+                var roles = await rolesTask;
+                if (!IsCurrentLoad(loadVersion))
+                    return;
+                _roleOptions.AddRange(roles.Roles.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase));
+            }
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(loadVersion))
+                _loadError = IdentityApiErrors.ToDisplayMessage(exception, "The user editor could not be loaded.");
+        }
+        finally
+        {
+            if (IsCurrentLoad(loadVersion))
+                _loading = false;
+        }
+    }
+
+    protected async Task SaveAsync()
+    {
+        var operationVersion = _loadVersion;
+        var operationId = Id;
+        var isNew = string.IsNullOrWhiteSpace(operationId);
+        await _form.Validate();
+        if (!IsCurrentLoad(operationVersion) || !_form.IsValid || !CanSave)
+            return;
+
+        var name = _name!.Trim();
+        var password = _password;
+        var suppliedPassword = !string.IsNullOrWhiteSpace(password);
+        var roles = _selectedRoles.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+        var rolesChanged = _rolesChanged;
+        _saving = true;
+        StateHasChanged();
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IUsersApi>();
+            if (!IsCurrentLoad(operationVersion))
+                return;
+
+            if (isNew)
+            {
+                var created = await api.CreateAsync(new()
+                {
+                    Name = name,
+                    Password = suppliedPassword ? password : null,
+                    Roles = roles
+                });
+                if (!IsCurrentLoad(operationVersion))
+                    return;
+
+                Snackbar.Add("User created.", Severity.Success);
+                if (!suppliedPassword && !string.IsNullOrWhiteSpace(created.Password))
+                    await ShowGeneratedPasswordAsync(created.Password);
+                if (!IsCurrentLoad(operationVersion))
+                    return;
+                NavigationManager.NavigateTo($"security/users/{Uri.EscapeDataString(created.Id)}");
+            }
+            else
+            {
+                await api.UpdateAsync(operationId!, new()
+                {
+                    Password = suppliedPassword ? password : null,
+                    Roles = rolesChanged ? roles : null
+                });
+                if (!IsCurrentLoad(operationVersion))
+                    return;
+                _originalRoles.Clear();
+                _originalRoles.UnionWith(roles);
+                _rolesChanged = false;
+                _password = null;
+                _passwordConfirmation = null;
+                Snackbar.Add("User updated.", Severity.Success);
+            }
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(operationVersion))
+                Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, isNew ? "The user could not be created." : "The user could not be updated."), Severity.Error);
+        }
+        finally
+        {
+            if (IsCurrentLoad(operationVersion))
+                _saving = false;
+        }
+    }
+
+    protected async Task DeleteAsync()
+    {
+        var operationVersion = _loadVersion;
+        var operationId = Id;
+        var operationName = _name;
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete user?",
+            $"Delete {operationName}? This cannot be undone.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+        if (confirmed != true || !IsCurrentLoad(operationVersion))
+            return;
+
+        _saving = true;
+        StateHasChanged();
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IUsersApi>();
+            if (!IsCurrentLoad(operationVersion))
+                return;
+            await api.DeleteAsync(operationId!);
+            if (!IsCurrentLoad(operationVersion))
+                return;
+            Snackbar.Add("User deleted.", Severity.Success);
+            NavigationManager.NavigateTo("security/users");
+        }
+        catch (Exception exception)
+        {
+            if (IsCurrentLoad(operationVersion))
+                Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, "The user could not be deleted."), Severity.Error);
+        }
+        finally
+        {
+            if (IsCurrentLoad(operationVersion))
+                _saving = false;
+        }
+    }
+
+    protected string? ValidatePasswordConfirmation(string? value)
+    {
+        if (string.IsNullOrEmpty(_password) && string.IsNullOrEmpty(value))
+            return null;
+        return string.Equals(_password, value, StringComparison.Ordinal) ? null : "Passwords do not match.";
+    }
+
+    protected Task OnSelectedRolesChanged(IReadOnlyCollection<string> roles)
+    {
+        var selectedRoles = roles.ToHashSet(StringComparer.Ordinal);
+        _selectedRoles = selectedRoles;
+        _rolesChanged = !_originalRoles.SetEquals(selectedRoles);
+        return Task.CompletedTask;
+    }
+
+    private void ResetEditorState()
+    {
+        _loading = true;
+        _saving = false;
+        _loadError = null;
+        _name = null;
+        _password = null;
+        _passwordConfirmation = null;
+        _permissions = new HashSet<string>();
+        _selectedRoles = [];
+        _roleOptions.Clear();
+        _originalRoles.Clear();
+        _rolesChanged = false;
+    }
+
+    private async Task ShowGeneratedPasswordAsync(string password)
+    {
+        var parameters = new DialogParameters<GeneratedPasswordDialog> { { x => x.Password, password } };
+        var options = new DialogOptions
+        {
+            BackdropClick = false,
+            CloseButton = false,
+            CloseOnEscapeKey = false,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Small
+        };
+        var dialog = await DialogService.ShowAsync<GeneratedPasswordDialog>("Save generated password", parameters, options);
+        await dialog.Result;
+    }
+
+    private bool Has(string permission) => _permissions.Contains("*") || _permissions.Contains(permission);
+    private bool IsCurrentLoad(long version) => !_disposed && version == _loadVersion;
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _loadVersion++;
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Pages/Users.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/Users.razor
@@ -4,5 +4,123 @@
 <PageTitle>Users</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.False">
-    <PageHeading Text="Users"></PageHeading>
+    <MudStack Spacing="3" Class="py-4">
+        <PageHeading Text="Users" />
+
+        @if (!_permissionsLoaded)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading user permissions" />
+        }
+        else if (!CanRead)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">You do not have permission to view users.</MudAlert>
+        }
+        else
+        {
+            @if (!string.IsNullOrWhiteSpace(_loadError))
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText>@_loadError</MudText>
+                        <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="LoadAsync">Retry</MudButton>
+                    </MudStack>
+                </MudAlert>
+            }
+
+            <MudTable T="UserSummary"
+                      Items="@FilteredUsers"
+                      Loading="@_loading"
+                      Dense="true"
+                      Hover="true"
+                      Elevation="0"
+                      Breakpoint="Breakpoint.Md"
+                      RowStyle="cursor: pointer;"
+                      OnRowClick="OpenUser">
+                <ToolBarContent>
+                    <MudTextField T="string"
+                                  @bind-Value="_search"
+                                  Placeholder="Search users"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Outlined.Search"
+                                  Clearable="true"
+                                  Immediate="true"
+                                  Class="flex-grow-1" />
+                    <MudSpacer />
+                    @if (CanCreate)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.PersonAdd"
+                                   Href="security/users/new">
+                            Create user
+                        </MudButton>
+                    }
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>Name</MudTh>
+                    <MudTh>Roles</MudTh>
+                    <MudTh>Scope</MudTh>
+                    <MudTh><span class="mud-sr-only">Actions</span></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">
+                        <span @onclick:stopPropagation="true">
+                            <MudLink Href="@UserUrl(context.Id)"
+                                     Color="Color.Inherit"
+                                     Underline="Underline.Hover"
+                                     Class="font-weight-medium"
+                                     aria-label="@($"Open user {context.Name}")">
+                                @context.Name
+                            </MudLink>
+                        </span>
+                        <MudText Typo="Typo.caption">@context.Id</MudText>
+                    </MudTd>
+                    <MudTd DataLabel="Roles">
+                        @if (context.Roles.Count == 0)
+                        {
+                            <MudText Typo="Typo.caption">No roles</MudText>
+                        }
+                        else
+                        {
+                            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
+                                @foreach (var role in Preview(context.Roles))
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@role</MudChip>
+                                }
+                                @if (context.Roles.Count > PreviewLimit)
+                                {
+                                    <MudChip T="string" Size="Size.Small">+@(context.Roles.Count - PreviewLimit) more</MudChip>
+                                }
+                            </MudStack>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Scope">@Scope(context.TenantId)</MudTd>
+                    <MudTd DataLabel="Actions">
+                        <div @onclick:stopPropagation="true">
+                            <MudIconButton Icon="@(CanUpdate ? Icons.Material.Outlined.Edit : Icons.Material.Outlined.Visibility)"
+                                           Href="@UserUrl(context.Id)"
+                                           aria-label="@(CanUpdate ? $"Edit user {context.Name}" : $"View user {context.Name}")" />
+                            @if (CanDelete)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Outlined.Delete"
+                                               Color="Color.Error"
+                                               Disabled="@IsDeleting(context.Id)"
+                                               OnClick="@(() => DeleteAsync(context))"
+                                               aria-label="@($"Delete user {context.Name}")" />
+                            }
+                        </div>
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-8">
+                        <MudIcon Icon="@Icons.Material.Outlined.People" Size="Size.Large" Color="Color.Secondary" />
+                        <MudText Typo="Typo.h6">@EmptyTitle</MudText>
+                        <MudText Typo="Typo.body2">@EmptyDescription</MudText>
+                    </MudStack>
+                </NoRecordsContent>
+            </MudTable>
+        }
+    </MudStack>
 </MudContainer>

--- a/src/modules/Elsa.Studio.Security/Pages/Users.razor.cs
+++ b/src/modules/Elsa.Studio.Security/Pages/Users.razor.cs
@@ -1,0 +1,121 @@
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Services;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Security.Pages;
+
+public partial class Users
+{
+    protected const int PreviewLimit = 3;
+    private readonly HashSet<string> _deletingIds = new(StringComparer.Ordinal);
+    private readonly List<UserSummary> _users = [];
+    private IReadOnlySet<string> _permissions = new HashSet<string>();
+    private bool _permissionsLoaded;
+    private bool _loading;
+    private string? _loadError;
+    private string? _search;
+
+    [Inject] private IBackendApiClientProvider ApiClientProvider { get; set; } = default!;
+    [Inject] private IIdentityPermissionService PermissionService { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    protected bool CanRead => Has(IdentityPermissions.ReadUser);
+    protected bool CanCreate => Has(IdentityPermissions.CreateUser);
+    protected bool CanUpdate => Has(IdentityPermissions.UpdateUser);
+    protected bool CanDelete => Has(IdentityPermissions.DeleteUser);
+    protected IEnumerable<UserSummary> FilteredUsers => string.IsNullOrWhiteSpace(_search)
+        ? _users
+        : _users.Where(MatchesSearch);
+    protected string EmptyTitle => string.IsNullOrWhiteSpace(_search) ? "No users yet" : "No matching users";
+    protected string EmptyDescription => string.IsNullOrWhiteSpace(_search)
+        ? "Create a user to grant access to Elsa."
+        : "Try a different name, role, or tenant.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _permissions = await PermissionService.ListAsync();
+        _permissionsLoaded = true;
+        if (CanRead)
+            await LoadAsync();
+    }
+
+    protected async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IUsersApi>();
+            var response = await api.ListAsync();
+            _users.Clear();
+            _users.AddRange(response.Users.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase));
+        }
+        catch (Exception exception)
+        {
+            _loadError = IdentityApiErrors.ToDisplayMessage(exception, "Users could not be loaded.");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    protected void OpenUser(TableRowClickEventArgs<UserSummary> args)
+    {
+        if (args.Item != null)
+            NavigationManager.NavigateTo(UserUrl(args.Item.Id));
+    }
+
+    protected async Task DeleteAsync(UserSummary user)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete user?",
+            $"Delete {user.Name}? This cannot be undone.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+        if (confirmed != true)
+            return;
+
+        if (!_deletingIds.Add(user.Id))
+            return;
+        StateHasChanged();
+
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IUsersApi>();
+            await api.DeleteAsync(user.Id);
+            _users.Remove(user);
+            Snackbar.Add("User deleted.", Severity.Success);
+        }
+        catch (Exception exception)
+        {
+            Snackbar.Add(IdentityApiErrors.ToDisplayMessage(exception, "The user could not be deleted."), Severity.Error);
+        }
+        finally
+        {
+            _deletingIds.Remove(user.Id);
+        }
+    }
+
+    protected static IEnumerable<string> Preview(ICollection<string> values) =>
+        values.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).Take(PreviewLimit);
+    protected static string Scope(string? tenantId) => string.IsNullOrWhiteSpace(tenantId) ? "Host" : tenantId;
+    protected static string UserUrl(string id) => $"security/users/{Uri.EscapeDataString(id)}";
+    protected bool IsDeleting(string id) => _deletingIds.Contains(id);
+
+    private bool MatchesSearch(UserSummary user)
+    {
+        var search = _search!.Trim();
+        return user.Name.Contains(search, StringComparison.OrdinalIgnoreCase)
+               || user.Id.Contains(search, StringComparison.OrdinalIgnoreCase)
+               || user.Roles.Any(x => x.Contains(search, StringComparison.OrdinalIgnoreCase))
+               || (user.TenantId?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private bool Has(string permission) => _permissions.Contains("*") || _permissions.Contains(permission);
+}

--- a/src/modules/Elsa.Studio.Security/Services/IdentityPermissionService.cs
+++ b/src/modules/Elsa.Studio.Security/Services/IdentityPermissionService.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Elsa.Studio.Security.Services;
+
+public interface IIdentityPermissionService
+{
+    ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>Reads Elsa permission claims to tailor identity-management affordances.</summary>
+public sealed class IdentityPermissionService(AuthenticationStateProvider authenticationStateProvider) : IIdentityPermissionService
+{
+    public async ValueTask<bool> HasAsync(string permission, CancellationToken cancellationToken = default)
+    {
+        var permissions = await ListAsync(cancellationToken);
+        return permissions.Contains("*") || permissions.Contains(permission);
+    }
+
+    public async ValueTask<IReadOnlySet<string>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var user = (await authenticationStateProvider.GetAuthenticationStateAsync()).User;
+        return user.FindAll("permissions").Select(x => x.Value).ToHashSet(StringComparer.Ordinal);
+    }
+}

--- a/src/modules/Elsa.Studio.Security/_Imports.razor
+++ b/src/modules/Elsa.Studio.Security/_Imports.razor
@@ -1,4 +1,5 @@
 ﻿@using Elsa.Studio.Components
+@using Elsa.Studio.Security.Models
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Routing


### PR DESCRIPTION
## Summary
- add permission-aware user and role list, create, edit, and delete experiences
- integrate identity management navigation and backend API clients for server and WebAssembly hosts
- handle generated passwords, role assignments, permission tokens, responsive tables, and stale asynchronous operations
- document the recommended design and add focused component coverage

## Verification
- 20 administration tests passed on net10.0
- server host build passed with zero warnings
- WebAssembly host build passed with zero warnings
- browser-tested the end-to-end user and role flows