### PR TITLE
Redesign StateMachine transition authoring

### DIFF
--- a/specs/005-state-machine-designer/quickstart.md
+++ b/specs/005-state-machine-designer/quickstart.md
@@ -2,64 +2,65 @@
 
 ## Prerequisites
 
-- Use the Studio worktree branch `005-state-machine-designer`.
-- Use a backend build that includes elsa-core issue #5085 / PR #7457 StateMachine activity support.
-- Confirm Studio's activity registry receives a descriptor for `Elsa.StateMachine`.
+- Run Studio from the `release/3.8.0` line with a 3.8 backend that advertises `Elsa.StateMachine`.
+- Confirm the activity library is available. Transition activity selection uses the same backend activity descriptors as the rest of Studio.
 
-## Scenario 1: Inspect an Existing StateMachine
+## Create a state machine
 
-1. Start the Studio sample host.
-2. Connect it to a backend that advertises `Elsa.StateMachine`.
-3. Open a workflow definition containing a StateMachine with at least three states and two transitions.
-4. Select or drill into the StateMachine activity from the workflow editor.
-5. Verify a dedicated State Machine designer opens.
-6. Verify each state appears once and each transition route card identifies its source and target.
-7. Verify terminal states are visually identifiable.
-8. Use zoom-to-fit and center controls.
-9. Return to the root Flowchart and verify normal Flowchart selection, drag/drop, and zoom behavior still works.
+1. Open **Workflows → Definitions** and select **Create workflow**.
+2. Choose **State machine**, give the workflow a name, and select **OK**.
+3. Use **Add** to create states and transitions.
+4. Set the initial state and select a transition route to open its inspector.
 
-## Scenario 2: Edit Graph Shape
+The transition inspector reads top to bottom as the runtime executes it:
 
-1. Open a workflow with an empty or small StateMachine.
-2. Add two states named `NewOrder` and `Paid`.
-3. Set `NewOrder` as the initial state.
-4. Add a transition from `NewOrder` to `Paid`.
-5. Save and reload the workflow definition.
-6. Verify `states`, `transitions`, `initialState`, and nested slot payloads remain intact.
+1. **WHEN** — the optional Trigger activity. With no Trigger, the transition is evaluated immediately after source Entry.
+2. **ONLY IF** — the optional Boolean Condition. With no Condition, the transition is always eligible.
+3. **THEN** — the optional Action activity, run after source Exit.
+4. **TO** — the target state.
 
-## Scenario 3: Edit Transition Slots
+## Configure Trigger and Action activities
 
-1. Select a transition route card.
-2. Set the transition display name.
-3. Drag an activity from the existing activity picker onto the trigger slot, or paste a valid trigger activity JSON payload.
-4. Edit the condition JSON payload.
-5. Drag an activity from the existing activity picker onto the action slot, or paste a valid action activity JSON payload.
-6. Save and reload the workflow definition.
-7. Verify the trigger, condition, and action remain attached to the same transition.
+1. Select **Add trigger** or **Add action**.
+2. Search the activity library by display name, type, category, or description, then choose an activity.
+3. Configure the selected activity with the normal activity property editor.
+4. Use **Open** to edit the configured activity, **Replace** to choose another activity, or **Clear** to remove it.
 
-## Scenario 4: Validate Broken References
+Replacing is transactional: canceling the picker leaves the original activity unchanged. Dragging an activity from the activity library onto an empty or configured slot follows the same add/replace path. A transition slot contains one activity. For multiple Action steps, choose the promoted **Sequence** option and select **Open** to edit its children in the regular Sequence designer.
 
-1. Load a StateMachine with a transition pointing to a missing state.
-2. Verify the graph still renders partial content.
-3. Verify Studio shows a blocking validation issue for the broken reference.
-4. Fix the target state or remove the transition.
-5. Verify the validation issue clears before save.
+Unavailable or malformed activity definitions remain visible and are preserved until they are explicitly replaced or cleared. Read-only workflows keep **Open** for inspectable activities but suppress mutation controls and ignore drops.
 
-## Scenario 5: Edit State Slots
+## Configure a Condition
 
-1. Select a state node.
-2. Drag an activity from the existing activity picker onto the entry slot.
-3. Drag an activity from the existing activity picker onto the exit slot.
-4. Save and reload the workflow definition.
-5. Verify the entry and exit payloads remain attached to the same state.
+1. Select **Edit** in **ONLY IF**. The wide condition workspace opens without changing the saved definition.
+2. Choose one mode:
+   - **Always** removes the Condition slot, so the runtime treats it as true.
+   - **Never** stores an explicit false condition.
+   - **Expression** stores a Boolean expression using an available provider such as JavaScript, Python, or Liquid.
+   - **Custom JSON** is the advanced escape hatch for definitions that do not map to a known provider.
+3. Select **Apply** to commit the change, or **Cancel** to preserve the original value byte-for-byte at its owning node.
 
-## Lightweight Validation Commands
+An existing explicit true expression is not silently normalized to a missing Condition. Switching away from an unknown or lossy representation shows a replacement warning. Invalid custom JSON disables **Apply** and leaves the original source intact.
+
+## Save, reload, and inspect
+
+1. Save the workflow and reload the definition.
+2. Verify each state and transition route is present once.
+3. Reopen each transition and verify Trigger, Condition, Action, and destination summaries.
+4. Open a Sequence Action and verify its nested children remain attached to the same transition slot.
+5. Open the workflow read-only and verify activity inspection remains available while Add, Replace, Clear, Edit, Delete, and drop mutation are unavailable.
+
+## Broken and unavailable definitions
+
+- A missing state reference is a blocking validation issue. Repair the target or remove the transition before export/publish.
+- Unknown providers, unavailable activities, unknown properties, and malformed source text are preserved on a no-op save.
+- Status is communicated in text (for example **Always**, **Never**, **Unavailable**, or **Invalid**), not by color alone.
+
+## Validation commands
 
 ```bash
-dotnet build src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
-dotnet build src/modules/Elsa.Studio.Workflows/Elsa.Studio.Workflows.csproj
-dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
-dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
+dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --no-restore
+dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj --no-restore
 ```
 
-The test command applies after the mapper test project exists.
+The Workflows suite validates the inspector, picker, condition workspace, read-only behavior, and slot ownership. The Designer suite validates mapper/session preservation and runs on .NET 8, 9, and 10.

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineEditorSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineEditorSessionTests.cs
@@ -143,6 +143,42 @@ public class StateMachineEditorSessionTests
     }
 
     [Fact]
+    public void SetTransitionCondition_ChangesOnlyConditionAndPreservesOtherTransitionJson()
+    {
+        var activity = CreateActivity();
+        activity["transitions"]![0]!["trigger"] = new JsonObject
+        {
+            ["id"] = "Trigger1", ["nodeId"] = "Machine1:Trigger1", ["name"] = "Event", ["type"] = "Elsa.Event", ["version"] = 1, ["opaque"] = true
+        };
+        activity["transitions"]![0]!["condition"] = new JsonObject { ["type"] = "Contoso.Condition", ["payload"] = "keep" };
+        activity["transitions"]![0]!["action"] = new JsonObject
+        {
+            ["id"] = "Action1", ["nodeId"] = "Machine1:Action1", ["name"] = "WriteLine", ["type"] = "Elsa.WriteLine", ["version"] = 1, ["text"] = "before"
+        };
+        var session = CreateSession(activity);
+        var transition = session.ProjectCanvas().Transitions.Single();
+        var before = session.Export();
+        var replacement = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "Literal", ["value"] = false }
+        };
+
+        session.SetTransitionSlot(transition.VisualId, StateMachineTransitionSlot.Condition, replacement);
+        replacement["expression"]!["value"] = true;
+
+        var after = session.Export();
+        var beforeTransition = before["transitions"]![0]!.AsObject();
+        var afterTransition = after["transitions"]![0]!.AsObject();
+        Assert.True(JsonNode.DeepEquals(before["unknownRoot"], after["unknownRoot"]));
+        Assert.True(JsonNode.DeepEquals(before["states"], after["states"]));
+        Assert.True(JsonNode.DeepEquals(beforeTransition["trigger"], afterTransition["trigger"]));
+        Assert.True(JsonNode.DeepEquals(beforeTransition["action"], afterTransition["action"]));
+        Assert.Equal("transition-value", afterTransition["unknownTransition"]!.GetValue<string>());
+        Assert.False(afterTransition["condition"]!["expression"]!["value"]!.GetValue<bool>());
+    }
+
+    [Fact]
     public void AddState_AfterDeletion_DoesNotReuseAnOccupiedDefaultPosition()
     {
         var session = CreateSession(CreateActivity());

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineMapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineMapperTests.cs
@@ -62,6 +62,20 @@ public class StateMachineMapperTests
         Assert.Null(activity["transitions"]![0]!["condition"]);
     }
 
+    [Theory]
+    [InlineData("{\"type\":\"Contoso.Condition\",\"payload\":{\"opaque\":true}}")]
+    [InlineData("{\"$invalidJson\":\"Elsa.Studio.Workflows.StateMachineDesigner.InvalidJsonSlot\",\"source\":\"{ broken\"}")]
+    public void Map_PreservesUnknownOrMalformedConditionOnNoOpRoundTrip(string conditionJson)
+    {
+        var source = CreateActivity();
+        source["transitions"]![0]!["condition"] = JsonNode.Parse(conditionJson);
+
+        var graph = _mapper.Map(source);
+        var activity = _mapper.Map(graph);
+
+        Assert.True(JsonNode.DeepEquals(source["transitions"]![0]!["condition"], activity["transitions"]![0]!["condition"]));
+    }
+
     [Fact]
     public void Map_RemovesBlankOptionalStateProperties()
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
@@ -1,8 +1,12 @@
 using System.Text.Json.Nodes;
+using System.Reflection;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Studio.Workflows.DiagramDesigners;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Services;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines;
+using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contexts;
@@ -88,6 +92,224 @@ public class StateMachineDesignerWrapperTests
         await (Task)method.Invoke(wrapper, [])!;
 
         Assert.False(graphUpdated);
