### PR TITLE
fix(host): restore runnable server authentication defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,10 @@ OpenCover/
 # Local History for Visual Studio
 .localhistory/
 
+# Per-developer host configuration overrides (auth provider, client secrets, backend URL, ...).
+# Keeps the shipped appsettings.json defaults intact.
+appsettings.Local.json
+
 src/modules/**/wwwroot/
 src/framework/**/wwwroot/
 !src/modules/Elsa.Studio.Authentication.UI/wwwroot/

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -49,6 +49,10 @@ using Microsoft.Extensions.Options;
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
 
+// Per-developer overrides (auth provider, client secrets, backend URL, ...) belong here, not in appsettings.json.
+// The file is git-ignored, so the shipped defaults stay runnable out of the box.
+configuration.AddJsonFile("appsettings.Local.json", true, true);
+
 // Register Razor services.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor(options =>

--- a/src/hosts/Elsa.Studio.Host.Server/appsettings.json
+++ b/src/hosts/Elsa.Studio.Host.Server/appsettings.json
@@ -26,7 +26,7 @@
     ]
   },
   "Authentication": {
-    "Provider": "ExternalAuthentication",
+    "Provider": "ElsaIdentity",
     "Login": {
       "Theme": "classic-refined-split"
     },
@@ -46,7 +46,7 @@
     },
     "ExternalAuthentication": {
       "ClientId": "elsa-studio-server",
-      "ClientSecret": "t/6A8piT0E1hbxBSqkppC9Ug2Nr3B9E++GBt10fwhu4=",
+      "ClientSecret": "",
       "CallbackPath": "/authentication/external/callback",
       "LogoutCallbackPath": "/authentication/external/logout-callback"
     }


### PR DESCRIPTION
## Problem

CI on `release/3.8.0` is failing:

```
Elsa.Studio.Core.Tests.HostAuthenticationConfigurationTests.ServerHostShipsWithRunnableAuthenticationDefaults [FAIL]
Assert.Equal() Failure: Strings differ
Expected: "ElsaIdentity"
Actual:   "ExternalAuthentication"
```

## Root cause

Commit a7c4385 committed a local dev configuration into the shipped `appsettings.json` of `Elsa.Studio.Host.Server`:

- `Authentication:Provider` flipped from `ElsaIdentity` to `ExternalAuthentication`
- `Authentication:ExternalAuthentication:ClientSecret` filled in with a local test credential

That contradicts the test added one commit earlier (d030aa5), which guards that the server host ships with defaults a user can run without first configuring an external identity broker.

The underlying cause is that there was no un-tracked place for local overrides — both `appsettings.json` and `appsettings.Development.json` are tracked, so switching providers locally means editing a file that gets committed.

## Changes

- Revert the shipped defaults to `ElsaIdentity` with an empty `ClientSecret`.
- Register an optional `appsettings.Local.json` configuration layer in the server host.
- Git-ignore `appsettings.Local.json` so per-developer overrides (auth provider, client secrets, backend URL) never reach a commit.

## Verification

- `HostAuthenticationConfigurationTests` passes locally.
- `Elsa.Studio.Host.Server` builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)