### PR TITLE
Improve StateMachine inspector and activity picker UX

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -2,7 +2,7 @@
 
 Status: Approved baseline
 
-Last updated: 2026-07-30
+Last updated: 2026-09-01
 
 ## Direction
 
@@ -192,6 +192,40 @@ metadata, lifecycle context, and a sensitive operational action.
 - Dashboard-like card grids for ordinary settings: use one primary form and only
   the supporting surfaces needed for context.
 - One-off CSS for spacing: use MudBlazor spacing and responsive utilities first.
+
+## StateMachine Authoring Pattern
+
+Use a lifecycle story instead of exposing serialized definitions as the primary
+editing surface.
+
+- State inspectors read top-to-bottom as `ON ENTRY → ACTIVE → ON EXIT`.
+- Transition inspectors read top-to-bottom as `WHEN → ONLY IF → THEN → TO`.
+- Activity slots use one shared semantic card for empty, configured, malformed,
+  and read-only states. Raw JSON is repair evidence under “View definition,”
+  never the default editor.
+- Empty slots explain execution behavior and offer one direct add action plus
+  drag-and-drop. Configured slots offer Open, Replace, and Clear.
+- Preserve unknown or malformed definitions until the author explicitly
+  replaces or clears them.
+- Keep destructive state/transition actions separated below details and
+  validation.
+- Show state status without relying on color: Initial, Current, and Terminal
+  remain textual badges.
+
+### Contextual activity picker
+
+- Open a wide command-palette dialog whose title names the destination slot.
+- Reinforce execution context with `WHEN`, `THEN`, `ON ENTRY`, or `ON EXIT` and
+  one short timing explanation.
+- Keep search sticky and search name, type, category, and description.
+- Use compact Suggested, Recent, All, and category filters with result counts.
+- Selecting a row updates a details pane; it must not mutate the workflow.
+  Commit only through the explicit Add action, Enter, or deliberate double
+  activation.
+- Recommend Sequence for action and lifecycle slots as the multi-activity
+  composition path, but do not present it as a separate oversized billboard.
+- On narrow screens, collapse filters to a horizontal strip, stack details
+  below results, and retain keyboard-accessible native buttons.
 
 ## Diagnostics Content
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
@@ -144,6 +144,29 @@ public class StateMachineDesignerWrapperTests
     }
 
     [Fact]
+    public async Task OpenStateSequence_UsesTheSameNestedDesignerNavigation()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        var sequence = root["transitions"]![0]!["action"]!.DeepClone();
+        root["states"]![0]!["entry"] = sequence;
+        var session = CreateSession(root);
+        var stateId = session.ProjectCanvas().States.Single(x => x.Name == "Pending").VisualId;
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetPrivateField(wrapper, "_session", session);
+        SetPrivateField(wrapper, "_selectedStateId", stateId);
+        JsonObject? opened = null;
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.ActivityDoubleClick),
+            EventCallback.Factory.Create<JsonObject>(new object(), (JsonObject activity) => opened = activity));
+
+        await InvokePrivateAsync(wrapper, "OpenStateActivityAsync", "entry");
+
+        Assert.NotNull(opened);
+        Assert.Equal("Elsa.Sequence", opened!.GetTypeName());
+        Assert.Equal("Sequence1", opened.GetId());
+    }
+
+    [Fact]
     public async Task SelectActivityAsync_SelectsNestedSequenceChildInTheOwningAction()
     {
         var root = CreateNestedSequenceStateMachine();

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -72,7 +72,9 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
     {
         var dialog = await ShowDialogAsync();
 
-        _dialogProvider.WaitForAssertion(() => Assert.Equal(3, _dialogProvider.FindAll("[data-activity-type]").Count));
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal)).Click();
+        Assert.Equal(3, _dialogProvider.FindAll("[data-activity-type]").Count);
         Assert.DoesNotContain(_dialogProvider.FindAll("[data-activity-type]"), element => element.GetAttribute("data-activity-type") == _internalActivity.TypeName);
         var search = _dialogProvider.Find("input[id*='state-machine-activity-picker']");
 
@@ -101,7 +103,12 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
 
         Assert.False(dialog.Result.IsCompleted);
         _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal)).Click();
         _dialogProvider.Find("[data-testid='state-machine-activity-option'][data-activity-type='Elsa.WriteLine']").Click();
+
+        Assert.False(dialog.Result.IsCompleted);
+        Assert.Contains("Write line", _dialogProvider.Find(".state-machine-activity-picker__details").TextContent);
+        _dialogProvider.Find("[data-testid='state-machine-activity-picker-commit']").Click();
 
         var result = await dialog.Result;
         Assert.False(result?.Canceled);
@@ -113,17 +120,90 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
     {
         var dialog = await ShowDialogAsync();
 
-        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-picker-sequence']")));
-        _dialogProvider.Find("[data-testid='state-machine-activity-picker-sequence']").Click();
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-activity-type='Elsa.Sequence']")));
+        var sequence = _dialogProvider.Find("[data-activity-type='Elsa.Sequence']");
+        Assert.Contains("Recommended", sequence.TextContent);
+        sequence.Click();
+        Assert.False(dialog.Result.IsCompleted);
+        _dialogProvider.Find("[data-testid='state-machine-activity-picker-commit']").Click();
 
         var result = await dialog.Result;
         Assert.Same(_sequence, result?.Data);
     }
 
-    private async Task<IDialogReference> ShowDialogAsync()
+    [Theory]
+    [InlineData("trigger", "Choose a trigger activity", "WHEN", "Starts the transition")]
+    [InlineData("action", "Choose an action activity", "THEN", "Runs after source exit")]
+    [InlineData("entry", "Choose an entry activity", "ON ENTRY", "Runs when this state becomes active")]
+    [InlineData("exit", "Choose an exit activity", "ON EXIT", "Runs before an accepted transition leaves this state")]
+    public async Task Picker_ExplainsTheSlotContext(string slotName, string heading, string kicker, string description)
+    {
+        var dialog = await ShowDialogAsync(slotName);
+
+        _dialogProvider.WaitForAssertion(() => Assert.Contains(heading, _dialogProvider.Markup));
+        Assert.Contains(kicker, _dialogProvider.Markup);
+        Assert.Contains(description, _dialogProvider.Markup);
+
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel").Click();
+        Assert.True((await dialog.Result)?.Canceled);
+    }
+
+    [Fact]
+    public async Task Picker_ExposesRecentAndCategoryViewsAndSupportsKeyboardCommit()
+    {
+        var dialog = await ShowDialogAsync("action", ["Elsa.WriteLine"]);
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("button")));
+        var recent = _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("Recent", StringComparison.Ordinal));
+        Assert.False(recent.HasAttribute("disabled"));
+        recent.Click();
+        Assert.Single(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']"));
+        Assert.Contains("Write line", _dialogProvider.Find("[data-testid='state-machine-activity-option']").TextContent);
+
+        _dialogProvider.Find("input[id*='state-machine-activity-picker']").KeyDown("Enter");
+        var result = await dialog.Result;
+        Assert.Same(_writeLine, result?.Data);
+    }
+
+    [Fact]
+    public async Task Picker_EnterOnAFilterDoesNotCommitTheCurrentSelection()
+    {
+        var dialog = await ShowDialogAsync();
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("button")));
+        var allActivities = _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal));
+        allActivities.KeyDown("Enter");
+
+        Assert.False(dialog.Result.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Picker_UsesReplacementLanguageWhenReplacingAnActivity()
+    {
+        var dialog = await ShowDialogAsync(isReplacing: true);
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal)).Click();
+        _dialogProvider.Find("[data-testid='state-machine-activity-option'][data-activity-type='Elsa.WriteLine']").Click();
+
+        Assert.Contains("Replace with Write line", _dialogProvider.Find("[data-testid='state-machine-activity-picker-commit']").TextContent);
+        Assert.False(dialog.Result.IsCompleted);
+    }
+
+    private async Task<IDialogReference> ShowDialogAsync(
+        string slotName = "action",
+        IReadOnlyCollection<string>? recentActivityTypes = null,
+        bool isReplacing = false)
     {
         var dialogService = Services.GetRequiredService<IDialogService>();
-        return await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<StateMachineActivityPickerDialog>("Add action"));
+        var parameters = new DialogParameters<StateMachineActivityPickerDialog>
+        {
+            { x => x.SlotName, slotName },
+            { x => x.IsReplacing, isReplacing },
+            { x => x.RecentActivityTypes, recentActivityTypes ?? [] }
+        };
+        var article = slotName == "trigger" ? "a" : "an";
+        return await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<StateMachineActivityPickerDialog>($"Choose {article} {slotName} activity", parameters));
     }
 
     private sealed class ActivityRegistryStub(IEnumerable<ActivityDescriptor> activities) : IActivityRegistry

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -84,47 +84,75 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void StateInspector_AssociatesLabelsAndEmitsEditsWithoutMutatingTheModel()
+    public void StateInspector_RendersLifecycleAndEmitsSemanticActionsWithoutMutatingTheModel()
     {
         var state = new StateMachineStateNode
         {
             Name = "Pending",
-            Entry = new JsonObject { ["type"] = "WriteLine" }
+            Entry = Activity("Elsa.WriteLine", "Entry1", "Workflow1:Entry1")
         };
         string? changedName = null;
-        StateMachineSlotValueChange? changedSlot = null;
-        string? clearedSlot = null;
+        var actions = new List<string>();
+        var viewedTransitions = false;
         var cut = Render<StateMachineStateInspector>(parameters => parameters
             .Add(component => component.State, state)
+            .Add(component => component.IsInitial, true)
+            .Add(component => component.IsCurrent, true)
+            .Add(component => component.IncomingTransitionCount, 1)
+            .Add(component => component.OutgoingTransitionCount, 2)
             .Add(component => component.NameChanged, value => changedName = value)
-            .Add(component => component.SlotChanged, value => changedSlot = value)
-            .Add(component => component.SlotCleared, value => clearedSlot = value));
+            .Add(component => component.ActivityOpenRequested, slot => actions.Add($"open:{slot}"))
+            .Add(component => component.ActivityReplaceRequested, slot => actions.Add($"replace:{slot}"))
+            .Add(component => component.ActivityClearRequested, slot => actions.Add($"clear:{slot}"))
+            .Add(component => component.ActivityAddRequested, slot => actions.Add($"add:{slot}"))
+            .Add(component => component.ActivityDropRequested, slot => actions.Add($"drop:{slot}"))
+            .Add(component => component.ViewTransitionsRequested, () => viewedTransitions = true));
 
         var nameInput = cut.Find("input[id$='-name']");
         var nameLabel = cut.Find($"label[for='{nameInput.Id}']");
         Assert.Equal("Name", nameLabel.TextContent);
+        var markup = cut.Markup;
+        Assert.True(markup.IndexOf("ON ENTRY", StringComparison.Ordinal) < markup.IndexOf("ACTIVE", StringComparison.Ordinal));
+        Assert.True(markup.IndexOf("ACTIVE", StringComparison.Ordinal) < markup.IndexOf("ON EXIT", StringComparison.Ordinal));
+        Assert.Contains("Initial", cut.Find("[aria-label='State status']").TextContent);
+        Assert.Contains("Current", cut.Find("[aria-label='State status']").TextContent);
+        Assert.Contains("2 outgoing transitions", cut.Find("[data-state-stage='active']").TextContent);
+        Assert.Contains("Elsa.WriteLine", cut.Find("[data-state-stage='entry']").TextContent);
+        Assert.Contains("No exit activity configured", cut.Find("[data-state-stage='exit']").TextContent);
 
         nameInput.Change("Review");
-        cut.Find("textarea[id$='-entry']").Change("{\"type\":\"RunTask\"}");
-        cut.Find("textarea[id$='-entry']").ParentElement!.QuerySelector("button")!.Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='open']").Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='replace']").Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='clear']").Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='drop']").TriggerEvent("ondrop", new DragEventArgs());
+        cut.Find("[data-state-stage='exit'] [data-slot-action='add']").Click();
+        cut.Find("[data-testid='state-machine-state-view-transitions']").Click();
 
         Assert.Equal("Review", changedName);
         Assert.Equal("Pending", state.Name);