+    }
+
+    [Fact]
+    public void CreateSlotActivity_AssignsStableIdentityForASequence()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var session = CreateSession(root);
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetPrivateField(wrapper, "_session", session);
+        SetPrivateField(wrapper, "_selectedTransitionId", session.ProjectCanvas().Transitions.Single().VisualId);
+        SetPrivateField(wrapper, "IdentityGenerator", new FixedIdentityGenerator("Sequence2"));
+        SetPrivateField(wrapper, "ActivityNameGenerator", new FixedActivityNameGenerator("Sequence2"));
+
+        var descriptor = new ActivityDescriptor
+        {
+            Name = "Sequence",
+            TypeName = "Elsa.Sequence",
+            Version = 1,
+            IsBrowsable = true
+        };
+        var sequence = (JsonObject)InvokePrivate(wrapper, "CreateSlotActivity", descriptor)!;
+
+        Assert.Equal("Sequence2", sequence.GetId());
+        Assert.Equal("Workflow1:Machine1:Sequence2", sequence.GetNodeId());
+        Assert.Equal("Elsa.Sequence", sequence.GetTypeName());
+        Assert.Equal(1, sequence.GetVersion());
+    }
+
+    [Fact]
+    public async Task OpenTransitionSequence_UsesDoubleClickNavigationEvenWhenReadOnly()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var session = CreateSession(root);
+        var transitionId = session.ProjectCanvas().Transitions.Single().VisualId;
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.IsReadOnly), true);
+        SetPrivateField(wrapper, "_session", session);
+        SetPrivateField(wrapper, "_selectedTransitionId", transitionId);
+        JsonObject? opened = null;
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.ActivityDoubleClick),
+            EventCallback.Factory.Create<JsonObject>(new object(), (JsonObject activity) => opened = activity));
+
+        await InvokePrivateAsync(wrapper, "OpenTransitionActivityAsync", "action");
+
+        Assert.NotNull(opened);
+        Assert.Equal("Elsa.Sequence", opened!.GetTypeName());
+        Assert.Equal("Sequence1", opened.GetId());
+    }
+
+    [Fact]
+    public async Task SelectActivityAsync_SelectsNestedSequenceChildInTheOwningAction()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var session = CreateSession(root);
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetPrivateField(wrapper, "_session", session);
+        JsonObject? selected = null;
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.ActivitySelected),
+            EventCallback.Factory.Create<JsonObject>(new object(), (JsonObject activity) => selected = activity));
+
+        await wrapper.SelectActivityAsync("Grandchild1");
+
+        Assert.NotNull(selected);
+        Assert.Equal("Grandchild1", selected!.GetId());
+        Assert.Equal("WriteLine2", selected.GetName());
+    }
+
+    [Fact]
+    public void NestedSequenceChild_IsFoundAndUpdatedThroughItsOwningTransitionSlot()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var session = CreateSession(root);
+        var transitionId = session.ProjectCanvas().Transitions.Single().VisualId;
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetPrivateField(wrapper, "_session", session);
+        SetPrivateField(wrapper, "_selectedTransitionId", transitionId);
+
+        var arguments = new object?[] { "Grandchild1", null, null, null, null };
+        var found = (bool)InvokePrivate(wrapper, "TryFindSlotActivity", arguments)!;
+
+        Assert.True(found);
+        Assert.Equal("action", arguments[4]);
+        Assert.Equal("Grandchild1", ((JsonObject)arguments[1]!).GetId());
+        Assert.NotNull(arguments[3]);
+
+        var replacement = new JsonObject
+        {
+            ["id"] = "Grandchild1",
+            ["nodeId"] = "Workflow1:Machine1:Sequence1:NestedSequence1:Grandchild1",
+            ["name"] = "UpdatedGrandchild",
+            ["type"] = "Elsa.WriteLine",
+            ["version"] = 1,
+            ["text"] = "updated"
+        };
+        var updated = (bool)InvokePrivate(wrapper, "TryUpdateSlotActivity", "Grandchild1", replacement)!;
+
+        Assert.True(updated);
+        var transition = session.Graph.Transitions.Single();
+        var action = (JsonObject)transition.Action!;
+        Assert.Equal("Sequence1", action.GetId());
+        Assert.Equal("NestedSequence1", action["activities"]![1]!["id"]!.GetValue<string>());
+        Assert.Equal("UpdatedGrandchild", action["activities"]![1]!["activities"]![0]!["name"]!.GetValue<string>());
+        Assert.Equal("Elsa.Event", ((JsonObject)transition.Trigger!).GetTypeName());
+
+        var reloaded = CreateSession(session.Export());
+        var reloadedAction = (JsonObject)reloaded.Graph.Transitions.Single().Action!;
+        Assert.Equal("Sequence1", reloadedAction.GetId());
+        Assert.Equal("Workflow1:Machine1:Sequence1", reloadedAction.GetNodeId());
+        Assert.Equal("NestedSequence1", reloadedAction["activities"]![1]!["id"]!.GetValue<string>());
+        Assert.Equal("Workflow1:Machine1:Sequence1:NestedSequence1", reloadedAction["activities"]![1]!["nodeId"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ReadOnlyUpdateActivity_RejectsNestedSequenceMutation()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var session = CreateSession(root);
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.IsReadOnly), true);
+        SetPrivateField(wrapper, "_session", session);
+
+        var replacement = new JsonObject
+        {
+            ["id"] = "Grandchild1",
+            ["nodeId"] = "Workflow1:Machine1:Sequence1:NestedSequence1:Grandchild1",
+            ["name"] = "ShouldNotApply",
+            ["type"] = "Elsa.WriteLine",
+            ["version"] = 1
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => wrapper.UpdateActivityAsync("Grandchild1", replacement));
+        Assert.Equal("Grandchild1", session.Graph.Transitions.Single().Action!["activities"]![1]!["activities"]![0]!["id"]!.GetValue<string>());
+    }
+
+    private static StateMachineEditorSession CreateSession(JsonObject activity)
+    {
+        var validator = new StateMachineValidator();
+        return new(new StateMachineMapper(validator), validator, activity);
+    }
+
+    private static JsonObject CreateNestedSequenceStateMachine() => JsonNode.Parse("""
+    {
+      "id": "Machine1",
+      "nodeId": "Workflow1:Machine1",
+      "type": "Elsa.StateMachine",
+      "initialState": "Pending",
+      "currentState": "Pending",
+      "states": [
+        { "name": "Pending" },
+        { "name": "Approved" }
+      ],
+      "transitions": [
+        {
+          "name": "Approve",
+          "from": "Pending",
+          "to": "Approved",
+          "trigger": { "id": "Trigger1", "nodeId": "Workflow1:Trigger1", "name": "Event1", "type": "Elsa.Event", "version": 1 },
+          "action": {
+            "id": "Sequence1",
+            "nodeId": "Workflow1:Machine1:Sequence1",
+            "name": "Sequence1",
+            "type": "Elsa.Sequence",
+            "version": 1,
+            "activities": [
+              { "id": "Child1", "nodeId": "Workflow1:Machine1:Sequence1:Child1", "name": "WriteLine1", "type": "Elsa.WriteLine", "version": 1 },
+              {
+                "id": "NestedSequence1",
+                "nodeId": "Workflow1:Machine1:Sequence1:NestedSequence1",
+                "name": "NestedSequence1",
+                "type": "Elsa.Sequence",
+                "version": 1,
+                "activities": [
+                  { "id": "Grandchild1", "nodeId": "Workflow1:Machine1:Sequence1:NestedSequence1:Grandchild1", "name": "WriteLine2", "type": "Elsa.WriteLine", "version": 1 }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+    """)!.AsObject();
+
+    private static object? InvokePrivate(object target, string methodName, params object?[] arguments) =>
+        target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(target, arguments);
+
+    private static async Task InvokePrivateAsync(object target, string methodName, params object?[] arguments) =>
+        await (Task)InvokePrivate(target, methodName, arguments)!;
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                    ?? target.GetType().GetField($"<{fieldName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (field != null)
+        {
+            field.SetValue(target, value);
+            return;
+        }
+
+        target.GetType().GetProperty(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(target, value);
+    }
+
+    private static void SetComponentParameter<T>(StateMachineDesignerWrapper wrapper, string propertyName, T value) =>
+        typeof(StateMachineDesignerWrapper).GetProperty(propertyName)!.SetValue(wrapper, value);
+
+    private sealed class FixedIdentityGenerator(string id) : IIdentityGenerator
+    {
+        public string GenerateId() => id;
+    }
+
+    private sealed class FixedActivityNameGenerator(string name) : IActivityNameGenerator
+    {
+        public bool GetNameExists(IEnumerable<JsonObject> activities, string name) => activities.Any(x => x.GetName() == name);
+        public string GenerateNextName(IEnumerable<JsonObject> activities, ActivityDescriptor activityDescriptor) => name;
     }
 
     private class ThrowingDiagramDesigner : IDiagramDesigner

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionAdapterTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionAdapterTests.cs
@@ -1,0 +1,239 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Designer;
+using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.StateMachines;
+
+public sealed class BooleanConditionAdapterTests
+{
+    private static readonly ISet<string> KnownProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "JavaScript"
+    };
+
+    [Fact]
+    public void Inspect_ClassifiesMissingConditionAsMissing()
+    {
+        var result = BooleanConditionAdapter.Inspect(null, KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Missing, result.Kind);
+        Assert.Null(result.LiteralValue);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Inspect_ClassifiesScalarBoolean(bool value)
+    {
+        var result = BooleanConditionAdapter.Inspect(JsonValue.Create(value), KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Literal, result.Kind);
+        Assert.Equal(value, result.LiteralValue);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Inspect_ClassifiesWrappedLiteralBoolean(bool value)
+    {
+        var input = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject
+            {
+                ["type"] = "Literal",
+                ["value"] = value
+            }
+        };
+
+        var result = BooleanConditionAdapter.Inspect(input, KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Literal, result.Kind);
+        Assert.Equal(value, result.LiteralValue);
+    }
+
+    [Fact]
+    public void Inspect_ClassifiesKnownProviderExpression()
+    {
+        var input = JsonNode.Parse("""
+            {
+              "typeName": "Boolean",
+              "expression": { "type": "JavaScript", "value": "order.Total > 0" }
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.Inspect(input, KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Expression, result.Kind);
+        Assert.Equal("JavaScript", result.ExpressionType);
+        Assert.Equal("order.Total > 0", result.ExpressionValue);
+    }
+
+    [Fact]
+    public void Inspect_ClassifiesUnavailableProviderAsUnknown()
+    {
+        var input = JsonNode.Parse("""
+            {
+              "typeName": "Boolean",
+              "expression": { "type": "Liquid", "value": "order.total > 0" }
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.Inspect(input, KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Unknown, result.Kind);
+        Assert.Equal("Liquid", result.ExpressionType);
+        Assert.Equal("order.total > 0", result.ExpressionValue);
+    }
+
+    [Theory]
+    [InlineData("{\"typeName\":\"Boolean\"}")]
+    [InlineData("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"Literal\"}}")]
+    [InlineData("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"Literal\",\"value\":1}}")]
+    [InlineData("{\"typeName\":\"String\",\"expression\":{\"type\":\"JavaScript\",\"value\":\"true\"}}")]
+    [InlineData("[true]")]
+    [InlineData("\"true\"")]
+    public void Inspect_ClassifiesMalformedCondition(string source)
+    {
+        var result = BooleanConditionAdapter.Inspect(JsonNode.Parse(source), KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void Inspect_ClassifiesInvalidJsonSlotMarkerAsMalformed()
+    {
+        var marker = new JsonObject
+        {
+            [StateMachineDesignerConstants.InvalidJsonSlotProperty] = StateMachineDesignerConstants.InvalidJsonSlotMarkerValue,
+            [StateMachineDesignerConstants.InvalidJsonSlotSourceProperty] = "{ broken"
+        };
+
+        var result = BooleanConditionAdapter.Inspect(marker, KnownProviders);
+
+        Assert.Equal(BooleanConditionKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void SetLiteral_EmitsCanonicalBooleanInputWithoutMutatingSource()
+    {
+        var source = JsonNode.Parse("""
+            {
+              "typeName": "Boolean",
+              "expression": { "type": "JavaScript", "value": "order.Total > 0" },
+              "custom": { "keep": true }
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.SetLiteral(source, true);
+
+        Assert.NotSame(source, result);
+        Assert.Equal("Boolean", result!["typeName"]!.GetValue<string>());
+        Assert.Equal("Literal", result["expression"]!["type"]!.GetValue<string>());
+        Assert.True(result["expression"]!["value"]!.GetValue<bool>());
+        Assert.True(result["custom"]!["keep"]!.GetValue<bool>());
+        Assert.Equal("JavaScript", source["expression"]!["type"]!.GetValue<string>());
+        Assert.NotNull(source["custom"]);
+    }
+
+    [Fact]
+    public void SetLiteral_PreservesOriginalReferenceWhenValueIsAlreadyTheSame()
+    {
+        var source = JsonNode.Parse("""
+            {
+              "typeName": "Boolean",
+              "expression": { "type": "Literal", "value": true },
+              "custom": "preserve"
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.SetLiteral(source, true);
+
+        Assert.Same(source, result);
+        Assert.Equal("preserve", result["custom"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SetExpression_EmitsCanonicalBooleanInputAndPreservesNoOpReference()
+    {
+        var source = JsonNode.Parse("""
+            {
+              "typeName": "Boolean",
+              "expression": { "type": "JavaScript", "value": "order.Total > 0" },
+              "custom": "preserve"
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.SetExpression(source, "JavaScript", "order.Total > 0");
+
+        Assert.Same(source, result);
+
+        var changed = BooleanConditionAdapter.SetExpression(source, "JavaScript", "order.Total >= 0");
+
+        Assert.NotSame(source, changed);
+        Assert.Equal("Boolean", changed!["typeName"]!.GetValue<string>());
+        Assert.Equal("JavaScript", changed["expression"]!["type"]!.GetValue<string>());
+        Assert.Equal("order.Total >= 0", changed["expression"]!["value"]!.GetValue<string>());
+        Assert.Equal("preserve", changed["custom"]!.GetValue<string>());
+        Assert.Equal("order.Total > 0", source["expression"]!["value"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ExplicitEdit_RemovesShorthandSemanticPropertiesButPreservesMetadata()
+    {
+        var source = JsonNode.Parse("""
+            {
+              "type": "JavaScript",
+              "value": "order.Total > 0",
+              "custom": "preserve"
+            }
+            """)!;
+
+        var result = BooleanConditionAdapter.SetLiteral(source, false);
+
+        Assert.Null(result!["type"]);
+        Assert.Null(result["value"]);
+        Assert.Null(result["literal"]);
+        Assert.Equal("preserve", result["custom"]!.GetValue<string>());
+        Assert.Equal("Boolean", result["typeName"]!.GetValue<string>());
+        Assert.False(result["expression"]!["value"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void TrySetAdvanced_PreservesOriginalReferenceForEquivalentJson()
+    {
+        var source = JsonNode.Parse("{ \"typeName\": \"Boolean\", \"expression\": { \"type\": \"Literal\", \"value\": true } }")!;
+
+        var result = BooleanConditionAdapter.TrySetAdvanced(source, "{\"expression\":{\"value\":true,\"type\":\"Literal\"},\"typeName\":\"Boolean\"}");
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Error);
+        Assert.Same(source, result.Value);
+    }
+
+    [Fact]
+    public void TrySetAdvanced_ReturnsOriginalAndErrorForInvalidJson()
+    {
+        var source = JsonNode.Parse("{ \"typeName\": \"Boolean\", \"expression\": { \"type\": \"Liquid\", \"value\": \"keep-me\" } }")!;
+
+        var result = BooleanConditionAdapter.TrySetAdvanced(source, "{ invalid");
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Error);
+        Assert.Same(source, result.Value);
+        Assert.Equal("Liquid", source["expression"]!["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void TrySetAdvanced_ReturnsOriginalAndErrorForValidMalformedCondition()
+    {
+        var source = JsonNode.Parse("{ \"typeName\": \"Boolean\", \"expression\": { \"type\": \"Liquid\", \"value\": \"keep-me\" } }")!;
+
+        var result = BooleanConditionAdapter.TrySetAdvanced(source, "{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"Literal\",\"value\":1}}");
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Error);
+        Assert.Same(source, result.Value);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionEditorDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionEditorDialogTests.cs
@@ -14,12 +14,15 @@ namespace Elsa.Studio.Workflows.Tests.StateMachines;
 
 public sealed class BooleanConditionEditorDialogTests : BunitContext, IAsyncLifetime
 {
+    private readonly ExpressionServiceStub _expressionService;
+
     public BooleanConditionEditorDialogTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
         Services.AddSingleton<ILocalizer, TestLocalizer>();
-        Services.AddSingleton<IExpressionService>(new ExpressionServiceStub());
+        _expressionService = new ExpressionServiceStub();
+        Services.AddSingleton<IExpressionService>(_expressionService);
     }
 
     Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
@@ -150,19 +153,39 @@ public sealed class BooleanConditionEditorDialogTests : BunitContext, IAsyncLife
         Assert.True((await reference.Result)?.Canceled);
     }
 
+    [Fact]
+    public async Task ProviderLoadFailure_ShowsRecoverableWarningAndKeepsCustomJsonAvailable()
+    {
+        _expressionService.ThrowOnList = true;
+        var original = JsonNode.Parse("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"Liquid\",\"value\":\"order.total > 0\"}}")!;
+
+        var (cut, reference) = await RenderDialog(original, providers: null, provideKnownProviders: false);
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='condition-editor-provider-load-warning']"));
+        Assert.Contains("Custom JSON", cut.Find("button[data-mode='custom']").TextContent);
+        Assert.Equal("custom", cut.Find("button.state-machine-condition-editor__mode--selected").GetAttribute("data-mode"));
+        var renderedSource = cut.Find("textarea[data-testid='condition-editor-custom-json']").GetAttribute("value");
+        Assert.NotNull(renderedSource);
+        Assert.True(JsonNode.DeepEquals(original, JsonNode.Parse(renderedSource!)));
+
+        cut.Find("button[data-testid='condition-editor-cancel']").Click();
+        Assert.True((await reference.Result)?.Canceled);
+    }
+
     private async Task<(IRenderedComponent<MudDialogProvider> Host, IDialogReference Reference)> RenderDialog(
         JsonNode? condition,
         bool readOnly = false,
-        IReadOnlyCollection<ExpressionDescriptor>? providers = null)
+        IReadOnlyCollection<ExpressionDescriptor>? providers = null,
+        bool provideKnownProviders = true)
     {
         var host = Render<MudDialogProvider>();
-        providers ??= [new ExpressionDescriptor("JavaScript", "JavaScript")];
         var parameters = new DialogParameters<BooleanConditionEditorDialog>
         {
             { x => x.Condition, condition },
-            { x => x.IsReadOnly, readOnly },
-            { x => x.KnownExpressionProviders, providers }
+            { x => x.IsReadOnly, readOnly }
         };
+        if (provideKnownProviders)
+            parameters.Add(x => x.KnownExpressionProviders, providers ?? [new ExpressionDescriptor("JavaScript", "JavaScript")]);
         var reference = await Services.GetRequiredService<IDialogService>().ShowAsync<BooleanConditionEditorDialog>("Edit condition", parameters);
         host.WaitForElement("[data-testid='condition-editor']");
         return (host, reference);
@@ -170,8 +193,12 @@ public sealed class BooleanConditionEditorDialogTests : BunitContext, IAsyncLife
 
     private sealed class ExpressionServiceStub : IExpressionService
     {
+        public bool ThrowOnList { get; set; }
+
         public Task<IEnumerable<ExpressionDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult<IEnumerable<ExpressionDescriptor>>([new("JavaScript", "JavaScript")]);
+            ThrowOnList
+                ? Task.FromException<IEnumerable<ExpressionDescriptor>>(new HttpRequestException("provider service unavailable"))
+                : Task.FromResult<IEnumerable<ExpressionDescriptor>>([new("JavaScript", "JavaScript")]);
 
         public Task<ExpressionDescriptor?> GetByTypeAsync(string type, CancellationToken cancellationToken = default) =>
             Task.FromResult<ExpressionDescriptor?>(new(type, type));

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionEditorDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/BooleanConditionEditorDialogTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.StateMachines;
+
+public sealed class BooleanConditionEditorDialogTests : BunitContext, IAsyncLifetime
+{
+    public BooleanConditionEditorDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IExpressionService>(new ExpressionServiceStub());
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task MissingCondition_OpensAsAlways_AndCancelDoesNotProduceAnEdit()
+    {
+        var (cut, reference) = await RenderDialog(null);
+
+        Assert.Contains("Always", cut.Find("button.state-machine-condition-editor__mode--selected").TextContent);
+        Assert.Empty(cut.FindAll("[data-testid='condition-editor-lossy-warning']"));
+
+        cut.Find("button[data-testid='condition-editor-cancel']").Click();
+        Assert.True((await reference.Result)?.Canceled);
+    }
+
+    [Fact]
+    public async Task NeverMode_ProducesCanonicalFalseCondition_OnlyOnApply()
+    {
+        var original = JsonNode.Parse("true")!;
+        var (cut, reference) = await RenderDialog(original);
+
+        Assert.Contains("Always", cut.Find("button.state-machine-condition-editor__mode--selected").TextContent);
+        cut.Find("button[data-mode='never']").Click();
+        cut.Find("button[data-testid='condition-editor-apply']").Click();
+
+        var result = Assert.IsType<BooleanConditionDialogResult>((await reference.Result)?.Data);
+        Assert.True(result.Applied);
+        Assert.False(result.Condition!["expression"]!["value"]!.GetValue<bool>());
+        Assert.Equal("Boolean", result.Condition["typeName"]!.GetValue<string>());
+        Assert.True(original.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task ExplicitTrue_IsPreservedByDefault_AndClearedOnlyByExplicitChoice()
+    {
+        var original = JsonNode.Parse("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"Literal\",\"value\":true},\"metadata\":\"keep\"}")!;
+        var (cut, reference) = await RenderDialog(original);
+
+        cut.Find("button[data-testid='condition-editor-apply']").Click();
+
+        var preserved = Assert.IsType<BooleanConditionDialogResult>((await reference.Result)?.Data);
+        Assert.Same(original, preserved.Condition);
+
+        var (clearCut, clearReference) = await RenderDialog(original);
+        clearCut.Find("input[data-testid='condition-editor-preserve-explicit-true']").Change(false);
+        Assert.NotEmpty(clearCut.FindAll("[data-testid='condition-editor-lossy-warning']"));
+        clearCut.Find("button[data-testid='condition-editor-apply']").Click();
+
+        var cleared = Assert.IsType<BooleanConditionDialogResult>((await clearReference.Result)?.Data);
+        Assert.Null(cleared.Condition);
+        Assert.Equal("keep", original["metadata"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InvalidCustomJson_DisablesApply_AndPreservesOriginal()
+    {
+        var original = JsonNode.Parse("{\"type\":\"Unknown\",\"value\":\"opaque\"}")!;
+        var (cut, reference) = await RenderDialog(original);
+
+        Assert.Contains("opaque", cut.Find("textarea[data-testid='condition-editor-custom-json']").GetAttribute("value"));
+        cut.Find("textarea[data-testid='condition-editor-custom-json']").Input("{ broken");
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='condition-editor-custom-error']"));
+        Assert.True(cut.Find("button[data-testid='condition-editor-apply']").HasAttribute("disabled"));
+        Assert.False(reference.Result.IsCompleted);
+        Assert.Equal("opaque", original["value"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task SwitchingAwayFromProvider_ShowsLossyWarning_AndApplyAlwaysClearsCondition()
+    {
+        var original = JsonNode.Parse("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"JavaScript\",\"value\":\"value > 0\"}}")!;
+        var (cut, reference) = await RenderDialog(original);
+
+        cut.Find("button[data-mode='always']").Click();
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='condition-editor-lossy-warning']"));
+        cut.Find("button[data-testid='condition-editor-apply']").Click();
+
+        var result = Assert.IsType<BooleanConditionDialogResult>((await reference.Result)?.Data);
+        Assert.Null(result.Condition);
+        Assert.NotNull(original["expression"]);
+    }
+
+    [Fact]
+    public async Task ProviderMode_UsesKnownProviderAndAppliesCanonicalExpression()
+    {
+        var (cut, reference) = await RenderDialog(null, providers:
+        [
+            new ExpressionDescriptor("JavaScript", "JavaScript"),
+            new ExpressionDescriptor("Liquid", "Liquid")
+        ]);
+
+        cut.Find("button[data-mode='provider']").Click();
+        cut.Find("textarea[data-testid='condition-editor-provider-expression']").Input("order.Total > 0");
+        cut.Find("button[data-testid='condition-editor-apply']").Click();
+
+        var result = Assert.IsType<BooleanConditionDialogResult>((await reference.Result)?.Data);
+        Assert.Equal("JavaScript", result.Condition!["expression"]!["type"]!.GetValue<string>());
+        Assert.Equal("order.Total > 0", result.Condition["expression"]!["value"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ChangingProviderType_ShowsLossyWarning()
+    {
+        var original = JsonNode.Parse("{\"typeName\":\"Boolean\",\"expression\":{\"type\":\"JavaScript\",\"value\":\"value > 0\"}}")!;
+        var (cut, _) = await RenderDialog(original, providers:
+        [
+            new ExpressionDescriptor("JavaScript", "JavaScript"),
+            new ExpressionDescriptor("Liquid", "Liquid")
+        ]);
+
+        cut.Find("select[data-testid='condition-editor-provider']").Change("Liquid");
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='condition-editor-lossy-warning']"));
+    }
+
+    [Fact]
+    public async Task ReadOnlyCondition_DisablesEditingControls()
+    {
+        var (cut, reference) = await RenderDialog(JsonValue.Create(false), true);
+
+        Assert.All(cut.FindAll("button[role='tab']"), button => Assert.True(button.HasAttribute("disabled")));
+        Assert.True(cut.Find("button[data-testid='condition-editor-apply']").HasAttribute("disabled"));
+        cut.Find("button[data-testid='condition-editor-cancel']").Click();
+        Assert.True((await reference.Result)?.Canceled);
+    }
+
+    private async Task<(IRenderedComponent<MudDialogProvider> Host, IDialogReference Reference)> RenderDialog(
+        JsonNode? condition,
+        bool readOnly = false,
+        IReadOnlyCollection<ExpressionDescriptor>? providers = null)
+    {
+        var host = Render<MudDialogProvider>();
+        providers ??= [new ExpressionDescriptor("JavaScript", "JavaScript")];
+        var parameters = new DialogParameters<BooleanConditionEditorDialog>
+        {
+            { x => x.Condition, condition },
+            { x => x.IsReadOnly, readOnly },
+            { x => x.KnownExpressionProviders, providers }
+        };
+        var reference = await Services.GetRequiredService<IDialogService>().ShowAsync<BooleanConditionEditorDialog>("Edit condition", parameters);
+        host.WaitForElement("[data-testid='condition-editor']");
+        return (host, reference);
+    }
+
+    private sealed class ExpressionServiceStub : IExpressionService
+    {
+        public Task<IEnumerable<ExpressionDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<ExpressionDescriptor>>([new("JavaScript", "JavaScript")]);
+
+        public Task<ExpressionDescriptor?> GetByTypeAsync(string type, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ExpressionDescriptor?>(new(type, type));
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -40,7 +40,16 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         TypeName = "Elsa.Sequence",
         Category = "Composition",
         Description = "Runs a sequence of activities.",
-        IsBrowsable = true
+        IsBrowsable = false
+    };
+
+    private readonly ActivityDescriptor _internalActivity = new()
+    {
+        Name = "InternalActivity",
+        DisplayName = "Internal activity",
+        TypeName = "Elsa.InternalActivity",
+        Category = "Internal",
+        IsBrowsable = false
     };
 
     private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
@@ -50,7 +59,7 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
         Services.AddSingleton<ILocalizer, TestLocalizer>();
-        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence]));
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence, _internalActivity]));
         Render<MudPopoverProvider>();
         _dialogProvider = Render<MudDialogProvider>();
     }
@@ -64,6 +73,7 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         var dialog = await ShowDialogAsync();
 
         _dialogProvider.WaitForAssertion(() => Assert.Equal(3, _dialogProvider.FindAll("[data-activity-type]").Count));
+        Assert.DoesNotContain(_dialogProvider.FindAll("[data-activity-type]"), element => element.GetAttribute("data-activity-type") == _internalActivity.TypeName);
         var search = _dialogProvider.Find("input[id*='state-machine-activity-picker']");
 
         search.Input("incoming");

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -1,0 +1,136 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests.StateMachines;
+
+public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsyncLifetime
+{
+    private readonly ActivityDescriptor _writeLine = new()
+    {
+        Name = "WriteLine",
+        DisplayName = "Write line",
+        TypeName = "Elsa.WriteLine",
+        Category = "Primitives",
+        Description = "Writes text to the log.",
+        IsBrowsable = true
+    };
+
+    private readonly ActivityDescriptor _http = new()
+    {
+        Name = "HttpEndpoint",
+        DisplayName = "HTTP endpoint",
+        TypeName = "Elsa.HttpEndpoint",
+        Category = "HTTP",
+        Description = "Waits for an incoming HTTP request.",
+        IsBrowsable = true
+    };
+
+    private readonly ActivityDescriptor _sequence = new()
+    {
+        Name = "Sequence",
+        DisplayName = "Sequence",
+        TypeName = "Elsa.Sequence",
+        Category = "Composition",
+        Description = "Runs a sequence of activities.",
+        IsBrowsable = true
+    };
+
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public StateMachineActivityPickerDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence]));
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task Picker_LoadsBrowsableActivitiesAndFiltersEverySearchField()
+    {
+        var dialog = await ShowDialogAsync();
+
+        _dialogProvider.WaitForAssertion(() => Assert.Equal(3, _dialogProvider.FindAll("[data-activity-type]").Count));
+        var search = _dialogProvider.Find("input[id*='state-machine-activity-picker']");
+
+        search.Input("incoming");
+        Assert.Single(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']"));
+        Assert.Contains("HTTP endpoint", _dialogProvider.Find("[data-testid='state-machine-activity-option']").TextContent);
+
+        search.Input("Elsa.WriteLine");
+        Assert.Single(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']"));
+        Assert.Contains("Write line", _dialogProvider.Find("[data-testid='state-machine-activity-option']").TextContent);
+
+        search.Input("Primitives");
+        Assert.Single(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']"));
+
+        search.Input("missing activity");
+        Assert.Contains("No matching activities", _dialogProvider.Markup);
+
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel").Click();
+        Assert.True((await dialog.Result)?.Canceled);
+    }
+
+    [Fact]
+    public async Task Picker_ReturnsDescriptorOnlyAfterExplicitSelection()
+    {
+        var dialog = await ShowDialogAsync();
+
+        Assert.False(dialog.Result.IsCompleted);
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.Find("[data-testid='state-machine-activity-option'][data-activity-type='Elsa.WriteLine']").Click();
+
+        var result = await dialog.Result;
+        Assert.False(result?.Canceled);
+        Assert.Same(_writeLine, result?.Data);
+    }
+
+    [Fact]
+    public async Task Picker_OffersSequenceAsTheProminentMultiActivityShortcut()
+    {
+        var dialog = await ShowDialogAsync();
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-picker-sequence']")));
+        _dialogProvider.Find("[data-testid='state-machine-activity-picker-sequence']").Click();
+
+        var result = await dialog.Result;
+        Assert.Same(_sequence, result?.Data);
+    }
+
+    private async Task<IDialogReference> ShowDialogAsync()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        return await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<StateMachineActivityPickerDialog>("Add action"));
+    }
+
+    private sealed class ActivityRegistryStub(IEnumerable<ActivityDescriptor> activities) : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => activities;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => activities.FirstOrDefault(x => x.TypeName == activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => activities.Where(x => x.TypeName == activityType);
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineCanvasLifecycleContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineCanvasLifecycleContractTests.cs
@@ -40,6 +40,18 @@ public sealed class StateMachineCanvasLifecycleContractTests
         Assert.Contains("public Task AutoLayoutAsync() => IsReadOnly", canvas, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TransitionInspector_UsesSemanticPickerCallbacksAndExcludesConditionFromActivityDrops()
+    {
+        var wrapper = ReadAsset("StateMachineDesignerWrapper.razor");
+
+        Assert.Contains("ActivityAddRequested=\"AddTransitionActivityAsync\"", wrapper, StringComparison.Ordinal);
+        Assert.Contains("ActivityOpenRequested=\"OpenTransitionActivityAsync\"", wrapper, StringComparison.Ordinal);
+        Assert.Contains("ActivityReplaceRequested=\"ReplaceTransitionActivityAsync\"", wrapper, StringComparison.Ordinal);
+        Assert.Contains("ActivityClearRequested=\"ClearTransitionSlotAsync\"", wrapper, StringComparison.Ordinal);
+        Assert.Contains("ActivityDropRequested=\"OnTransitionSlotDropAsync\"", wrapper, StringComparison.Ordinal);
+    }
+
     private static string ReadAsset(string name) =>
         File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "DesignerAssets", name));
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -135,9 +135,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             Name = "Approve",
             From = "Pending",
             To = "Approved",
-            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+            Trigger = Activity("Elsa.Event", "Trigger1", "Workflow1:Trigger1"),
             Condition = JsonValue.Create(true),
-            Action = new JsonObject { ["type"] = "Elsa.WriteLine", ["text"] = "Approved" }
+            Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1", ("text", "Approved"))
         };
         var states = new[]
         {
@@ -254,6 +254,59 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public void TransitionInspector_PreservesCanonicalWrappedUnavailableProvider()
+    {
+        var condition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "Liquid", ["value"] = "order.total > 0" }
+        };
+        var source = condition.ToJsonString();
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = condition }));
+
+        var summary = cut.Find("[data-testid='state-machine-transition-condition-summary']");
+        Assert.Equal("unknown", summary.GetAttribute("data-condition-state"));
+        Assert.Contains("Liquid", summary.TextContent);
+        Assert.Contains("\"typeName\": \"Boolean\"", cut.Find("[data-testid='state-machine-transition-condition-definition']").TextContent);
+        Assert.Equal(source, condition.ToJsonString());
+    }
+
+    [Fact]
+    public void TransitionInspector_RecognizesProviderAdvertisedByTheBackend()
+    {
+        var condition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "Liquid", ["value"] = "order.total > 0" }
+        };
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition,
+                new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = condition })
+            .Add(component => component.KnownExpressionProviderTypes, ["JavaScript", "Liquid"]));
+
+        var summary = cut.Find("[data-testid='state-machine-transition-condition-summary']");
+        Assert.Equal("expression", summary.GetAttribute("data-condition-state"));
+        Assert.Contains("Liquid", summary.TextContent);
+    }
+
+    [Fact]
+    public void TransitionInspector_ClassifiesPartialActivityAsMalformedAndDoesNotOfferOpen()
+    {
+        var action = new JsonObject { ["type"] = "Elsa.WriteLine", ["text"] = "incomplete" };
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Action = action }));
+
+        var slot = "[data-transition-slot='action']";
+        Assert.Equal("malformed", cut.Find($"{slot} [data-activity-state]").GetAttribute("data-activity-state"));
+        Assert.Contains("incomplete", cut.Find($"{slot} [data-testid='state-machine-transition-action-definition']").TextContent);
+        Assert.Empty(cut.FindAll($"{slot} [data-slot-action='open']"));
+        Assert.NotEmpty(cut.FindAll($"{slot} [data-slot-action='replace']"));
+        Assert.NotEmpty(cut.FindAll($"{slot} [data-slot-action='clear']"));
+        Assert.Equal("Elsa.WriteLine", action["type"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void TransitionInspector_PreservesMalformedAndUnknownDefinitionsForInspection()
     {
         var transition = new StateMachineTransitionEdge
@@ -314,8 +367,8 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         {
             From = "Pending",
             To = "Approved",
-            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
-            Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+            Trigger = Activity("Elsa.Event", "Trigger1", "Workflow1:Trigger1"),
+            Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1")
         };
         var configuredCut = Render<StateMachineTransitionInspector>(parameters => parameters
             .Add(component => component.Transition, configured)
@@ -345,9 +398,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             {
                 From = "Pending",
                 To = "Approved",
-                Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+                Trigger = Activity("Elsa.Event", "Trigger1", "Workflow1:Trigger1"),
                 Condition = JsonValue.Create(false),
-                Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+                Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1")
             })
             .Add(component => component.IsReadOnly, true));
 
@@ -368,8 +421,8 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         {
             From = "Pending",
             To = "Approved",
-            Trigger = new JsonObject { ["type"] = "Elsa.Event", ["payload"] = "keep-trigger" },
-            Action = new JsonObject { ["type"] = "Elsa.WriteLine", ["payload"] = "keep-action" }
+            Trigger = Activity("Elsa.Event", "Trigger1", "Workflow1:Trigger1", ("payload", "keep-trigger")),
+            Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1", ("payload", "keep-action"))
         };
         var triggerSource = transition.Trigger.DeepClone();
         var actionSource = transition.Action.DeepClone();
@@ -398,9 +451,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         {
             From = "Pending",
             To = "Approved",
-            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+            Trigger = Activity("Elsa.Event", "Trigger1", "Workflow1:Trigger1"),
             Condition = JsonValue.Create(true),
-            Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+            Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1")
         };
         var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, transition));
 
@@ -432,6 +485,21 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         var conditionEdit = cut.Find("[data-transition-slot='condition'] [data-slot-action='edit']");
         Assert.Equal("state-machine-transition-condition-edit", conditionEdit.GetAttribute("data-testid"));
         Assert.Contains("Edit", conditionEdit.TextContent);
+    }
+
+    private static JsonObject Activity(string type, string id, string nodeId, params (string Name, string Value)[] properties)
+    {
+        var activity = new JsonObject
+        {
+            ["type"] = type,
+            ["id"] = id,
+            ["nodeId"] = nodeId
+        };
+
+        foreach (var (name, value) in properties)
+            activity[name] = value;
+
+        return activity;
     }
 
     private sealed class TestLocalizer : ILocalizer

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Bunit;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 using Microsoft.AspNetCore.Components.Web;
@@ -277,6 +278,35 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public void TransitionInspector_PreservesUnknownAndMalformedJsonDuringInspection()
+    {
+        var trigger = new JsonObject { ["type"] = "Contoso.Trigger", ["opaque"] = new JsonObject { ["value"] = 42 } };
+        var condition = new JsonObject
+        {
+            [StateMachineDesignerConstants.InvalidJsonSlotProperty] = StateMachineDesignerConstants.InvalidJsonSlotMarkerValue,
+            [StateMachineDesignerConstants.InvalidJsonSlotSourceProperty] = "{ broken"
+        };
+        var action = JsonValue.Create("legacy-action");
+        var triggerSource = trigger.DeepClone();
+        var conditionSource = condition.DeepClone();
+        var actionSource = action.DeepClone();
+        var transition = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Trigger = trigger,
+            Condition = condition,
+            Action = action
+        };
+
+        Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, transition));
+
+        Assert.True(JsonNode.DeepEquals(triggerSource, transition.Trigger));
+        Assert.True(JsonNode.DeepEquals(conditionSource, transition.Condition));
+        Assert.True(JsonNode.DeepEquals(actionSource, transition.Action));
+    }
+
+    [Fact]
     public void TransitionInspector_EmitsSemanticActivityCallbacksWithSlotNames()
     {
         var slots = new List<string>();
@@ -329,6 +359,79 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         Assert.Empty(cut.FindAll("[data-slot-action='clear']"));
         Assert.Empty(cut.FindAll("[data-slot-action='edit']"));
         Assert.All(cut.FindAll("[data-slot-action='drop']"), element => Assert.False(element.HasAttribute("ondrop")));
+    }
+
+    [Fact]
+    public void TransitionInspector_ReadOnlyModeAllowsOpenButNeverInvokesDropOrMutatesSlots()
+    {
+        var transition = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Trigger = new JsonObject { ["type"] = "Elsa.Event", ["payload"] = "keep-trigger" },
+            Action = new JsonObject { ["type"] = "Elsa.WriteLine", ["payload"] = "keep-action" }
+        };
+        var triggerSource = transition.Trigger.DeepClone();
+        var actionSource = transition.Action.DeepClone();
+        var opened = new List<string>();
+        var dropped = new List<string>();
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition, transition)
+            .Add(component => component.IsReadOnly, true)
+            .Add(component => component.ActivityOpenRequested, slot => opened.Add(slot))
+            .Add(component => component.ActivityDropRequested, slot => dropped.Add(slot)));
+
+        cut.Find("[data-transition-slot='trigger'] [data-slot-action='open']").Click();
+        cut.Find("[data-transition-slot='action'] [data-slot-action='open']").Click();
+
+        Assert.Equal(["trigger", "action"], opened);
+        Assert.Empty(dropped);
+        Assert.All(cut.FindAll("[data-slot-action='drop']"), element => Assert.False(element.HasAttribute("ondrop")));
+        Assert.True(JsonNode.DeepEquals(triggerSource, transition.Trigger));
+        Assert.True(JsonNode.DeepEquals(actionSource, transition.Action));
+    }
+
+    [Fact]
+    public void TransitionInspector_UsesKeyboardButtonsWithStableAccessibleNamesForEveryMutationAction()
+    {
+        var transition = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+            Condition = JsonValue.Create(true),
+            Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+        };
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, transition));
+
+        var actionButtons = cut.FindAll("[data-transition-slot] button");
+        Assert.NotEmpty(actionButtons);
+        Assert.All(actionButtons, button =>
+        {
+            Assert.Equal("button", button.GetAttribute("type"));
+            Assert.False(string.IsNullOrWhiteSpace(button.GetAttribute("aria-label")) && string.IsNullOrWhiteSpace(button.TextContent));
+        });
+
+        foreach (var action in new[] { "open", "replace", "clear" })
+        {
+            var triggerButton = cut.Find($"[data-transition-slot='trigger'] [data-slot-action='{action}']");
+            var activityButton = cut.Find($"[data-transition-slot='action'] [data-slot-action='{action}']");
+            Assert.False(string.IsNullOrWhiteSpace(triggerButton.GetAttribute("aria-label")));
+            Assert.False(string.IsNullOrWhiteSpace(activityButton.GetAttribute("aria-label")));
+        }
+
+        var emptyCut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved" }));
+        foreach (var slot in new[] { "trigger", "action" })
+        {
+            var addButton = emptyCut.Find($"[data-transition-slot='{slot}'] [data-slot-action='add']");
+            Assert.Equal("button", addButton.GetAttribute("type"));
+            Assert.False(string.IsNullOrWhiteSpace(addButton.GetAttribute("aria-label")));
+        }
+
+        var conditionEdit = cut.Find("[data-transition-slot='condition'] [data-slot-action='edit']");
+        Assert.Equal("state-machine-transition-condition-edit", conditionEdit.GetAttribute("data-testid"));
+        Assert.Contains("Edit", conditionEdit.TextContent);
     }
 
     private sealed class TestLocalizer : ILocalizer

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -3,6 +3,7 @@ using Bunit;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Xunit;
@@ -126,41 +127,205 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void TransitionInspector_EmitsRouteAndSlotChangesWithExplicitlyLabelledControls()
+    public void TransitionInspector_RendersExecutionStoryAndSemanticSlotSummaries()
     {
         var transition = new StateMachineTransitionEdge
         {
             Name = "Approve",
             From = "Pending",
-            To = "Approved"
+            To = "Approved",
+            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+            Condition = JsonValue.Create(true),
+            Action = new JsonObject { ["type"] = "Elsa.WriteLine", ["text"] = "Approved" }
         };
         var states = new[]
         {
             new StateMachineStateNode { Name = "Pending" },
             new StateMachineStateNode { Name = "Approved" }
         };
+        string? editedCondition = null;
         string? changedFrom = null;
         string? changedName = "not-called";
-        StateMachineSlotValueChange? changedSlot = null;
         var cut = Render<StateMachineTransitionInspector>(parameters => parameters
             .Add(component => component.Transition, transition)
             .Add(component => component.States, states)
+            .Add(component => component.ConditionEditRequested, value => editedCondition = value)
             .Add(component => component.FromChanged, value => changedFrom = value)
-            .Add(component => component.NameChanged, value => changedName = value)
-            .Add(component => component.SlotChanged, value => changedSlot = value));
+            .Add(component => component.NameChanged, value => changedName = value));
 
-        var fromSelect = cut.Find("select[id$='-from']");
-        Assert.Equal("From", cut.Find($"label[for='{fromSelect.Id}']").TextContent);
+        var markup = cut.Markup;
+        Assert.True(markup.IndexOf("WHEN", StringComparison.Ordinal) < markup.IndexOf("ONLY IF", StringComparison.Ordinal));
+        Assert.True(markup.IndexOf("ONLY IF", StringComparison.Ordinal) < markup.IndexOf("THEN", StringComparison.Ordinal));
+        Assert.True(markup.IndexOf("THEN", StringComparison.Ordinal) < markup.IndexOf("TO", StringComparison.Ordinal));
+        Assert.Equal(4, cut.FindAll("[data-transition-slot]").Count);
+        Assert.Contains("Elsa.Event", cut.Find("[data-transition-slot='trigger']").TextContent);
+        Assert.Contains("Elsa.WriteLine", cut.Find("[data-transition-slot='action']").TextContent);
+        Assert.Equal("always", cut.Find("[data-transition-slot='condition'] [data-condition-state]").GetAttribute("data-condition-state"));
+        Assert.NotEmpty(cut.FindAll("[data-slot-action='open']"));
+        Assert.NotEmpty(cut.FindAll("[data-slot-action='replace']"));
+        Assert.NotEmpty(cut.FindAll("[data-slot-action='clear']"));
 
-        fromSelect.Change("Approved");
+        cut.Find("select[id$='-from']").Change("Approved");
         cut.Find("input[id$='-name']").Change("");
-        cut.Find("textarea[id$='-condition']").Change("{\"type\":\"Boolean\"}");
+        cut.Find("[data-transition-slot='condition'] [data-slot-action='edit']").Click();
 
         Assert.Equal("Approved", changedFrom);
         Assert.Null(changedName);
-        Assert.Equal("condition", changedSlot?.SlotName);
-        Assert.Equal("{\"type\":\"Boolean\"}", changedSlot?.Value);
+        Assert.Equal("condition", editedCondition);
+        Assert.True(transition.Condition!.GetValue<bool>());
         Assert.Equal("Pending", transition.From);
+        Assert.DoesNotContain("textarea", cut.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TransitionInspector_DescribesMissingAndFalseConditionsWithoutMutatingThem()
+    {
+        var missing = new StateMachineTransitionEdge { From = "Pending", To = "Approved" };
+        var missingCut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, missing));
+
+        Assert.Contains("No trigger configured", missingCut.Find("[data-transition-slot='trigger']").TextContent);
+        Assert.Contains("evaluates immediately", missingCut.Find("[data-transition-slot='trigger']").TextContent);
+        Assert.Equal("missing", missingCut.Find("[data-transition-slot='condition'] [data-condition-state]").GetAttribute("data-condition-state"));
+        Assert.Contains("Always", missingCut.Find("[data-transition-slot='condition']").TextContent);
+        Assert.Null(missing.Condition);
+
+        var falseCondition = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Condition = JsonValue.Create(false)
+        };
+        var falseCut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, falseCondition));
+
+        var condition = falseCut.Find("[data-transition-slot='condition']");
+        Assert.Equal("never", condition.QuerySelector("[data-condition-state]")!.GetAttribute("data-condition-state"));
+        Assert.Contains("Never", condition.TextContent);
+        Assert.Contains("cannot pass", condition.TextContent);
+        Assert.False(falseCondition.Condition!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void TransitionInspector_DescribesCanonicalWrappedBooleanConditionsWithoutNormalizingThem()
+    {
+        var trueCondition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "Literal", ["value"] = true }
+        };
+        var falseCondition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "Literal", ["value"] = false }
+        };
+        var trueSource = trueCondition.ToJsonString();
+        var falseSource = falseCondition.ToJsonString();
+
+        var trueCut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = trueCondition }));
+        var falseCut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = falseCondition }));
+
+        Assert.Equal("always", trueCut.Find("[data-condition-state]").GetAttribute("data-condition-state"));
+        Assert.Contains("Always", trueCut.Find("[data-testid='state-machine-transition-condition-summary']").TextContent);
+        Assert.Equal("never", falseCut.Find("[data-condition-state]").GetAttribute("data-condition-state"));
+        Assert.Contains("Never", falseCut.Find("[data-testid='state-machine-transition-condition-summary']").TextContent);
+        Assert.Equal(trueSource, trueCondition.ToJsonString());
+        Assert.Equal(falseSource, falseCondition.ToJsonString());
+    }
+
+    [Fact]
+    public void TransitionInspector_DescribesCanonicalWrappedProviderExpression()
+    {
+        var condition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "JavaScript", ["value"] = "context.input === true" }
+        };
+        var source = condition.ToJsonString();
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = condition }));
+
+        var summary = cut.Find("[data-testid='state-machine-transition-condition-summary']");
+        Assert.Equal("expression", summary.GetAttribute("data-condition-state"));
+        Assert.Contains("JavaScript", summary.TextContent);
+        Assert.Contains("context.input === true", summary.TextContent);
+        Assert.Equal(source, condition.ToJsonString());
+    }
+
+    [Fact]
+    public void TransitionInspector_PreservesMalformedAndUnknownDefinitionsForInspection()
+    {
+        var transition = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Trigger = new JsonObject { ["id"] = "LegacyTrigger", ["payload"] = "keep-me" },
+            Condition = new JsonObject { ["type"] = "Contoso.CustomCondition", ["payload"] = "keep-me" },
+            Action = JsonValue.Create("not-an-activity")
+        };
+
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, transition));
+
+        Assert.Equal("malformed", cut.Find("[data-transition-slot='trigger'] [data-activity-state]").GetAttribute("data-activity-state"));
+        Assert.Contains("keep-me", cut.Find("[data-testid='state-machine-transition-trigger-definition']").TextContent);
+        Assert.Equal("unknown", cut.Find("[data-transition-slot='condition'] [data-condition-state]").GetAttribute("data-condition-state"));
+        Assert.Contains("Contoso.CustomCondition", cut.Find("[data-testid='state-machine-transition-condition-definition']").TextContent);
+        Assert.Equal("malformed", cut.Find("[data-transition-slot='action'] [data-activity-state]").GetAttribute("data-activity-state"));
+        Assert.Contains("not-an-activity", cut.Find("[data-testid='state-machine-transition-action-definition']").TextContent);
+        Assert.NotEmpty(cut.FindAll("[data-transition-slot='trigger'] [data-slot-action='replace']"));
+        Assert.Empty(cut.FindAll("[data-transition-slot='trigger'] [data-slot-action='open']"));
+    }
+
+    [Fact]
+    public void TransitionInspector_EmitsSemanticActivityCallbacksWithSlotNames()
+    {
+        var slots = new List<string>();
+        var configured = new StateMachineTransitionEdge
+        {
+            From = "Pending",
+            To = "Approved",
+            Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+            Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+        };
+        var configuredCut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition, configured)
+            .Add(component => component.ActivityOpenRequested, slot => slots.Add($"open:{slot}"))
+            .Add(component => component.ActivityReplaceRequested, slot => slots.Add($"replace:{slot}"))
+            .Add(component => component.ActivityClearRequested, slot => slots.Add($"clear:{slot}"))
+            .Add(component => component.ActivityDropRequested, slot => slots.Add($"drop:{slot}")));
+
+        configuredCut.Find("[data-transition-slot='trigger'] [data-slot-action='open']").Click();
+        configuredCut.Find("[data-transition-slot='action'] [data-slot-action='replace']").Click();
+        configuredCut.Find("[data-transition-slot='action'] [data-slot-action='clear']").Click();
+        configuredCut.Find("[data-transition-slot='trigger'] [data-slot-action='drop']").TriggerEvent("ondrop", new DragEventArgs());
+
+        var emptyCut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition, new StateMachineTransitionEdge { From = "Pending", To = "Approved" })
+            .Add(component => component.ActivityAddRequested, slot => slots.Add($"add:{slot}")));
+        emptyCut.Find("[data-transition-slot='action'] [data-slot-action='add']").Click();
+
+        Assert.Equal(["open:trigger", "replace:action", "clear:action", "drop:trigger", "add:action"], slots);
+    }
+
+    [Fact]
+    public void TransitionInspector_ReadOnlyModeRetainsInspectionButSuppressesMutationControlsAndDrops()
+    {
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition, new StateMachineTransitionEdge
+            {
+                From = "Pending",
+                To = "Approved",
+                Trigger = new JsonObject { ["type"] = "Elsa.Event" },
+                Condition = JsonValue.Create(false),
+                Action = new JsonObject { ["type"] = "Elsa.WriteLine" }
+            })
+            .Add(component => component.IsReadOnly, true));
+
+        Assert.Contains("WHEN", cut.Markup);
+        Assert.Contains("Never", cut.Markup);
+        Assert.Empty(cut.FindAll("button"));
+        Assert.Empty(cut.FindAll("[data-slot-action='edit']"));
+        Assert.All(cut.FindAll("[data-slot-action='drop']"), element => Assert.False(element.HasAttribute("ondrop")));
     }
 
     private sealed class TestLocalizer : ILocalizer

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -323,7 +323,10 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
 
         Assert.Contains("WHEN", cut.Markup);
         Assert.Contains("Never", cut.Markup);
-        Assert.Empty(cut.FindAll("button"));
+        Assert.Equal(2, cut.FindAll("[data-slot-action='open']").Count);
+        Assert.Empty(cut.FindAll("[data-slot-action='add']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='replace']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='clear']"));
         Assert.Empty(cut.FindAll("[data-slot-action='edit']"));
         Assert.All(cut.FindAll("[data-slot-action='drop']"), element => Assert.False(element.HasAttribute("ondrop")));
     }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionAdapter.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionAdapter.cs
@@ -1,0 +1,297 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Designer;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+
+/// <summary>
+/// Describes the lossless forms a StateMachine transition condition can have in JSON.
+/// </summary>
+public enum BooleanConditionKind
+{
+    Missing,
+    Literal,
+    Expression,
+    Unknown,
+    Malformed
+}
+
+/// <summary>
+/// A read-only projection of a condition JSON value.
+/// </summary>
+public sealed record BooleanConditionDescription(
+    BooleanConditionKind Kind,
+    bool? LiteralValue = null,
+    string? ExpressionType = null,
+    string? ExpressionValue = null);
+
+/// <summary>
+/// The result of applying an advanced JSON edit to a condition.
+/// </summary>
+public sealed record BooleanConditionEditResult(JsonNode? Value, string? Error)
+{
+    /// <summary>
+    /// Gets a value indicating whether the edit produced a valid value.
+    /// </summary>
+    public bool Succeeded => Error == null;
+}
+
+/// <summary>
+/// Reads and edits StateMachine boolean conditions without changing unknown JSON.
+/// </summary>
+public static class BooleanConditionAdapter
+{
+    /// <summary>
+    /// The canonical backend type name for an Elsa boolean input.
+    /// </summary>
+    public const string BooleanTypeName = "Boolean";
+
+    /// <summary>
+    /// Inspects a condition. When provider names are supplied, an expression provider
+    /// outside that set is classified as unknown and remains available through its source JSON.
+    /// </summary>
+    public static BooleanConditionDescription Inspect(JsonNode? value, IEnumerable<string>? knownExpressionTypes = null)
+    {
+        if (value == null)
+            return new(BooleanConditionKind.Missing);
+
+        if (value is JsonValue scalar && scalar.TryGetValue<bool>(out var scalarValue))
+            return new(BooleanConditionKind.Literal, LiteralValue: scalarValue);
+
+        if (value is not JsonObject obj)
+            return new(BooleanConditionKind.Malformed);
+
+        if (StateMachineDesignerConstants.IsInvalidJsonSlotMarker(obj))
+            return new(BooleanConditionKind.Malformed);
+
+        var knownTypes = knownExpressionTypes?.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Runtime Input<T> JSON uses { typeName, expression }. Keep support for the
+        // older shorthand { type, value/expression } as it is still encountered in
+        // imported definitions.
+        if (obj["expression"] is JsonObject expressionObject)
+            return InspectWrapped(obj, expressionObject, knownTypes);
+
+        if (obj.ContainsKey("expression") || obj.ContainsKey("typeName"))
+            return new(BooleanConditionKind.Malformed);
+
+        return InspectShorthand(obj, knownTypes);
+    }
+
+    /// <summary>
+    /// Sets a literal condition. A new canonical Boolean Input JSON value is emitted
+    /// only when the requested value differs from the existing literal.
+    /// </summary>
+    public static JsonNode SetLiteral(JsonNode? original, bool value)
+    {
+        var description = Inspect(original);
+        if (description.Kind == BooleanConditionKind.Literal && description.LiteralValue == value)
+            return original!;
+
+        return CreateCanonicalLiteral(original, value);
+    }
+
+    /// <summary>
+    /// Sets a provider expression using canonical Boolean Input JSON.
+    /// </summary>
+    public static JsonNode SetExpression(JsonNode? original, string expressionType, string expressionValue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(expressionType);
+        ArgumentNullException.ThrowIfNull(expressionValue);
+
+        var description = Inspect(original);
+        if ((description.Kind is BooleanConditionKind.Expression or BooleanConditionKind.Unknown)
+            && string.Equals(description.ExpressionType, expressionType, StringComparison.Ordinal)
+            && string.Equals(description.ExpressionValue, expressionValue, StringComparison.Ordinal))
+        {
+            return original!;
+        }
+
+        return CreateCanonicalExpression(original, expressionType, expressionValue);
+    }
+
+    /// <summary>
+    /// Applies an advanced JSON edit. Invalid JSON returns the original node and an error;
+    /// equivalent JSON returns the original node to preserve its identity and metadata.
+    /// </summary>
+    public static BooleanConditionEditResult TrySetAdvanced(JsonNode? original, string? source)
+    {
+        if (source == null)
+            return new(original, "Condition JSON is required.");
+
+        JsonNode? parsed;
+        try
+        {
+            parsed = JsonNode.Parse(source);
+        }
+        catch (JsonException)
+        {
+            return new(original, "Condition JSON is invalid.");
+        }
+
+        if (Inspect(parsed).Kind == BooleanConditionKind.Malformed)
+            return new(original, "Condition JSON is not a valid Boolean condition.");
+
+        return JsonNode.DeepEquals(original, parsed)
+            ? new(original, null)
+            : new(parsed, null);
+    }
+
+    private static BooleanConditionDescription InspectWrapped(
+        JsonObject wrapper,
+        JsonObject expression,
+        ISet<string>? knownTypes)
+    {
+        var typeName = GetString(wrapper["typeName"]);
+        if (wrapper.ContainsKey("typeName") && typeName == null)
+            return new(BooleanConditionKind.Malformed);
+
+        if (!string.IsNullOrWhiteSpace(typeName) && !IsBooleanInputType(typeName))
+            return new(BooleanConditionKind.Malformed);
+
+        var expressionType = GetString(expression["type"]);
+        if (string.IsNullOrWhiteSpace(expressionType))
+            return new(BooleanConditionKind.Malformed);
+
+        if (string.Equals(expressionType, "Literal", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!IsBooleanInputType(typeName) && !string.IsNullOrWhiteSpace(typeName))
+                return new(BooleanConditionKind.Malformed);
+
+            if (TryGetBoolean(expression["value"], out var literalValue)
+                || TryGetBoolean(expression["literal"], out literalValue))
+            {
+                return new(BooleanConditionKind.Literal, LiteralValue: literalValue);
+            }
+
+            return new(BooleanConditionKind.Malformed);
+        }
+
+        if (!HasValue(expression, "value") && !HasValue(expression, "expression"))
+            return new(BooleanConditionKind.Malformed);
+
+        var expressionValue = GetExpressionValue(expression);
+        var kind = knownTypes == null || knownTypes.Contains(expressionType)
+            ? BooleanConditionKind.Expression
+            : BooleanConditionKind.Unknown;
+
+        return new(kind, ExpressionType: expressionType, ExpressionValue: expressionValue);
+    }
+
+    private static BooleanConditionDescription InspectShorthand(JsonObject value, ISet<string>? knownTypes)
+    {
+        var type = GetString(value["type"]);
+        if (string.IsNullOrWhiteSpace(type))
+            return new(BooleanConditionKind.Unknown);
+
+        if (string.Equals(type, "Literal", StringComparison.OrdinalIgnoreCase)
+            || IsBooleanInputType(type))
+        {
+            if (TryGetBoolean(value["value"], out var literalValue)
+                || TryGetBoolean(value["literal"], out literalValue))
+            {
+                return new(BooleanConditionKind.Literal, LiteralValue: literalValue);
+            }
+
+            return new(BooleanConditionKind.Malformed);
+        }
+
+        if (!HasValue(value, "expression") && !HasValue(value, "value"))
+            return new(BooleanConditionKind.Unknown);
+
+        var expressionValue = GetExpressionValue(value);
+        var kind = knownTypes == null || knownTypes.Contains(type)
+            ? BooleanConditionKind.Expression
+            : BooleanConditionKind.Unknown;
+
+        return new(kind, ExpressionType: type, ExpressionValue: expressionValue);
+    }
+
+    private static JsonObject CreateCanonicalLiteral(JsonNode? original, bool value)
+    {
+        var result = CloneForExplicitEdit(original);
+        result["typeName"] = BooleanTypeName;
+        result["expression"] = new JsonObject
+        {
+            ["type"] = "Literal",
+            ["value"] = value
+        };
+        return result;
+    }
+
+    private static JsonObject CreateCanonicalExpression(JsonNode? original, string expressionType, string expressionValue)
+    {
+        var result = CloneForExplicitEdit(original);
+        result["typeName"] = BooleanTypeName;
+        result["expression"] = new JsonObject
+        {
+            ["type"] = expressionType,
+            ["value"] = expressionValue
+        };
+        return result;
+    }
+
+    private static JsonObject CloneForExplicitEdit(JsonNode? original)
+    {
+        var result = original is JsonObject obj ? obj.DeepClone().AsObject() : [];
+
+        // These properties describe the previous condition representation. They must
+        // not survive beside the canonical wrapper, while all unrelated metadata does.
+        result.Remove("type");
+        result.Remove("value");
+        result.Remove("literal");
+        result.Remove("expression");
+        result.Remove(StateMachineDesignerConstants.InvalidJsonSlotProperty);
+        result.Remove(StateMachineDesignerConstants.InvalidJsonSlotSourceProperty);
+        result.Remove("slot");
+        return result;
+    }
+
+    private static bool HasValue(JsonObject obj, string propertyName) => obj.TryGetPropertyValue(propertyName, out var value) && value != null;
+
+    private static string? GetString(JsonNode? node) => node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+
+    private static string? GetExpressionValue(JsonObject obj)
+    {
+        var value = obj.TryGetPropertyValue("value", out var valueNode) && valueNode != null
+            ? valueNode
+            : obj.TryGetPropertyValue("expression", out var expressionNode) && expressionNode != null
+                ? expressionNode
+                : null;
+
+        return value switch
+        {
+            null => null,
+            JsonValue jsonValue when jsonValue.TryGetValue<string>(out var text) => text,
+            _ => value.ToJsonString()
+        };
+    }
+
+    private static bool IsBooleanInputType(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return false;
+
+        var normalized = typeName.Split(',', 2)[0].Trim();
+        return normalized.Equals(BooleanTypeName, StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("System.Boolean", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("bool", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("Elsa.Boolean", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetBoolean(JsonNode? node, out bool value)
+    {
+        if (node is JsonValue jsonValue && jsonValue.TryGetValue<bool>(out value))
+            return true;
+
+        if (node is JsonValue stringValue
+            && stringValue.TryGetValue<string>(out var text)
+            && bool.TryParse(text, out value))
+        {
+            return true;
+        }
+
+        value = false;
+        return false;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor
@@ -1,0 +1,142 @@
+@using Elsa.Api.Client.Resources.Scripting.Models
+@using Elsa.Studio.Localization
+@using MudBlazor
+@using MudVariant = MudBlazor.Variant
+@namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
+@inject ILocalizer Localizer
+
+<MudDialog Class="state-machine-condition-editor-dialog">
+    <TitleContent>
+        <MudStack Spacing="0">
+            <MudText Typo="Typo.h5">@Localizer["Edit transition condition"]</MudText>
+            <MudText Typo="Typo.body2">@Localizer["Choose when this transition is eligible. Changes are applied only when you select Apply."]</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <div class="state-machine-condition-editor" data-testid="condition-editor">
+            <div class="state-machine-condition-editor__story" aria-label="@Localizer["Condition story"]">
+                <span class="state-machine-condition-editor__story-label">@Localizer["WHEN"]</span>
+                <span class="state-machine-condition-editor__story-arrow" aria-hidden="true">→</span>
+                <strong>@Localizer["ONLY IF"]</strong>
+                <span class="state-machine-condition-editor__story-arrow" aria-hidden="true">→</span>
+                <span class="state-machine-condition-editor__story-label">@Localizer["THEN"]</span>
+            </div>
+
+            <div class="state-machine-condition-editor__modes" role="tablist" aria-label="@Localizer["Condition mode"]">
+                <button type="button" role="tab" data-mode="always" aria-selected="@(_mode == BooleanConditionEditorMode.Always)" class="@ModeClass(BooleanConditionEditorMode.Always)" disabled="@IsReadOnly" @onclick="() => SetMode(BooleanConditionEditorMode.Always)">
+                    <strong>@Localizer["Always"]</strong>
+                    <span>@Localizer["No condition"]</span>
+                </button>
+                <button type="button" role="tab" data-mode="never" aria-selected="@(_mode == BooleanConditionEditorMode.Never)" class="@ModeClass(BooleanConditionEditorMode.Never)" disabled="@IsReadOnly" @onclick="() => SetMode(BooleanConditionEditorMode.Never)">
+                    <strong>@Localizer["Never"]</strong>
+                    <span>@Localizer["Explicitly false"]</span>
+                </button>
+                <button type="button" role="tab" data-mode="provider" aria-selected="@(_mode == BooleanConditionEditorMode.Provider)" class="@ModeClass(BooleanConditionEditorMode.Provider)" disabled="@(IsReadOnly || !HasProviders)" @onclick="() => SetMode(BooleanConditionEditorMode.Provider)">
+                    <strong>@Localizer["Expression"]</strong>
+                    <span>@Localizer["Use a provider"]</span>
+                </button>
+                <button type="button" role="tab" data-mode="custom" aria-selected="@(_mode == BooleanConditionEditorMode.Custom)" class="@ModeClass(BooleanConditionEditorMode.Custom)" disabled="@IsReadOnly" @onclick="() => SetMode(BooleanConditionEditorMode.Custom)">
+                    <strong>@Localizer["Custom JSON"]</strong>
+                    <span>@Localizer["Advanced escape hatch"]</span>
+                </button>
+            </div>
+
+            @if (IsLossySwitch)
+            {
+                <div role="status" data-testid="condition-editor-lossy-warning">
+                    <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true">
+                        @Localizer["Applying this mode will replace the existing condition representation. Cancel to keep it unchanged."]
+                    </MudAlert>
+                </div>
+            }
+
+            @if (_mode == BooleanConditionEditorMode.Always)
+            {
+                <MudAlert Severity="Severity.Info" Variant="MudVariant.Outlined" Dense="true">
+                    @Localizer["This transition is always eligible."]
+                </MudAlert>
+                @if (_originalIsExplicitTrue)
+                {
+                    <label class="state-machine-condition-editor__preserve-option">
+                        <input type="checkbox"
+                               data-testid="condition-editor-preserve-explicit-true"
+                               checked="@_preserveExplicitTrue"
+                               disabled="@IsReadOnly"
+                               @onchange="OnPreserveExplicitTrueChanged" />
+                        <span>
+                            <strong>@Localizer["Preserve the explicit true definition"]</strong>
+                            <small>@Localizer["Turn this off only if you want Apply to clear the condition slot."]</small>
+                        </span>
+                    </label>
+                }
+                else
+                {
+                    <p class="state-machine-condition-editor__hint">@Localizer["Apply stores Always as an empty condition slot."]</p>
+                }
+            }
+            else if (_mode == BooleanConditionEditorMode.Never)
+            {
+                <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true" data-testid="condition-editor-never-warning">
+                    @Localizer["This transition will never be taken while the condition is false."]
+                </MudAlert>
+            }
+            else if (_mode == BooleanConditionEditorMode.Provider)
+            {
+                @if (_providerLoadError != null)
+                {
+                    <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true">@_providerLoadError</MudAlert>
+                }
+                else if (!HasProviders)
+                {
+                    <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true">@Localizer["No expression providers are available. Use Custom JSON to preserve this condition."]</MudAlert>
+                }
+                else
+                {
+                    <div class="state-machine-condition-editor__provider">
+                        <label for="condition-editor-provider">@Localizer["Expression provider"]</label>
+                        <select id="condition-editor-provider" data-testid="condition-editor-provider" value="@_providerType" disabled="@IsReadOnly" @onchange="OnProviderChanged">
+                            @foreach (var provider in _providers)
+                            {
+                                <option value="@provider.Type">@DisplayProvider(provider)</option>
+                            }
+                        </select>
+                        <label for="condition-editor-provider-expression">@Localizer["Expression"]</label>
+                        <textarea id="condition-editor-provider-expression"
+                                  data-testid="condition-editor-provider-expression"
+                                  rows="8"
+                                  spellcheck="false"
+                                  value="@(_providerExpression?.Value?.ToString() ?? string.Empty)"
+                                  disabled="@IsReadOnly"
+                                  @oninput="OnProviderInput"></textarea>
+                        <p class="state-machine-condition-editor__hint">@Localizer["The expression is evaluated by the selected provider and must return Boolean."]</p>
+                    </div>
+                }
+            }
+            else
+            {
+                <div class="state-machine-condition-editor__custom">
+                    <label for="condition-editor-custom-json">@Localizer["Condition JSON"]</label>
+                    <textarea id="condition-editor-custom-json"
+                              data-testid="condition-editor-custom-json"
+                              rows="12"
+                              spellcheck="false"
+                              value="@_customSource"
+                              disabled="@IsReadOnly"
+                              @oninput="OnCustomInput"></textarea>
+                    @if (_customError != null)
+                    {
+                        <p class="state-machine-condition-editor__error" role="alert" data-testid="condition-editor-custom-error">@_customError</p>
+                    }
+                    else
+                    {
+                        <p class="state-machine-condition-editor__hint">@Localizer["Unknown condition shapes are preserved. Valid JSON must represent a Boolean condition."]</p>
+                    }
+                </div>
+            }
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton data-testid="condition-editor-cancel" Variant="MudVariant.Text" OnClick="Cancel">@Localizer["Cancel"]</MudButton>
+        <MudButton data-testid="condition-editor-apply" Variant="MudVariant.Filled" Color="Color.Primary" Disabled="@(!CanApply)" OnClick="Apply">@Localizer["Apply"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor
@@ -50,6 +50,13 @@
                 </div>
             }
 
+            @if (_providerLoadError != null)
+            {
+                <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true" data-testid="condition-editor-provider-load-warning" role="status">
+                    @_providerLoadError
+                </MudAlert>
+            }
+
             @if (_mode == BooleanConditionEditorMode.Always)
             {
                 <MudAlert Severity="Severity.Info" Variant="MudVariant.Outlined" Dense="true">
@@ -82,11 +89,7 @@
             }
             else if (_mode == BooleanConditionEditorMode.Provider)
             {
-                @if (_providerLoadError != null)
-                {
-                    <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true">@_providerLoadError</MudAlert>
-                }
-                else if (!HasProviders)
+                @if (!HasProviders)
                 {
                     <MudAlert Severity="Severity.Warning" Variant="MudVariant.Outlined" Dense="true">@Localizer["No expression providers are available. Use Custom JSON to preserve this condition."]</MudAlert>
                 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Designer;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+
+/// <summary>
+/// The authoring modes supported by the transition condition editor.
+/// </summary>
+public enum BooleanConditionEditorMode
+{
+    Always,
+    Never,
+    Provider,
+    Custom
+}
+
+/// <summary>
+/// The explicit result returned by the condition editor. The explicit Applied flag
+/// distinguishes Apply-to-missing from cancelling the dialog.
+/// </summary>
+public sealed record BooleanConditionDialogResult(bool Applied, JsonNode? Condition);
+
+/// <summary>
+/// Provides a transactional editor for a StateMachine transition condition.
+/// </summary>
+public partial class BooleanConditionEditorDialog
+{
+    private static readonly JsonSerializerOptions PrettyJson = new() { WriteIndented = true };
+    private static readonly HashSet<string> NonProviderExpressionTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Literal", "Object", "Variable", "Input"
+    };
+
+    private JsonNode? _originalCondition;
+    private BooleanConditionEditorMode _originalMode;
+    private string? _originalProviderType;
+    private bool _originalIsExplicitTrue;
+    private bool _preserveExplicitTrue;
+    private BooleanConditionEditorMode _mode;
+    private string _customSource = "null";
+    private string? _customError;
+    private string? _providerType;
+    private Expression? _providerExpression;
+    private IReadOnlyList<ExpressionDescriptor> _providers = [];
+    private string? _providerLoadError;
+
+    [Parameter] public JsonNode? Condition { get; set; }
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public IReadOnlyCollection<ExpressionDescriptor>? KnownExpressionProviders { get; set; }
+
+    [Inject] private IExpressionService ExpressionService { get; set; } = null!;
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private bool HasProviders => _providers.Count > 0;
+    private bool CustomIsValid => _customError == null;
+    private bool CanApply => !IsReadOnly && (_mode != BooleanConditionEditorMode.Provider || _providerExpression != null) && (_mode != BooleanConditionEditorMode.Custom || CustomIsValid);
+    private bool IsLossySwitch =>
+        ((_originalMode is BooleanConditionEditorMode.Provider or BooleanConditionEditorMode.Custom) && _mode != _originalMode)
+        || (_originalMode == BooleanConditionEditorMode.Provider
+            && _mode == BooleanConditionEditorMode.Provider
+            && !string.Equals(_originalProviderType, _providerType, StringComparison.OrdinalIgnoreCase))
+        || (_originalIsExplicitTrue && _mode == BooleanConditionEditorMode.Always && !_preserveExplicitTrue);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadProvidersAsync();
+        InitializeDraft();
+    }
+
+    private async Task LoadProvidersAsync()
+    {
+        if (KnownExpressionProviders != null)
+        {
+            _providers = FilterProviders(KnownExpressionProviders);
+            return;
+        }
+
+        try
+        {
+            var descriptors = await ExpressionService.ListDescriptorsAsync();
+            _providers = FilterProviders(descriptors);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException)
+        {
+            _providers = [];
+            _providerLoadError = "Expression providers could not be loaded. Use Custom JSON to preserve or repair this condition.";
+        }
+    }
+
+    private static IReadOnlyList<ExpressionDescriptor> FilterProviders(IEnumerable<ExpressionDescriptor> descriptors) =>
+        descriptors
+            .Where(x => x.IsBrowsable && !string.IsNullOrWhiteSpace(x.Type) && !NonProviderExpressionTypes.Contains(x.Type))
+            .GroupBy(x => x.Type, StringComparer.OrdinalIgnoreCase)
+            .Select(x => x.First())
+            .ToList();
+
+    private void InitializeDraft()
+    {
+        _originalCondition = Condition;
+        var knownProviderTypes = _providers.Select(x => x.Type).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var description = BooleanConditionAdapter.Inspect(Condition, knownProviderTypes);
+
+        _mode = description.Kind switch
+        {
+            BooleanConditionKind.Missing => BooleanConditionEditorMode.Always,
+            BooleanConditionKind.Literal when description.LiteralValue == false => BooleanConditionEditorMode.Never,
+            BooleanConditionKind.Literal => BooleanConditionEditorMode.Always,
+            BooleanConditionKind.Expression when description.ExpressionType != null => BooleanConditionEditorMode.Provider,
+            _ => BooleanConditionEditorMode.Custom
+        };
+
+        _providerType = description.ExpressionType;
+        _originalMode = _mode;
+        _originalProviderType = description.ExpressionType;
+        _originalIsExplicitTrue = description.Kind == BooleanConditionKind.Literal && description.LiteralValue == true;
+        _preserveExplicitTrue = _originalIsExplicitTrue;
+        _providerExpression = description.ExpressionType == null
+            ? null
+            : new Expression(description.ExpressionType, description.ExpressionValue ?? string.Empty);
+        _customSource = Condition is JsonObject obj && StateMachineDesignerConstants.IsInvalidJsonSlotMarker(obj)
+            ? obj[StateMachineDesignerConstants.InvalidJsonSlotSourceProperty]?.GetValue<string>() ?? string.Empty
+            : Condition?.ToJsonString(PrettyJson) ?? "null";
+        ValidateCustomSource();
+
+        // An expression can only be edited with the provider-native editor when its
+        // provider is available. Unknown expressions remain in the lossless Custom mode.
+        if (_mode == BooleanConditionEditorMode.Provider && !HasProvider(_providerType))
+            _mode = BooleanConditionEditorMode.Custom;
+    }
+
+    private bool HasProvider(string? type) => !string.IsNullOrWhiteSpace(type) && _providers.Any(x => string.Equals(x.Type, type, StringComparison.OrdinalIgnoreCase));
+
+    private void SetMode(BooleanConditionEditorMode mode)
+    {
+        if (IsReadOnly || (mode == BooleanConditionEditorMode.Provider && !HasProviders))
+            return;
+
+        _mode = mode;
+        if (mode == BooleanConditionEditorMode.Provider)
+            EnsureProviderExpression();
+        if (mode == BooleanConditionEditorMode.Custom)
+            ValidateCustomSource();
+    }
+
+    private void EnsureProviderExpression()
+    {
+        if (!HasProviders)
+            return;
+
+        if (!HasProvider(_providerType))
+            _providerType = _providers[0].Type;
+
+        _providerExpression ??= new Expression(_providerType!, string.Empty);
+        if (!string.Equals(_providerExpression.Type, _providerType, StringComparison.Ordinal))
+            _providerExpression = new Expression(_providerType!, _providerExpression.Value?.ToString() ?? string.Empty);
+    }
+
+    private void OnProviderChanged(ChangeEventArgs args)
+    {
+        if (IsReadOnly)
+            return;
+
+        var type = args.Value?.ToString();
+        if (!HasProvider(type))
+            return;
+
+        _providerType = type;
+        _providerExpression = new Expression(type!, _providerExpression?.Value?.ToString() ?? string.Empty);
+    }
+
+    private void OnProviderInput(ChangeEventArgs args)
+    {
+        if (IsReadOnly || _providerExpression == null)
+            return;
+
+        _providerExpression.Value = args.Value?.ToString() ?? string.Empty;
+    }
+
+    private void OnCustomInput(ChangeEventArgs args)
+    {
+        if (IsReadOnly)
+            return;
+
+        _customSource = args.Value?.ToString() ?? string.Empty;
+        ValidateCustomSource();
+    }
+
+    private void OnPreserveExplicitTrueChanged(ChangeEventArgs args)
+    {
+        if (IsReadOnly)
+            return;
+
+        _preserveExplicitTrue = args.Value is true || string.Equals(args.Value?.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void ValidateCustomSource() => _customError = BooleanConditionAdapter.TrySetAdvanced(_originalCondition, _customSource).Error;
+
+    private void Apply()
+    {
+        if (!CanApply)
+            return;
+
+        var condition = _mode switch
+        {
+            BooleanConditionEditorMode.Always when _originalIsExplicitTrue && _preserveExplicitTrue => BooleanConditionAdapter.SetLiteral(_originalCondition, true),
+            BooleanConditionEditorMode.Always => (JsonNode?)null,
+            BooleanConditionEditorMode.Never => BooleanConditionAdapter.SetLiteral(_originalCondition, false),
+            BooleanConditionEditorMode.Provider when _providerExpression != null => BooleanConditionAdapter.SetExpression(_originalCondition, _providerExpression.Type, _providerExpression.Value?.ToString() ?? string.Empty),
+            BooleanConditionEditorMode.Custom => BooleanConditionAdapter.TrySetAdvanced(_originalCondition, _customSource).Value,
+            _ => _originalCondition
+        };
+
+        MudDialog.Close(DialogResult.Ok(new BooleanConditionDialogResult(true, condition)));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private string ModeClass(BooleanConditionEditorMode mode) => _mode == mode
+        ? "state-machine-condition-editor__mode state-machine-condition-editor__mode--selected"
+        : "state-machine-condition-editor__mode";
+
+    private static string DisplayProvider(ExpressionDescriptor descriptor) => string.IsNullOrWhiteSpace(descriptor.DisplayName) ? descriptor.Type : descriptor.DisplayName;
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.cs
@@ -6,6 +6,7 @@ using Elsa.Studio.Workflows.Designer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
+using Refit;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 
@@ -78,6 +79,7 @@ public partial class BooleanConditionEditorDialog
         if (KnownExpressionProviders != null)
         {
             _providers = FilterProviders(KnownExpressionProviders);
+            _providerLoadError = null;
             return;
         }
 
@@ -86,14 +88,14 @@ public partial class BooleanConditionEditorDialog
             var descriptors = await ExpressionService.ListDescriptorsAsync();
             _providers = FilterProviders(descriptors);
         }
-        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException)
+        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or ApiException)
         {
             _providers = [];
             _providerLoadError = "Expression providers could not be loaded. Use Custom JSON to preserve or repair this condition.";
         }
     }
 
-    private static IReadOnlyList<ExpressionDescriptor> FilterProviders(IEnumerable<ExpressionDescriptor> descriptors) =>
+    internal static IReadOnlyList<ExpressionDescriptor> FilterProviders(IEnumerable<ExpressionDescriptor> descriptors) =>
         descriptors
             .Where(x => x.IsBrowsable && !string.IsNullOrWhiteSpace(x.Type) && !NonProviderExpressionTypes.Contains(x.Type))
             .GroupBy(x => x.Type, StringComparer.OrdinalIgnoreCase)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/BooleanConditionEditorDialog.razor.css
@@ -1,0 +1,147 @@
+.state-machine-condition-editor {
+    width: min(100%, 860px);
+    min-width: min(100%, 680px);
+}
+
+.state-machine-condition-editor__story {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    padding: .75rem 1rem;
+    margin-bottom: 1rem;
+    border-radius: .35rem;
+    background: var(--mud-palette-background-grey);
+    color: var(--mud-palette-text-secondary);
+}
+
+.state-machine-condition-editor__story strong {
+    color: var(--mud-palette-primary);
+}
+
+.state-machine-condition-editor__story-arrow {
+    color: var(--mud-palette-text-disabled);
+}
+
+.state-machine-condition-editor__modes {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: .6rem;
+    margin-bottom: 1rem;
+}
+
+.state-machine-condition-editor__mode {
+    display: flex;
+    min-height: 4.4rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: .25rem;
+    padding: .75rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: .35rem;
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    cursor: pointer;
+    text-align: left;
+}
+
+.state-machine-condition-editor__mode span {
+    color: var(--mud-palette-text-secondary);
+    font-size: .8rem;
+}
+
+.state-machine-condition-editor__mode:hover:not(:disabled),
+.state-machine-condition-editor__mode:focus-visible {
+    border-color: var(--mud-palette-primary);
+    outline: 2px solid var(--mud-palette-primary);
+    outline-offset: 1px;
+}
+
+.state-machine-condition-editor__mode--selected {
+    border-color: var(--mud-palette-primary);
+    box-shadow: inset 3px 0 0 var(--mud-palette-primary);
+}
+
+.state-machine-condition-editor__mode:disabled {
+    cursor: not-allowed;
+    opacity: .58;
+}
+
+.state-machine-condition-editor__provider,
+.state-machine-condition-editor__custom {
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+}
+
+.state-machine-condition-editor__provider select,
+.state-machine-condition-editor__provider textarea,
+.state-machine-condition-editor__custom textarea {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: .25rem;
+    padding: .6rem .7rem;
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    font: inherit;
+}
+
+.state-machine-condition-editor__provider textarea,
+.state-machine-condition-editor__custom textarea {
+    min-height: 14rem;
+    font-family: "Roboto Mono", monospace;
+    resize: vertical;
+}
+
+.state-machine-condition-editor__preserve-option {
+    display: flex;
+    align-items: flex-start;
+    gap: .65rem;
+    margin-top: .75rem;
+    padding: .75rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: .35rem;
+    cursor: pointer;
+}
+
+.state-machine-condition-editor__preserve-option > span {
+    display: grid;
+    gap: .2rem;
+}
+
+.state-machine-condition-editor__preserve-option small {
+    color: var(--mud-palette-text-secondary);
+}
+
+.state-machine-condition-editor__error {
+    margin: 0;
+    color: var(--mud-palette-error);
+}
+
+.state-machine-condition-editor__hint {
+    margin: 0;
+    color: var(--mud-palette-text-secondary);
+    font-size: .8rem;
+}
+
+@media (max-width: 700px) {
+    .state-machine-condition-editor {
+        min-width: 0;
+    }
+
+    .state-machine-condition-editor__modes {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 420px) {
+    .state-machine-condition-editor__story {
+        gap: .3rem;
+        padding-inline: .6rem;
+        font-size: .8rem;
+    }
+
+    .state-machine-condition-editor__modes {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
@@ -1,0 +1,103 @@
+@using Elsa.Api.Client.Resources.ActivityDescriptors.Models
+@using Elsa.Studio.Localization
+@using Variant = MudBlazor.Variant
+@inject ILocalizer Localizer
+
+<MudDialog Class="state-machine-activity-picker-dialog">
+    <DialogContent>
+        <section class="state-machine-activity-picker" data-testid="state-machine-activity-picker" aria-labelledby="@HeadingId">
+            <div class="state-machine-activity-picker__intro">
+                <p class="state-machine-activity-picker__eyebrow">@Localizer["Activity library"]</p>
+                <MudText Typo="Typo.h6" id="@HeadingId">@Localizer["Choose an activity"]</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">@Localizer["Search by name, type, category, or what the activity does."]</MudText>
+            </div>
+
+            @if (_isLoading)
+            {
+                <div class="state-machine-activity-picker__state" role="status" aria-live="polite" data-picker-state="loading">
+                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
+                    <span>@Localizer["Loading activities…"]</span>
+                </div>
+            }
+            else if (_loadError != null)
+            {
+                <div class="state-machine-activity-picker__state state-machine-activity-picker__state--error" role="alert" data-picker-state="error">
+                    <strong>@Localizer["Activities could not be loaded"]</strong>
+                    <span>@Localizer["Close this dialog and try again."]</span>
+                </div>
+            }
+            else
+            {
+                <MudTextField T="string"
+                              @bind-Value="_searchText"
+                              Immediate="true"
+                              Clearable="true"
+                              InputId="@SearchInputId"
+                              Label="@Localizer["Search activities"]"
+                              Placeholder="@Localizer["Search by display name, type, category, or description"]"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Adornment="Adornment.End"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Class="state-machine-activity-picker__search" />
+
+                @if (!FilteredDescriptors.Any())
+                {
+                    <div class="state-machine-activity-picker__state" role="status" data-picker-state="empty">
+                        <strong>@Localizer["No matching activities"]</strong>
+                        <span>@Localizer["Try a different name, type, category, or description."]</span>
+                    </div>
+                }
+                else
+                {
+                    @if (SequenceDescriptor != null && string.IsNullOrWhiteSpace(_searchText))
+                    {
+                        <button type="button"
+                                class="state-machine-activity-picker__quick-option"
+                                data-testid="state-machine-activity-picker-sequence"
+                                data-activity-type="@SequenceDescriptor.TypeName"
+                                @onclick="() => SelectAsync(SequenceDescriptor)">
+                            <span class="state-machine-activity-picker__quick-icon" aria-hidden="true">＋</span>
+                            <span>
+                                <strong>@Localizer["Run multiple activities"]</strong>
+                                <span>@Localizer["Add a Sequence to run more than one activity in this slot."]</span>
+                            </span>
+                        </button>
+                    }
+
+                    <div class="state-machine-activity-picker__groups" role="list" aria-label="@Localizer["Available activities"]">
+                        @foreach (var group in GroupedDescriptors)
+                        {
+                            <section class="state-machine-activity-picker__group" aria-labelledby="@GetGroupId(group.Key)">
+                                <h3 id="@GetGroupId(group.Key)">@DisplayCategory(group.Key)</h3>
+                                <div class="state-machine-activity-picker__options">
+                                    @foreach (var descriptor in group)
+                                    {
+                                        <button type="button"
+                                                class="state-machine-activity-picker__option"
+                                                data-testid="state-machine-activity-option"
+                                                data-activity-type="@descriptor.TypeName"
+                                                data-activity-name="@GetDisplayName(descriptor)"
+                                                @onclick="() => SelectAsync(descriptor)">
+                                            <span class="state-machine-activity-picker__option-copy">
+                                                <strong>@GetDisplayName(descriptor)</strong>
+                                                <span>@descriptor.TypeName</span>
+                                            </span>
+                                            @if (!string.IsNullOrWhiteSpace(descriptor.Description))
+                                            {
+                                                <span class="state-machine-activity-picker__option-description">@Localizer[descriptor.Description]</span>
+                                            }
+                                        </button>
+                                    }
+                                </div>
+                            </section>
+                        }
+                    </div>
+                }
+            }
+        </section>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">@Localizer["Cancel"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
@@ -46,7 +46,18 @@ public partial class StateMachineActivityPickerDialog
         try
         {
             await ActivityRegistry.EnsureLoadedAsync();
-            _descriptors = ActivityRegistry.ListBrowsable()
+            var descriptors = ActivityRegistry.List().ToList();
+            var browsableDescriptors = ActivityRegistry.ListBrowsable().ToList();
+
+            // Sequence is the editor's composition escape hatch. The backend may mark it
+            // non-browsable because it is normally opened through a designer, but it must
+            // still be available as the explicit multi-activity shortcut here.
+            var sequence = descriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal))
+                           ?? ActivityRegistry.Find("Elsa.Sequence");
+            if (sequence != null && browsableDescriptors.All(x => !string.Equals(x.TypeName, sequence.TypeName, StringComparison.Ordinal)))
+                browsableDescriptors.Add(sequence);
+
+            _descriptors = browsableDescriptors
                 .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
                 .ToList();

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
@@ -1,0 +1,97 @@
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Extensions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+
+/// <summary>
+/// Presents browsable activities for a StateMachine transition slot.
+/// </summary>
+public partial class StateMachineActivityPickerDialog
+{
+    private readonly string _id = $"state-machine-activity-picker-{Guid.NewGuid():N}";
+    private IReadOnlyList<ActivityDescriptor> _descriptors = [];
+    private string _searchText = string.Empty;
+    private Exception? _loadError;
+    private bool _isLoading = true;
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
+
+    private string HeadingId => $"{_id}-heading";
+    private string SearchInputId => $"{_id}-search";
+
+    private IEnumerable<ActivityDescriptor> FilteredDescriptors =>
+        _descriptors.Where(MatchesSearch);
+
+    private IEnumerable<IGrouping<string, ActivityDescriptor>> GroupedDescriptors =>
+        FilteredDescriptors
+            .Where(x => !IsPromotedSequence(x))
+            .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(x => string.IsNullOrWhiteSpace(x.Category) ? Localizer["Other"].Value : x.Category, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
+
+    private ActivityDescriptor? SequenceDescriptor =>
+        _descriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal));
+
+    private bool IsPromotedSequence(ActivityDescriptor descriptor) =>
+        SequenceDescriptor != null && string.IsNullOrWhiteSpace(_searchText) && ReferenceEquals(descriptor, SequenceDescriptor);
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            await ActivityRegistry.EnsureLoadedAsync();
+            _descriptors = ActivityRegistry.ListBrowsable()
+                .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception exception)
+        {
+            _loadError = exception;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private bool MatchesSearch(ActivityDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(_searchText))
+            return true;
+
+        var search = _searchText.Trim();
+        return Contains(GetDisplayName(descriptor), search)
+               || Contains(descriptor.Name, search)
+               || Contains(descriptor.TypeName, search)
+               || Contains(descriptor.Category, search)
+               || Contains(descriptor.Description, search);
+    }
+
+    private static bool Contains(string? value, string search) =>
+        value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
+
+    private string GetDisplayName(ActivityDescriptor descriptor) =>
+        Localizer[descriptor.DisplayName ?? descriptor.Name].Value;
+
+    private string DisplayCategory(string category) => Localizer[category].Value;
+
+    private string GetGroupId(string category) => $"{_id}-group-{SanitizeId(category)}";
+
+    private static string SanitizeId(string value) =>
+        new(value.Select(character => char.IsLetterOrDigit(character) ? character : '-').ToArray());
+
+    private Task SelectAsync(ActivityDescriptor descriptor)
+    {
+        MudDialog.Close(DialogResult.Ok(descriptor));
+        return Task.CompletedTask;
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.css
@@ -1,0 +1,155 @@
+.state-machine-activity-picker {
+    display: grid;
+    gap: 1rem;
+    min-width: 0;
+    color: var(--mud-palette-text-primary);
+}
+
+.state-machine-activity-picker__intro,
+.state-machine-activity-picker__state,
+.state-machine-activity-picker__group,
+.state-machine-activity-picker__option,
+.state-machine-activity-picker__quick-option {
+    display: grid;
+    gap: .375rem;
+}
+
+.state-machine-activity-picker__intro p,
+.state-machine-activity-picker__intro h2,
+.state-machine-activity-picker__intro h3,
+.state-machine-activity-picker__intro h6,
+.state-machine-activity-picker__group h3,
+.state-machine-activity-picker__state strong,
+.state-machine-activity-picker__state span,
+.state-machine-activity-picker__option strong,
+.state-machine-activity-picker__option span,
+.state-machine-activity-picker__quick-option strong,
+.state-machine-activity-picker__quick-option span {
+    margin: 0;
+}
+
+.state-machine-activity-picker__eyebrow {
+    color: var(--mud-palette-primary);
+    font-size: .6875rem;
+    font-weight: 700;
+    letter-spacing: .055em;
+    text-transform: uppercase;
+}
+
+.state-machine-activity-picker__search {
+    min-width: 0;
+}
+
+.state-machine-activity-picker__groups {
+    display: grid;
+    gap: 1rem;
+    max-height: min(52vh, 32rem);
+    overflow-y: auto;
+    padding: .125rem .125rem .25rem;
+}
+
+.state-machine-activity-picker__group {
+    gap: .5rem;
+}
+
+.state-machine-activity-picker__group h3 {
+    color: var(--mud-palette-text-secondary);
+    font-size: .75rem;
+    font-weight: 700;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.state-machine-activity-picker__options {
+    display: grid;
+    gap: .5rem;
+}
+
+.state-machine-activity-picker__option,
+.state-machine-activity-picker__quick-option {
+    width: 100%;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    cursor: pointer;
+    padding: .75rem;
+    text-align: left;
+}
+
+.state-machine-activity-picker__option:hover,
+.state-machine-activity-picker__option:focus-visible {
+    border-color: var(--mud-palette-primary);
+    background: var(--mud-palette-action-default-hover);
+}
+
+.state-machine-activity-picker__quick-option {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    border-color: var(--mud-palette-primary);
+    background: var(--mud-palette-action-default-hover);
+}
+
+.state-machine-activity-picker__quick-option:hover,
+.state-machine-activity-picker__quick-option:focus-visible {
+    background: var(--mud-palette-surface);
+}
+
+.state-machine-activity-picker__quick-icon {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--mud-palette-primary);
+    color: var(--mud-palette-primary-text);
+    font-size: 1.25rem;
+}
+
+.state-machine-activity-picker__option-copy,
+.state-machine-activity-picker__quick-option > span:last-child {
+    display: grid;
+    gap: .125rem;
+    min-width: 0;
+}
+
+.state-machine-activity-picker__option-copy span,
+.state-machine-activity-picker__quick-option > span:last-child > span,
+.state-machine-activity-picker__option-description,
+.state-machine-activity-picker__state span {
+    color: var(--mud-palette-text-secondary);
+    font-size: .8125rem;
+}
+
+.state-machine-activity-picker__option-description {
+    line-height: 1.4;
+}
+
+.state-machine-activity-picker__state {
+    min-height: 8rem;
+    place-content: center;
+    justify-items: center;
+    padding: 1.5rem;
+    border: 1px dashed var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    text-align: center;
+}
+
+.state-machine-activity-picker__state--error {
+    border-color: var(--mud-palette-error);
+}
+
+.state-machine-activity-picker__state--error strong {
+    color: var(--mud-palette-error);
+}
+
+button:focus-visible {
+    outline: 2px solid var(--mud-palette-primary);
+    outline-offset: 2px;
+}
+
+@media (max-width: 700px) {
+    .state-machine-activity-picker__groups {
+        max-height: 48vh;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
@@ -1,5 +1,5 @@
-@using Elsa.Studio.Workflows.Designer.Models
 @using Elsa.Studio.Localization
+@using Elsa.Studio.Workflows.Designer.Models
 @namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
 @inject ILocalizer Localizer
 
@@ -13,6 +13,7 @@
         {
             <button class="state-machine-transition-inspector__button state-machine-transition-inspector__button--danger"
                     type="button"
+                    data-testid="state-machine-transition-delete"
                     @onclick="() => DeleteRequested.InvokeAsync()">
                 @Localizer["Delete"]
             </button>
@@ -21,54 +22,127 @@
 
     @if (Transition == null)
     {
-        <p class="state-machine-transition-inspector__empty">@Localizer["Select a transition in the diagram or outline to inspect it."]</p>
+        <p class="state-machine-transition-inspector__empty" role="status">@Localizer["Select a transition in the diagram or outline to inspect it."]</p>
     }
     else
     {
-        <div class="state-machine-transition-inspector__route" aria-label="@Localizer["Transition route"]">
-            <span>@StateMachinePresentationFormatter.DisplayValue(Transition.From)</span>
-            <span aria-hidden="true">→</span>
-            <span>@StateMachinePresentationFormatter.DisplayValue(Transition.To)</span>
+        <div class="state-machine-transition-inspector__story" aria-label="@Localizer["Execution story"]">
+            <section class="state-machine-transition-inspector__stage" data-transition-slot="trigger" aria-labelledby="@TriggerStageId">
+                <div class="state-machine-transition-inspector__stage-marker" aria-hidden="true">@Localizer["WHEN"]</div>
+                <div class="state-machine-transition-inspector__stage-content">
+                    <div class="state-machine-transition-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-transition-inspector__stage-kicker">@Localizer["WHEN"]</p>
+                            <h4 id="@TriggerStageId">@Localizer["Trigger"]</h4>
+                        </div>
+                        <span class="state-machine-transition-inspector__stage-note">@Localizer["Starts the transition"]</span>
+                    </div>
+                    @RenderActivitySlot("trigger", Transition.Trigger, true)
+                </div>
+            </section>
+
+            <div class="state-machine-transition-inspector__connector" aria-hidden="true">↓</div>
+
+            <section class="state-machine-transition-inspector__stage" data-transition-slot="condition" aria-labelledby="@ConditionStageId">
+                <div class="state-machine-transition-inspector__stage-marker" aria-hidden="true">@Localizer["ONLY IF"]</div>
+                <div class="state-machine-transition-inspector__stage-content">
+                    <div class="state-machine-transition-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-transition-inspector__stage-kicker">@Localizer["ONLY IF"]</p>
+                            <h4 id="@ConditionStageId">@Localizer["Condition"]</h4>
+                        </div>
+                        @if (!IsReadOnly)
+                        {
+                            <button class="state-machine-transition-inspector__button"
+                                    type="button"
+                                    data-slot-action="edit"
+                                    data-testid="state-machine-transition-condition-edit"
+                                    @onclick="RequestConditionEditAsync">
+                                @Localizer["Edit"]
+                            </button>
+                        }
+                    </div>
+                    @RenderCondition(Transition.Condition)
+                </div>
+            </section>
+
+            <div class="state-machine-transition-inspector__connector" aria-hidden="true">↓</div>
+
+            <section class="state-machine-transition-inspector__stage" data-transition-slot="action" aria-labelledby="@ActionStageId">
+                <div class="state-machine-transition-inspector__stage-marker" aria-hidden="true">@Localizer["THEN"]</div>
+                <div class="state-machine-transition-inspector__stage-content">
+                    <div class="state-machine-transition-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-transition-inspector__stage-kicker">@Localizer["THEN"]</p>
+                            <h4 id="@ActionStageId">@Localizer["Action"]</h4>
+                        </div>
+                        <span class="state-machine-transition-inspector__stage-note">@Localizer["Runs after source exit"]</span>
+                    </div>
+                    @RenderActivitySlot("action", Transition.Action, false)
+                </div>
+            </section>
+
+            <div class="state-machine-transition-inspector__connector" aria-hidden="true">↓</div>
+
+            <section class="state-machine-transition-inspector__stage state-machine-transition-inspector__stage--destination" data-transition-slot="to" aria-labelledby="@DestinationStageId">
+                <div class="state-machine-transition-inspector__stage-marker" aria-hidden="true">@Localizer["TO"]</div>
+                <div class="state-machine-transition-inspector__stage-content">
+                    <div class="state-machine-transition-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-transition-inspector__stage-kicker">@Localizer["TO"]</p>
+                            <h4 id="@DestinationStageId">@StateMachinePresentationFormatter.DisplayValue(Transition.To)</h4>
+                        </div>
+                        <span class="state-machine-transition-inspector__stage-note">@Localizer["Target state"]</span>
+                    </div>
+                </div>
+            </section>
         </div>
 
-        <div class="state-machine-transition-inspector__fields">
-            <div class="state-machine-transition-inspector__field-grid">
-                <div class="state-machine-transition-inspector__field">
-                    <label for="@NameId">@Localizer["Name"]</label>
-                    <input id="@NameId" class="state-machine-transition-inspector__control" value="@Transition.Name" disabled="@IsReadOnly" @onchange="ChangeNameAsync" />
-                </div>
-                <div class="state-machine-transition-inspector__field">
-                    <label for="@DisplayNameId">@Localizer["Display name"]</label>
-                    <input id="@DisplayNameId" class="state-machine-transition-inspector__control" value="@Transition.DisplayName" disabled="@IsReadOnly" @onchange="ChangeDisplayNameAsync" />
-                </div>
-                <div class="state-machine-transition-inspector__field">
-                    <label for="@FromId">@Localizer["From"]</label>
-                    <select id="@FromId" class="state-machine-transition-inspector__control" value="@Transition.From" disabled="@IsReadOnly" @onchange="ChangeFromAsync">
-                        @foreach (var state in States)
-                        {
-                            <option value="@state.Name">@StateMachinePresentationFormatter.DisplayValue(state.Name)</option>
-                        }
-                    </select>
-                </div>
-                <div class="state-machine-transition-inspector__field">
-                    <label for="@ToId">@Localizer["To"]</label>
-                    <select id="@ToId" class="state-machine-transition-inspector__control" value="@Transition.To" disabled="@IsReadOnly" @onchange="ChangeToAsync">
-                        @foreach (var state in States)
-                        {
-                            <option value="@state.Name">@StateMachinePresentationFormatter.DisplayValue(state.Name)</option>
-                        }
-                    </select>
+        <details class="state-machine-transition-inspector__details">
+            <summary>
+                <span>@Localizer["Transition details"]</span>
+                <span class="state-machine-transition-inspector__details-route">
+                    @StateMachinePresentationFormatter.DisplayValue(Transition.From)
+                    <span aria-hidden="true">→</span>
+                    @StateMachinePresentationFormatter.DisplayValue(Transition.To)
+                </span>
+            </summary>
+            <div class="state-machine-transition-inspector__fields">
+                <div class="state-machine-transition-inspector__field-grid">
+                    <div class="state-machine-transition-inspector__field">
+                        <label for="@NameId">@Localizer["Name"]</label>
+                        <input id="@NameId" class="state-machine-transition-inspector__control" value="@Transition.Name" disabled="@IsReadOnly" @onchange="ChangeNameAsync" />
+                    </div>
+                    <div class="state-machine-transition-inspector__field">
+                        <label for="@DisplayNameId">@Localizer["Display name"]</label>
+                        <input id="@DisplayNameId" class="state-machine-transition-inspector__control" value="@Transition.DisplayName" disabled="@IsReadOnly" @onchange="ChangeDisplayNameAsync" />
+                    </div>
+                    <div class="state-machine-transition-inspector__field">
+                        <label for="@FromId">@Localizer["From"]</label>
+                        <select id="@FromId" class="state-machine-transition-inspector__control" value="@Transition.From" disabled="@IsReadOnly" @onchange="ChangeFromAsync">
+                            @foreach (var state in States)
+                            {
+                                <option value="@state.Name">@StateMachinePresentationFormatter.DisplayValue(state.Name)</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="state-machine-transition-inspector__field">
+                        <label for="@ToId">@Localizer["To"]</label>
+                        <select id="@ToId" class="state-machine-transition-inspector__control" value="@Transition.To" disabled="@IsReadOnly" @onchange="ChangeToAsync">
+                            @foreach (var state in States)
+                            {
+                                <option value="@state.Name">@StateMachinePresentationFormatter.DisplayValue(state.Name)</option>
+                            }
+                        </select>
+                    </div>
                 </div>
             </div>
-
-            @RenderSlot("trigger", Localizer["Trigger"], Transition.Trigger)
-            @RenderSlot("condition", Localizer["Condition"], Transition.Condition, false)
-            @RenderSlot("action", Localizer["Action"], Transition.Action)
-        </div>
+        </details>
 
         @if (ValidationIssues.Count > 0)
         {
             <div class="state-machine-transition-inspector__issues" role="alert" aria-label="@Localizer["Transition validation issues"]">
+                <strong>@Localizer["Validation"]</strong>
                 @foreach (var issue in ValidationIssues)
                 {
                     <p><strong>@issue.Severity:</strong> @Localizer[issue.Message]</p>
@@ -77,85 +151,3 @@
         }
     }
 </section>
-
-@code {
-    private readonly string _id = $"state-machine-transition-inspector-{Guid.NewGuid():N}";
-
-    [Parameter] public StateMachineTransitionEdge? Transition { get; set; }
-    [Parameter] public IReadOnlyCollection<StateMachineStateNode> States { get; set; } = [];
-    [Parameter] public bool IsReadOnly { get; set; }
-    [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
-    [Parameter] public EventCallback<string?> NameChanged { get; set; }
-    [Parameter] public EventCallback<string?> DisplayNameChanged { get; set; }
-    [Parameter] public EventCallback<string> FromChanged { get; set; }
-    [Parameter] public EventCallback<string> ToChanged { get; set; }
-    [Parameter] public EventCallback<StateMachineSlotValueChange> SlotChanged { get; set; }
-    [Parameter] public EventCallback<string> SlotCleared { get; set; }
-    [Parameter] public EventCallback<string> SlotDropRequested { get; set; }
-    [Parameter] public EventCallback DeleteRequested { get; set; }
-
-    private string HeadingId => $"{_id}-heading";
-    private string NameId => $"{_id}-name";
-    private string DisplayNameId => $"{_id}-display-name";
-    private string FromId => $"{_id}-from";
-    private string ToId => $"{_id}-to";
-
-    private Task ChangeNameAsync(ChangeEventArgs args) => NameChanged.InvokeAsync(NormalizeOptionalValue(args.Value));
-    private Task ChangeDisplayNameAsync(ChangeEventArgs args) => DisplayNameChanged.InvokeAsync(NormalizeOptionalValue(args.Value));
-    private Task ChangeFromAsync(ChangeEventArgs args) => FromChanged.InvokeAsync(args.Value?.ToString() ?? "");
-    private Task ChangeToAsync(ChangeEventArgs args) => ToChanged.InvokeAsync(args.Value?.ToString() ?? "");
-
-    private static string? NormalizeOptionalValue(object? value)
-    {
-        var text = value?.ToString();
-        return string.IsNullOrWhiteSpace(text) ? null : text;
-    }
-
-    private RenderFragment RenderSlot(string slotName, string label, System.Text.Json.Nodes.JsonNode? value, bool acceptsDrop = true) => builder =>
-    {
-        var fieldId = $"{_id}-{slotName}";
-        var helpId = $"{fieldId}-help";
-        var sequence = 0;
-
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__field");
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__field-heading");
-        builder.OpenElement(sequence++, "label");
-        builder.AddAttribute(sequence++, "for", fieldId);
-        builder.AddContent(sequence++, label);
-        builder.CloseElement();
-        if (!IsReadOnly)
-        {
-            builder.OpenElement(sequence++, "button");
-            builder.AddAttribute(sequence++, "type", "button");
-            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__button");
-            builder.AddAttribute(sequence++, "onclick", EventCallback.Factory.Create(this, () => SlotCleared.InvokeAsync(slotName)));
-            builder.AddContent(sequence++, Localizer["Clear"]);
-            builder.CloseElement();
-        }
-        builder.CloseElement();
-        builder.OpenElement(sequence++, "textarea");
-        builder.AddAttribute(sequence++, "id", fieldId);
-        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__control state-machine-transition-inspector__control--code");
-        builder.AddAttribute(sequence++, "aria-describedby", helpId);
-        builder.AddAttribute(sequence++, "disabled", IsReadOnly);
-        builder.AddAttribute(sequence++, "value", StateMachinePresentationFormatter.JsonSlot(value));
-        builder.AddAttribute(sequence++, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, args => SlotChanged.InvokeAsync(new(slotName, args.Value?.ToString()))));
-        if (acceptsDrop)
-        {
-            builder.AddAttribute(sequence++, "ondragover", EventCallback.Factory.Create<DragEventArgs>(this, _ => Task.CompletedTask));
-            builder.AddEventPreventDefaultAttribute(sequence++, "ondragover", true);
-            builder.AddAttribute(sequence++, "ondrop", EventCallback.Factory.Create<DragEventArgs>(this, _ => SlotDropRequested.InvokeAsync(slotName)));
-        }
-        builder.CloseElement();
-        builder.OpenElement(sequence++, "p");
-        builder.AddAttribute(sequence++, "id", helpId);
-        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__help");
-        builder.AddContent(sequence++, acceptsDrop
-            ? Localizer["Enter activity JSON or drop an activity here."]
-            : Localizer["Enter a JSON condition."]);
-        builder.CloseElement();
-        builder.CloseElement();
-    };
-}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
@@ -148,14 +148,17 @@ public partial class StateMachineTransitionInspector
                 builder.CloseElement();
             }
 
-            if (!IsReadOnly)
+            if (activity.State != ActivityState.Malformed || !IsReadOnly)
             {
                 builder.OpenElement(sequence++, "div");
                 builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-actions");
                 if (activity.State != ActivityState.Malformed)
                     AddSlotButton(builder, ref sequence, "open", Localizer["Open"], $"Open {slotName} activity", slotName, RequestActivityOpenAsync);
-                AddSlotButton(builder, ref sequence, "replace", Localizer["Replace"], $"Replace {slotName} activity", slotName, RequestActivityReplaceAsync);
-                AddSlotButton(builder, ref sequence, "clear", Localizer["Clear"], $"Clear {slotName} activity", slotName, RequestActivityClearAsync);
+                if (!IsReadOnly)
+                {
+                    AddSlotButton(builder, ref sequence, "replace", Localizer["Replace"], $"Replace {slotName} activity", slotName, RequestActivityReplaceAsync);
+                    AddSlotButton(builder, ref sequence, "clear", Localizer["Clear"], $"Clear {slotName} activity", slotName, RequestActivityClearAsync);
+                }
                 builder.CloseElement();
             }
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
@@ -10,12 +10,14 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 
 public partial class StateMachineTransitionInspector
 {
+    private static readonly IReadOnlyCollection<string> DefaultKnownExpressionProviderTypes = ["JavaScript"];
     private readonly string _id = $"state-machine-transition-inspector-{Guid.NewGuid():N}";
 
     [Parameter] public StateMachineTransitionEdge? Transition { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineStateNode> States { get; set; } = [];
     [Parameter] public bool IsReadOnly { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
+    [Parameter] public IReadOnlyCollection<string> KnownExpressionProviderTypes { get; set; } = DefaultKnownExpressionProviderTypes;
     [Parameter] public EventCallback<string?> NameChanged { get; set; }
     [Parameter] public EventCallback<string?> DisplayNameChanged { get; set; }
     [Parameter] public EventCallback<string> FromChanged { get; set; }
@@ -251,6 +253,9 @@ public partial class StateMachineTransitionInspector
         if (string.IsNullOrWhiteSpace(typeName))
             return new(ActivityState.Malformed, Localizer["Unavailable activity definition"], Localizer["The activity type is missing."], rawDefinition);
 
+        if (string.IsNullOrWhiteSpace(GetString(obj, "id")) || string.IsNullOrWhiteSpace(GetString(obj, "nodeId")))
+            return new(ActivityState.Malformed, Localizer["Incomplete activity definition"], Localizer["An activity id and node ID are required."], rawDefinition);
+
         var title = FirstNonEmpty(GetString(obj, "displayName"), GetString(obj, "name"), typeName)!;
         var version = GetString(obj, "version");
         var detail = string.IsNullOrWhiteSpace(version) ? typeName : $"{typeName} · v{version}";
@@ -259,7 +264,7 @@ public partial class StateMachineTransitionInspector
 
     private ConditionPresentation DescribeCondition(JsonNode? value)
     {
-        var description = BooleanConditionAdapter.Inspect(value);
+        var description = BooleanConditionAdapter.Inspect(value, KnownExpressionProviderTypes ?? DefaultKnownExpressionProviderTypes);
         return description.Kind switch
         {
             BooleanConditionKind.Missing => new(

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
@@ -1,0 +1,324 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer;
+using Elsa.Studio.Workflows.Designer.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+
+public partial class StateMachineTransitionInspector
+{
+    private readonly string _id = $"state-machine-transition-inspector-{Guid.NewGuid():N}";
+
+    [Parameter] public StateMachineTransitionEdge? Transition { get; set; }
+    [Parameter] public IReadOnlyCollection<StateMachineStateNode> States { get; set; } = [];
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
+    [Parameter] public EventCallback<string?> NameChanged { get; set; }
+    [Parameter] public EventCallback<string?> DisplayNameChanged { get; set; }
+    [Parameter] public EventCallback<string> FromChanged { get; set; }
+    [Parameter] public EventCallback<string> ToChanged { get; set; }
+
+    // Retained for compatibility with the original wrapper contract. New callers should use
+    // the semantic activity events below so the wrapper can choose the appropriate mutation path.
+    [Parameter] public EventCallback<StateMachineSlotValueChange> SlotChanged { get; set; }
+    [Parameter] public EventCallback<string> SlotCleared { get; set; }
+    [Parameter] public EventCallback<string> SlotDropRequested { get; set; }
+
+    [Parameter] public EventCallback<string> ActivityAddRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityOpenRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityReplaceRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityClearRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityDropRequested { get; set; }
+    [Parameter] public EventCallback<string> ConditionEditRequested { get; set; }
+    [Parameter] public EventCallback DeleteRequested { get; set; }
+
+    private string HeadingId => $"{_id}-heading";
+    private string TriggerStageId => $"{_id}-trigger-stage";
+    private string ConditionStageId => $"{_id}-condition-stage";
+    private string ActionStageId => $"{_id}-action-stage";
+    private string DestinationStageId => $"{_id}-destination-stage";
+    private string NameId => $"{_id}-name";
+    private string DisplayNameId => $"{_id}-display-name";
+    private string FromId => $"{_id}-from";
+    private string ToId => $"{_id}-to";
+
+    private Task ChangeNameAsync(ChangeEventArgs args) => NameChanged.InvokeAsync(NormalizeOptionalValue(args.Value));
+    private Task ChangeDisplayNameAsync(ChangeEventArgs args) => DisplayNameChanged.InvokeAsync(NormalizeOptionalValue(args.Value));
+    private Task ChangeFromAsync(ChangeEventArgs args) => FromChanged.InvokeAsync(args.Value?.ToString() ?? "");
+    private Task ChangeToAsync(ChangeEventArgs args) => ToChanged.InvokeAsync(args.Value?.ToString() ?? "");
+
+    private Task RequestConditionEditAsync() => ConditionEditRequested.InvokeAsync("condition");
+
+    private Task RequestActivityAddAsync(string slotName) => ActivityAddRequested.InvokeAsync(slotName);
+    private Task RequestActivityOpenAsync(string slotName) => ActivityOpenRequested.InvokeAsync(slotName);
+    private Task RequestActivityReplaceAsync(string slotName) => ActivityReplaceRequested.InvokeAsync(slotName);
+
+    private Task RequestActivityClearAsync(string slotName) => ActivityClearRequested.HasDelegate
+        ? ActivityClearRequested.InvokeAsync(slotName)
+        : SlotCleared.InvokeAsync(slotName);
+
+    private Task RequestActivityDropAsync(string slotName) => ActivityDropRequested.HasDelegate
+        ? ActivityDropRequested.InvokeAsync(slotName)
+        : SlotDropRequested.InvokeAsync(slotName);
+
+    private static string? NormalizeOptionalValue(object? value)
+    {
+        var text = value?.ToString();
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private RenderFragment RenderActivitySlot(string slotName, JsonNode? value, bool isTrigger) => builder =>
+    {
+        var activity = DescribeActivity(value);
+        var sequence = 0;
+
+        builder.OpenElement(sequence++, "div");
+        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot");
+        builder.AddAttribute(sequence++, "data-slot-state", activity.State.ToString().ToLowerInvariant());
+        builder.AddAttribute(sequence++, "data-slot-action", "drop");
+        builder.AddAttribute(sequence++, "aria-label", Localizer[$"{slotName} activity slot"]);
+
+        if (!IsReadOnly)
+        {
+            builder.AddAttribute(sequence++, "ondragover", EventCallback.Factory.Create<DragEventArgs>(this, OnDragOverAsync));
+            builder.AddEventPreventDefaultAttribute(sequence++, "ondragover", true);
+            builder.AddAttribute(sequence++, "ondrop", EventCallback.Factory.Create<DragEventArgs>(this, _ => RequestActivityDropAsync(slotName)));
+            builder.AddEventPreventDefaultAttribute(sequence++, "ondrop", true);
+        }
+
+        if (activity.State == ActivityState.Empty)
+        {
+            builder.OpenElement(sequence++, "div");
+            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-empty");
+            builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-empty");
+            builder.OpenElement(sequence++, "strong");
+            builder.AddContent(sequence++, isTrigger ? Localizer["No trigger configured"] : Localizer["No action configured"]);
+            builder.CloseElement();
+            builder.OpenElement(sequence++, "span");
+            builder.AddContent(sequence++, isTrigger
+                ? Localizer["This transition evaluates immediately after source entry."]
+                : Localizer["No activity runs between source exit and the target state."]);
+            builder.CloseElement();
+            if (!IsReadOnly)
+                AddSlotButton(builder, ref sequence, "add", isTrigger ? Localizer["Add trigger"] : Localizer["Add action"], $"Add {slotName} activity", slotName, RequestActivityAddAsync);
+            builder.CloseElement();
+        }
+        else
+        {
+            builder.OpenElement(sequence++, "div");
+            builder.AddAttribute(sequence++, "class", activity.State == ActivityState.Malformed
+                ? "state-machine-transition-inspector__activity-card state-machine-transition-inspector__activity-card--invalid"
+                : "state-machine-transition-inspector__activity-card");
+            builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-activity");
+            builder.AddAttribute(sequence++, "data-activity-state", activity.State.ToString().ToLowerInvariant());
+
+            builder.OpenElement(sequence++, "div");
+            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__activity-copy");
+            builder.OpenElement(sequence++, "strong");
+            builder.AddContent(sequence++, activity.Title);
+            builder.CloseElement();
+            builder.OpenElement(sequence++, "span");
+            builder.AddContent(sequence++, activity.Detail);
+            builder.CloseElement();
+            builder.CloseElement();
+
+            if (activity.State == ActivityState.Malformed)
+            {
+                builder.OpenElement(sequence++, "p");
+                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-warning");
+                builder.AddAttribute(sequence++, "role", "status");
+                builder.AddContent(sequence++, Localizer["This definition is invalid and will be preserved until you replace or clear it."]);
+                builder.CloseElement();
+            }
+
+            if (!string.IsNullOrWhiteSpace(activity.RawDefinition))
+            {
+                builder.OpenElement(sequence++, "details");
+                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__definition");
+                builder.OpenElement(sequence++, "summary");
+                builder.AddContent(sequence++, Localizer["View definition"]);
+                builder.CloseElement();
+                builder.OpenElement(sequence++, "pre");
+                builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-definition");
+                builder.AddContent(sequence++, activity.RawDefinition);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+
+            if (!IsReadOnly)
+            {
+                builder.OpenElement(sequence++, "div");
+                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-actions");
+                if (activity.State != ActivityState.Malformed)
+                    AddSlotButton(builder, ref sequence, "open", Localizer["Open"], $"Open {slotName} activity", slotName, RequestActivityOpenAsync);
+                AddSlotButton(builder, ref sequence, "replace", Localizer["Replace"], $"Replace {slotName} activity", slotName, RequestActivityReplaceAsync);
+                AddSlotButton(builder, ref sequence, "clear", Localizer["Clear"], $"Clear {slotName} activity", slotName, RequestActivityClearAsync);
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        }
+
+        builder.CloseElement();
+    };
+
+    private RenderFragment RenderCondition(JsonNode? value) => builder =>
+    {
+        var condition = DescribeCondition(value);
+        var sequence = 0;
+
+        builder.OpenElement(sequence++, "div");
+        builder.AddAttribute(sequence++, "class", condition.State is ConditionState.Never or ConditionState.Malformed
+            ? "state-machine-transition-inspector__condition state-machine-transition-inspector__condition--warning"
+            : "state-machine-transition-inspector__condition");
+        builder.AddAttribute(sequence++, "data-condition-state", condition.State.ToString().ToLowerInvariant());
+        builder.AddAttribute(sequence++, "data-testid", "state-machine-transition-condition-summary");
+        builder.OpenElement(sequence++, "strong");
+        builder.AddContent(sequence++, condition.Title);
+        builder.CloseElement();
+        builder.OpenElement(sequence++, "span");
+        builder.AddContent(sequence++, condition.Detail);
+        builder.CloseElement();
+
+        if (!string.IsNullOrWhiteSpace(condition.Warning))
+        {
+            builder.OpenElement(sequence++, "p");
+            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-warning");
+            builder.AddAttribute(sequence++, "role", "status");
+            builder.AddContent(sequence++, condition.Warning);
+            builder.CloseElement();
+        }
+
+        if (!string.IsNullOrWhiteSpace(condition.RawDefinition))
+        {
+            builder.OpenElement(sequence++, "details");
+            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__definition");
+            builder.OpenElement(sequence++, "summary");
+            builder.AddContent(sequence++, Localizer["View definition"]);
+            builder.CloseElement();
+            builder.OpenElement(sequence++, "pre");
+            builder.AddAttribute(sequence++, "data-testid", "state-machine-transition-condition-definition");
+            builder.AddContent(sequence++, condition.RawDefinition);
+            builder.CloseElement();
+            builder.CloseElement();
+        }
+
+        builder.CloseElement();
+    };
+
+    private void AddSlotButton(
+        RenderTreeBuilder builder,
+        ref int sequence,
+        string action,
+        string text,
+        string ariaLabel,
+        string slotName,
+        Func<string, Task> callback)
+    {
+        builder.OpenElement(sequence++, "button");
+        builder.AddAttribute(sequence++, "type", "button");
+        builder.AddAttribute(sequence++, "class", action == "clear"
+            ? "state-machine-transition-inspector__button state-machine-transition-inspector__button--subtle"
+            : "state-machine-transition-inspector__button");
+        builder.AddAttribute(sequence++, "data-slot-action", action);
+        builder.AddAttribute(sequence++, "aria-label", Localizer[ariaLabel]);
+        builder.AddAttribute(sequence++, "onclick", EventCallback.Factory.Create(this, () => callback(slotName)));
+        builder.AddContent(sequence++, text);
+        builder.CloseElement();
+    }
+
+    private static Task OnDragOverAsync(DragEventArgs _) => Task.CompletedTask;
+
+    private ActivityPresentation DescribeActivity(JsonNode? value)
+    {
+        if (value == null)
+            return new(ActivityState.Empty, string.Empty, string.Empty, string.Empty);
+
+        var rawDefinition = StateMachinePresentationFormatter.JsonSlot(value);
+        if (value is not JsonObject obj)
+            return new(ActivityState.Malformed, Localizer["Invalid activity definition"], Localizer["Expected an activity object."], rawDefinition);
+
+        if (StateMachineDesignerConstants.IsInvalidJsonSlotMarker(obj))
+            return new(ActivityState.Malformed, Localizer["Invalid activity definition"], Localizer["The original source is preserved."], rawDefinition);
+
+        var typeName = GetString(obj, "type");
+        if (string.IsNullOrWhiteSpace(typeName))
+            return new(ActivityState.Malformed, Localizer["Unavailable activity definition"], Localizer["The activity type is missing."], rawDefinition);
+
+        var title = FirstNonEmpty(GetString(obj, "displayName"), GetString(obj, "name"), typeName)!;
+        var version = GetString(obj, "version");
+        var detail = string.IsNullOrWhiteSpace(version) ? typeName : $"{typeName} · v{version}";
+        return new(ActivityState.Configured, Localizer[title], detail, rawDefinition);
+    }
+
+    private ConditionPresentation DescribeCondition(JsonNode? value)
+    {
+        var description = BooleanConditionAdapter.Inspect(value);
+        return description.Kind switch
+        {
+            BooleanConditionKind.Missing => new(
+                ConditionState.Missing,
+                Localizer["Always"],
+                Localizer["No condition configured; this transition evaluates as true."],
+                string.Empty,
+                string.Empty),
+            BooleanConditionKind.Literal => BooleanCondition(
+                description.LiteralValue == true,
+                description.LiteralValue == true ? Localizer["Explicitly enabled."] : Localizer["Explicitly disabled."]),
+            BooleanConditionKind.Expression => new(
+                ConditionState.Expression,
+                Localizer[description.ExpressionType ?? "Expression"],
+                description.ExpressionValue ?? string.Empty,
+                string.Empty,
+                string.Empty),
+            BooleanConditionKind.Unknown => new(
+                ConditionState.Unknown,
+                string.IsNullOrWhiteSpace(description.ExpressionType) ? Localizer["Custom condition"] : Localizer["Unavailable condition"],
+                string.IsNullOrWhiteSpace(description.ExpressionType)
+                    ? Localizer["A custom definition is preserved."]
+                    : $"{description.ExpressionType} · {Localizer["definition preserved"]}",
+                StateMachinePresentationFormatter.JsonSlot(value),
+                string.Empty),
+            _ => new(
+                ConditionState.Malformed,
+                Localizer["Invalid condition definition"],
+                Localizer["The original source is preserved."],
+                StateMachinePresentationFormatter.JsonSlot(value),
+                Localizer["This condition cannot be evaluated until it is repaired or replaced."])
+        };
+    }
+
+    private ConditionPresentation BooleanCondition(bool value, string detail) => value
+        ? new(ConditionState.Always, Localizer["Always"], detail, string.Empty, string.Empty)
+        : new(ConditionState.Never, Localizer["Never"], detail, string.Empty, Localizer["This transition cannot pass while the condition is false."]);
+
+    private static string? GetString(JsonObject obj, string propertyName) => obj[propertyName] is JsonValue value && value.TryGetValue<string>(out var text)
+        ? text
+        : null;
+
+    private static string? FirstNonEmpty(params string?[] values) => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+    private enum ActivityState
+    {
+        Empty,
+        Configured,
+        Malformed
+    }
+
+    private enum ConditionState
+    {
+        Missing,
+        Always,
+        Never,
+        Expression,
+        Unknown,
+        Malformed
+    }
+
+    private sealed record ActivityPresentation(ActivityState State, string Title, string Detail, string RawDefinition);
+
+    private sealed record ConditionPresentation(ConditionState State, string Title, string Detail, string RawDefinition, string Warning);
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
@@ -1,12 +1,13 @@
 .state-machine-transition-inspector {
     display: grid;
     gap: 1rem;
+    min-width: 0;
     color: var(--mud-palette-text-primary);
 }
 
 .state-machine-transition-inspector__header,
-.state-machine-transition-inspector__field-heading,
-.state-machine-transition-inspector__route {
+.state-machine-transition-inspector__stage-heading,
+.state-machine-transition-inspector__details summary {
     display: flex;
     align-items: center;
 }
@@ -18,8 +19,18 @@
 
 .state-machine-transition-inspector__header h3,
 .state-machine-transition-inspector__eyebrow,
-.state-machine-transition-inspector__help,
-.state-machine-transition-inspector__issues p {
+.state-machine-transition-inspector__stage-kicker,
+.state-machine-transition-inspector__stage-heading h4,
+.state-machine-transition-inspector__stage-note,
+.state-machine-transition-inspector__slot-empty,
+.state-machine-transition-inspector__slot-empty span,
+.state-machine-transition-inspector__slot-warning,
+.state-machine-transition-inspector__condition span,
+.state-machine-transition-inspector__condition p,
+.state-machine-transition-inspector__issues p,
+.state-machine-transition-inspector__details summary,
+.state-machine-transition-inspector__details-route,
+.state-machine-transition-inspector__definition summary {
     margin: 0;
 }
 
@@ -29,26 +40,261 @@
 }
 
 .state-machine-transition-inspector__eyebrow,
-.state-machine-transition-inspector__help {
+.state-machine-transition-inspector__stage-kicker,
+.state-machine-transition-inspector__stage-note,
+.state-machine-transition-inspector__details-route {
     color: var(--mud-palette-text-secondary);
     font-size: .75rem;
 }
 
-.state-machine-transition-inspector__eyebrow {
-    margin-bottom: .125rem;
+.state-machine-transition-inspector__eyebrow,
+.state-machine-transition-inspector__stage-kicker {
     font-weight: 600;
     letter-spacing: .04em;
     text-transform: uppercase;
 }
 
-.state-machine-transition-inspector__route {
+.state-machine-transition-inspector__eyebrow {
+    margin-bottom: .125rem;
+}
+
+.state-machine-transition-inspector__story {
+    display: grid;
     gap: .5rem;
+}
+
+.state-machine-transition-inspector__stage {
+    display: grid;
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+    gap: .75rem;
+    min-width: 0;
+    padding: .875rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-surface);
+}
+
+.state-machine-transition-inspector__stage--destination {
+    border-color: var(--mud-palette-primary);
+}
+
+.state-machine-transition-inspector__stage-marker {
+    align-self: start;
+    padding-top: .125rem;
+    color: var(--mud-palette-primary);
+    font-size: .6875rem;
+    font-weight: 700;
+    letter-spacing: .055em;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.state-machine-transition-inspector__stage-content {
+    display: grid;
+    gap: .75rem;
+    min-width: 0;
+}
+
+.state-machine-transition-inspector__stage-heading {
+    justify-content: space-between;
+    gap: .75rem;
+    min-width: 0;
+}
+
+.state-machine-transition-inspector__stage-heading h4 {
+    font-size: .9375rem;
+    font-weight: 600;
+}
+
+.state-machine-transition-inspector__stage-note {
+    max-width: 50%;
+    text-align: right;
+}
+
+.state-machine-transition-inspector__connector {
+    height: 1rem;
+    color: var(--mud-palette-text-secondary);
+    font-size: 1rem;
+    line-height: 1rem;
+    text-align: center;
+}
+
+.state-machine-transition-inspector__slot,
+.state-machine-transition-inspector__condition {
+    display: grid;
+    gap: .625rem;
+    min-width: 0;
+}
+
+.state-machine-transition-inspector__slot {
+    padding: .75rem;
+    border: 1px dashed var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+}
+
+.state-machine-transition-inspector__slot:not([data-slot-state="empty"]):hover {
+    border-color: var(--mud-palette-primary);
+}
+
+.state-machine-transition-inspector__slot-empty {
+    display: grid;
+    gap: .25rem;
+    color: var(--mud-palette-text-secondary);
+    font-size: .8125rem;
+}
+
+.state-machine-transition-inspector__slot-empty strong {
+    color: var(--mud-palette-text-primary);
+    font-weight: 600;
+}
+
+.state-machine-transition-inspector__slot-empty span,
+.state-machine-transition-inspector__condition span,
+.state-machine-transition-inspector__slot-warning {
+    font-size: .75rem;
+    line-height: 1.45;
+}
+
+.state-machine-transition-inspector__activity-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: .75rem;
+    min-width: 0;
+}
+
+.state-machine-transition-inspector__activity-card--invalid {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.state-machine-transition-inspector__activity-copy,
+.state-machine-transition-inspector__condition {
+    overflow-wrap: anywhere;
+}
+
+.state-machine-transition-inspector__activity-copy {
+    display: grid;
+    gap: .25rem;
+}
+
+.state-machine-transition-inspector__activity-copy strong,
+.state-machine-transition-inspector__condition strong {
+    font-size: .8125rem;
+    font-weight: 600;
+}
+
+.state-machine-transition-inspector__activity-copy span {
+    color: var(--mud-palette-text-secondary);
+    font-family: var(--mud-typography-default-family);
+    font-size: .6875rem;
+}
+
+.state-machine-transition-inspector__slot-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: .25rem;
+}
+
+.state-machine-transition-inspector__button {
+    min-height: 2.25rem;
+    padding: .375rem .625rem;
+    border: 1px solid transparent;
+    border-radius: var(--mud-default-borderradius);
+    background: transparent;
+    color: var(--mud-palette-primary);
+    font: inherit;
+    font-size: .75rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.state-machine-transition-inspector__button:hover {
+    border-color: var(--mud-palette-lines-default);
+    background: var(--mud-palette-action-default-hover);
+}
+
+.state-machine-transition-inspector__button--subtle {
+    color: var(--mud-palette-text-secondary);
+}
+
+.state-machine-transition-inspector__button--danger {
+    color: var(--mud-palette-error);
+}
+
+.state-machine-transition-inspector__button:focus-visible,
+.state-machine-transition-inspector__details summary:focus-visible {
+    outline: 2px solid var(--mud-palette-primary);
+    outline-offset: 2px;
+}
+
+.state-machine-transition-inspector__condition {
     padding: .75rem;
     border: 1px solid var(--mud-palette-lines-default);
     border-radius: var(--mud-default-borderradius);
     background: var(--mud-palette-surface);
-    font-size: .875rem;
+}
+
+.state-machine-transition-inspector__condition--warning,
+.state-machine-transition-inspector__activity-card--invalid {
+    border-color: var(--mud-palette-warning);
+}
+
+.state-machine-transition-inspector__condition--warning strong,
+.state-machine-transition-inspector__slot-warning {
+    color: var(--mud-palette-warning);
+}
+
+.state-machine-transition-inspector__slot-warning {
+    display: block;
+}
+
+.state-machine-transition-inspector__definition {
+    min-width: 0;
+}
+
+.state-machine-transition-inspector__definition summary,
+.state-machine-transition-inspector__details summary {
+    color: var(--mud-palette-primary);
+    cursor: pointer;
+    font-size: .75rem;
     font-weight: 600;
+    list-style-position: inside;
+}
+
+.state-machine-transition-inspector__definition pre {
+    max-height: 10rem;
+    margin: .5rem 0 0;
+    overflow: auto;
+    padding: .625rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-background-grey);
+    color: var(--mud-palette-text-secondary);
+    font-family: monospace;
+    font-size: .6875rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.state-machine-transition-inspector__details {
+    border-top: 1px solid var(--mud-palette-lines-default);
+    padding-top: .75rem;
+}
+
+.state-machine-transition-inspector__details summary {
+    justify-content: space-between;
+    gap: .75rem;
+    min-height: 2.25rem;
+}
+
+.state-machine-transition-inspector__details-route {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: .375rem;
+    justify-content: flex-end;
+    font-family: monospace;
 }
 
 .state-machine-transition-inspector__fields,
@@ -59,17 +305,13 @@
 
 .state-machine-transition-inspector__fields {
     gap: 1rem;
+    padding-top: .875rem;
 }
 
 .state-machine-transition-inspector__field-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem;
-}
-
-.state-machine-transition-inspector__field-heading {
-    justify-content: space-between;
-    gap: .75rem;
 }
 
 .state-machine-transition-inspector__field label {
@@ -89,19 +331,11 @@
     font: inherit;
 }
 
-.state-machine-transition-inspector__control--code {
-    min-height: 7rem;
-    resize: vertical;
-    font-family: var(--mud-typography-default-family);
-    font-size: .8125rem;
-}
-
 .state-machine-transition-inspector__control:hover:not(:disabled) {
     border-color: var(--mud-palette-text-secondary);
 }
 
-.state-machine-transition-inspector__control:focus-visible,
-.state-machine-transition-inspector__button:focus-visible {
+.state-machine-transition-inspector__control:focus-visible {
     outline: 2px solid var(--mud-palette-primary);
     outline-offset: 2px;
 }
@@ -109,27 +343,6 @@
 .state-machine-transition-inspector__control:disabled {
     background: var(--mud-palette-action-disabled-background);
     color: var(--mud-palette-action-disabled);
-}
-
-.state-machine-transition-inspector__button {
-    min-height: 2.25rem;
-    padding: .375rem .625rem;
-    border: 0;
-    border-radius: var(--mud-default-borderradius);
-    background: transparent;
-    color: var(--mud-palette-primary);
-    font: inherit;
-    font-size: .75rem;
-    font-weight: 600;
-    cursor: pointer;
-}
-
-.state-machine-transition-inspector__button:hover {
-    background: color-mix(in srgb, currentColor 8%, transparent);
-}
-
-.state-machine-transition-inspector__button--danger {
-    color: var(--mud-palette-error);
 }
 
 .state-machine-transition-inspector__empty,
@@ -150,8 +363,50 @@
     color: var(--mud-palette-error);
 }
 
+.state-machine-transition-inspector__issues > strong {
+    font-size: .8125rem;
+}
+
 @media (max-width: 700px) {
+    .state-machine-transition-inspector__stage {
+        grid-template-columns: minmax(0, 1fr);
+        gap: .5rem;
+    }
+
+    .state-machine-transition-inspector__stage-marker {
+        padding-top: 0;
+    }
+
+    .state-machine-transition-inspector__stage-heading {
+        align-items: flex-start;
+    }
+
+    .state-machine-transition-inspector__stage-note {
+        max-width: 45%;
+    }
+
+    .state-machine-transition-inspector__activity-card,
     .state-machine-transition-inspector__field-grid {
         grid-template-columns: minmax(0, 1fr);
+    }
+
+    .state-machine-transition-inspector__slot-actions {
+        justify-content: flex-start;
+    }
+
+    .state-machine-transition-inspector__details summary {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .state-machine-transition-inspector__details-route {
+        justify-content: flex-start;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .state-machine-transition-inspector * {
+        scroll-behavior: auto;
+        transition: none;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
@@ -155,6 +155,7 @@
                 {
                     <StateMachineTransitionInspector Transition="@SelectedTransition"
                                                      States="@_session.Graph.States.ToList()"
+                                                     KnownExpressionProviderTypes="@_knownExpressionProviderTypes"
                                                      IsReadOnly="@IsReadOnly"
                                                      ValidationIssues="@GetSelectedTransitionIssues()"
                                                      NameChanged="SetTransitionNameAsync"

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
@@ -161,9 +161,12 @@
                                                      DisplayNameChanged="SetTransitionDisplayNameAsync"
                                                      FromChanged="SetTransitionFromAsync"
                                                      ToChanged="SetTransitionToAsync"
-                                                     SlotChanged="SetTransitionSlotAsync"
-                                                     SlotCleared="ClearTransitionSlotAsync"
-                                                     SlotDropRequested="OnTransitionSlotDropAsync"
+                                                     ActivityAddRequested="AddTransitionActivityAsync"
+                                                     ActivityOpenRequested="OpenTransitionActivityAsync"
+                                                     ActivityReplaceRequested="ReplaceTransitionActivityAsync"
+                                                     ActivityClearRequested="ClearTransitionSlotAsync"
+                                                     ActivityDropRequested="OnTransitionSlotDropAsync"
+                                                     ConditionEditRequested="OpenConditionEditorAsync"
                                                      DeleteRequested="DeleteSelectedTransitionAsync" />
                 }
                 else

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -13,6 +13,7 @@ using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using static Elsa.Studio.Workflows.Designer.StateMachineDesignerConstants;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines;
@@ -51,6 +52,7 @@ public partial class StateMachineDesignerWrapper
     [Inject] private IActivityNameGenerator ActivityNameGenerator { get; set; } = null!;
     [Inject] private IStateMachineMapper StateMachineMapper { get; set; } = null!;
     [Inject] private StateMachineValidator StateMachineValidator { get; set; } = null!;
+    [Inject] private IDialogService DialogService { get; set; } = null!;
 
     private StateMachineStateNode? SelectedState =>
         _session != null && _selectedStateId != null ? TryGetState(_selectedStateId) : null;
@@ -272,10 +274,84 @@ public partial class StateMachineDesignerWrapper
 
     private async Task ClearTransitionSlotAsync(string slotName)
     {
-        if (_session == null || _selectedTransitionId == null || IsReadOnly)
+        if (_session == null || _selectedTransitionId == null || IsReadOnly || !IsTransitionActivitySlot(slotName))
             return;
         _session.SetTransitionSlot(_selectedTransitionId, ParseTransitionSlot(slotName), null);
         await ApplySessionChangesAndRefreshSlotAsync(slotName, false);
+    }
+
+    private Task AddTransitionActivityAsync(string slotName) => OpenTransitionActivityPickerAsync(slotName, false);
+
+    private Task ReplaceTransitionActivityAsync(string slotName) => OpenTransitionActivityPickerAsync(slotName, true);
+
+    private async Task OpenTransitionActivityAsync(string slotName)
+    {
+        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || SelectedTransition is not { } transition)
+            return;
+
+        if (GetTransitionSlot(transition, slotName) is JsonObject activity && activity.IsActivity())
+            await SelectSlotActivityForPropertiesAsync(activity);
+    }
+
+    private async Task OpenTransitionActivityPickerAsync(string slotName, bool replacing)
+    {
+        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName))
+            return;
+
+        var title = replacing ? Localizer[$"Replace {slotName} activity"] : Localizer[$"Add {slotName} activity"];
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            CloseButton = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Medium
+        };
+        var dialog = await DialogService.ShowAsync<StateMachineActivityPickerDialog>(title, options);
+        var result = await dialog.Result;
+
+        // Do not touch the slot until the picker returns an explicit descriptor. In particular,
+        // cancelling Replace leaves the exact existing JSON object in place.
+        if (result is { Canceled: false, Data: ActivityDescriptor descriptor })
+            await ApplyTransitionActivityDescriptorAsync(slotName, descriptor);
+    }
+
+    private async Task OpenConditionEditorAsync(string slotName)
+    {
+        if (IsReadOnly || _session == null || _selectedTransitionId == null || !string.Equals(slotName, "condition", StringComparison.Ordinal))
+            return;
+
+        var transitionId = _selectedTransitionId;
+        var transition = TryGetTransition(transitionId);
+        if (transition == null)
+            return;
+
+        var parameters = new DialogParameters<BooleanConditionEditorDialog>
+        {
+            { x => x.Condition, transition.Condition },
+            { x => x.IsReadOnly, IsReadOnly }
+        };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            CloseButton = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Large,
+            Position = DialogPosition.Center
+        };
+        var dialog = await DialogService.ShowAsync<BooleanConditionEditorDialog>(Localizer["Edit transition condition"], parameters, options);
+        var result = await dialog.Result;
+
+        // The condition editor owns a local draft. A cancelled dialog, including Escape,
+        // must not enter the session mutation path. Applying Always uses null to clear the
+        // condition slot, so the result DTO also distinguishes that from cancellation.
+        if (result is not { Canceled: false, Data: BooleanConditionDialogResult { Applied: true } edit }
+            || _session == null
+            || TryGetTransition(transitionId) is not { } currentTransition
+            || JsonNode.DeepEquals(currentTransition.Condition, edit.Condition))
+            return;
+
+        _session.SetTransitionSlot(transitionId, StateMachineTransitionSlot.Condition, edit.Condition);
+        await ApplySessionChangesAsync();
     }
 
     private async Task OnStateSlotDropAsync(string slotName)
@@ -291,14 +367,27 @@ public partial class StateMachineDesignerWrapper
 
     private async Task OnTransitionSlotDropAsync(string slotName)
     {
-        if (IsReadOnly || _session == null || _selectedTransitionId == null || DragDropManager.Payload is not ActivityDescriptor descriptor || slotName == "condition")
+        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || DragDropManager.Payload is not ActivityDescriptor descriptor)
+            return;
+
+        await ApplyTransitionActivityDescriptorAsync(slotName, descriptor, clearDragPayload: true);
+    }
+
+    private async Task ApplyTransitionActivityDescriptorAsync(string slotName, ActivityDescriptor descriptor, bool clearDragPayload = false)
+    {
+        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName))
             return;
 
         var activity = CreateSlotActivity(descriptor);
         _session.SetTransitionSlot(_selectedTransitionId, ParseTransitionSlot(slotName), activity);
-        DragDropManager.Payload = null;
+        if (clearDragPayload)
+            DragDropManager.Payload = null;
         await ApplySessionChangesAndRefreshSlotAsync(slotName, true);
     }
+
+    private static bool IsTransitionActivitySlot(string slotName) =>
+        string.Equals(slotName, "trigger", StringComparison.Ordinal) ||
+        string.Equals(slotName, "action", StringComparison.Ordinal);
 
     private async Task ApplySessionChangesAndRefreshSlotAsync(string slotName, bool selectSlot)
     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -45,6 +45,7 @@ public partial class StateMachineDesignerWrapper
     [Parameter] public IDictionary<string, ActivityStats>? ActivityStats { get; set; }
     [Parameter] public bool IsReadOnly { get; set; }
     [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
+    [Parameter] public EventCallback<JsonObject> ActivityDoubleClick { get; set; }
     [Parameter] public EventCallback GraphUpdated { get; set; }
 
     [CascadingParameter] private DragDropManager DragDropManager { get; set; } = null!;
@@ -286,11 +287,19 @@ public partial class StateMachineDesignerWrapper
 
     private async Task OpenTransitionActivityAsync(string slotName)
     {
-        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || SelectedTransition is not { } transition)
+        if (_session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || SelectedTransition is not { } transition)
             return;
 
-        if (GetTransitionSlot(transition, slotName) is JsonObject activity && activity.IsActivity())
-            await SelectSlotActivityForPropertiesAsync(activity);
+        if (GetTransitionSlot(transition, slotName) is not JsonObject activity || !activity.IsActivity())
+            return;
+
+        if (string.Equals(activity.GetTypeName(), "Elsa.Sequence", StringComparison.Ordinal) && ActivityDoubleClick.HasDelegate)
+        {
+            await ActivityDoubleClick.InvokeAsync(activity);
+            return;
+        }
+
+        await SelectSlotActivityForPropertiesAsync(activity);
     }
 
     private async Task OpenTransitionActivityPickerAsync(string slotName, bool replacing)
@@ -693,7 +702,8 @@ public partial class StateMachineDesignerWrapper
         var slots = _session.Graph.States.SelectMany(x => new[] { x.Entry, x.Exit })
             .Concat(_session.Graph.Transitions.SelectMany(x => new[] { x.Trigger, x.Action }));
         foreach (var slot in slots)
-            if (slot is JsonObject activity && activity.IsActivity()) yield return activity;
+        foreach (var activity in EnumerateActivities(slot))
+            yield return activity;
     }
 
     private bool TryFindSlotActivity(string id, out JsonObject activity, out StateMachineStateNode? state, out StateMachineTransitionEdge? transition, out string? slotName)
@@ -702,13 +712,13 @@ public partial class StateMachineDesignerWrapper
         {
             foreach (var candidate in _session.Graph.States)
             {
-                if (TryMatchSlotActivity(candidate.Entry, id, out activity)) { state = candidate; transition = null; slotName = "entry"; return true; }
-                if (TryMatchSlotActivity(candidate.Exit, id, out activity)) { state = candidate; transition = null; slotName = "exit"; return true; }
+                if (TryFindActivity(candidate.Entry, id, out activity)) { state = candidate; transition = null; slotName = "entry"; return true; }
+                if (TryFindActivity(candidate.Exit, id, out activity)) { state = candidate; transition = null; slotName = "exit"; return true; }
             }
             foreach (var candidate in _session.Graph.Transitions)
             {
-                if (TryMatchSlotActivity(candidate.Trigger, id, out activity)) { state = null; transition = candidate; slotName = "trigger"; return true; }
-                if (TryMatchSlotActivity(candidate.Action, id, out activity)) { state = null; transition = candidate; slotName = "action"; return true; }
+                if (TryFindActivity(candidate.Trigger, id, out activity)) { state = null; transition = candidate; slotName = "trigger"; return true; }
+                if (TryFindActivity(candidate.Action, id, out activity)) { state = null; transition = candidate; slotName = "action"; return true; }
             }
         }
         activity = []; state = null; transition = null; slotName = null; return false;
@@ -719,13 +729,31 @@ public partial class StateMachineDesignerWrapper
         if (_session == null) return false;
         foreach (var state in _session.Graph.States)
         {
-            if (IsSlotActivityMatch(state.Entry, id, replacement)) { _session.SetStateSlot(_session.GetStateVisualId(state), StateMachineStateSlot.Entry, replacement); return true; }
-            if (IsSlotActivityMatch(state.Exit, id, replacement)) { _session.SetStateSlot(_session.GetStateVisualId(state), StateMachineStateSlot.Exit, replacement); return true; }
+            if (TryCreateUpdatedSlotValue(state.Entry, id, replacement, out var updatedEntry))
+            {
+                _session.SetStateSlot(_session.GetStateVisualId(state), StateMachineStateSlot.Entry, updatedEntry);
+                return true;
+            }
+
+            if (TryCreateUpdatedSlotValue(state.Exit, id, replacement, out var updatedExit))
+            {
+                _session.SetStateSlot(_session.GetStateVisualId(state), StateMachineStateSlot.Exit, updatedExit);
+                return true;
+            }
         }
         foreach (var transition in _session.Graph.Transitions)
         {
-            if (IsSlotActivityMatch(transition.Trigger, id, replacement)) { _session.SetTransitionSlot(_session.GetTransitionVisualId(transition), StateMachineTransitionSlot.Trigger, replacement); return true; }
-            if (IsSlotActivityMatch(transition.Action, id, replacement)) { _session.SetTransitionSlot(_session.GetTransitionVisualId(transition), StateMachineTransitionSlot.Action, replacement); return true; }
+            if (TryCreateUpdatedSlotValue(transition.Trigger, id, replacement, out var updatedTrigger))
+            {
+                _session.SetTransitionSlot(_session.GetTransitionVisualId(transition), StateMachineTransitionSlot.Trigger, updatedTrigger);
+                return true;
+            }
+
+            if (TryCreateUpdatedSlotValue(transition.Action, id, replacement, out var updatedAction))
+            {
+                _session.SetTransitionSlot(_session.GetTransitionVisualId(transition), StateMachineTransitionSlot.Action, updatedAction);
+                return true;
+            }
         }
         return false;
     }
@@ -768,14 +796,103 @@ public partial class StateMachineDesignerWrapper
         _ => null
     };
 
-    private static bool TryMatchSlotActivity(JsonNode? slot, string id, out JsonObject activity)
+    private static bool TryFindActivity(JsonNode? node, string id, out JsonObject activity)
     {
-        if (slot is JsonObject obj && obj.IsActivity() && (obj.GetId() == id || obj.GetNodeId() == id)) { activity = obj; return true; }
-        activity = []; return false;
+        if (node is JsonObject obj)
+        {
+            if (obj.IsActivity() && (obj.GetId() == id || obj.GetNodeId() == id))
+            {
+                activity = obj;
+                return true;
+            }
+
+            foreach (var child in obj.Select(x => x.Value))
+            {
+                if (TryFindActivity(child, id, out activity))
+                    return true;
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var child in array)
+            {
+                if (TryFindActivity(child, id, out activity))
+                    return true;
+            }
+        }
+
+        activity = [];
+        return false;
     }
 
-    private static bool IsSlotActivityMatch(JsonNode? slot, string id, JsonObject replacement) =>
-        slot is JsonObject obj && obj.IsActivity() && (ReferenceEquals(obj, replacement) || obj.GetId() == id || obj.GetNodeId() == id);
+    private static bool TryCreateUpdatedSlotValue(JsonNode? slot, string id, JsonObject replacement, out JsonNode? updated)
+    {
+        updated = slot?.DeepClone();
+        if (updated == null || !TryReplaceActivity(updated, id, replacement))
+        {
+            updated = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReplaceActivity(JsonNode node, string id, JsonObject replacement)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj.IsActivity() && (ReferenceEquals(obj, replacement) || obj.GetId() == id || obj.GetNodeId() == id))
+            {
+                ReplaceJsonObjectContents(obj, replacement);
+                return true;
+            }
+
+            foreach (var child in obj.Select(x => x.Value))
+            {
+                if (child != null && TryReplaceActivity(child, id, replacement))
+                    return true;
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var child in array)
+            {
+                if (child != null && TryReplaceActivity(child, id, replacement))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<JsonObject> EnumerateActivities(JsonNode? node)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj.IsActivity())
+                yield return obj;
+
+            foreach (var child in obj.Select(x => x.Value))
+            foreach (var activity in EnumerateActivities(child))
+                yield return activity;
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var child in array)
+            foreach (var activity in EnumerateActivities(child))
+                yield return activity;
+        }
+    }
+
+    private static void ReplaceJsonObjectContents(JsonObject target, JsonObject replacement)
+    {
+        if (ReferenceEquals(target, replacement))
+            return;
+
+        target.Clear();
+        foreach (var property in replacement)
+            target[property.Key] = property.Value?.DeepClone();
+    }
 
     private static string? GetActivitySelectionId(JsonObject activity) => NormalizeOptional(activity.GetId()) ?? NormalizeOptional(activity.GetNodeId());
     private static string? NormalizeOptional(object? value) => string.IsNullOrWhiteSpace(value?.ToString()) ? null : value.ToString();

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Components;
 using Elsa.Studio.Workflows.Designer.Contracts;
@@ -14,6 +15,7 @@ using Elsa.Studio.Workflows.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
+using Refit;
 using static Elsa.Studio.Workflows.Designer.StateMachineDesignerConstants;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines;
@@ -40,6 +42,7 @@ public partial class StateMachineDesignerWrapper
     private string? _newTransitionToId;
     private bool _showOutline;
     private bool _processingCanvasChange;
+    private IReadOnlyCollection<string> _knownExpressionProviderTypes = ["JavaScript"];
 
     [Parameter] public JsonObject StateMachine { get; set; } = [];
     [Parameter] public IDictionary<string, ActivityStats>? ActivityStats { get; set; }
@@ -54,12 +57,29 @@ public partial class StateMachineDesignerWrapper
     [Inject] private IStateMachineMapper StateMachineMapper { get; set; } = null!;
     [Inject] private StateMachineValidator StateMachineValidator { get; set; } = null!;
     [Inject] private IDialogService DialogService { get; set; } = null!;
+    [Inject] private IExpressionService ExpressionService { get; set; } = null!;
 
     private StateMachineStateNode? SelectedState =>
         _session != null && _selectedStateId != null ? TryGetState(_selectedStateId) : null;
 
     private StateMachineTransitionEdge? SelectedTransition =>
         _session != null && _selectedTransitionId != null ? TryGetTransition(_selectedTransitionId) : null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _knownExpressionProviderTypes = BooleanConditionEditorDialog
+                .FilterProviders(await ExpressionService.ListDescriptorsAsync())
+                .Select(x => x.Type)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or ApiException)
+        {
+            // The editor dialog exposes the recoverable provider-load warning. Keep the
+            // inspector's safe built-in fallback until providers can be loaded there.
+        }
+    }
 
     protected override void OnParametersSet()
     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDiagramDesigner.cs
@@ -65,6 +65,7 @@ public class StateMachineDiagramDesigner(ILocalizer localizer) : IDiagramDesigne
             builder.AddAttribute(sequence++, nameof(StateMachineDesignerWrapper.IsReadOnly), context.IsReadOnly);
             builder.AddAttribute(sequence++, nameof(StateMachineDesignerWrapper.ActivityStats), context.ActivityStats);
             builder.AddAttribute(sequence++, nameof(StateMachineDesignerWrapper.ActivitySelected), context.ActivitySelectedCallback);
+            builder.AddAttribute(sequence++, nameof(StateMachineDesignerWrapper.ActivityDoubleClick), context.ActivityDoubleClickCallback);
             builder.AddAttribute(sequence++, nameof(StateMachineDesignerWrapper.GraphUpdated), context.GraphUpdatedCallback);
             builder.AddComponentReferenceCapture(sequence++, @ref => _designerWrapper = (StateMachineDesignerWrapper)@ref);
             builder.CloseComponent();


### PR DESCRIPTION
## Summary
- replace raw transition slots with a causal WHEN → ONLY IF → THEN → TO inspector
- add searchable Trigger/Action selection, safe replacement, and nested Sequence authoring
- add a transactional, lossless Boolean condition workspace with explicit Always/Never/provider/custom modes
- preserve unknown, unavailable, incomplete, and malformed definitions for safe repair
- promote Sequence as the intentional multi-activity THEN path even when its backend descriptor is non-browsable
- make expression-provider discovery resilient and keep provider summaries accurate

## Runtime alignment
Designed against the ratified WF4-aligned contract in elsa-workflows/elsa-foundation#1457 and validated with elsa-workflows/elsa-core#8010.

## Validation
- Workflows tests: 112 passed
- Designer tests: 68 passed on each of net8.0, net9.0, and net10.0
- `Elsa.Studio.Workflows` builds for net8.0, net9.0, and net10.0 with 0 warnings/errors
- production-like browser verification covers causal presentation, preservation, read-only behavior, and Sequence drill-in
- M3 save/reload/publish/execute/event journey finishes with 0 incidents

Closes #947
Closes #948
Closes #949
Closes #950
Closes #951
Closes #952
Closes #953
Closes #954
Closes #955
Closes #956
Closes #957
