### PR TITLE
fix(activity-labels): prefer custom display text over activity name

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Helpers/ActivityLabelResolver.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Helpers/ActivityLabelResolver.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+
+namespace Elsa.Studio.Workflows.Helpers;
+
+/// <summary>
+/// Resolves the label to display for an activity, both on the designer and in the workflow instance views.
+/// </summary>
+public static class ActivityLabelResolver
+{
+    /// <summary>
+    /// The label to use when an activity provides nothing to identify itself with.
+    /// </summary>
+    public const string UnknownActivityLabel = "Unknown Activity";
+
+    /// <summary>
+    /// Resolves the label using the hierarchy: custom display text > activity name > fallback.
+    /// </summary>
+    /// <param name="displayText">The display text the user entered for the activity.</param>
+    /// <param name="name">The name of the activity, e.g. "WriteLine1".</param>
+    /// <param name="fallback">The label to use when neither a display text nor a name is available, typically the activity type's display name.</param>
+    /// <returns>The label to display.</returns>
+    public static string Resolve(string? displayText, string? name, string? fallback = null)
+    {
+        if (!string.IsNullOrWhiteSpace(displayText))
+            return displayText.Trim();
+
+        if (!string.IsNullOrWhiteSpace(name))
+            return name.Trim();
+
+        return !string.IsNullOrWhiteSpace(fallback) ? fallback.Trim() : UnknownActivityLabel;
+    }
+
+    /// <summary>
+    /// Resolves the label for the specified activity, falling back to the display name or name of its descriptor.
+    /// </summary>
+    /// <param name="activity">The activity to resolve the label for.</param>
+    /// <param name="descriptor">The descriptor of the activity, if available.</param>
+    /// <returns>The label to display.</returns>
+    public static string Resolve(JsonObject activity, ActivityDescriptor? descriptor) =>
+        Resolve(activity.GetDisplayText(), activity.GetName(), descriptor?.DisplayName ?? descriptor?.Name);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/ActivityLabelResolverTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/ActivityLabelResolverTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Workflows.Helpers;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+public sealed class ActivityLabelResolverTests
+{
+    [Fact]
+    public void CustomDisplayText_TakesPrecedenceOverActivityName()
+    {
+        Assert.Equal("Send welcome e-mail", ActivityLabelResolver.Resolve("Send welcome e-mail", "SendEmail1", "Send Email"));
+    }
+
+    [Fact]
+    public void ActivityName_IsUsedWhenNoDisplayTextIsSet()
+    {
+        Assert.Equal("SendEmail1", ActivityLabelResolver.Resolve(null, "SendEmail1", "Send Email"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankDisplayText_FallsBackToActivityName(string displayText)
+    {
+        Assert.Equal("SendEmail1", ActivityLabelResolver.Resolve(displayText, "SendEmail1", "Send Email"));
+    }
+
+    [Fact]
+    public void TypeDisplayName_IsUsedWhenNeitherDisplayTextNorNameIsSet()
+    {
+        Assert.Equal("Send Email", ActivityLabelResolver.Resolve(null, null, "Send Email"));
+    }
+
+    [Fact]
+    public void UnknownActivityLabel_IsUsedWhenNothingIsAvailable()
+    {
+        Assert.Equal(ActivityLabelResolver.UnknownActivityLabel, ActivityLabelResolver.Resolve(null, null, null));
+    }
+
+    [Fact]
+    public void ResolvedLabels_AreTrimmed()
+    {
+        Assert.Equal("Send welcome e-mail", ActivityLabelResolver.Resolve("  Send welcome e-mail  ", null, null));
+        Assert.Equal("SendEmail1", ActivityLabelResolver.Resolve(null, "  SendEmail1  ", null));
+    }
+
+    [Fact]
+    public void ActivityDisplayText_TakesPrecedenceOverActivityNameAndDescriptor()
+    {
+        var activity = CreateActivity("SendEmail1", "Send welcome e-mail");
+        var descriptor = new ActivityDescriptor
+        {
+            Name = "SendEmail",
+            DisplayName = "Send Email"
+        };
+
+        Assert.Equal("Send welcome e-mail", ActivityLabelResolver.Resolve(activity, descriptor));
+    }
+
+    [Fact]
+    public void ActivityWithoutDisplayText_FallsBackToNameThenDescriptor()
+    {
+        var descriptor = new ActivityDescriptor
+        {
+            Name = "SendEmail",
+            DisplayName = "Send Email"
+        };
+
+        Assert.Equal("SendEmail1", ActivityLabelResolver.Resolve(CreateActivity("SendEmail1", null), descriptor));
+        Assert.Equal("Send Email", ActivityLabelResolver.Resolve(CreateActivity(null, null), descriptor));
+        Assert.Equal(ActivityLabelResolver.UnknownActivityLabel, ActivityLabelResolver.Resolve(CreateActivity(null, null), null));
+    }
+
+    private static JsonObject CreateActivity(string? name, string? displayText)
+    {
+        var activity = new JsonObject
+        {
+            ["type"] = "Elsa.SendEmail",
+            ["version"] = 1
+        };
+
+        if (name != null)
+            activity["name"] = name;
+
+        if (displayText != null)
+            activity["metadata"] = new JsonObject
+            {
+                ["displayText"] = displayText
+            };
+
+        return activity;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/ActivityWrapperBase.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/ActivityWrapperBase.cs
@@ -7,6 +7,7 @@ using Elsa.Studio.Workflows.Designer.Interop;
 using Elsa.Studio.Workflows.Domain.Contexts;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Helpers;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
 
@@ -114,11 +115,9 @@ public abstract class ActivityWrapperBase : StudioComponentBase
         var descriptor = ActivityRegistry.Find(activityType, activityVersion);
         var displaySettings = ActivityDisplaySettingsRegistry.GetSettings(activityType);
 
-        // Hierarchy: Activity Name > Custom Display Text > Type Name
-        Label = !string.IsNullOrEmpty(activityName) 
-            ? activityName 
-            : (!string.IsNullOrEmpty(activityDisplayText) ? activityDisplayText : descriptor?.DisplayName ?? descriptor?.Name ?? "Unknown Activity");
-        TypeName = descriptor?.DisplayName ?? "Unknown Activity";
+        // Hierarchy: Custom Display Text > Activity Name > Type Name
+        Label = ActivityLabelResolver.Resolve(activityDisplayText, activityName, descriptor?.DisplayName ?? descriptor?.Name);
+        TypeName = descriptor?.DisplayName ?? ActivityLabelResolver.UnknownActivityLabel;
         Description = !string.IsNullOrEmpty(activityDescription) ? activityDescription : descriptor?.Description ?? string.Empty;
         var currentShowDescription = activity.GetShowDescription() == true;
         ShowDescription = currentShowDescription;

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/EmbeddedActivityWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/ActivityWrappers/EmbeddedActivityWrapper.razor.cs
@@ -4,6 +4,7 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Studio.Components;
 using Elsa.Studio.Workflows.Designer.Interop;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Helpers;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
 
@@ -62,11 +63,10 @@ public abstract class EmbeddedActivityWrapperBase : StudioComponentBase
         var activityType = activity.GetTypeName();
         var activityVersion = activity.GetVersion();
         var descriptor = (ActivityRegistry.Find(activityType, activityVersion) ?? ActivityRegistry.Find("Elsa.UnknownActivity"))!;
-        var activityDisplayText = activity.GetDisplayText()?.Trim() ?? activity.GetName() ?? descriptor.DisplayName ?? descriptor.Name;
         var activityDescription = activity.GetDescription()?.Trim();
         var displaySettings = ActivityDisplaySettingsRegistry.GetSettings(activityType);
 
-        Label = activityDisplayText;
+        Label = ActivityLabelResolver.Resolve(activity.GetDisplayText(), activity.GetName(), descriptor.DisplayName ?? descriptor.Name);
         Description = !string.IsNullOrEmpty(activityDescription) ? activityDescription : descriptor.Description ?? string.Empty;
         ShowDescription = activity.GetShowDescription() == true;
         Color = displaySettings.Color;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityCallStack.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityCallStack.razor
@@ -47,16 +47,14 @@
                     var activityIcon = displaySettings?.Icon;
                     var activityColor = displaySettings?.Color;
                     
-                    // UX Logic: prioritize activity name (e.g., "WriteLine1") for visual correlation with designer
-                    // Fall back to custom display name, then to activity type for uniqueness
+                    // UX Logic: prioritize the custom display text the user entered for the activity, to correlate to what the designer shows on the node.
+                    // Fall back to the activity name (e.g., "WriteLine1"), then to the activity type for uniqueness.
                     var designerActivityName = GetActivityName?.Invoke(record.ActivityId);
                     var customDisplayName = GetCustomActivityName?.Invoke(record.ActivityId);
                     var typeName = entry.ActivityDescriptor?.DisplayName ?? record.ActivityType;
                     
-                    // Hierarchy: Activity Name > Custom Display Name > Activity Type
-                    var displayName = !string.IsNullOrWhiteSpace(designerActivityName) 
-                        ? designerActivityName 
-                        : (!string.IsNullOrWhiteSpace(customDisplayName) ? customDisplayName : typeName);
+                    // Hierarchy: Custom Display Text > Activity Name > Activity Type
+                    var displayName = ActivityLabelResolver.Resolve(customDisplayName, designerActivityName, typeName);
                     
                     var isSelected = SelectedEntry != null && record.Id == SelectedEntry.Record.Id;
                     var durationText = entry.Duration.HasValue ? entry.Duration.Value.ToString("hh\\:mm\\:ss\\.fff") : "-";

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/Journal.razor
@@ -44,16 +44,14 @@
                 var activityIcon = displaySettings?.Icon;
                 var timeMetric = context.TimeMetric;
                 
-                // UX Logic: prioritize activity name (e.g., "WriteLine1") for visual correlation with designer
-                // Fall back to custom display name, then to technical name for uniqueness
+                // UX Logic: prioritize the custom display text the user entered for the activity, to correlate to what the designer shows on the node.
+                // Fall back to the activity name (e.g., "WriteLine1"), then to the activity type for uniqueness.
                 var designerActivityName = GetActivityName?.Invoke(record.ActivityId);
                 var customDisplayName = GetCustomActivityName?.Invoke(record.ActivityId);
                 var typeName = activityDescriptor?.DisplayName ?? record.ActivityType;
                 
-                // Hierarchy: Activity Name > Custom Display Name > Activity Type
-                var displayName = !string.IsNullOrWhiteSpace(designerActivityName) 
-                    ? designerActivityName 
-                    : (!string.IsNullOrWhiteSpace(customDisplayName) ? customDisplayName : typeName);
+                // Hierarchy: Custom Display Text > Activity Name > Activity Type
+                var displayName = ActivityLabelResolver.Resolve(customDisplayName, designerActivityName, typeName);
                 
                 var bgClass = SelectedEntry != null && journalEntry.Record.Id == SelectedEntry.Record.Id ? "gray lighten-3 rounded" : "";
                 var statusColor =

--- a/src/modules/Elsa.Studio.Workflows/_Imports.razor
+++ b/src/modules/Elsa.Studio.Workflows/_Imports.razor
@@ -15,6 +15,7 @@
 @using Elsa.Studio.Workflows.Components.WorkflowInstanceList
 @using Elsa.Studio.Workflows.Constants
 @using Elsa.Studio.Workflows.Designer.Components
+@using Elsa.Studio.Workflows.Helpers
 @using Elsa.Studio.Workflows.Shared.Components
 @using Elsa.Studio.Localization.Time.Components
 @using Humanizer


### PR DESCRIPTION
Fixes #909 

## Purpose
Prioritize custom display text in activity labels, over activity name.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem
A previous commit (691d373b) made the node label prefer an activity's auto-generated name over the display text entered in the Common tab, and gave the new journal and call stack the same order so they'd correlate with the designer.

### Solution
Put display text first in all three, with the name as the fallback ahead of the type name, so they remain consistent. The hierarchy now lives in the shared ActivityLabelResolver helper.

---

## Verification

Steps:
1. Create a workflow definition
2. In the definition, assign a custom display text for one or more activities.
3. Run the definition

Expected outcome:
1. In the instance Viewer (and also in the Journal), observe how the activity label references the display text instead of the activity Name
2. For activities that have no display text set, the activity Name will still show up in the Viewer & Journal

---

Screenshots:
<img width="1149" height="396" alt="image" src="https://github.com/user-attachments/assets/2d0d575c-1729-4da7-84ea-fd98506e2d24" />
<img width="1165" height="473" alt="image" src="https://github.com/user-attachments/assets/a7ae9525-e73c-42ee-a829-a071b03da2bf" />

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass

---