-        Assert.Equal("entry", changedSlot?.SlotName);
-        Assert.Equal("{\"type\":\"RunTask\"}", changedSlot?.Value);
-        Assert.Equal("entry", clearedSlot);
+        Assert.Equal(["open:entry", "replace:entry", "clear:entry", "drop:entry", "add:exit"], actions);
+        Assert.True(viewedTransitions);
+        Assert.DoesNotContain("textarea", cut.Markup, StringComparison.Ordinal);
     }
 
     [Fact]
     public void StateInspector_ReadOnlyModeSuppressesDestructiveActionsAndDisablesFields()
     {
         var cut = Render<StateMachineStateInspector>(parameters => parameters
-            .Add(component => component.State, new StateMachineStateNode { Name = "Pending" })
+            .Add(component => component.State, new StateMachineStateNode
+            {
+                Name = "Pending",
+                Entry = Activity("Elsa.WriteLine", "Entry1", "Workflow1:Entry1")
+            })
             .Add(component => component.IsReadOnly, true));
 
         Assert.True(cut.Find("input[id$='-name']").HasAttribute("disabled"));
-        Assert.True(cut.Find("textarea[id$='-entry']").HasAttribute("disabled"));
-        Assert.Empty(cut.FindAll("button"));
+        Assert.Single(cut.FindAll("[data-slot-action='open']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='add']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='replace']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='clear']"));
+        Assert.Empty(cut.FindAll("[data-testid='state-machine-state-delete']"));
+        Assert.All(cut.FindAll("[data-slot-action='drop']"), element => Assert.False(element.HasAttribute("ondrop")));
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
@@ -1,16 +1,15 @@
 @using Elsa.Api.Client.Resources.ActivityDescriptors.Models
-@using Elsa.Studio.Localization
-@using Variant = MudBlazor.Variant
-@inject ILocalizer Localizer
+@namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
 
 <MudDialog Class="state-machine-activity-picker-dialog">
     <DialogContent>
-        <section class="state-machine-activity-picker" data-testid="state-machine-activity-picker" aria-labelledby="@HeadingId">
-            <div class="state-machine-activity-picker__intro">
+        <section class="state-machine-activity-picker"
+                 data-testid="state-machine-activity-picker"
+                 aria-label="@PickerHeading">
+            <header class="state-machine-activity-picker__header">
                 <p class="state-machine-activity-picker__eyebrow">@Localizer["Activity library"]</p>
-                <MudText Typo="Typo.h6" id="@HeadingId">@Localizer["Choose an activity"]</MudText>
-                <MudText Typo="Typo.body2" Color="Color.Secondary">@Localizer["Search by name, type, category, or what the activity does."]</MudText>
-            </div>
+                <p class="state-machine-activity-picker__context"><strong>@ContextKicker</strong><span aria-hidden="true">·</span>@ContextDescription</p>
+            </header>
 
             @if (_isLoading)
             {
@@ -28,76 +27,124 @@
             }
             else
             {
-                <MudTextField T="string"
-                              @bind-Value="_searchText"
-                              Immediate="true"
-                              Clearable="true"
-                              InputId="@SearchInputId"
-                              Label="@Localizer["Search activities"]"
-                              Placeholder="@Localizer["Search by display name, type, category, or description"]"
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              Adornment="Adornment.End"
-                              AdornmentIcon="@Icons.Material.Filled.Search"
-                              Class="state-machine-activity-picker__search" />
-
-                @if (!FilteredDescriptors.Any())
-                {
-                    <div class="state-machine-activity-picker__state" role="status" data-picker-state="empty">
-                        <strong>@Localizer["No matching activities"]</strong>
-                        <span>@Localizer["Try a different name, type, category, or description."]</span>
+                <div class="state-machine-activity-picker__search-wrap">
+                    <label for="@SearchInputId">@Localizer["Search activities"]</label>
+                    <div class="state-machine-activity-picker__search-control">
+                        <input @ref="_searchInput"
+                               id="@SearchInputId"
+                               type="search"
+                               value="@_searchText"
+                               placeholder="@Localizer["Search activities by name, category, or description"]"
+                               autocomplete="off"
+                               role="combobox"
+                               aria-autocomplete="list"
+                               aria-expanded="true"
+                               aria-controls="@ResultsId"
+                               aria-activedescendant="@SelectedResultId"
+                               @oninput="OnSearchInput"
+                               @onkeydown="HandleKeyboardAsync" />
+                        <kbd aria-label="@Localizer["Keyboard shortcut: slash"]">/</kbd>
                     </div>
-                }
-                else
-                {
-                    @if (SequenceDescriptor != null && string.IsNullOrWhiteSpace(_searchText))
-                    {
-                        <button type="button"
-                                class="state-machine-activity-picker__quick-option"
-                                data-testid="state-machine-activity-picker-sequence"
-                                data-activity-type="@SequenceDescriptor.TypeName"
-                                @onclick="() => SelectAsync(SequenceDescriptor)">
-                            <span class="state-machine-activity-picker__quick-icon" aria-hidden="true">＋</span>
-                            <span>
-                                <strong>@Localizer["Run multiple activities"]</strong>
-                                <span>@Localizer["Add a Sequence to run more than one activity in this slot."]</span>
-                            </span>
-                        </button>
-                    }
+                </div>
 
-                    <div class="state-machine-activity-picker__groups" role="list" aria-label="@Localizer["Available activities"]">
-                        @foreach (var group in GroupedDescriptors)
+                <div class="state-machine-activity-picker__workspace">
+                    <nav class="state-machine-activity-picker__filters" aria-label="@Localizer["Activity filters"]">
+                        <button type="button" class="@GetSectionClass(SuggestedSection)" aria-pressed="@IsSectionSelected(SuggestedSection)"
+                                disabled="@(SuggestedDescriptors.Count == 0)" @onclick="() => SelectSection(SuggestedSection)">
+                            <span>@Localizer["Suggested"]</span><span>@SuggestedDescriptors.Count</span>
+                        </button>
+                        <button type="button" class="@GetSectionClass(RecentSection)" aria-pressed="@IsSectionSelected(RecentSection)"
+                                disabled="@(RecentDescriptors.Count == 0)" @onclick="() => SelectSection(RecentSection)">
+                            <span>@Localizer["Recent"]</span><span>@RecentDescriptors.Count</span>
+                        </button>
+                        <button type="button" class="@GetSectionClass(AllSection)" aria-pressed="@IsSectionSelected(AllSection)"
+                                @onclick="() => SelectSection(AllSection)">
+                            <span>@Localizer["All activities"]</span><span>@_descriptors.Count</span>
+                        </button>
+                        <div class="state-machine-activity-picker__filter-separator" aria-hidden="true"></div>
+                        @foreach (var group in CategoryGroups)
                         {
-                            <section class="state-machine-activity-picker__group" aria-labelledby="@GetGroupId(group.Key)">
-                                <h3 id="@GetGroupId(group.Key)">@DisplayCategory(group.Key)</h3>
-                                <div class="state-machine-activity-picker__options">
-                                    @foreach (var descriptor in group)
-                                    {
-                                        <button type="button"
-                                                class="state-machine-activity-picker__option"
-                                                data-testid="state-machine-activity-option"
-                                                data-activity-type="@descriptor.TypeName"
-                                                data-activity-name="@GetDisplayName(descriptor)"
-                                                @onclick="() => SelectAsync(descriptor)">
-                                            <span class="state-machine-activity-picker__option-copy">
+                            <button type="button" class="@GetSectionClass(group.Key)" aria-pressed="@IsSectionSelected(group.Key)"
+                                    @onclick="() => SelectSection(group.Key)">
+                                <span>@group.Key</span><span>@group.Count()</span>
+                            </button>
+                        }
+                    </nav>
+
+                    <div class="state-machine-activity-picker__results-panel">
+                        <div class="state-machine-activity-picker__results-heading">
+                            <strong>@(string.IsNullOrWhiteSpace(_searchText) ? Localizer["Activities"] : Localizer["Search results"])</strong>
+                            <span>@Localizer["{0} results", VisibleDescriptors.Count]</span>
+                        </div>
+                        @if (VisibleDescriptors.Count == 0)
+                        {
+                            <div class="state-machine-activity-picker__state" role="status" data-picker-state="empty">
+                                <strong>@Localizer["No matching activities"]</strong>
+                                <span>@Localizer["Try another search or category."]</span>
+                            </div>
+                        }
+                        else
+                        {
+                            <div id="@ResultsId" class="state-machine-activity-picker__results" role="listbox" aria-label="@Localizer["Available activities"]">
+                                @foreach (var descriptor in VisibleDescriptors)
+                                {
+                                    <div @key="descriptor.TypeName"
+                                         id="@GetResultId(descriptor)"
+                                         class="@(IsSelected(descriptor) ? "state-machine-activity-picker__result state-machine-activity-picker__result--selected" : "state-machine-activity-picker__result")"
+                                         role="option"
+                                         aria-selected="@IsSelected(descriptor)"
+                                         aria-describedby="@DetailsId"
+                                         data-testid="state-machine-activity-option"
+                                         data-activity-type="@descriptor.TypeName"
+                                         data-activity-name="@GetDisplayName(descriptor)"
+                                         @onclick="() => Select(descriptor)"
+                                         @ondblclick="() => SelectAndCommitAsync(descriptor)">
+                                        <span class="state-machine-activity-picker__result-copy">
+                                            <span class="state-machine-activity-picker__result-title">
                                                 <strong>@GetDisplayName(descriptor)</strong>
-                                                <span>@descriptor.TypeName</span>
+                                                @if (ReferenceEquals(descriptor, SequenceDescriptor) && SuggestedDescriptors.Count > 0)
+                                                {
+                                                    <span class="state-machine-activity-picker__recommended">@Localizer["Recommended"]</span>
+                                                }
                                             </span>
-                                            @if (!string.IsNullOrWhiteSpace(descriptor.Description))
-                                            {
-                                                <span class="state-machine-activity-picker__option-description">@Localizer[descriptor.Description]</span>
-                                            }
-                                        </button>
-                                    }
-                                </div>
-                            </section>
+                                            <span>@descriptor.TypeName</span>
+                                        </span>
+                                        <span class="state-machine-activity-picker__result-category">@GetCategory(descriptor)</span>
+                                    </div>
+                                }
+                            </div>
                         }
                     </div>
-                }
+
+                    <aside id="@DetailsId" class="state-machine-activity-picker__details" aria-live="polite">
+                        @if (_selectedDescriptor == null)
+                        {
+                            <strong>@Localizer["Select an activity"]</strong>
+                            <p>@Localizer["Choose a result to review it before adding it."]</p>
+                        }
+                        else
+                        {
+                            <p class="state-machine-activity-picker__details-kicker">@GetCategory(_selectedDescriptor)</p>
+                            <h3>@GetDisplayName(_selectedDescriptor)</h3>
+                            <code>@_selectedDescriptor.TypeName</code>
+                            <p>@(string.IsNullOrWhiteSpace(_selectedDescriptor.Description) ? Localizer["No description is available."] : Localizer[_selectedDescriptor.Description])</p>
+                            @if (ReferenceEquals(_selectedDescriptor, SequenceDescriptor))
+                            {
+                                <div class="state-machine-activity-picker__note" role="note">
+                                    <strong>@Localizer["Runs multiple activities"]</strong>
+                                    <span>@Localizer["After adding Sequence, open it to arrange its child activities."]</span>
+                                </div>
+                            }
+                        }
+                    </aside>
+                </div>
             }
         </section>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">@Localizer["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="MudBlazor.Variant.Filled" Disabled="@(_selectedDescriptor == null)" OnClick="CommitAsync" data-testid="state-machine-activity-picker-commit">
+            @CommitLabel
+        </MudButton>
     </DialogActions>
 </MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
@@ -3,64 +3,135 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Extensions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 
 /// <summary>
-/// Presents browsable activities for a StateMachine transition slot.
+/// Contextual activity command palette for StateMachine lifecycle and transition slots.
 /// </summary>
 public partial class StateMachineActivityPickerDialog
 {
+    private const string SuggestedSection = "suggested";
+    private const string RecentSection = "recent";
+    private const string AllSection = "all";
     private readonly string _id = $"state-machine-activity-picker-{Guid.NewGuid():N}";
     private IReadOnlyList<ActivityDescriptor> _descriptors = [];
     private string _searchText = string.Empty;
+    private string _selectedSection = SuggestedSection;
+    private ActivityDescriptor? _selectedDescriptor;
     private Exception? _loadError;
     private bool _isLoading = true;
+    private bool _focusSearch;
+    private ElementReference _searchInput;
 
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
+    [Inject] private ILocalizer Localizer { get; set; } = null!;
 
-    private string HeadingId => $"{_id}-heading";
+    [Parameter] public string SlotName { get; set; } = "action";
+    [Parameter] public bool IsReplacing { get; set; }
+    [Parameter] public IReadOnlyCollection<string> RecentActivityTypes { get; set; } = [];
+
     private string SearchInputId => $"{_id}-search";
+    private string ResultsId => $"{_id}-results";
+    private string DetailsId => $"{_id}-details";
+    private string PickerHeading => IsReplacing
+        ? Localizer[$"Choose a replacement {SlotDisplayName} activity"]
+        : Localizer[$"Choose {SlotArticle} {SlotDisplayName} activity"];
+    private string SlotArticle => SlotName.Equals("trigger", StringComparison.OrdinalIgnoreCase) ? Localizer["a"] : Localizer["an"];
+    private string SlotDisplayName => SlotName.ToLowerInvariant() switch
+    {
+        "entry" => Localizer["entry"],
+        "exit" => Localizer["exit"],
+        "trigger" => Localizer["trigger"],
+        _ => Localizer["action"]
+    };
+    private string ContextKicker => SlotName.ToLowerInvariant() switch
+    {
+        "entry" => Localizer["ON ENTRY"],
+        "exit" => Localizer["ON EXIT"],
+        "trigger" => Localizer["WHEN"],
+        _ => Localizer["THEN"]
+    };
+    private string ContextDescription => SlotName.ToLowerInvariant() switch
+    {
+        "entry" => Localizer["Runs when this state becomes active"],
+        "exit" => Localizer["Runs before an accepted transition leaves this state"],
+        "trigger" => Localizer["Starts the transition"],
+        _ => Localizer["Runs after source exit"]
+    };
 
-    private IEnumerable<ActivityDescriptor> FilteredDescriptors =>
-        _descriptors.Where(MatchesSearch);
+    private IReadOnlyList<ActivityDescriptor> SuggestedDescriptors =>
+        string.Equals(SlotName, "trigger", StringComparison.OrdinalIgnoreCase) || SequenceDescriptor == null
+            ? []
+            : [SequenceDescriptor];
 
-    private IEnumerable<IGrouping<string, ActivityDescriptor>> GroupedDescriptors =>
-        FilteredDescriptors
-            .Where(x => !IsPromotedSequence(x))
-            .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
-            .GroupBy(x => string.IsNullOrWhiteSpace(x.Category) ? Localizer["Other"].Value : x.Category, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
+    private IReadOnlyList<ActivityDescriptor> RecentDescriptors => RecentActivityTypes
+        .Select(type => _descriptors.FirstOrDefault(x => string.Equals(x.TypeName, type, StringComparison.Ordinal)))
+        .Where(x => x != null)
+        .Cast<ActivityDescriptor>()
+        .DistinctBy(x => x.TypeName, StringComparer.Ordinal)
+        .ToList();
+
+    private IReadOnlyList<ActivityDescriptor> VisibleDescriptors
+    {
+        get
+        {
+            IEnumerable<ActivityDescriptor> descriptors = string.IsNullOrWhiteSpace(_searchText)
+                ? _selectedSection switch
+                {
+                    SuggestedSection => SuggestedDescriptors,
+                    RecentSection => RecentDescriptors,
+                    AllSection => _descriptors,
+                    _ => _descriptors.Where(x => string.Equals(GetCategory(x), _selectedSection, StringComparison.OrdinalIgnoreCase))
+                }
+                : _descriptors.Where(MatchesSearch);
+
+            return descriptors
+                .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+
+    private IEnumerable<IGrouping<string, ActivityDescriptor>> CategoryGroups => _descriptors
+        .GroupBy(GetCategory, StringComparer.OrdinalIgnoreCase)
+        .OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
 
     private ActivityDescriptor? SequenceDescriptor =>
         _descriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal));
 
-    private bool IsPromotedSequence(ActivityDescriptor descriptor) =>
-        SequenceDescriptor != null && string.IsNullOrWhiteSpace(_searchText) && ReferenceEquals(descriptor, SequenceDescriptor);
+    private string CommitLabel => (_selectedDescriptor, IsReplacing) switch
+    {
+        (null, true) => Localizer["Replace activity"],
+        (null, false) => Localizer["Add activity"],
+        ({ } descriptor, true) => Localizer["Replace with {0}", GetDisplayName(descriptor)],
+        ({ } descriptor, false) => Localizer["Add {0}", GetDisplayName(descriptor)]
+    };
+    private string? SelectedResultId => _selectedDescriptor == null ? null : GetResultId(_selectedDescriptor);
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
             await ActivityRegistry.EnsureLoadedAsync();
-            var descriptors = ActivityRegistry.List().ToList();
+            var allDescriptors = ActivityRegistry.List().ToList();
             var browsableDescriptors = ActivityRegistry.ListBrowsable().ToList();
-
-            // Sequence is the editor's composition escape hatch. The backend may mark it
-            // non-browsable because it is normally opened through a designer, but it must
-            // still be available as the explicit multi-activity shortcut here.
-            var sequence = descriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal))
+            var sequence = allDescriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal))
                            ?? ActivityRegistry.Find("Elsa.Sequence");
             if (sequence != null && browsableDescriptors.All(x => !string.Equals(x.TypeName, sequence.TypeName, StringComparison.Ordinal)))
                 browsableDescriptors.Add(sequence);
 
             _descriptors = browsableDescriptors
+                .DistinctBy(x => x.TypeName, StringComparer.Ordinal)
                 .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
+            _selectedSection = SuggestedDescriptors.Count > 0 ? SuggestedSection : AllSection;
+            EnsureSelection();
+            _focusSearch = true;
         }
         catch (Exception exception)
         {
@@ -70,6 +141,78 @@ public partial class StateMachineActivityPickerDialog
         {
             _isLoading = false;
         }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_focusSearch || _isLoading || _loadError != null)
+            return;
+
+        _focusSearch = false;
+        await _searchInput.FocusAsync();
+    }
+
+    private void OnSearchInput(ChangeEventArgs args)
+    {
+        _searchText = args.Value?.ToString() ?? string.Empty;
+        EnsureSelection();
+    }
+
+    private void SelectSection(string section)
+    {
+        _selectedSection = section;
+        _searchText = string.Empty;
+        EnsureSelection();
+    }
+
+    private void Select(ActivityDescriptor descriptor) => _selectedDescriptor = descriptor;
+
+    private Task SelectAndCommitAsync(ActivityDescriptor descriptor)
+    {
+        _selectedDescriptor = descriptor;
+        return CommitAsync();
+    }
+
+    private Task CommitAsync()
+    {
+        if (_selectedDescriptor != null)
+            MudDialog.Close(DialogResult.Ok(_selectedDescriptor));
+        return Task.CompletedTask;
+    }
+
+    private Task HandleKeyboardAsync(KeyboardEventArgs args)
+    {
+        if (args.Key == "/")
+        {
+            _focusSearch = true;
+            return InvokeAsync(StateHasChanged);
+        }
+
+        var results = VisibleDescriptors;
+        if (results.Count == 0)
+            return Task.CompletedTask;
+
+        var currentIndex = _selectedDescriptor == null ? -1 : results.IndexOf(_selectedDescriptor);
+        switch (args.Key)
+        {
+            case "ArrowDown":
+                _selectedDescriptor = results[(currentIndex + 1 + results.Count) % results.Count];
+                break;
+            case "ArrowUp":
+                _selectedDescriptor = results[(currentIndex - 1 + results.Count) % results.Count];
+                break;
+            case "Enter":
+                return CommitAsync();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void EnsureSelection()
+    {
+        var results = VisibleDescriptors;
+        if (_selectedDescriptor == null || results.All(x => !ReferenceEquals(x, _selectedDescriptor)))
+            _selectedDescriptor = results.FirstOrDefault();
     }
 
     private bool MatchesSearch(ActivityDescriptor descriptor)
@@ -88,21 +231,28 @@ public partial class StateMachineActivityPickerDialog
     private static bool Contains(string? value, string search) =>
         value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
 
-    private string GetDisplayName(ActivityDescriptor descriptor) =>
-        Localizer[descriptor.DisplayName ?? descriptor.Name].Value;
-
-    private string DisplayCategory(string category) => Localizer[category].Value;
-
-    private string GetGroupId(string category) => $"{_id}-group-{SanitizeId(category)}";
-
-    private static string SanitizeId(string value) =>
-        new(value.Select(character => char.IsLetterOrDigit(character) ? character : '-').ToArray());
-
-    private Task SelectAsync(ActivityDescriptor descriptor)
-    {
-        MudDialog.Close(DialogResult.Ok(descriptor));
-        return Task.CompletedTask;
-    }
-
+    private string GetDisplayName(ActivityDescriptor descriptor) => Localizer[descriptor.DisplayName ?? descriptor.Name].Value;
+    private string GetCategory(ActivityDescriptor descriptor) => string.IsNullOrWhiteSpace(descriptor.Category) ? Localizer["Other"] : Localizer[descriptor.Category];
+    private string GetResultId(ActivityDescriptor descriptor) => $"{_id}-activity-{SanitizeId(descriptor.TypeName)}";
+    private static string SanitizeId(string value) => new(value.Select(character => char.IsLetterOrDigit(character) ? character : '-').ToArray());
+    private bool IsSelected(ActivityDescriptor descriptor) => ReferenceEquals(_selectedDescriptor, descriptor);
+    private bool IsSectionSelected(string section) => _selectedSection == section && string.IsNullOrWhiteSpace(_searchText);
+    private string GetSectionClass(string section) => IsSectionSelected(section)
+        ? "state-machine-activity-picker__filter state-machine-activity-picker__filter--selected"
+        : "state-machine-activity-picker__filter";
     private void Cancel() => MudDialog.Cancel();
+}
+
+file static class ActivityDescriptorListExtensions
+{
+    public static int IndexOf(this IReadOnlyList<ActivityDescriptor> descriptors, ActivityDescriptor descriptor)
+    {
+        for (var index = 0; index < descriptors.Count; index++)
+        {
+            if (ReferenceEquals(descriptors[index], descriptor))
+                return index;
+        }
+
+        return -1;
+    }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.css
@@ -1,155 +1,329 @@
 .state-machine-activity-picker {
-    display: grid;
-    gap: 1rem;
-    min-width: 0;
-    color: var(--mud-palette-text-primary);
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  color: var(--mud-palette-text-primary);
 }
-
-.state-machine-activity-picker__intro,
-.state-machine-activity-picker__state,
-.state-machine-activity-picker__group,
-.state-machine-activity-picker__option,
-.state-machine-activity-picker__quick-option {
-    display: grid;
-    gap: .375rem;
+.state-machine-activity-picker__header {
+  display: grid;
+  gap: 0.25rem;
 }
-
-.state-machine-activity-picker__intro p,
-.state-machine-activity-picker__intro h2,
-.state-machine-activity-picker__intro h3,
-.state-machine-activity-picker__intro h6,
-.state-machine-activity-picker__group h3,
-.state-machine-activity-picker__state strong,
-.state-machine-activity-picker__state span,
-.state-machine-activity-picker__option strong,
-.state-machine-activity-picker__option span,
-.state-machine-activity-picker__quick-option strong,
-.state-machine-activity-picker__quick-option span {
-    margin: 0;
+.state-machine-activity-picker__header h2,
+.state-machine-activity-picker__header p,
+.state-machine-activity-picker__details h3,
+.state-machine-activity-picker__details p {
+  margin: 0;
 }
-
-.state-machine-activity-picker__eyebrow {
-    color: var(--mud-palette-primary);
-    font-size: .6875rem;
-    font-weight: 700;
-    letter-spacing: .055em;
-    text-transform: uppercase;
+.state-machine-activity-picker__header h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
 }
-
-.state-machine-activity-picker__search {
-    min-width: 0;
+.state-machine-activity-picker__eyebrow,
+.state-machine-activity-picker__details-kicker {
+  color: var(--mud-palette-primary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
 }
-
-.state-machine-activity-picker__groups {
-    display: grid;
-    gap: 1rem;
-    max-height: min(52vh, 32rem);
-    overflow-y: auto;
-    padding: .125rem .125rem .25rem;
+.state-machine-activity-picker__context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
 }
-
-.state-machine-activity-picker__group {
-    gap: .5rem;
+.state-machine-activity-picker__context strong {
+  color: var(--mud-palette-primary);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
 }
-
-.state-machine-activity-picker__group h3 {
-    color: var(--mud-palette-text-secondary);
-    font-size: .75rem;
-    font-weight: 700;
-    letter-spacing: .04em;
-    text-transform: uppercase;
+.state-machine-activity-picker__search-wrap {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  display: grid;
+  gap: 0.375rem;
+  padding: 0.25rem 0;
+  background: var(--mud-palette-surface);
 }
-
-.state-machine-activity-picker__options {
-    display: grid;
-    gap: .5rem;
+.state-machine-activity-picker__search-wrap label {
+  font-size: 0.75rem;
+  font-weight: 600;
 }
-
-.state-machine-activity-picker__option,
-.state-machine-activity-picker__quick-option {
-    width: 100%;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
-    color: var(--mud-palette-text-primary);
-    cursor: pointer;
-    padding: .75rem;
-    text-align: left;
+.state-machine-activity-picker__search-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 2.75rem;
+  border: 1px solid var(--mud-palette-lines-inputs);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
 }
-
-.state-machine-activity-picker__option:hover,
-.state-machine-activity-picker__option:focus-visible {
-    border-color: var(--mud-palette-primary);
-    background: var(--mud-palette-action-default-hover);
+.state-machine-activity-picker__search-control:focus-within {
+  border-color: var(--mud-palette-primary);
+  outline: 2px solid
+    color-mix(in srgb, var(--mud-palette-primary) 25%, transparent);
 }
-
-.state-machine-activity-picker__quick-option {
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: center;
-    border-color: var(--mud-palette-primary);
-    background: var(--mud-palette-action-default-hover);
+.state-machine-activity-picker__search-control input {
+  min-width: 0;
+  height: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--mud-palette-text-primary);
+  font: inherit;
 }
-
-.state-machine-activity-picker__quick-option:hover,
-.state-machine-activity-picker__quick-option:focus-visible {
-    background: var(--mud-palette-surface);
+.state-machine-activity-picker__search-control kbd {
+  margin-right: 0.625rem;
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: 0.25rem;
+  color: var(--mud-palette-text-secondary);
+  font: inherit;
+  font-size: 0.6875rem;
 }
-
-.state-machine-activity-picker__quick-icon {
-    display: grid;
-    width: 2rem;
-    height: 2rem;
-    place-items: center;
-    border-radius: 50%;
-    background: var(--mud-palette-primary);
-    color: var(--mud-palette-primary-text);
-    font-size: 1.25rem;
+.state-machine-activity-picker__workspace {
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.7fr) minmax(16rem, 1.6fr) minmax(
+      13rem,
+      1fr
+    );
+  min-height: 24rem;
+  max-height: min(58vh, 36rem);
+  overflow: hidden;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
 }
-
-.state-machine-activity-picker__option-copy,
-.state-machine-activity-picker__quick-option > span:last-child {
-    display: grid;
-    gap: .125rem;
-    min-width: 0;
+.state-machine-activity-picker__filters {
+  display: grid;
+  align-content: start;
+  gap: 0.125rem;
+  padding: 0.625rem;
+  overflow-y: auto;
+  border-right: 1px solid var(--mud-palette-lines-default);
+  background: var(--mud-palette-background-grey);
 }
-
-.state-machine-activity-picker__option-copy span,
-.state-machine-activity-picker__quick-option > span:last-child > span,
-.state-machine-activity-picker__option-description,
-.state-machine-activity-picker__state span {
-    color: var(--mud-palette-text-secondary);
-    font-size: .8125rem;
+.state-machine-activity-picker__filter {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+  background: transparent;
+  color: var(--mud-palette-text-secondary);
+  font: inherit;
+  font-size: 0.75rem;
+  text-align: left;
+  cursor: pointer;
 }
-
-.state-machine-activity-picker__option-description {
-    line-height: 1.4;
+.state-machine-activity-picker__filter:hover:not(:disabled) {
+  background: var(--mud-palette-action-default-hover);
+  color: var(--mud-palette-text-primary);
 }
-
+.state-machine-activity-picker__filter--selected {
+  border-color: var(--mud-palette-primary);
+  background: var(--mud-palette-action-default-hover);
+  color: var(--mud-palette-primary);
+  font-weight: 600;
+}
+.state-machine-activity-picker__filter:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.state-machine-activity-picker__filter-separator {
+  height: 1px;
+  margin: 0.5rem 0;
+  background: var(--mud-palette-lines-default);
+}
+.state-machine-activity-picker__results-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  border-right: 1px solid var(--mud-palette-lines-default);
+}
+.state-machine-activity-picker__results-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--mud-palette-lines-default);
+  font-size: 0.75rem;
+}
+.state-machine-activity-picker__results-heading span {
+  color: var(--mud-palette-text-secondary);
+}
+.state-machine-activity-picker__results {
+  display: grid;
+  align-content: start;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+.state-machine-activity-picker__result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 3.5rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+  background: transparent;
+  color: var(--mud-palette-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.state-machine-activity-picker__result:hover {
+  background: var(--mud-palette-action-default-hover);
+}
+.state-machine-activity-picker__result--selected {
+  border-color: var(--mud-palette-primary);
+  background: var(--mud-palette-action-default-hover);
+}
+.state-machine-activity-picker__result-copy {
+  display: grid;
+  gap: 0.125rem;
+  min-width: 0;
+}
+.state-machine-activity-picker__result-copy > span:last-child,
+.state-machine-activity-picker__result-category {
+  overflow: hidden;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.6875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.state-machine-activity-picker__result-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  min-width: 0;
+}
+.state-machine-activity-picker__result-title strong {
+  overflow: hidden;
+  font-size: 0.8125rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.state-machine-activity-picker__recommended {
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--mud-palette-primary);
+  border-radius: 999px;
+  color: var(--mud-palette-primary);
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.state-machine-activity-picker__details {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 1rem;
+  overflow-y: auto;
+  background: var(--mud-palette-surface);
+}
+.state-machine-activity-picker__details h3 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.state-machine-activity-picker__details code {
+  overflow-wrap: anywhere;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.75rem;
+}
+.state-machine-activity-picker__details
+  > p:not(.state-machine-activity-picker__details-kicker) {
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+.state-machine-activity-picker__note {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-background-grey);
+  font-size: 0.75rem;
+}
+.state-machine-activity-picker__note span {
+  color: var(--mud-palette-text-secondary);
+  line-height: 1.45;
+}
 .state-machine-activity-picker__state {
-    min-height: 8rem;
-    place-content: center;
-    justify-items: center;
-    padding: 1.5rem;
-    border: 1px dashed var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    text-align: center;
+  display: grid;
+  min-height: 8rem;
+  place-content: center;
+  justify-items: center;
+  gap: 0.375rem;
+  padding: 1.5rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
 }
-
-.state-machine-activity-picker__state--error {
-    border-color: var(--mud-palette-error);
-}
-
 .state-machine-activity-picker__state--error strong {
-    color: var(--mud-palette-error);
+  color: var(--mud-palette-error);
+}
+.state-machine-activity-picker button:focus-visible {
+  outline: 2px solid var(--mud-palette-primary);
+  outline-offset: 2px;
 }
 
-button:focus-visible {
-    outline: 2px solid var(--mud-palette-primary);
-    outline-offset: 2px;
+@media (max-width: 900px) {
+  .state-machine-activity-picker__workspace {
+    grid-template-columns: minmax(8rem, 0.6fr) minmax(15rem, 1.4fr);
+  }
+  .state-machine-activity-picker__details {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--mud-palette-lines-default);
+  }
 }
 
 @media (max-width: 700px) {
-    .state-machine-activity-picker__groups {
-        max-height: 48vh;
-    }
+  .state-machine-activity-picker__workspace {
+    display: flex;
+    max-height: min(62vh, 34rem);
+    flex-direction: column;
+    overflow-y: auto;
+  }
+  .state-machine-activity-picker__filters {
+    display: flex;
+    flex: 0 0 auto;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+  }
+  .state-machine-activity-picker__filter {
+    flex: 0 0 auto;
+  }
+  .state-machine-activity-picker__filter-separator {
+    width: 1px;
+    height: auto;
+    margin: 0 0.375rem;
+  }
+  .state-machine-activity-picker__results-panel {
+    min-height: 17rem;
+    border-right: 0;
+  }
+  .state-machine-activity-picker__details {
+    flex: 0 0 auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .state-machine-activity-picker * {
+    scroll-behavior: auto;
+    transition: none;
+  }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
@@ -1,0 +1,120 @@
+@using System.Text.Json.Nodes
+@using Elsa.Studio.Localization
+@namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
+@inject ILocalizer Localizer
+
+<div class="state-machine-activity-slot"
+     data-slot-state="@Presentation.State.ToString().ToLowerInvariant()"
+     data-slot-action="drop"
+     aria-label="@Localizer[$"{SlotName} activity slot"]"
+     @ondragover="DragOverCallback"
+     @ondragover:preventDefault="@(!IsReadOnly)"
+     @ondrop="DropCallback"
+     @ondrop:preventDefault="@(!IsReadOnly)">
+    @if (Presentation.State == StateMachineActivityState.Empty)
+    {
+        <div class="state-machine-activity-slot__empty" data-testid="@($"{TestIdPrefix}-{SlotName}-empty")">
+            <strong>@EmptyTitle</strong>
+            <span>@EmptyDescription</span>
+            @if (!IsReadOnly)
+            {
+                <button type="button"
+                        class="state-machine-activity-slot__button"
+                        data-slot-action="add"
+                        aria-label="@Localizer[$"Add {SlotName} activity"]"
+                        @onclick="RequestAddAsync">
+                    @AddLabel
+                </button>
+                <span class="state-machine-activity-slot__drop-hint">@Localizer["or drop an activity here"]</span>
+            }
+        </div>
+    }
+    else
+    {
+        <div class="@(Presentation.State == StateMachineActivityState.Malformed ? "state-machine-activity-slot__card state-machine-activity-slot__card--invalid" : "state-machine-activity-slot__card")"
+             data-testid="@($"{TestIdPrefix}-{SlotName}-activity")"
+             data-activity-state="@Presentation.State.ToString().ToLowerInvariant()">
+            <div class="state-machine-activity-slot__copy">
+                <strong>@Presentation.Title</strong>
+                <span>@Presentation.Detail</span>
+            </div>
+
+            @if (Presentation.State == StateMachineActivityState.Malformed)
+            {
+                <p class="state-machine-activity-slot__warning" role="status">
+                    @Localizer["This definition is invalid and will be preserved until you replace or clear it."]
+                </p>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(Presentation.RawDefinition))
+            {
+                <details class="state-machine-activity-slot__definition">
+                    <summary>@Localizer["View definition"]</summary>
+                    <pre data-testid="@($"{TestIdPrefix}-{SlotName}-definition")">@Presentation.RawDefinition</pre>
+                </details>
+            }
+
+            @if (Presentation.State != StateMachineActivityState.Malformed || !IsReadOnly)
+            {
+                <div class="state-machine-activity-slot__actions">
+                    @if (Presentation.State != StateMachineActivityState.Malformed)
+                    {
+                        <button type="button"
+                                class="state-machine-activity-slot__button"
+                                data-slot-action="open"
+                                aria-label="@Localizer[$"Open {SlotName} activity"]"
+                                @onclick="RequestOpenAsync">
+                            @Localizer["Open"]
+                        </button>
+                    }
+                    @if (!IsReadOnly)
+                    {
+                        <button type="button"
+                                class="state-machine-activity-slot__button"
+                                data-slot-action="replace"
+                                aria-label="@Localizer[$"Replace {SlotName} activity"]"
+                                @onclick="RequestReplaceAsync">
+                            @Localizer["Replace"]
+                        </button>
+                        <button type="button"
+                                class="state-machine-activity-slot__button state-machine-activity-slot__button--subtle"
+                                data-slot-action="clear"
+                                aria-label="@Localizer[$"Clear {SlotName} activity"]"
+                                @onclick="RequestClearAsync">
+                            @Localizer["Clear"]
+                        </button>
+                    }
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string SlotName { get; set; } = null!;
+    [Parameter, EditorRequired] public string TestIdPrefix { get; set; } = null!;
+    [Parameter] public JsonNode? Value { get; set; }
+    [Parameter, EditorRequired] public string EmptyTitle { get; set; } = null!;
+    [Parameter, EditorRequired] public string EmptyDescription { get; set; } = null!;
+    [Parameter, EditorRequired] public string AddLabel { get; set; } = null!;
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public EventCallback<string> AddRequested { get; set; }
+    [Parameter] public EventCallback<string> OpenRequested { get; set; }
+    [Parameter] public EventCallback<string> ReplaceRequested { get; set; }
+    [Parameter] public EventCallback<string> ClearRequested { get; set; }
+    [Parameter] public EventCallback<string> DropRequested { get; set; }
+
+    private StateMachineActivityPresentation Presentation => StateMachineActivityPresentation.Describe(Value, Localizer);
+    private EventCallback<DragEventArgs> DragOverCallback => IsReadOnly
+        ? default
+        : EventCallback.Factory.Create<DragEventArgs>(this, _ => Task.CompletedTask);
+    private EventCallback<DragEventArgs> DropCallback => IsReadOnly
+        ? default
+        : EventCallback.Factory.Create<DragEventArgs>(this, _ => RequestDropAsync());
+
+    private Task RequestAddAsync() => AddRequested.InvokeAsync(SlotName);
+    private Task RequestOpenAsync() => OpenRequested.InvokeAsync(SlotName);
+    private Task RequestReplaceAsync() => ReplaceRequested.InvokeAsync(SlotName);
+    private Task RequestClearAsync() => ClearRequested.InvokeAsync(SlotName);
+    private Task RequestDropAsync() => IsReadOnly ? Task.CompletedTask : DropRequested.InvokeAsync(SlotName);
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+
+internal enum StateMachineActivityState
+{
+    Empty,
+    Configured,
+    Malformed
+}
+
+internal sealed record StateMachineActivityPresentation(
+    StateMachineActivityState State,
+    string Title,
+    string Detail,
+    string RawDefinition)
+{
+    public static StateMachineActivityPresentation Describe(JsonNode? value, ILocalizer localizer)
+    {
+        if (value == null)
+            return new(StateMachineActivityState.Empty, string.Empty, string.Empty, string.Empty);
+
+        var rawDefinition = StateMachinePresentationFormatter.JsonSlot(value);
+        if (value is not JsonObject obj)
+            return new(StateMachineActivityState.Malformed, localizer["Invalid activity definition"], localizer["Expected an activity object."], rawDefinition);
+
+        if (StateMachineDesignerConstants.IsInvalidJsonSlotMarker(obj))
+            return new(StateMachineActivityState.Malformed, localizer["Invalid activity definition"], localizer["The original source is preserved."], rawDefinition);
+
+        var typeName = GetString(obj, "type");
+        if (string.IsNullOrWhiteSpace(typeName))
+            return new(StateMachineActivityState.Malformed, localizer["Unavailable activity definition"], localizer["The activity type is missing."], rawDefinition);
+
+        if (string.IsNullOrWhiteSpace(GetString(obj, "id")) || string.IsNullOrWhiteSpace(GetString(obj, "nodeId")))
+            return new(StateMachineActivityState.Malformed, localizer["Incomplete activity definition"], localizer["An activity id and node ID are required."], rawDefinition);
+
+        var title = FirstNonEmpty(GetString(obj, "displayName"), GetString(obj, "name"), typeName)!;
+        var version = GetString(obj, "version");
+        var detail = string.IsNullOrWhiteSpace(version) ? typeName : $"{typeName} · v{version}";
+        return new(StateMachineActivityState.Configured, localizer[title], detail, rawDefinition);
+    }
+
+    private static string? GetString(JsonObject obj, string propertyName) =>
+        obj[propertyName] is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.css
@@ -1,0 +1,125 @@
+.state-machine-activity-slot {
+  display: grid;
+  gap: 0.625rem;
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px dashed var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+}
+
+.state-machine-activity-slot:not([data-slot-state="empty"]):hover {
+  border-color: var(--mud-palette-primary);
+}
+
+.state-machine-activity-slot__empty,
+.state-machine-activity-slot__copy {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.state-machine-activity-slot__empty {
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
+}
+
+.state-machine-activity-slot__empty strong,
+.state-machine-activity-slot__copy strong {
+  color: var(--mud-palette-text-primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.state-machine-activity-slot__empty span,
+.state-machine-activity-slot__warning {
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.state-machine-activity-slot__drop-hint {
+  margin-top: -0.125rem;
+}
+
+.state-machine-activity-slot__card {
+  display: grid;
+  align-items: start;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.state-machine-activity-slot__copy {
+  overflow-wrap: anywhere;
+}
+
+.state-machine-activity-slot__copy span {
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.6875rem;
+}
+
+.state-machine-activity-slot__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 0.25rem;
+}
+
+.state-machine-activity-slot__button {
+  min-height: 2.25rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+  background: transparent;
+  color: var(--mud-palette-primary);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.state-machine-activity-slot__button:hover {
+  border-color: var(--mud-palette-lines-default);
+  background: var(--mud-palette-action-default-hover);
+}
+
+.state-machine-activity-slot__button--subtle {
+  color: var(--mud-palette-text-secondary);
+}
+
+.state-machine-activity-slot__button:focus-visible,
+.state-machine-activity-slot__definition summary:focus-visible {
+  outline: 2px solid var(--mud-palette-primary);
+  outline-offset: 2px;
+}
+
+.state-machine-activity-slot__warning {
+  margin: 0;
+  color: var(--mud-palette-warning);
+}
+
+.state-machine-activity-slot__definition {
+  min-width: 0;
+}
+
+.state-machine-activity-slot__definition summary {
+  color: var(--mud-palette-primary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  list-style-position: inside;
+}
+
+.state-machine-activity-slot__definition pre {
+  max-height: 10rem;
+  margin: 0.5rem 0 0;
+  overflow: auto;
+  padding: 0.625rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-background-grey);
+  color: var(--mud-palette-text-secondary);
+  font-family: monospace;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor
@@ -9,59 +9,152 @@
             <p class="state-machine-inspector__eyebrow">@Localizer["Inspector"]</p>
             <h3 id="@HeadingId">@Localizer["State"]</h3>
         </div>
-        @if (State != null && !IsReadOnly)
-        {
-            <button class="state-machine-inspector__button state-machine-inspector__button--danger"
-                    type="button"
-                    @onclick="() => DeleteRequested.InvokeAsync()">
-                @Localizer["Delete"]
-            </button>
-        }
     </header>
 
     @if (State == null)
     {
-        <p class="state-machine-inspector__empty">@Localizer["Select a state in the diagram or outline to inspect it."]</p>
+        <p class="state-machine-inspector__empty" role="status">@Localizer["Select a state in the diagram or outline to inspect it."]</p>
     }
     else
     {
-        <div class="state-machine-inspector__summary" aria-label="@Localizer["State status"]">
-            <strong>@StateMachinePresentationFormatter.DisplayValue(State.Name)</strong>
-            @if (State.IsTerminal)
-            {
-                <span class="state-machine-inspector__badge">@Localizer["Terminal"]</span>
-            }
-            @if (State.Entry != null)
-            {
-                <span class="state-machine-inspector__badge">@Localizer["Entry"]</span>
-            }
-            @if (State.Exit != null)
-            {
-                <span class="state-machine-inspector__badge">@Localizer["Exit"]</span>
-            }
-        </div>
-
-        <div class="state-machine-inspector__fields">
-            <div class="state-machine-inspector__field">
-                <label for="@NameId">@Localizer["Name"]</label>
-                <input id="@NameId"
-                       class="state-machine-inspector__control"
-                       value="@State.Name"
-                       disabled="@IsReadOnly"
-                       @onchange="ChangeNameAsync" />
+        <div class="state-machine-inspector__identity">
+            <label for="@NameId">@Localizer["Name"]</label>
+            <input id="@NameId"
+                   class="state-machine-inspector__control state-machine-inspector__control--name"
+                   value="@State.Name"
+                   disabled="@IsReadOnly"
+                   @onchange="ChangeNameAsync" />
+            <div class="state-machine-inspector__badges" aria-label="@Localizer["State status"]">
+                @if (IsInitial)
+                {
+                    <span class="state-machine-inspector__badge state-machine-inspector__badge--primary">@Localizer["Initial"]</span>
+                }
+                @if (IsCurrent)
+                {
+                    <span class="state-machine-inspector__badge state-machine-inspector__badge--success">@Localizer["Current"]</span>
+                }
+                @if (State.IsTerminal)
+                {
+                    <span class="state-machine-inspector__badge">@Localizer["Terminal"]</span>
+                }
+                <span class="state-machine-inspector__badge">@Localizer["State"]</span>
             </div>
-
-            @RenderSlot("entry", Localizer["Entry"], State.Entry)
-            @RenderSlot("exit", Localizer["Exit"], State.Exit)
         </div>
+
+        <div class="state-machine-inspector__lifecycle" aria-label="@Localizer["State lifecycle"]">
+            <section class="state-machine-inspector__stage" data-state-stage="entry" aria-labelledby="@EntryStageId">
+                <div class="state-machine-inspector__stage-marker" aria-hidden="true">@Localizer["ON ENTRY"]</div>
+                <div class="state-machine-inspector__stage-content">
+                    <div class="state-machine-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-inspector__stage-kicker">@Localizer["ON ENTRY"]</p>
+                            <h4 id="@EntryStageId">@Localizer["Entry action"]</h4>
+                        </div>
+                        <span class="state-machine-inspector__stage-note">@Localizer["Runs when this state becomes active"]</span>
+                    </div>
+                    <StateMachineActivitySlot SlotName="entry"
+                                              TestIdPrefix="state-machine-state"
+                                              Value="@State.Entry"
+                                              EmptyTitle="@Localizer["No entry activity configured"]"
+                                              EmptyDescription="@Localizer["Nothing runs when this state becomes active."]"
+                                              AddLabel="@Localizer["Add activity"]"
+                                              IsReadOnly="@IsReadOnly"
+                                              AddRequested="RequestActivityAddAsync"
+                                              OpenRequested="RequestActivityOpenAsync"
+                                              ReplaceRequested="RequestActivityReplaceAsync"
+                                              ClearRequested="RequestActivityClearAsync"
+                                              DropRequested="RequestActivityDropAsync" />
+                </div>
+            </section>
+
+            <div class="state-machine-inspector__connector" aria-hidden="true">↓</div>
+
+            <section class="state-machine-inspector__stage state-machine-inspector__stage--active" data-state-stage="active" aria-labelledby="@ActiveStageId">
+                <div class="state-machine-inspector__stage-marker" aria-hidden="true">@Localizer["ACTIVE"]</div>
+                <div class="state-machine-inspector__stage-content">
+                    <div class="state-machine-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-inspector__stage-kicker">@Localizer["ACTIVE"]</p>
+                            <h4 id="@ActiveStageId">@Localizer["Transitions"]</h4>
+                        </div>
+                        <span class="state-machine-inspector__stage-note">@Localizer["Evaluated while {0} is active", StateMachinePresentationFormatter.DisplayValue(State.Name)]</span>
+                    </div>
+                    <div class="state-machine-inspector__transition-summary">
+                        <strong>@OutgoingTransitionLabel</strong>
+                        @if (OutgoingTransitionCount > 0)
+                        {
+                            <button type="button"
+                                    class="state-machine-inspector__button"
+                                    data-testid="state-machine-state-view-transitions"
+                                    @onclick="() => ViewTransitionsRequested.InvokeAsync()">
+                                @Localizer["View transitions"]
+                            </button>
+                        }
+                    </div>
+                </div>
+            </section>
+
+            <div class="state-machine-inspector__connector" aria-hidden="true">↓</div>
+
+            <section class="state-machine-inspector__stage" data-state-stage="exit" aria-labelledby="@ExitStageId">
+                <div class="state-machine-inspector__stage-marker" aria-hidden="true">@Localizer["ON EXIT"]</div>
+                <div class="state-machine-inspector__stage-content">
+                    <div class="state-machine-inspector__stage-heading">
+                        <div>
+                            <p class="state-machine-inspector__stage-kicker">@Localizer["ON EXIT"]</p>
+                            <h4 id="@ExitStageId">@Localizer["Exit action"]</h4>
+                        </div>
+                        <span class="state-machine-inspector__stage-note">@Localizer["Runs before an accepted transition leaves this state"]</span>
+                    </div>
+                    <StateMachineActivitySlot SlotName="exit"
+                                              TestIdPrefix="state-machine-state"
+                                              Value="@State.Exit"
+                                              EmptyTitle="@Localizer["No exit activity configured"]"
+                                              EmptyDescription="@Localizer["Nothing runs before this state is left."]"
+                                              AddLabel="@Localizer["Add activity"]"
+                                              IsReadOnly="@IsReadOnly"
+                                              AddRequested="RequestActivityAddAsync"
+                                              OpenRequested="RequestActivityOpenAsync"
+                                              ReplaceRequested="RequestActivityReplaceAsync"
+                                              ClearRequested="RequestActivityClearAsync"
+                                              DropRequested="RequestActivityDropAsync" />
+                </div>
+            </section>
+        </div>
+
+        <details class="state-machine-inspector__details">
+            <summary>
+                <span>@Localizer["State details"]</span>
+                <span class="state-machine-inspector__details-summary">@Localizer["{0} incoming · {1} outgoing", IncomingTransitionCount, OutgoingTransitionCount]</span>
+            </summary>
+            <dl>
+                <div><dt>@Localizer["Incoming transitions"]</dt><dd>@IncomingTransitionCount</dd></div>
+                <div><dt>@Localizer["Outgoing transitions"]</dt><dd>@OutgoingTransitionCount</dd></div>
+                <div><dt>@Localizer["Entry activity"]</dt><dd>@(State.Entry == null ? Localizer["Not configured"] : Localizer["Configured"])</dd></div>
+                <div><dt>@Localizer["Exit activity"]</dt><dd>@(State.Exit == null ? Localizer["Not configured"] : Localizer["Configured"])</dd></div>
+            </dl>
+        </details>
 
         @if (ValidationIssues.Count > 0)
         {
             <div class="state-machine-inspector__issues" role="alert" aria-label="@Localizer["State validation issues"]">
+                <strong>@Localizer["Validation"]</strong>
                 @foreach (var issue in ValidationIssues)
                 {
                     <p><strong>@issue.Severity:</strong> @Localizer[issue.Message]</p>
                 }
+            </div>
+        }
+
+        @if (!IsReadOnly)
+        {
+            <div class="state-machine-inspector__danger-zone">
+                <button class="state-machine-inspector__button state-machine-inspector__button--danger"
+                        type="button"
+                        data-testid="state-machine-state-delete"
+                        @onclick="() => DeleteRequested.InvokeAsync()">
+                    @Localizer["Delete state"]
+                </button>
             </div>
         }
     }
@@ -72,58 +165,33 @@
 
     [Parameter] public StateMachineStateNode? State { get; set; }
     [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public bool IsInitial { get; set; }
+    [Parameter] public bool IsCurrent { get; set; }
+    [Parameter] public int IncomingTransitionCount { get; set; }
+    [Parameter] public int OutgoingTransitionCount { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
     [Parameter] public EventCallback<string> NameChanged { get; set; }
-    [Parameter] public EventCallback<StateMachineSlotValueChange> SlotChanged { get; set; }
-    [Parameter] public EventCallback<string> SlotCleared { get; set; }
-    [Parameter] public EventCallback<string> SlotDropRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityAddRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityOpenRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityReplaceRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityClearRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityDropRequested { get; set; }
+    [Parameter] public EventCallback ViewTransitionsRequested { get; set; }
     [Parameter] public EventCallback DeleteRequested { get; set; }
 
     private string HeadingId => $"{_id}-heading";
     private string NameId => $"{_id}-name";
+    private string EntryStageId => $"{_id}-entry-stage";
+    private string ActiveStageId => $"{_id}-active-stage";
+    private string ExitStageId => $"{_id}-exit-stage";
+    private string OutgoingTransitionLabel => OutgoingTransitionCount == 1
+        ? Localizer["1 outgoing transition"]
+        : Localizer["{0} outgoing transitions", OutgoingTransitionCount];
 
     private Task ChangeNameAsync(ChangeEventArgs args) => NameChanged.InvokeAsync(args.Value?.ToString() ?? "");
-
-    private RenderFragment RenderSlot(string slotName, string label, System.Text.Json.Nodes.JsonNode? value) => builder =>
-    {
-        var fieldId = $"{_id}-{slotName}";
-        var helpId = $"{fieldId}-help";
-        var sequence = 0;
-
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", "state-machine-inspector__field");
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", "state-machine-inspector__field-heading");
-        builder.OpenElement(sequence++, "label");
-        builder.AddAttribute(sequence++, "for", fieldId);
-        builder.AddContent(sequence++, label);
-        builder.CloseElement();
-        if (!IsReadOnly)
-        {
-            builder.OpenElement(sequence++, "button");
-            builder.AddAttribute(sequence++, "type", "button");
-            builder.AddAttribute(sequence++, "class", "state-machine-inspector__button");
-            builder.AddAttribute(sequence++, "onclick", EventCallback.Factory.Create(this, () => SlotCleared.InvokeAsync(slotName)));
-            builder.AddContent(sequence++, Localizer["Clear"]);
-            builder.CloseElement();
-        }
-        builder.CloseElement();
-        builder.OpenElement(sequence++, "textarea");
-        builder.AddAttribute(sequence++, "id", fieldId);
-        builder.AddAttribute(sequence++, "class", "state-machine-inspector__control state-machine-inspector__control--code");
-        builder.AddAttribute(sequence++, "aria-describedby", helpId);
-        builder.AddAttribute(sequence++, "disabled", IsReadOnly);
-        builder.AddAttribute(sequence++, "value", StateMachinePresentationFormatter.JsonSlot(value));
-        builder.AddAttribute(sequence++, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, args => SlotChanged.InvokeAsync(new(slotName, args.Value?.ToString()))));
-        builder.AddAttribute(sequence++, "ondragover", EventCallback.Factory.Create<DragEventArgs>(this, _ => Task.CompletedTask));
-        builder.AddEventPreventDefaultAttribute(sequence++, "ondragover", true);
-        builder.AddAttribute(sequence++, "ondrop", EventCallback.Factory.Create<DragEventArgs>(this, _ => SlotDropRequested.InvokeAsync(slotName)));
-        builder.CloseElement();
-        builder.OpenElement(sequence++, "p");
-        builder.AddAttribute(sequence++, "id", helpId);
-        builder.AddAttribute(sequence++, "class", "state-machine-inspector__help");
-        builder.AddContent(sequence++, Localizer["Enter activity JSON or drop an activity here."]);
-        builder.CloseElement();
-        builder.CloseElement();
-    };
+    private Task RequestActivityAddAsync(string slotName) => ActivityAddRequested.InvokeAsync(slotName);
+    private Task RequestActivityOpenAsync(string slotName) => ActivityOpenRequested.InvokeAsync(slotName);
+    private Task RequestActivityReplaceAsync(string slotName) => ActivityReplaceRequested.InvokeAsync(slotName);
+    private Task RequestActivityClearAsync(string slotName) => ActivityClearRequested.InvokeAsync(slotName);
+    private Task RequestActivityDropAsync(string slotName) => ActivityDropRequested.InvokeAsync(slotName);
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor.css
@@ -1,160 +1,269 @@
 .state-machine-inspector {
-    display: grid;
-    gap: 1rem;
-    color: var(--mud-palette-text-primary);
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  color: var(--mud-palette-text-primary);
 }
-
 .state-machine-inspector__header,
-.state-machine-inspector__summary,
-.state-machine-inspector__field-heading {
-    display: flex;
-    align-items: center;
+.state-machine-inspector__stage-heading,
+.state-machine-inspector__transition-summary,
+.state-machine-inspector__details summary {
+  display: flex;
+  align-items: center;
 }
-
 .state-machine-inspector__header {
-    justify-content: space-between;
-    gap: 1rem;
+  justify-content: space-between;
+  gap: 1rem;
 }
-
 .state-machine-inspector__header h3,
 .state-machine-inspector__eyebrow,
-.state-machine-inspector__help,
-.state-machine-inspector__issues p {
-    margin: 0;
+.state-machine-inspector__stage-kicker,
+.state-machine-inspector__stage-heading h4,
+.state-machine-inspector__stage-note,
+.state-machine-inspector__issues p,
+.state-machine-inspector__details summary,
+.state-machine-inspector__details-summary {
+  margin: 0;
 }
-
 .state-machine-inspector__header h3 {
-    font-size: 1rem;
-    font-weight: 600;
+  font-size: 1rem;
+  font-weight: 600;
 }
-
 .state-machine-inspector__eyebrow,
-.state-machine-inspector__help {
-    color: var(--mud-palette-text-secondary);
-    font-size: .75rem;
+.state-machine-inspector__stage-kicker,
+.state-machine-inspector__stage-note,
+.state-machine-inspector__details-summary {
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.75rem;
 }
-
+.state-machine-inspector__eyebrow,
+.state-machine-inspector__stage-kicker {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
 .state-machine-inspector__eyebrow {
-    margin-bottom: .125rem;
-    font-weight: 600;
-    letter-spacing: .04em;
-    text-transform: uppercase;
+  margin-bottom: 0.125rem;
 }
-
-.state-machine-inspector__summary {
-    flex-wrap: wrap;
-    gap: .375rem;
-    padding: .75rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
+.state-machine-inspector__identity {
+  display: grid;
+  gap: 0.5rem;
 }
-
-.state-machine-inspector__summary strong {
-    margin-right: auto;
+.state-machine-inspector__identity label {
+  font-size: 0.75rem;
+  font-weight: 600;
 }
-
+.state-machine-inspector__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
 .state-machine-inspector__badge {
-    display: inline-flex;
-    align-items: center;
-    min-height: 1.25rem;
-    padding: 0 .5rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: 999px;
-    color: var(--mud-palette-text-secondary);
-    font-size: .6875rem;
-    font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.25rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: 999px;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
 }
-
-.state-machine-inspector__fields,
-.state-machine-inspector__field {
-    display: grid;
-    gap: .5rem;
+.state-machine-inspector__badge--primary {
+  border-color: var(--mud-palette-primary);
+  color: var(--mud-palette-primary);
 }
-
-.state-machine-inspector__fields {
-    gap: 1rem;
+.state-machine-inspector__badge--success {
+  border-color: var(--mud-palette-success);
+  color: var(--mud-palette-success);
 }
-
-.state-machine-inspector__field-heading {
-    justify-content: space-between;
-    gap: .75rem;
-}
-
-.state-machine-inspector__field label {
-    font-size: .8125rem;
-    font-weight: 600;
-}
-
 .state-machine-inspector__control {
-    width: 100%;
-    min-height: 2.5rem;
-    box-sizing: border-box;
-    padding: .5rem .75rem;
-    border: 1px solid var(--mud-palette-lines-inputs);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
-    color: var(--mud-palette-text-primary);
-    font: inherit;
+  width: 100%;
+  min-height: 2.5rem;
+  box-sizing: border-box;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--mud-palette-lines-inputs);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
+  color: var(--mud-palette-text-primary);
+  font: inherit;
 }
-
-.state-machine-inspector__control--code {
-    min-height: 7rem;
-    resize: vertical;
-    font-family: var(--mud-typography-default-family);
-    font-size: .8125rem;
+.state-machine-inspector__control--name {
+  font-weight: 600;
 }
-
 .state-machine-inspector__control:hover:not(:disabled) {
-    border-color: var(--mud-palette-text-secondary);
+  border-color: var(--mud-palette-text-secondary);
 }
-
 .state-machine-inspector__control:focus-visible,
-.state-machine-inspector__button:focus-visible {
-    outline: 2px solid var(--mud-palette-primary);
-    outline-offset: 2px;
+.state-machine-inspector__button:focus-visible,
+.state-machine-inspector__details summary:focus-visible {
+  outline: 2px solid var(--mud-palette-primary);
+  outline-offset: 2px;
 }
-
 .state-machine-inspector__control:disabled {
-    background: var(--mud-palette-action-disabled-background);
-    color: var(--mud-palette-action-disabled);
+  background: var(--mud-palette-action-disabled-background);
+  color: var(--mud-palette-action-disabled);
 }
-
+.state-machine-inspector__lifecycle {
+  display: grid;
+  gap: 0.5rem;
+}
+.state-machine-inspector__stage {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.875rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
+}
+.state-machine-inspector__stage--active {
+  border-color: var(--mud-palette-primary);
+}
+.state-machine-inspector__stage-marker {
+  align-self: start;
+  padding-top: 0.125rem;
+  color: var(--mud-palette-primary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+.state-machine-inspector__stage-content {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.state-machine-inspector__stage-heading,
+.state-machine-inspector__transition-summary {
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.state-machine-inspector__stage-heading h4 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+.state-machine-inspector__stage-note {
+  max-width: 55%;
+  text-align: right;
+}
+.state-machine-inspector__connector {
+  height: 1rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 1rem;
+  line-height: 1rem;
+  text-align: center;
+}
+.state-machine-inspector__transition-summary {
+  min-height: 3rem;
+  padding: 0.75rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-background-grey);
+}
+.state-machine-inspector__transition-summary strong {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
 .state-machine-inspector__button {
-    min-height: 2.25rem;
-    padding: .375rem .625rem;
-    border: 0;
-    border-radius: var(--mud-default-borderradius);
-    background: transparent;
-    color: var(--mud-palette-primary);
-    font: inherit;
-    font-size: .75rem;
-    font-weight: 600;
-    cursor: pointer;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+  background: transparent;
+  color: var(--mud-palette-primary);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
 }
-
 .state-machine-inspector__button:hover {
-    background: color-mix(in srgb, currentColor 8%, transparent);
+  border-color: var(--mud-palette-lines-default);
+  background: var(--mud-palette-action-default-hover);
 }
-
 .state-machine-inspector__button--danger {
-    color: var(--mud-palette-error);
+  color: var(--mud-palette-error);
 }
-
+.state-machine-inspector__details,
+.state-machine-inspector__danger-zone {
+  border-top: 1px solid var(--mud-palette-lines-default);
+  padding-top: 0.75rem;
+}
+.state-machine-inspector__details summary {
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.25rem;
+  color: var(--mud-palette-primary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.state-machine-inspector__details dl {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+}
+.state-machine-inspector__details dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.75rem;
+}
+.state-machine-inspector__details dt,
+.state-machine-inspector__details dd {
+  margin: 0;
+}
+.state-machine-inspector__details dd {
+  color: var(--mud-palette-text-primary);
+}
+.state-machine-inspector__danger-zone {
+  display: flex;
+  justify-content: flex-end;
+}
 .state-machine-inspector__empty,
 .state-machine-inspector__issues {
-    margin: 0;
-    padding: .75rem;
-    border: 1px dashed var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    color: var(--mud-palette-text-secondary);
-    font-size: .8125rem;
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px dashed var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
+}
+.state-machine-inspector__issues {
+  display: grid;
+  gap: 0.375rem;
+  border-style: solid;
+  border-color: var(--mud-palette-error);
+  color: var(--mud-palette-error);
 }
 
-.state-machine-inspector__issues {
-    display: grid;
-    gap: .375rem;
-    border-style: solid;
-    border-color: var(--mud-palette-error);
-    color: var(--mud-palette-error);
+@media (max-width: 700px) {
+  .state-machine-inspector__stage {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.5rem;
+  }
+  .state-machine-inspector__stage-marker {
+    padding-top: 0;
+  }
+  .state-machine-inspector__stage-heading,
+  .state-machine-inspector__transition-summary,
+  .state-machine-inspector__details summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .state-machine-inspector__stage-note {
+    max-width: none;
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .state-machine-inspector * {
+    scroll-behavior: auto;
+    transition: none;
+  }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
@@ -37,7 +37,18 @@
                         </div>
                         <span class="state-machine-transition-inspector__stage-note">@Localizer["Starts the transition"]</span>
                     </div>
-                    @RenderActivitySlot("trigger", Transition.Trigger, true)
+                    <StateMachineActivitySlot SlotName="trigger"
+                                              TestIdPrefix="state-machine-transition"
+                                              Value="@Transition.Trigger"
+                                              EmptyTitle="@Localizer["No trigger configured"]"
+                                              EmptyDescription="@Localizer["This transition evaluates immediately after source entry."]"
+                                              AddLabel="@Localizer["Add trigger"]"
+                                              IsReadOnly="@IsReadOnly"
+                                              AddRequested="RequestActivityAddAsync"
+                                              OpenRequested="RequestActivityOpenAsync"
+                                              ReplaceRequested="RequestActivityReplaceAsync"
+                                              ClearRequested="RequestActivityClearAsync"
+                                              DropRequested="RequestActivityDropAsync" />
                 </div>
             </section>
 
@@ -78,7 +89,18 @@
                         </div>
                         <span class="state-machine-transition-inspector__stage-note">@Localizer["Runs after source exit"]</span>
                     </div>
-                    @RenderActivitySlot("action", Transition.Action, false)
+                    <StateMachineActivitySlot SlotName="action"
+                                              TestIdPrefix="state-machine-transition"
+                                              Value="@Transition.Action"
+                                              EmptyTitle="@Localizer["No action configured"]"
+                                              EmptyDescription="@Localizer["No activity runs between source exit and the target state."]"
+                                              AddLabel="@Localizer["Add action"]"
+                                              IsReadOnly="@IsReadOnly"
+                                              AddRequested="RequestActivityAddAsync"
+                                              OpenRequested="RequestActivityOpenAsync"
+                                              ReplaceRequested="RequestActivityReplaceAsync"
+                                              ClearRequested="RequestActivityClearAsync"
+                                              DropRequested="RequestActivityDropAsync" />
                 </div>
             </section>
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
@@ -3,7 +3,6 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Models;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
@@ -72,104 +71,6 @@ public partial class StateMachineTransitionInspector
         return string.IsNullOrWhiteSpace(text) ? null : text;
     }
 
-    private RenderFragment RenderActivitySlot(string slotName, JsonNode? value, bool isTrigger) => builder =>
-    {
-        var activity = DescribeActivity(value);
-        var sequence = 0;
-
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot");
-        builder.AddAttribute(sequence++, "data-slot-state", activity.State.ToString().ToLowerInvariant());
-        builder.AddAttribute(sequence++, "data-slot-action", "drop");
-        builder.AddAttribute(sequence++, "aria-label", Localizer[$"{slotName} activity slot"]);
-
-        if (!IsReadOnly)
-        {
-            builder.AddAttribute(sequence++, "ondragover", EventCallback.Factory.Create<DragEventArgs>(this, OnDragOverAsync));
-            builder.AddEventPreventDefaultAttribute(sequence++, "ondragover", true);
-            builder.AddAttribute(sequence++, "ondrop", EventCallback.Factory.Create<DragEventArgs>(this, _ => RequestActivityDropAsync(slotName)));
-            builder.AddEventPreventDefaultAttribute(sequence++, "ondrop", true);
-        }
-
-        if (activity.State == ActivityState.Empty)
-        {
-            builder.OpenElement(sequence++, "div");
-            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-empty");
-            builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-empty");
-            builder.OpenElement(sequence++, "strong");
-            builder.AddContent(sequence++, isTrigger ? Localizer["No trigger configured"] : Localizer["No action configured"]);
-            builder.CloseElement();
-            builder.OpenElement(sequence++, "span");
-            builder.AddContent(sequence++, isTrigger
-                ? Localizer["This transition evaluates immediately after source entry."]
-                : Localizer["No activity runs between source exit and the target state."]);
-            builder.CloseElement();
-            if (!IsReadOnly)
-                AddSlotButton(builder, ref sequence, "add", isTrigger ? Localizer["Add trigger"] : Localizer["Add action"], $"Add {slotName} activity", slotName, RequestActivityAddAsync);
-            builder.CloseElement();
-        }
-        else
-        {
-            builder.OpenElement(sequence++, "div");
-            builder.AddAttribute(sequence++, "class", activity.State == ActivityState.Malformed
-                ? "state-machine-transition-inspector__activity-card state-machine-transition-inspector__activity-card--invalid"
-                : "state-machine-transition-inspector__activity-card");
-            builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-activity");
-            builder.AddAttribute(sequence++, "data-activity-state", activity.State.ToString().ToLowerInvariant());
-
-            builder.OpenElement(sequence++, "div");
-            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__activity-copy");
-            builder.OpenElement(sequence++, "strong");
-            builder.AddContent(sequence++, activity.Title);
-            builder.CloseElement();
-            builder.OpenElement(sequence++, "span");
-            builder.AddContent(sequence++, activity.Detail);
-            builder.CloseElement();
-            builder.CloseElement();
-
-            if (activity.State == ActivityState.Malformed)
-            {
-                builder.OpenElement(sequence++, "p");
-                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-warning");
-                builder.AddAttribute(sequence++, "role", "status");
-                builder.AddContent(sequence++, Localizer["This definition is invalid and will be preserved until you replace or clear it."]);
-                builder.CloseElement();
-            }
-
-            if (!string.IsNullOrWhiteSpace(activity.RawDefinition))
-            {
-                builder.OpenElement(sequence++, "details");
-                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__definition");
-                builder.OpenElement(sequence++, "summary");
-                builder.AddContent(sequence++, Localizer["View definition"]);
-                builder.CloseElement();
-                builder.OpenElement(sequence++, "pre");
-                builder.AddAttribute(sequence++, "data-testid", $"state-machine-transition-{slotName}-definition");
-                builder.AddContent(sequence++, activity.RawDefinition);
-                builder.CloseElement();
-                builder.CloseElement();
-            }
-
-            if (activity.State != ActivityState.Malformed || !IsReadOnly)
-            {
-                builder.OpenElement(sequence++, "div");
-                builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-actions");
-                if (activity.State != ActivityState.Malformed)
-                    AddSlotButton(builder, ref sequence, "open", Localizer["Open"], $"Open {slotName} activity", slotName, RequestActivityOpenAsync);
-                if (!IsReadOnly)
-                {
-                    AddSlotButton(builder, ref sequence, "replace", Localizer["Replace"], $"Replace {slotName} activity", slotName, RequestActivityReplaceAsync);
-                    AddSlotButton(builder, ref sequence, "clear", Localizer["Clear"], $"Clear {slotName} activity", slotName, RequestActivityClearAsync);
-                }
-                builder.CloseElement();
-            }
-
-            builder.CloseElement();
-        }
-
-        builder.CloseElement();
-    };
-
     private RenderFragment RenderCondition(JsonNode? value) => builder =>
     {
         var condition = DescribeCondition(value);
@@ -213,54 +114,6 @@ public partial class StateMachineTransitionInspector
 
         builder.CloseElement();
     };
-
-    private void AddSlotButton(
-        RenderTreeBuilder builder,
-        ref int sequence,
-        string action,
-        string text,
-        string ariaLabel,
-        string slotName,
-        Func<string, Task> callback)
-    {
-        builder.OpenElement(sequence++, "button");
-        builder.AddAttribute(sequence++, "type", "button");
-        builder.AddAttribute(sequence++, "class", action == "clear"
-            ? "state-machine-transition-inspector__button state-machine-transition-inspector__button--subtle"
-            : "state-machine-transition-inspector__button");
-        builder.AddAttribute(sequence++, "data-slot-action", action);
-        builder.AddAttribute(sequence++, "aria-label", Localizer[ariaLabel]);
-        builder.AddAttribute(sequence++, "onclick", EventCallback.Factory.Create(this, () => callback(slotName)));
-        builder.AddContent(sequence++, text);
-        builder.CloseElement();
-    }
-
-    private static Task OnDragOverAsync(DragEventArgs _) => Task.CompletedTask;
-
-    private ActivityPresentation DescribeActivity(JsonNode? value)
-    {
-        if (value == null)
-            return new(ActivityState.Empty, string.Empty, string.Empty, string.Empty);
-
-        var rawDefinition = StateMachinePresentationFormatter.JsonSlot(value);
-        if (value is not JsonObject obj)
-            return new(ActivityState.Malformed, Localizer["Invalid activity definition"], Localizer["Expected an activity object."], rawDefinition);
-
-        if (StateMachineDesignerConstants.IsInvalidJsonSlotMarker(obj))
-            return new(ActivityState.Malformed, Localizer["Invalid activity definition"], Localizer["The original source is preserved."], rawDefinition);
-
-        var typeName = GetString(obj, "type");
-        if (string.IsNullOrWhiteSpace(typeName))
-            return new(ActivityState.Malformed, Localizer["Unavailable activity definition"], Localizer["The activity type is missing."], rawDefinition);
-
-        if (string.IsNullOrWhiteSpace(GetString(obj, "id")) || string.IsNullOrWhiteSpace(GetString(obj, "nodeId")))
-            return new(ActivityState.Malformed, Localizer["Incomplete activity definition"], Localizer["An activity id and node ID are required."], rawDefinition);
-
-        var title = FirstNonEmpty(GetString(obj, "displayName"), GetString(obj, "name"), typeName)!;
-        var version = GetString(obj, "version");
-        var detail = string.IsNullOrWhiteSpace(version) ? typeName : $"{typeName} · v{version}";
-        return new(ActivityState.Configured, Localizer[title], detail, rawDefinition);
-    }
 
     private ConditionPresentation DescribeCondition(JsonNode? value)
     {
@@ -307,15 +160,6 @@ public partial class StateMachineTransitionInspector
         ? text
         : null;
 
-    private static string? FirstNonEmpty(params string?[] values) => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
-
-    private enum ActivityState
-    {
-        Empty,
-        Configured,
-        Malformed
-    }
-
     private enum ConditionState
     {
         Missing,
@@ -325,8 +169,6 @@ public partial class StateMachineTransitionInspector
         Unknown,
         Malformed
     }
-
-    private sealed record ActivityPresentation(ActivityState State, string Title, string Detail, string RawDefinition);
 
     private sealed record ConditionPresentation(ConditionState State, string Title, string Detail, string RawDefinition, string Warning);
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
@@ -1,20 +1,20 @@
 .state-machine-transition-inspector {
-    display: grid;
-    gap: 1rem;
-    min-width: 0;
-    color: var(--mud-palette-text-primary);
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  color: var(--mud-palette-text-primary);
 }
 
 .state-machine-transition-inspector__header,
 .state-machine-transition-inspector__stage-heading,
 .state-machine-transition-inspector__details summary {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .state-machine-transition-inspector__header {
-    justify-content: space-between;
-    gap: 1rem;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .state-machine-transition-inspector__header h3,
@@ -22,8 +22,6 @@
 .state-machine-transition-inspector__stage-kicker,
 .state-machine-transition-inspector__stage-heading h4,
 .state-machine-transition-inspector__stage-note,
-.state-machine-transition-inspector__slot-empty,
-.state-machine-transition-inspector__slot-empty span,
 .state-machine-transition-inspector__slot-warning,
 .state-machine-transition-inspector__condition span,
 .state-machine-transition-inspector__condition p,
@@ -31,382 +29,320 @@
 .state-machine-transition-inspector__details summary,
 .state-machine-transition-inspector__details-route,
 .state-machine-transition-inspector__definition summary {
-    margin: 0;
+  margin: 0;
 }
 
 .state-machine-transition-inspector__header h3 {
-    font-size: 1rem;
-    font-weight: 600;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .state-machine-transition-inspector__eyebrow,
 .state-machine-transition-inspector__stage-kicker,
 .state-machine-transition-inspector__stage-note,
 .state-machine-transition-inspector__details-route {
-    color: var(--mud-palette-text-secondary);
-    font-size: .75rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.75rem;
 }
 
 .state-machine-transition-inspector__eyebrow,
 .state-machine-transition-inspector__stage-kicker {
-    font-weight: 600;
-    letter-spacing: .04em;
-    text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .state-machine-transition-inspector__eyebrow {
-    margin-bottom: .125rem;
+  margin-bottom: 0.125rem;
 }
 
 .state-machine-transition-inspector__story {
-    display: grid;
-    gap: .5rem;
+  display: grid;
+  gap: 0.5rem;
 }
 
 .state-machine-transition-inspector__stage {
-    display: grid;
-    grid-template-columns: 4.5rem minmax(0, 1fr);
-    gap: .75rem;
-    min-width: 0;
-    padding: .875rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.875rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
 }
 
 .state-machine-transition-inspector__stage--destination {
-    border-color: var(--mud-palette-primary);
+  border-color: var(--mud-palette-primary);
 }
 
 .state-machine-transition-inspector__stage-marker {
-    align-self: start;
-    padding-top: .125rem;
-    color: var(--mud-palette-primary);
-    font-size: .6875rem;
-    font-weight: 700;
-    letter-spacing: .055em;
-    line-height: 1.2;
-    text-transform: uppercase;
+  align-self: start;
+  padding-top: 0.125rem;
+  color: var(--mud-palette-primary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 .state-machine-transition-inspector__stage-content {
-    display: grid;
-    gap: .75rem;
-    min-width: 0;
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
 .state-machine-transition-inspector__stage-heading {
-    justify-content: space-between;
-    gap: .75rem;
-    min-width: 0;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
 .state-machine-transition-inspector__stage-heading h4 {
-    font-size: .9375rem;
-    font-weight: 600;
+  font-size: 0.9375rem;
+  font-weight: 600;
 }
 
 .state-machine-transition-inspector__stage-note {
-    max-width: 50%;
-    text-align: right;
+  max-width: 50%;
+  text-align: right;
 }
 
 .state-machine-transition-inspector__connector {
-    height: 1rem;
-    color: var(--mud-palette-text-secondary);
-    font-size: 1rem;
-    line-height: 1rem;
-    text-align: center;
+  height: 1rem;
+  color: var(--mud-palette-text-secondary);
+  font-size: 1rem;
+  line-height: 1rem;
+  text-align: center;
 }
 
-.state-machine-transition-inspector__slot,
 .state-machine-transition-inspector__condition {
-    display: grid;
-    gap: .625rem;
-    min-width: 0;
+  display: grid;
+  gap: 0.625rem;
+  min-width: 0;
 }
 
-.state-machine-transition-inspector__slot {
-    padding: .75rem;
-    border: 1px dashed var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-}
-
-.state-machine-transition-inspector__slot:not([data-slot-state="empty"]):hover {
-    border-color: var(--mud-palette-primary);
-}
-
-.state-machine-transition-inspector__slot-empty {
-    display: grid;
-    gap: .25rem;
-    color: var(--mud-palette-text-secondary);
-    font-size: .8125rem;
-}
-
-.state-machine-transition-inspector__slot-empty strong {
-    color: var(--mud-palette-text-primary);
-    font-weight: 600;
-}
-
-.state-machine-transition-inspector__slot-empty span,
 .state-machine-transition-inspector__condition span,
 .state-machine-transition-inspector__slot-warning {
-    font-size: .75rem;
-    line-height: 1.45;
+  font-size: 0.75rem;
+  line-height: 1.45;
 }
 
-.state-machine-transition-inspector__activity-card {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: start;
-    gap: .75rem;
-    min-width: 0;
-}
-
-.state-machine-transition-inspector__activity-card--invalid {
-    grid-template-columns: minmax(0, 1fr);
-}
-
-.state-machine-transition-inspector__activity-copy,
 .state-machine-transition-inspector__condition {
-    overflow-wrap: anywhere;
+  overflow-wrap: anywhere;
 }
 
-.state-machine-transition-inspector__activity-copy {
-    display: grid;
-    gap: .25rem;
-}
-
-.state-machine-transition-inspector__activity-copy strong,
 .state-machine-transition-inspector__condition strong {
-    font-size: .8125rem;
-    font-weight: 600;
-}
-
-.state-machine-transition-inspector__activity-copy span {
-    color: var(--mud-palette-text-secondary);
-    font-family: var(--mud-typography-default-family);
-    font-size: .6875rem;
-}
-
-.state-machine-transition-inspector__slot-actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: .25rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
 }
 
 .state-machine-transition-inspector__button {
-    min-height: 2.25rem;
-    padding: .375rem .625rem;
-    border: 1px solid transparent;
-    border-radius: var(--mud-default-borderradius);
-    background: transparent;
-    color: var(--mud-palette-primary);
-    font: inherit;
-    font-size: .75rem;
-    font-weight: 600;
-    cursor: pointer;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+  background: transparent;
+  color: var(--mud-palette-primary);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 .state-machine-transition-inspector__button:hover {
-    border-color: var(--mud-palette-lines-default);
-    background: var(--mud-palette-action-default-hover);
+  border-color: var(--mud-palette-lines-default);
+  background: var(--mud-palette-action-default-hover);
 }
 
 .state-machine-transition-inspector__button--subtle {
-    color: var(--mud-palette-text-secondary);
+  color: var(--mud-palette-text-secondary);
 }
 
 .state-machine-transition-inspector__button--danger {
-    color: var(--mud-palette-error);
+  color: var(--mud-palette-error);
 }
 
 .state-machine-transition-inspector__button:focus-visible,
 .state-machine-transition-inspector__details summary:focus-visible {
-    outline: 2px solid var(--mud-palette-primary);
-    outline-offset: 2px;
+  outline: 2px solid var(--mud-palette-primary);
+  outline-offset: 2px;
 }
 
 .state-machine-transition-inspector__condition {
-    padding: .75rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
+  padding: 0.75rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
 }
 
-.state-machine-transition-inspector__condition--warning,
-.state-machine-transition-inspector__activity-card--invalid {
-    border-color: var(--mud-palette-warning);
+.state-machine-transition-inspector__condition--warning {
+  border-color: var(--mud-palette-warning);
 }
 
 .state-machine-transition-inspector__condition--warning strong,
 .state-machine-transition-inspector__slot-warning {
-    color: var(--mud-palette-warning);
+  color: var(--mud-palette-warning);
 }
 
 .state-machine-transition-inspector__slot-warning {
-    display: block;
+  display: block;
 }
 
 .state-machine-transition-inspector__definition {
-    min-width: 0;
+  min-width: 0;
 }
 
 .state-machine-transition-inspector__definition summary,
 .state-machine-transition-inspector__details summary {
-    color: var(--mud-palette-primary);
-    cursor: pointer;
-    font-size: .75rem;
-    font-weight: 600;
-    list-style-position: inside;
+  color: var(--mud-palette-primary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  list-style-position: inside;
 }
 
 .state-machine-transition-inspector__definition pre {
-    max-height: 10rem;
-    margin: .5rem 0 0;
-    overflow: auto;
-    padding: .625rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-background-grey);
-    color: var(--mud-palette-text-secondary);
-    font-family: monospace;
-    font-size: .6875rem;
-    line-height: 1.45;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
+  max-height: 10rem;
+  margin: 0.5rem 0 0;
+  overflow: auto;
+  padding: 0.625rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-background-grey);
+  color: var(--mud-palette-text-secondary);
+  font-family: monospace;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .state-machine-transition-inspector__details {
-    border-top: 1px solid var(--mud-palette-lines-default);
-    padding-top: .75rem;
+  border-top: 1px solid var(--mud-palette-lines-default);
+  padding-top: 0.75rem;
 }
 
 .state-machine-transition-inspector__details summary {
-    justify-content: space-between;
-    gap: .75rem;
-    min-height: 2.25rem;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.25rem;
 }
 
 .state-machine-transition-inspector__details-route {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: .375rem;
-    justify-content: flex-end;
-    font-family: monospace;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  justify-content: flex-end;
+  font-family: monospace;
 }
 
 .state-machine-transition-inspector__fields,
 .state-machine-transition-inspector__field {
-    display: grid;
-    gap: .5rem;
+  display: grid;
+  gap: 0.5rem;
 }
 
 .state-machine-transition-inspector__fields {
-    gap: 1rem;
-    padding-top: .875rem;
+  gap: 1rem;
+  padding-top: 0.875rem;
 }
 
 .state-machine-transition-inspector__field-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 .state-machine-transition-inspector__field label {
-    font-size: .8125rem;
-    font-weight: 600;
+  font-size: 0.8125rem;
+  font-weight: 600;
 }
 
 .state-machine-transition-inspector__control {
-    width: 100%;
-    min-height: 2.5rem;
-    box-sizing: border-box;
-    padding: .5rem .75rem;
-    border: 1px solid var(--mud-palette-lines-inputs);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
-    color: var(--mud-palette-text-primary);
-    font: inherit;
+  width: 100%;
+  min-height: 2.5rem;
+  box-sizing: border-box;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--mud-palette-lines-inputs);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-surface);
+  color: var(--mud-palette-text-primary);
+  font: inherit;
 }
 
 .state-machine-transition-inspector__control:hover:not(:disabled) {
-    border-color: var(--mud-palette-text-secondary);
+  border-color: var(--mud-palette-text-secondary);
 }
 
 .state-machine-transition-inspector__control:focus-visible {
-    outline: 2px solid var(--mud-palette-primary);
-    outline-offset: 2px;
+  outline: 2px solid var(--mud-palette-primary);
+  outline-offset: 2px;
 }
 
 .state-machine-transition-inspector__control:disabled {
-    background: var(--mud-palette-action-disabled-background);
-    color: var(--mud-palette-action-disabled);
+  background: var(--mud-palette-action-disabled-background);
+  color: var(--mud-palette-action-disabled);
 }
 
 .state-machine-transition-inspector__empty,
 .state-machine-transition-inspector__issues {
-    margin: 0;
-    padding: .75rem;
-    border: 1px dashed var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    color: var(--mud-palette-text-secondary);
-    font-size: .8125rem;
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px dashed var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.8125rem;
 }
 
 .state-machine-transition-inspector__issues {
-    display: grid;
-    gap: .375rem;
-    border-style: solid;
-    border-color: var(--mud-palette-error);
-    color: var(--mud-palette-error);
+  display: grid;
+  gap: 0.375rem;
+  border-style: solid;
+  border-color: var(--mud-palette-error);
+  color: var(--mud-palette-error);
 }
 
 .state-machine-transition-inspector__issues > strong {
-    font-size: .8125rem;
+  font-size: 0.8125rem;
 }
 
 @media (max-width: 700px) {
-    .state-machine-transition-inspector__stage {
-        grid-template-columns: minmax(0, 1fr);
-        gap: .5rem;
-    }
+  .state-machine-transition-inspector__stage {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.5rem;
+  }
 
-    .state-machine-transition-inspector__stage-marker {
-        padding-top: 0;
-    }
+  .state-machine-transition-inspector__stage-marker {
+    padding-top: 0;
+  }
 
-    .state-machine-transition-inspector__stage-heading {
-        align-items: flex-start;
-    }
+  .state-machine-transition-inspector__stage-heading {
+    align-items: flex-start;
+  }
 
-    .state-machine-transition-inspector__stage-note {
-        max-width: 45%;
-    }
+  .state-machine-transition-inspector__stage-note {
+    max-width: 45%;
+  }
 
-    .state-machine-transition-inspector__activity-card,
-    .state-machine-transition-inspector__field-grid {
-        grid-template-columns: minmax(0, 1fr);
-    }
+  .state-machine-transition-inspector__field-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 
-    .state-machine-transition-inspector__slot-actions {
-        justify-content: flex-start;
-    }
+  .state-machine-transition-inspector__details summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 
-    .state-machine-transition-inspector__details summary {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-
-    .state-machine-transition-inspector__details-route {
-        justify-content: flex-start;
-    }
+  .state-machine-transition-inspector__details-route {
+    justify-content: flex-start;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .state-machine-transition-inspector * {
-        scroll-behavior: auto;
-        transition: none;
-    }
+  .state-machine-transition-inspector * {
+    scroll-behavior: auto;
+    transition: none;
+  }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
@@ -144,11 +144,18 @@
                 {
                     <StateMachineStateInspector State="@SelectedState"
                                                 IsReadOnly="@IsReadOnly"
+                                                IsInitial="@IsSelectedStateInitial()"
+                                                IsCurrent="@IsSelectedStateCurrent()"
+                                                IncomingTransitionCount="@GetSelectedStateIncomingTransitionCount()"
+                                                OutgoingTransitionCount="@GetSelectedStateOutgoingTransitionCount()"
                                                 ValidationIssues="@GetSelectedStateIssues()"
                                                 NameChanged="RenameSelectedStateAsync"
-                                                SlotChanged="SetStateSlotAsync"
-                                                SlotCleared="ClearStateSlotAsync"
-                                                SlotDropRequested="OnStateSlotDropAsync"
+                                                ActivityAddRequested="AddStateActivityAsync"
+                                                ActivityOpenRequested="OpenStateActivityAsync"
+                                                ActivityReplaceRequested="ReplaceStateActivityAsync"
+                                                ActivityClearRequested="ClearStateSlotAsync"
+                                                ActivityDropRequested="OnStateSlotDropAsync"
+                                                ViewTransitionsRequested="ViewSelectedStateTransitionsAsync"
                                                 DeleteRequested="RequestDeleteSelectedStateAsync" />
                 }
                 else if (SelectedTransition != null)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -43,6 +43,7 @@ public partial class StateMachineDesignerWrapper
     private bool _showOutline;
     private bool _processingCanvasChange;
     private IReadOnlyCollection<string> _knownExpressionProviderTypes = ["JavaScript"];
+    private readonly List<string> _recentActivityTypes = [];
 
     [Parameter] public JsonObject StateMachine { get; set; } = [];
     [Parameter] public IDictionary<string, ActivityStats>? ActivityStats { get; set; }
@@ -287,7 +288,7 @@ public partial class StateMachineDesignerWrapper
 
     private async Task ClearStateSlotAsync(string slotName)
     {
-        if (_session == null || _selectedStateId == null || IsReadOnly)
+        if (_session == null || _selectedStateId == null || IsReadOnly || !IsStateActivitySlot(slotName))
             return;
         _session.SetStateSlot(_selectedStateId, ParseStateSlot(slotName), null);
         await ApplySessionChangesAndRefreshSlotAsync(slotName, false);
@@ -301,9 +302,24 @@ public partial class StateMachineDesignerWrapper
         await ApplySessionChangesAndRefreshSlotAsync(slotName, false);
     }
 
-    private Task AddTransitionActivityAsync(string slotName) => OpenTransitionActivityPickerAsync(slotName, false);
+    private Task AddStateActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, false, true);
 
-    private Task ReplaceTransitionActivityAsync(string slotName) => OpenTransitionActivityPickerAsync(slotName, true);
+    private Task ReplaceStateActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, true, true);
+
+    private async Task OpenStateActivityAsync(string slotName)
+    {
+        if (_session == null || _selectedStateId == null || !IsStateActivitySlot(slotName) || SelectedState is not { } state)
+            return;
+
+        if (GetStateSlot(state, slotName) is not JsonObject activity || !activity.IsActivity())
+            return;
+
+        await OpenSlotActivityAsync(activity);
+    }
+
+    private Task AddTransitionActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, false, false);
+
+    private Task ReplaceTransitionActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, true, false);
 
     private async Task OpenTransitionActivityAsync(string slotName)
     {
@@ -313,34 +329,52 @@ public partial class StateMachineDesignerWrapper
         if (GetTransitionSlot(transition, slotName) is not JsonObject activity || !activity.IsActivity())
             return;
 
-        if (string.Equals(activity.GetTypeName(), "Elsa.Sequence", StringComparison.Ordinal) && ActivityDoubleClick.HasDelegate)
-        {
-            await ActivityDoubleClick.InvokeAsync(activity);
-            return;
-        }
-
-        await SelectSlotActivityForPropertiesAsync(activity);
+        await OpenSlotActivityAsync(activity);
     }
 
-    private async Task OpenTransitionActivityPickerAsync(string slotName, bool replacing)
+    private async Task OpenSlotActivityAsync(JsonObject activity)
     {
-        if (IsReadOnly || _session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName))
+        await SelectSlotActivityForPropertiesAsync(activity);
+
+        // Let the host decide whether the activity owns a nested designer. This supports
+        // Sequence as well as any other current or future composite activity.
+        if (ActivityDoubleClick.HasDelegate)
+            await ActivityDoubleClick.InvokeAsync(activity);
+    }
+
+    private async Task OpenActivityPickerAsync(string slotName, bool replacing, bool isStateSlot)
+    {
+        if (IsReadOnly || _session == null ||
+            (isStateSlot && (_selectedStateId == null || !IsStateActivitySlot(slotName))) ||
+            (!isStateSlot && (_selectedTransitionId == null || !IsTransitionActivitySlot(slotName))))
             return;
 
-        var title = replacing ? Localizer[$"Replace {slotName} activity"] : Localizer[$"Add {slotName} activity"];
+        var title = GetActivityPickerTitle(slotName, replacing);
+        var parameters = new DialogParameters<StateMachineActivityPickerDialog>
+        {
+            { x => x.SlotName, slotName },
+            { x => x.IsReplacing, replacing },
+            { x => x.RecentActivityTypes, _recentActivityTypes.ToArray() }
+        };
         var options = new DialogOptions
         {
             CloseOnEscapeKey = true,
             CloseButton = true,
             FullWidth = true,
-            MaxWidth = MaxWidth.Medium
+            MaxWidth = MaxWidth.Large
         };
-        var dialog = await DialogService.ShowAsync<StateMachineActivityPickerDialog>(title, options);
+        var dialog = await DialogService.ShowAsync<StateMachineActivityPickerDialog>(title, parameters, options);
         var result = await dialog.Result;
 
         // Do not touch the slot until the picker returns an explicit descriptor. In particular,
         // cancelling Replace leaves the exact existing JSON object in place.
-        if (result is { Canceled: false, Data: ActivityDescriptor descriptor })
+        if (result is not { Canceled: false, Data: ActivityDescriptor descriptor })
+            return;
+
+        RememberRecentActivity(descriptor.TypeName);
+        if (isStateSlot)
+            await ApplyStateActivityDescriptorAsync(slotName, descriptor);
+        else
             await ApplyTransitionActivityDescriptorAsync(slotName, descriptor);
     }
 
@@ -385,12 +419,20 @@ public partial class StateMachineDesignerWrapper
 
     private async Task OnStateSlotDropAsync(string slotName)
     {
-        if (IsReadOnly || _session == null || _selectedStateId == null || DragDropManager.Payload is not ActivityDescriptor descriptor)
+        if (IsReadOnly || _session == null || _selectedStateId == null || !IsStateActivitySlot(slotName) || DragDropManager.Payload is not ActivityDescriptor descriptor)
             return;
 
-        var activity = CreateSlotActivity(descriptor);
-        _session.SetStateSlot(_selectedStateId, ParseStateSlot(slotName), activity);
-        DragDropManager.Payload = null;
+        await ApplyStateActivityDescriptorAsync(slotName, descriptor, clearDragPayload: true);
+    }
+
+    private async Task ApplyStateActivityDescriptorAsync(string slotName, ActivityDescriptor descriptor, bool clearDragPayload = false)
+    {
+        if (IsReadOnly || _session == null || _selectedStateId == null || !IsStateActivitySlot(slotName))
+            return;
+
+        _session.SetStateSlot(_selectedStateId, ParseStateSlot(slotName), CreateSlotActivity(descriptor));
+        if (clearDragPayload)
+            DragDropManager.Payload = null;
         await ApplySessionChangesAndRefreshSlotAsync(slotName, true);
     }
 
@@ -417,6 +459,27 @@ public partial class StateMachineDesignerWrapper
     private static bool IsTransitionActivitySlot(string slotName) =>
         string.Equals(slotName, "trigger", StringComparison.Ordinal) ||
         string.Equals(slotName, "action", StringComparison.Ordinal);
+
+    private static bool IsStateActivitySlot(string slotName) =>
+        string.Equals(slotName, "entry", StringComparison.Ordinal) ||
+        string.Equals(slotName, "exit", StringComparison.Ordinal);
+
+    private void RememberRecentActivity(string activityType)
+    {
+        _recentActivityTypes.RemoveAll(x => string.Equals(x, activityType, StringComparison.Ordinal));
+        _recentActivityTypes.Insert(0, activityType);
+        if (_recentActivityTypes.Count > 8)
+            _recentActivityTypes.RemoveRange(8, _recentActivityTypes.Count - 8);
+    }
+
+    private string GetActivityPickerTitle(string slotName, bool replacing)
+    {
+        if (replacing)
+            return Localizer[$"Choose a replacement {slotName} activity"];
+
+        var article = string.Equals(slotName, "trigger", StringComparison.OrdinalIgnoreCase) ? "a" : "an";
+        return Localizer[$"Choose {article} {slotName} activity"];
+    }
 
     private async Task ApplySessionChangesAndRefreshSlotAsync(string slotName, bool selectSlot)
     {
@@ -560,6 +623,12 @@ public partial class StateMachineDesignerWrapper
 
     private Task RequestDeleteSelectedStateAsync() => _selectedStateId == null ? Task.CompletedTask : RequestDeleteStateAsync(_selectedStateId);
 
+    private Task ViewSelectedStateTransitionsAsync()
+    {
+        _showOutline = true;
+        return InvokeAsync(StateHasChanged);
+    }
+
     private async Task RequestDeleteStateAsync(string visualId)
     {
         if (IsReadOnly || _session == null || TryGetState(visualId) == null) return;
@@ -665,6 +734,20 @@ public partial class StateMachineDesignerWrapper
         var state = TryGetState(visualId);
         return state == null || _session == null ? 0 : _session.Graph.Transitions.Count(x => x.From == state.Name || x.To == state.Name);
     }
+
+    private bool IsSelectedStateInitial() =>
+        SelectedState != null && string.Equals(_session?.Graph.InitialState, SelectedState.Name, StringComparison.Ordinal);
+
+    private bool IsSelectedStateCurrent() =>
+        SelectedState != null && string.Equals(_session?.Graph.CurrentState, SelectedState.Name, StringComparison.Ordinal);
+
+    private int GetSelectedStateIncomingTransitionCount() => SelectedState == null || _session == null
+        ? 0
+        : _session.Graph.Transitions.Count(x => string.Equals(x.To, SelectedState.Name, StringComparison.Ordinal));
+
+    private int GetSelectedStateOutgoingTransitionCount() => SelectedState == null || _session == null
+        ? 0
+        : _session.Graph.Transitions.Count(x => string.Equals(x.From, SelectedState.Name, StringComparison.Ordinal));
 
     private IReadOnlyCollection<StateMachineValidationIssue> GetSelectedStateIssues() =>
         _session == null || SelectedState == null


### PR DESCRIPTION
## Summary
- replace raw State entry/exit JSON editing with lifecycle-oriented semantic activity slots
- redesign the StateMachine activity picker as a contextual, searchable command palette with suggestions, recents, categories, details, and explicit commit
- share safe activity-slot behavior across state and transition inspectors, preserving malformed definitions for repair
- support nested designers for composite slot activities and capture the authoring pattern in the interface design system

## Verification
- dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj -f net10.0 --no-build (120 passed)
- dotnet build src/modules/Elsa.Studio.Workflows/Elsa.Studio.Workflows.csproj --no-restore (net8.0, net9.0, net10.0; 0 warnings, 0 errors)
- isolated browser verification of the implemented State inspector and Activity Picker shell; loaded picker interactions covered by bUnit because the isolated browser profile was not authenticated to the activity descriptor API