### PR TITLE
Role permission management: authoring UI

### DIFF
--- a/src/modules/Elsa.Studio.Security.Tests/IdentityApiErrorMapperTests.cs
+++ b/src/modules/Elsa.Studio.Security.Tests/IdentityApiErrorMapperTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using Elsa.Studio.Security.Services;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Security.Tests;
+
+public sealed class IdentityApiErrorMapperTests
+{
+    [Fact]
+    public void Describe_PreservesStructuredConflictCodeWithoutExposingRawDetails()
+    {
+        var exception = CreateApiException(HttpStatusCode.Conflict,
+            """{ "error": "role_dependency_changed", "message": "Dependencies changed.", "details": { "secret": "hidden" } }""");
+
+        var error = IdentityApiErrorMapper.Describe(exception);
+
+        Assert.Equal("role_dependency_changed", error.Code);
+        Assert.Equal("Dependencies changed.", error.Message);
+        Assert.True(error.IsConflict);
+        Assert.DoesNotContain("hidden", error.Message);
+    }
+
+    [Fact]
+    public void Describe_FlattensValidationMessagesDeterministically()
+    {
+        var exception = CreateApiException(HttpStatusCode.BadRequest,
+            """{ "statusCode": 400, "message": "Validation failed.", "errors": { "Permissions": ["Grant is invalid."], "Name": ["Name is required."] } }""");
+
+        var error = IdentityApiErrorMapper.Describe(exception);
+
+        Assert.Equal("validation_failed", error.Code);
+        Assert.Equal("Name is required. Grant is invalid.", error.Message);
+        Assert.True(error.IsValidation);
+    }
+
+    [Fact]
+    public void Describe_DiscardsNonJsonBodies()
+    {
+        var exception = CreateApiException(HttpStatusCode.BadGateway, "<html>proxy details</html>");
+
+        var error = IdentityApiErrorMapper.Describe(exception);
+
+        Assert.Equal("unavailable", error.Code);
+        Assert.DoesNotContain("proxy", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ApiException CreateApiException(HttpStatusCode statusCode, string content) =>
+        ApiException.Create(
+            new HttpRequestMessage(HttpMethod.Post, "https://elsa.example/identity/roles"),
+            HttpMethod.Post,
+            new HttpResponseMessage(statusCode) { Content = new StringContent(content) },
+            new RefitSettings()).GetAwaiter().GetResult();
+}

--- a/src/modules/Elsa.Studio.Security.Tests/RoleEditorSurfaceTests.cs
+++ b/src/modules/Elsa.Studio.Security.Tests/RoleEditorSurfaceTests.cs
@@ -1,0 +1,164 @@
+using Bunit;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Components;
+using Elsa.Studio.Security.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Security.Tests;
+
+public sealed class RoleEditorSurfaceTests : BunitContext, IAsyncLifetime
+{
+    public RoleEditorSurfaceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+    }
+
+    [Fact]
+    public void EditSurfaceShowsDirectCoveredUnverifiedAndRepairStates()
+    {
+        var roles = new StubRolesApi
+        {
+            Response = new ListRolesResponse
+            {
+                Roles =
+                [
+                    new RoleSummary
+                    {
+                        Id = "auditors",
+                        Name = "Auditors",
+                        Permissions = ["workflows/definitions:update", "workflows/*:view", "WorkflowDefinitions:Publish"]
+                    }
+                ]
+            }
+        };
+        var permissions = new StubPermissionsApi
+        {
+            Response = new PermissionCatalogResponse
+            {
+                Resources =
+                [
+                    new PermissionResourceDescriptor
+                    {
+                        Resource = "workflows/definitions",
+                        DisplayName = "Definitions",
+                        Description = "Workflow definitions.",
+                        Category = "Workflows",
+                        SupportedVerbs = ["view", "update"],
+                        Verified = false
+                    }
+                ]
+            }
+        };
+        Register(roles, permissions);
+
+        var cut = Render<RoleEditorSurface>(parameters => parameters
+            .Add(x => x.RoleId, "auditors")
+            .Add(x => x.Access, ReadyAccess));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Edit role — Auditors", cut.Markup);
+            Assert.Contains("Direct grant", cut.Markup);
+            Assert.Contains("Covered by workflows/*:view", cut.Markup);
+            Assert.Contains("Unverified · verified:false", cut.Markup);
+            Assert.Contains("WorkflowDefinitions:Publish", cut.Markup);
+            Assert.Contains("Save changes is disabled until issues are resolved", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void CreateSurfaceSendsNormalizedGrantsOnceAndNavigatesToCreatedRole()
+    {
+        var roles = new StubRolesApi
+        {
+            Created = new CreateRoleResponse { Id = "new-role", Name = "New role", Permissions = ["workflows/definitions:view"] }
+        };
+        var permissions = new StubPermissionsApi
+        {
+            Response = new PermissionCatalogResponse
+            {
+                Resources =
+                [
+                    new PermissionResourceDescriptor
+                    {
+                        Resource = "workflows/definitions",
+                        DisplayName = "Definitions",
+                        Category = "Workflows",
+                        SupportedVerbs = ["view"]
+                    }
+                ]
+            }
+        };
+        Register(roles, permissions);
+
+        var cut = Render<RoleEditorSurface>(parameters => parameters
+            .Add(x => x.Access, ReadyAccess));
+        cut.WaitForAssertion(() => Assert.Contains("New role", cut.Markup));
+
+        cut.Find("input[aria-label='Role name']").Input("  New role  ");
+        cut.Find("input[aria-label='workflows/definitions:view']").Change(true);
+        cut.FindAll("button").Single(x => x.TextContent.Contains("Create role", StringComparison.Ordinal)).Click();
+
+        cut.WaitForAssertion(() => Assert.Equal(1, roles.CreateCalls));
+        Assert.Equal("New role", roles.LastCreate!.Name);
+        Assert.Equal(["workflows/definitions:view"], roles.LastCreate.Permissions);
+        Assert.EndsWith("/security/roles/new-role", Services.GetRequiredService<NavigationManager>().Uri, StringComparison.Ordinal);
+    }
+
+    private void Register(IRolesApi roles, IPermissionsApi permissions)
+    {
+        Services.AddSingleton<IBackendApiClientProvider>(new StubBackendApiClientProvider(roles, permissions));
+    }
+
+    private static RoleAdministrationAccess ReadyAccess =>
+        new(RoleAdministrationAccessState.Ready, CanView: true, CanCreate: true, CanUpdate: true, CanDelete: false);
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await base.DisposeAsync();
+
+    private sealed class StubBackendApiClientProvider(IRolesApi roles, IPermissionsApi permissions) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://localhost/");
+
+        public ValueTask<T> GetApiAsync<T>(CancellationToken cancellationToken = default) where T : class =>
+            ValueTask.FromResult(typeof(T) == typeof(IRolesApi) ? (T)(object)roles : (T)(object)permissions);
+    }
+
+    private sealed class StubRolesApi : IRolesApi
+    {
+        public ListRolesResponse Response { get; set; } = new();
+        public CreateRoleResponse Created { get; set; } = new();
+        public int CreateCalls { get; private set; }
+        public CreateRoleRequest? LastCreate { get; private set; }
+
+        public Task<ListRolesResponse> ListAsync(CancellationToken cancellationToken = default) => Task.FromResult(Response);
+
+        public Task<CreateRoleResponse> CreateAsync(CreateRoleRequest request, CancellationToken cancellationToken = default)
+        {
+            CreateCalls++;
+            LastCreate = request;
+            return Task.FromResult(Created);
+        }
+
+        public Task<UpdateRoleResponse> UpdateAsync(string id, UpdateRoleRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<RoleDeletionImpactResponse> GetDeletionImpactAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task RemediateAndDeleteAsync(string id, RoleRemediationRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class StubPermissionsApi : IPermissionsApi
+    {
+        public PermissionCatalogResponse Response { get; set; } = new();
+
+        public Task<PermissionCatalogResponse> ListAsync(CancellationToken cancellationToken = default) => Task.FromResult(Response);
+
+        public Task<PermissionReachResponse> GetReachAsync(string resource, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new PermissionReachResponse { Resource = resource, Covers = ["workflows/definitions"], Count = 1 });
+    }
+}

--- a/src/modules/Elsa.Studio.Security.Tests/RolePermissionAuthoringTests.cs
+++ b/src/modules/Elsa.Studio.Security.Tests/RolePermissionAuthoringTests.cs
@@ -1,0 +1,97 @@
+using Elsa.Studio.Security.Models;
+using Xunit;
+
+namespace Elsa.Studio.Security.Tests;
+
+public sealed class RolePermissionAuthoringTests
+{
+    private static readonly PermissionResourceDescriptor[] Catalog =
+    [
+        new()
+        {
+            Resource = "workflows/definitions",
+            SupportedVerbs = ["view", "update"],
+            DisplayName = "Definitions",
+            Category = "Workflows",
+            Verified = true
+        },
+        new()
+        {
+            Resource = "workflows/instances",
+            SupportedVerbs = ["view", "retry"],
+            DisplayName = "Instances",
+            Category = "Workflows",
+            Verified = false
+        }
+    ];
+
+    [Fact]
+    public void NormalizePermissionsTrimsDeduplicatesOrdinallyAndSortsDeterministically()
+    {
+        var result = RolePermissionAuthoring.NormalizePermissions(
+            [" workflows/instances:view ", "workflows/definitions:update", "workflows/instances:view", " ", "A", "a"]);
+
+        Assert.Equal(["A", "a", "workflows/definitions:update", "workflows/instances:view"], result);
+    }
+
+    [Fact]
+    public void NormalizePermissionsPreservesTheBareGlobalWildcardAsAStoredGrant()
+    {
+        var result = RolePermissionAuthoring.NormalizePermissions([" * ", "*"]);
+
+        Assert.Equal(["*"], result);
+        Assert.True(RolePermissionAuthoring.TryParse(result[0], out var pattern));
+        Assert.True(RolePermissionAuthoring.Matches(pattern, "new/module", "future-verb"));
+    }
+
+    [Theory]
+    [InlineData("*", "*", "*", "*")]
+    [InlineData("workflows/*:view", "workflows/*", "view", "workflows/instances")]
+    [InlineData("workflows/instances:*", "workflows/instances", "*", "workflows/instances")]
+    public void TryParseUnderstandsGlobalResourceSubtreeAndVerbWildcards(string value, string resource, string verb, string coveredResource)
+    {
+        Assert.True(RolePermissionAuthoring.TryParse(value, out var pattern));
+        Assert.Equal(resource, pattern.Resource);
+        Assert.Equal(verb, pattern.Verb);
+        Assert.True(RolePermissionAuthoring.IsValidPattern(pattern));
+        Assert.True(RolePermissionAuthoring.Matches(pattern, coveredResource, "view"));
+    }
+
+    [Theory]
+    [InlineData("workflows*:view")]
+    [InlineData("workflows/definitions:vi*ew")]
+    [InlineData("unknown: view")]
+    public void InvalidOrUnknownGrantsRemainUnresolved(string value)
+    {
+        Assert.False(RolePermissionAuthoring.IsRecognized(value, Catalog, out var kind));
+        Assert.Equal(RolePermissionGrantKind.Unresolved, kind);
+    }
+
+    [Fact]
+    public void RecognizedExactAndWildcardGrantsAreClassifiedWithoutCatalogMaterialization()
+    {
+        Assert.True(RolePermissionAuthoring.IsRecognized("workflows/definitions:view", Catalog, out var exactKind));
+        Assert.Equal(RolePermissionGrantKind.Exact, exactKind);
+
+        Assert.True(RolePermissionAuthoring.IsRecognized("workflows/*:view", Catalog, out var wildcardKind));
+        Assert.Equal(RolePermissionGrantKind.Wildcard, wildcardKind);
+
+        Assert.True(RolePermissionAuthoring.IsCoveredByWildcard("workflows/instances", "view", ["workflows/*:view"]));
+        Assert.False(RolePermissionAuthoring.IsCoveredByWildcard("workflows/instances", "retry", ["workflows/*:view"]));
+    }
+
+    [Fact]
+    public void ConcreteGrantsContainOnlyCurrentDescriptorsAndVerbs()
+    {
+        var result = RolePermissionAuthoring.GetConcreteGrants(Catalog);
+
+        Assert.Equal(
+            [
+                "workflows/definitions:view",
+                "workflows/definitions:update",
+                "workflows/instances:view",
+                "workflows/instances:retry"
+            ],
+            result);
+    }
+}

--- a/src/modules/Elsa.Studio.Security.Tests/RolesPageTests.cs
+++ b/src/modules/Elsa.Studio.Security.Tests/RolesPageTests.cs
@@ -1,0 +1,233 @@
+using Bunit;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Security.Client;
+using Elsa.Studio.Security.Contracts;
+using Elsa.Studio.Security.Models;
+using Elsa.Studio.Security.Pages;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Security.Tests;
+
+public sealed class RolesPageTests : BunitContext, IAsyncLifetime
+{
+    public RolesPageTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+    }
+
+    [Fact]
+    public void Render_WhenRolesAreLoaded_ShowsTheNonPaginatedListWithoutTenantUi()
+    {
+        var api = new StubRolesApi
+        {
+            Response = new ListRolesResponse
+            {
+                Roles = [
+                    new RoleSummary { Id = "administrators", Name = "Administrators", Permissions = ["*"] },
+                    new RoleSummary { Id = "workflow-authors", Name = "Workflow Authors", Permissions = ["workflows/definitions:view"] }
+                ]
+            }
+        };
+        Register(api, ReadyAccess);
+
+        var cut = RenderRoles();
+
+        cut.WaitForAssertion(() => Assert.Contains("Administrators", cut.Markup));
+        Assert.Contains("2 roles · all loaded", cut.Markup);
+        Assert.Contains("Global access (*)", cut.Markup);
+        Assert.DoesNotContain("Tenant", cut.Markup);
+        Assert.DoesNotContain("mud-table-pagination", cut.Markup);
+    }
+
+    [Fact]
+    public void Search_WhenNameIdOrPermissionMatches_ShowsOnlyMatchingRoles()
+    {
+        var api = new StubRolesApi
+        {
+            Response = new ListRolesResponse
+            {
+                Roles = [
+                    new RoleSummary { Id = "workflow-authors", Name = "Workflow Authors", Permissions = ["workflows/definitions:edit"] },
+                    new RoleSummary { Id = "operations", Name = "Operations", Permissions = ["workflows/instances:retry"] }
+                ]
+            }
+        };
+        Register(api, ReadyAccess);
+
+        var cut = RenderRoles();
+        cut.WaitForAssertion(() => Assert.Contains("Workflow Authors", cut.Markup));
+
+        var search = cut.Find("input[aria-label='Search roles by name, ID, or permission']");
+        search.Input("retry");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Operations", cut.Markup);
+            Assert.DoesNotContain("Workflow Authors", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void Render_WhenCallerIsReadOnly_ShowsRolesButHidesMutationActions()
+    {
+        var api = new StubRolesApi
+        {
+            Response = new ListRolesResponse
+            {
+                Roles = [new RoleSummary { Id = "auditors", Name = "Auditors", Permissions = ["workflows/*:view"] }]
+            }
+        };
+        Register(api, new RoleAdministrationAccess(RoleAdministrationAccessState.Ready, CanView: true, CanCreate: false, CanUpdate: false, CanDelete: false));
+
+        var cut = RenderRoles();
+
+        cut.WaitForAssertion(() => Assert.Contains("Auditors", cut.Markup));
+        Assert.Contains("You can view roles, but you cannot create, edit, or delete them.", cut.Markup);
+        Assert.DoesNotContain("New role", cut.Markup);
+        Assert.DoesNotContain("Edit", cut.Markup);
+        Assert.DoesNotContain("Delete", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WhenListIsLoading_ShowsTheLoadingState()
+    {
+        var rolesLoaded = new TaskCompletionSource<ListRolesResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var api = new StubRolesApi
+        {
+            ListHandler = (_, _) => rolesLoaded.Task
+        };
+        Register(api, ReadyAccess);
+
+        var cut = RenderRoles();
+
+        cut.WaitForAssertion(() => Assert.Contains("Loading roles...", cut.Markup));
+        rolesLoaded.SetResult(new ListRolesResponse());
+    }
+
+    [Fact]
+    public void Render_WhenListIsEmpty_ShowsCreateFirstRoleAction()
+    {
+        var api = new StubRolesApi { Response = new ListRolesResponse { Roles = [] } };
+        Register(api, ReadyAccess);
+
+        var cut = RenderRoles();
+
+        cut.WaitForAssertion(() => Assert.Contains("No roles yet", cut.Markup));
+        Assert.Contains("Create first role", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_WhenListFails_ShowsRetryAndLoadsRolesAfterRetry()
+    {
+        var api = new StubRolesApi
+        {
+            ListHandler = (_, call) => call == 1
+                ? Task.FromException<ListRolesResponse>(new InvalidOperationException("connection failed"))
+                : Task.FromResult(new ListRolesResponse { Roles = [new RoleSummary { Id = "ops", Name = "Operations" }] })
+        };
+        Register(api, ReadyAccess);
+
+        var cut = RenderRoles();
+        cut.WaitForAssertion(() => Assert.Contains("Roles could not be loaded", cut.Markup));
+
+        cut.Find("button[aria-label='Try loading roles again']").Click();
+
+        cut.WaitForAssertion(() => Assert.Contains("Operations", cut.Markup));
+        Assert.Equal(2, api.ListCalls);
+    }
+
+    [Fact]
+    public void CreateAndRowActions_NavigateToTheApprovedDetailsRoutes()
+    {
+        var api = new StubRolesApi
+        {
+            Response = new ListRolesResponse
+            {
+                Roles = [new RoleSummary { Id = "auditors/read only", Name = "Auditors" }]
+            }
+        };
+        Register(api, ReadyAccess);
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        var cut = RenderRoles();
+        cut.WaitForAssertion(() => Assert.Contains("Auditors", cut.Markup));
+
+        cut.Find("button[aria-label='Create a new role']").Click();
+        Assert.EndsWith("/security/roles/new", navigation.Uri, StringComparison.Ordinal);
+
+        // A fresh render represents the list after the browser returns from the create route.
+        var secondCut = Render<Roles>();
+        secondCut.WaitForAssertion(() => Assert.Contains("Auditors", secondCut.Markup));
+        secondCut.Find("tbody tr").Click();
+
+        Assert.EndsWith("/security/roles/auditors%2Fread%20only", navigation.Uri, StringComparison.Ordinal);
+    }
+
+    private void Register(IRolesApi api, RoleAdministrationAccess access)
+    {
+        Services.AddSingleton<IRoleAdministrationAccessService>(new TestRoleAccessService(access));
+        Services.AddSingleton<IBackendApiClientProvider>(new TestBackendApiClientProvider(api));
+    }
+
+    private IRenderedComponent<Roles> RenderRoles()
+    {
+        Render<MudPopoverProvider>();
+        return Render<Roles>();
+    }
+
+    private static RoleAdministrationAccess ReadyAccess =>
+        new(RoleAdministrationAccessState.Ready, CanView: true, CanCreate: true, CanUpdate: true, CanDelete: true);
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await base.DisposeAsync();
+
+    private sealed class TestRoleAccessService(RoleAdministrationAccess access) : IRoleAdministrationAccessService
+    {
+        public Task<RoleAdministrationAccess> GetAsync(CancellationToken cancellationToken = default) => Task.FromResult(access);
+
+        public void Invalidate()
+        {
+        }
+    }
+
+    private sealed class TestBackendApiClientProvider(IRolesApi api) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://localhost/");
+
+        public ValueTask<T> GetApiAsync<T>(CancellationToken cancellationToken = default) where T : class =>
+            ValueTask.FromResult((T)(object)api);
+    }
+
+    private sealed class StubRolesApi : IRolesApi
+    {
+        public ListRolesResponse Response { get; set; } = new();
+        public Func<CancellationToken, int, Task<ListRolesResponse>>? ListHandler { get; set; }
+        public int ListCalls { get; private set; }
+
+        public Task<ListRolesResponse> ListAsync(CancellationToken cancellationToken = default)
+        {
+            ListCalls++;
+            return ListHandler?.Invoke(cancellationToken, ListCalls) ?? Task.FromResult(Response);
+        }
+
+        public Task<CreateRoleResponse> CreateAsync(CreateRoleRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<UpdateRoleResponse> UpdateAsync(string id, UpdateRoleRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<RoleDeletionImpactResponse> GetDeletionImpactAsync(string id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task RemediateAndDeleteAsync(string id, RoleRemediationRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Components/RoleAdvancedGrantCard.razor
+++ b/src/modules/Elsa.Studio.Security/Components/RoleAdvancedGrantCard.razor
@@ -1,0 +1,93 @@
+@using Elsa.Studio.Security.Models
+
+<style>
+    .role-reach-grid { display: grid; gap: 1rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .role-reach-item { min-width: 0; }
+    .role-reach-value { font-size: 1.35rem; font-weight: 650; }
+    .role-code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+    @@media (max-width: 60rem) {
+        .role-reach-grid { grid-template-columns: 1fr; }
+    }
+</style>
+
+@if (RolePermissionAuthoring.TryParse(Grant, out var pattern))
+{
+    <MudPaper Outlined="true" Elevation="0" Class="pa-4">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+            <div>
+                <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">@GrantType(pattern)</MudChip>
+                <MudText Typo="Typo.h6" Class="role-code mt-2">@Grant</MudText>
+                <MudChip T="string" Size="Size.Small" Color="Color.Warning">Broad access</MudChip>
+            </div>
+            @if (!IsReadOnly)
+            {
+                <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small" OnClick="OnRemove">Remove</MudButton>
+            }
+        </MudStack>
+        <MudDivider Class="my-3" />
+        <div class="role-reach-grid">
+            <div class="role-reach-item">
+                <MudText Typo="Typo.caption">Current coverage</MudText>
+                <MudText Class="role-reach-value">@(Reach is null ? "—" : Reach.Count) <small>resources today</small></MudText>
+            </div>
+            <div class="role-reach-item">
+                <MudText Typo="Typo.caption">Future reach</MudText>
+                <MudText Typo="Typo.body2">@GetFutureReach(pattern)</MudText>
+            </div>
+            <div class="role-reach-item">
+                <MudText Typo="Typo.caption">Materialized duplicates</MudText>
+                <MudText Class="role-reach-value">@MaterializedDuplicates</MudText>
+            </div>
+        </div>
+        @if (ReachError != null)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-3">@ReachError</MudAlert>
+        }
+        else if (ReachLoading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mt-3" aria-label="Loading grant reach" />
+        }
+        else if (Reach != null)
+        {
+            <MudStack Spacing="1" Class="mt-3">
+                <MudText Typo="Typo.caption">Current coverage examples</MudText>
+                @foreach (var permission in RolePermissionAuthoring.GetReachedPermissions(pattern, Reach).Take(5))
+                {
+                    <MudText Typo="Typo.caption" Class="role-code">@permission · Covered, not stored</MudText>
+                }
+                <MudText Typo="Typo.caption">Reach is calculated for this wildcard only.</MudText>
+            </MudStack>
+        }
+        else
+        {
+            <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="OnLoadReach">Load current coverage</MudButton>
+        }
+    </MudPaper>
+}
+
+@code {
+    [Parameter] public string Grant { get; set; } = string.Empty;
+    [Parameter] public PermissionReachResponse? Reach { get; set; }
+    [Parameter] public bool ReachLoading { get; set; }
+    [Parameter] public string? ReachError { get; set; }
+    [Parameter] public int MaterializedDuplicates { get; set; }
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
+    [Parameter] public EventCallback OnLoadReach { get; set; }
+
+    private static string GrantType(RolePermissionPattern pattern) => pattern switch
+    {
+        { IsResourceWildcard: true } => "Global wildcard",
+        { IsSubtree: true } => "Resource wildcard",
+        { IsVerbWildcard: true } => "Verb wildcard",
+        _ => "Advanced grant"
+    };
+
+    private static string GetFutureReach(RolePermissionPattern pattern) => pattern switch
+    {
+        { IsResourceWildcard: true } => "Every current and future resource will match.",
+        { IsSubtree: true } => $"New resources under {pattern.Resource[..^2]} will also match.",
+        { IsVerbWildcard: true } => $"Future verbs on {pattern.Resource} will also match.",
+        _ => "No future reach: this is an exact grant."
+    };
+}

--- a/src/modules/Elsa.Studio.Security/Components/RoleEditorSurface.razor
+++ b/src/modules/Elsa.Studio.Security/Components/RoleEditorSurface.razor
@@ -1,0 +1,645 @@
+@using Elsa.Studio.Contracts
+@using Elsa.Studio.Security.Client
+@using Elsa.Studio.Security.Services
+@inherits StudioComponentBase
+@implements IAsyncDisposable
+@inject IBackendApiClientProvider ApiClientProvider
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+
+<style>
+    .role-editor-header { align-items: flex-start; display: flex; gap: 1rem; justify-content: space-between; flex-wrap: wrap; }
+    .role-editor-actions { align-items: center; display: flex; gap: .5rem; flex-wrap: wrap; }
+    .role-editor-id { color: var(--mud-palette-text-secondary); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+    .role-permission-row { align-items: flex-start; display: flex; gap: .5rem; justify-content: space-between; min-width: 0; padding: .65rem .75rem; }
+    .role-permission-copy { min-width: 0; }
+    .role-permission-name { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+    .role-permission-meta { align-items: center; display: flex; gap: .5rem; flex-wrap: wrap; }
+    .role-code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+</style>
+
+@if (_loading)
+{
+    <MudStack AlignItems="AlignItems.Center" Class="pa-8" Role="status">
+        <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading role" />
+        <MudText Typo="Typo.body2">Loading role…</MudText>
+    </MudStack>
+}
+else if (_loadError != null)
+{
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
+        <MudText Typo="Typo.subtitle1">Could not load role</MudText>
+        <MudText Typo="Typo.body2">@_loadError</MudText>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-3" Disabled="@_loading" OnClick="ReloadAsync">Try again</MudButton>
+    </MudAlert>
+}
+else if (!CanOpen)
+{
+    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+        You can view roles, but your current sign-in cannot create a role.
+    </MudAlert>
+}
+else
+{
+    <MudStack Spacing="4">
+        <div class="role-editor-header">
+            <div>
+                <MudBreadcrumbs Items="@Breadcrumbs" Class="pa-0" />
+                <MudText Typo="Typo.h4">@(_isCreate ? "New role" : $"Edit role — {_name}")</MudText>
+                @if (!_isCreate)
+                {
+                    <MudText Typo="Typo.body2" Class="role-editor-id mt-1">ID <code>@RoleId</code></MudText>
+                }
+            </div>
+            <div class="role-editor-actions">
+                <MudButton Variant="Variant.Outlined" OnClick="Cancel">Cancel</MudButton>
+                @if (!IsReadOnly)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!CanSave)" OnClick="SaveAsync">
+                        @(_saving ? "Saving…" : _isCreate ? "Create role" : "Save changes")
+                    </MudButton>
+                }
+            </div>
+        </div>
+
+        <MudPaper Outlined="true" Elevation="0" Class="pa-4">
+            <MudForm @ref="_form">
+                <MudText Typo="Typo.h6">Role details</MudText>
+                <MudGrid Spacing="4" Class="mt-1">
+                    <MudItem xs="12" md="@(_isCreate ? 12 : 6)">
+                        <MudTextField T="string" Label="Role name" Value="@_name" ValueChanged="OnNameChanged" Required="true" RequiredError="Role name is required." Disabled="@IsReadOnly" Variant="Variant.Outlined" Immediate="true" aria-label="Role name" />
+                    </MudItem>
+                    @if (!_isCreate)
+                    {
+                        <MudItem xs="12" md="6">
+                            <MudTextField T="string" Label="ID" Value="@RoleId" Disabled="true" Variant="Variant.Outlined" HelperText="ID cannot be changed." />
+                        </MudItem>
+                    }
+                </MudGrid>
+                @if (_isCreate)
+                {
+                    <MudText Typo="Typo.caption" Class="mt-2">Core generates the role ID after creation.</MudText>
+                }
+            </MudForm>
+        </MudPaper>
+
+        @if (_saveError != null)
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_saveError</MudAlert>
+        }
+
+        <MudPaper Outlined="true" Elevation="0" Class="pa-4">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
+                <MudText Typo="Typo.h6">Permissions</MudText>
+                <MudText Typo="Typo.caption">@DirectCount direct · @CoveredCount covered · @_advanced.Count advanced</MudText>
+            </MudStack>
+            <MudTabs Border="false" Elevation="0" ActivePanelIndex="@_activeTab" ActivePanelIndexChanged="OnTabChanged" KeepPanelsAlive="true">
+                <MudTabPanel Text="Exact permissions">
+                    <MudStack Spacing="3" Class="pt-3">
+                        <MudText Typo="Typo.body2">Select concrete permissions. Category actions add exact grants only and never create a wildcard.</MudText>
+                        <MudTextField T="string" Label="Filter permissions" Placeholder="Search by name, ID, or permission" Value="@_search" ValueChanged="OnSearchChanged" Immediate="true" Clearable="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Outlined.Search" />
+                        <MudExpansionPanels MultiExpansion="true">
+                            @foreach (var category in Categories)
+                            {
+                                var resources = GetFilteredResources(category).ToArray();
+                                if (resources.Length == 0)
+                                    continue;
+
+                                <MudExpansionPanel Text="@category" Expanded="true" Class="role-category-panel">
+                                    <TitleContent>
+                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width:100%">
+                                            <MudText>@category</MudText>
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                                <MudChip T="string" Size="Size.Small">@ConcreteCount(GetCategoryResources(category)) permissions</MudChip>
+                                                @if (!IsReadOnly)
+                                                {
+                                                    <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="@(() => SelectCategory(GetCategoryResources(category)))">Select all exact</MudButton>
+                                                }
+                                            </MudStack>
+                                        </MudStack>
+                                    </TitleContent>
+                                    <ChildContent>
+                                        <MudStack Spacing="0">
+                                            @foreach (var resource in resources)
+                                            {
+                                                <MudPaper Outlined="true" Elevation="0" Class="pa-2 mb-2">
+                                                    <MudText Typo="Typo.subtitle2">@resource.DisplayName</MudText>
+                                                    <MudText Typo="Typo.caption" Class="role-code">@resource.Resource</MudText>
+                                                    @if (!string.IsNullOrWhiteSpace(resource.Description))
+                                                    {
+                                                        <MudText Typo="Typo.caption">@resource.Description</MudText>
+                                                    }
+                                                    @if (!resource.Verified)
+                                                    {
+                                                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Unverified · verified:false</MudChip>
+                                                    }
+                                                    @if (resource.NonCoreVerbs.Count > 0)
+                                                    {
+                                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">Non-core: @string.Join(", ", resource.NonCoreVerbs)</MudChip>
+                                                    }
+                                                    @foreach (var verb in resource.SupportedVerbs.OrderBy(x => x, StringComparer.Ordinal))
+                                                    {
+                                                        var permission = $"{resource.Resource}:{verb}";
+                                                        var direct = IsDirect(permission);
+                                                        var covering = FindCoveringWildcard(resource.Resource, verb);
+                                                        <div class="role-permission-row">
+                                                            <div class="role-permission-copy">
+                                                                <MudText Class="role-permission-name">@permission</MudText>
+                                                                @if (direct)
+                                                                {
+                                                                    <div class="role-permission-meta"><MudChip T="string" Size="Size.Small" Color="Color.Success">Direct grant</MudChip></div>
+                                                                }
+                                                                else if (covering != null)
+                                                                {
+                                                                    <div class="role-permission-meta">
+                                                                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">Covered by @covering</MudChip>
+                                                                        <MudText Typo="Typo.caption">Effective access only — not stored twice</MudText>
+                                                                    </div>
+                                                                }
+                                                            </div>
+                                                            <MudCheckBox T="bool" Value="@direct" ValueChanged="@((bool value) => SetDirectGrant(permission, value))" Disabled="@(IsReadOnly || (!direct && covering != null))" Color="Color.Primary" aria-label="@permission" />
+                                                        </div>
+                                                    }
+                                                </MudPaper>
+                                            }
+                                        </MudStack>
+                                    </ChildContent>
+                                </MudExpansionPanel>
+                            }
+                        </MudExpansionPanels>
+                    </MudStack>
+                </MudTabPanel>
+                <MudTabPanel Text="@($"Advanced grants{(_advanced.Count == 0 ? string.Empty : $" · {_advanced.Count}")}")">
+                    <MudStack Spacing="3" Class="pt-3">
+                        <MudText Typo="Typo.body2">Advanced grants are stored independently from exact selections. Each wildcard can cover current and future permissions.</MudText>
+                        @if (!IsReadOnly)
+                        {
+                            <MudStack Row="true" AlignItems="AlignItems.Start" Spacing="2">
+                                <MudTextField T="string" Label="Advanced grant" Placeholder="workflows/*:view or *" Value="@_advancedDraft" ValueChanged="@(value => _advancedDraft = value)" Variant="Variant.Outlined" Class="flex-grow-1" />
+                                <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" OnClick="AddAdvancedGrant">Add advanced grant</MudButton>
+                            </MudStack>
+                        }
+                        @if (_advancedError != null)
+                        {
+                            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_advancedError</MudAlert>
+                        }
+                        @if (_advanced.Count == 0)
+                        {
+                            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">No advanced grants. Add a wildcard only when its current coverage and future reach are understood.</MudAlert>
+                        }
+                        @foreach (var grant in _advanced)
+                        {
+                            <RoleAdvancedGrantCard Grant="@grant"
+                                                    Reach="@(_reach.TryGetValue(grant, out var reach) ? reach : null)"
+                                                    ReachLoading="@_reachLoading.Contains(grant)"
+                                                    ReachError="@(_reachErrors.TryGetValue(grant, out var reachError) ? reachError : null)"
+                                                    MaterializedDuplicates="@GetMaterializedDuplicates(grant)"
+                                                    IsReadOnly="@IsReadOnly"
+                                                    OnRemove="@(() => RemoveAdvancedGrant(grant))"
+                                                    OnLoadReach="@(() => LoadReachAsync(grant))" />
+                        }
+                    </MudStack>
+                </MudTabPanel>
+            </MudTabs>
+        </MudPaper>
+
+        @if (_unresolved.Count > 0)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                <MudText Typo="Typo.subtitle1">Review and repair · @_unresolved.Count issue(s)</MudText>
+                <MudText Typo="Typo.body2">Original grants are preserved verbatim. Remove or replace every unresolved grant before saving.</MudText>
+                @foreach (var original in _unresolved)
+                {
+                    <MudPaper Outlined="true" Elevation="0" Class="pa-3 mt-3">
+                        <MudText Class="role-code">@original</MudText>
+                        <MudText Typo="Typo.caption">Unresolved legacy grant · verified:false</MudText>
+                        @if (!IsReadOnly)
+                        {
+                            <MudStack Row="true" AlignItems="AlignItems.End" Spacing="2" Class="mt-2">
+                                <MudTextField T="string" Label="Replacement grant" Placeholder="resource:verb or wildcard" Value="@GetReplacement(original)" ValueChanged="@(value => SetReplacement(original, value))" Variant="Variant.Outlined" Class="flex-grow-1" />
+                                <MudButton Variant="Variant.Outlined" Color="Color.Warning" OnClick="@(() => ReplaceGrant(original))">Replace</MudButton>
+                                <MudButton Variant="Variant.Outlined" Color="Color.Error" OnClick="@(() => RemoveUnresolved(original))">Remove</MudButton>
+                            </MudStack>
+                            @if (_repairErrors.TryGetValue(original, out var repairError))
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Error" Class="mt-1">@repairError</MudText>
+                            }
+                        }
+                    </MudPaper>
+                }
+            </MudAlert>
+        }
+
+        @if (!IsReadOnly && _unresolved.Count > 0)
+        {
+            <MudText Typo="Typo.caption"><MudIcon Icon="@Icons.Material.Outlined.Lock" Size="Size.Small" /> Save changes is disabled until issues are resolved.</MudText>
+        }
+        else if (IsReadOnly)
+        {
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">You can view this role, but your current sign-in cannot edit it.</MudAlert>
+        }
+    </MudStack>
+}
+
+@code {
+    [Parameter] public string? RoleId { get; set; }
+    [Parameter, EditorRequired] public RoleAdministrationAccess Access { get; set; } = RoleAdministrationAccess.Unavailable;
+
+    private MudForm? _form;
+    private PermissionCatalogResponse _catalog = new();
+    private string _name = string.Empty;
+    private string _search = string.Empty;
+    private string _advancedDraft = string.Empty;
+    private string? _loadError;
+    private string? _saveError;
+    private string? _advancedError;
+    private bool _loading = true;
+    private bool _saving;
+    private bool _initialized;
+    private int _activeTab;
+    private RoleSummary? _role;
+    private readonly HashSet<string> _direct = new(StringComparer.Ordinal);
+    private readonly List<string> _advanced = [];
+    private readonly List<string> _unresolved = [];
+    private readonly Dictionary<string, string> _replacementDrafts = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _repairErrors = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, PermissionReachResponse?> _reach = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _reachLoading = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _reachErrors = new(StringComparer.Ordinal);
+    private readonly CancellationTokenSource _lifetime = new();
+    private string? _loadedRoleId;
+
+    private bool _isCreate => string.IsNullOrWhiteSpace(RoleId);
+    private bool IsReadOnly => !_isCreate && !Access.CanUpdate;
+    private bool CanOpen => _isCreate ? Access.CanCreate : Access.CanView;
+    private bool CanSave => !IsReadOnly && !_saving && _unresolved.Count == 0 && !string.IsNullOrWhiteSpace(_name);
+    private IEnumerable<string> Categories => _catalog.Resources
+        .Select(x => string.IsNullOrWhiteSpace(x.Category) ? "Other" : x.Category)
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(x => x, StringComparer.Ordinal);
+    private int DirectCount => _direct.Count;
+    private int CoveredCount => _catalog.Resources.Sum(x => x.SupportedVerbs.Count(verb => FindCoveringWildcard(x.Resource, verb) != null && !IsDirect($"{x.Resource}:{verb}")));
+    private IReadOnlyList<BreadcrumbItem> Breadcrumbs =>
+        _isCreate
+            ? [new("Roles", href: "security/roles"), new("New role", href: null)]
+            : [new("Roles", href: "security/roles"), new(_name, href: null)];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_initialized && string.Equals(_loadedRoleId, RoleId, StringComparison.Ordinal))
+            return;
+
+        _initialized = true;
+        _loadedRoleId = RoleId;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        _saveError = null;
+        ClearGrantState();
+        if (_isCreate)
+        {
+            _role = null;
+            _name = string.Empty;
+        }
+
+        try
+        {
+            if (!CanOpen)
+                return;
+
+            var permissionsApi = await ApiClientProvider.GetApiAsync<IPermissionsApi>(_lifetime.Token);
+            _catalog = await permissionsApi.ListAsync(_lifetime.Token);
+
+            if (!_isCreate)
+            {
+                var rolesApi = await ApiClientProvider.GetApiAsync<IRolesApi>(_lifetime.Token);
+                var roles = await rolesApi.ListAsync(_lifetime.Token);
+                _role = roles.Roles.FirstOrDefault(x => string.Equals(x.Id, RoleId, StringComparison.Ordinal));
+                if (_role == null)
+                {
+                    _loadError = "The role no longer exists.";
+                    return;
+                }
+
+                _name = _role.Name;
+                LoadStoredGrants(_role.Permissions);
+                await LoadAllReachAsync(permissionsApi);
+            }
+            else
+            {
+                _role = null;
+                _name = string.Empty;
+            }
+        }
+        catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _loadError = IdentityApiErrorMapper.Describe(exception).Message;
+        }
+        finally
+        {
+            if (!_lifetime.IsCancellationRequested)
+                _loading = false;
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        if (_lifetime.IsCancellationRequested)
+            return;
+
+        await LoadAsync();
+    }
+
+    private void LoadStoredGrants(IEnumerable<string>? permissions)
+    {
+        ClearGrantState();
+        foreach (var original in permissions ?? [])
+        {
+            if (!RolePermissionAuthoring.IsRecognized(original, _catalog.Resources, out var kind))
+            {
+                _unresolved.Add(original);
+                continue;
+            }
+
+            var normalized = original.Trim();
+            if (kind == RolePermissionGrantKind.Exact)
+                _direct.Add(normalized);
+            else
+                _advanced.Add(normalized);
+        }
+
+        SortGrantState();
+    }
+
+    private void ClearGrantState()
+    {
+        _direct.Clear();
+        _advanced.Clear();
+        _unresolved.Clear();
+        _replacementDrafts.Clear();
+        _repairErrors.Clear();
+        _reach.Clear();
+        _reachLoading.Clear();
+        _reachErrors.Clear();
+    }
+
+    private void SortGrantState()
+    {
+        var orderedAdvanced = RolePermissionAuthoring.NormalizePermissions(_advanced);
+        _advanced.Clear();
+        _advanced.AddRange(orderedAdvanced);
+        var orderedUnresolved = _unresolved.ToArray();
+        _unresolved.Clear();
+        _unresolved.AddRange(orderedUnresolved);
+    }
+
+    private IEnumerable<PermissionResourceDescriptor> GetCategoryResources(string category) =>
+        _catalog.Resources
+            .Where(x => string.Equals(string.IsNullOrWhiteSpace(x.Category) ? "Other" : x.Category, category, StringComparison.Ordinal));
+
+    private IEnumerable<PermissionResourceDescriptor> GetFilteredResources(string category) =>
+        GetCategoryResources(category)
+            .Where(MatchesSearch)
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.Resource, StringComparer.Ordinal);
+
+    private bool MatchesSearch(PermissionResourceDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(_search))
+            return true;
+
+        var search = _search.Trim();
+        return descriptor.DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               descriptor.Resource.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               descriptor.Category.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               descriptor.Description.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               descriptor.SupportedVerbs.Any(x => x.Contains(search, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static int ConcreteCount(IEnumerable<PermissionResourceDescriptor> resources) =>
+        resources.Sum(x => x.SupportedVerbs.Count);
+
+    private bool IsDirect(string permission) => _direct.Contains(permission);
+
+    private string? FindCoveringWildcard(string resource, string verb) =>
+        _advanced.FirstOrDefault(grant =>
+            RolePermissionAuthoring.TryParse(grant, out var pattern) &&
+            pattern.HasWildcard &&
+            RolePermissionAuthoring.IsValidPattern(pattern) &&
+            RolePermissionAuthoring.Matches(pattern, resource, verb));
+
+    private void SelectCategory(IEnumerable<PermissionResourceDescriptor> resources)
+    {
+        if (IsReadOnly)
+            return;
+
+        var additions = RolePermissionAuthoring.GetConcreteGrants(resources)
+            .Where(x => RolePermissionAuthoring.TryParse(x, out var pattern) && FindCoveringWildcard(pattern.Resource, pattern.Verb) == null);
+        foreach (var permission in additions)
+            _direct.Add(permission);
+    }
+
+    private void SetDirectGrant(string permission, bool selected)
+    {
+        if (IsReadOnly)
+            return;
+
+        if (!selected)
+            _direct.Remove(permission);
+        else if (RolePermissionAuthoring.TryParse(permission, out var pattern) && FindCoveringWildcard(pattern.Resource, pattern.Verb) == null)
+            _direct.Add(permission);
+    }
+
+    private async Task AddAdvancedGrant()
+    {
+        _advancedError = null;
+        var value = _advancedDraft.Trim();
+        if (!RolePermissionAuthoring.TryParse(value, out var pattern) || !RolePermissionAuthoring.IsValidPattern(pattern))
+        {
+            _advancedError = "Enter a valid grant. Wildcards may be *, a trailing resource /*, or the entire verb *.";
+            return;
+        }
+
+        if (!pattern.HasWildcard)
+        {
+            _advancedError = "This is an exact permission. Select it on the Exact permissions tab.";
+            return;
+        }
+
+        if (!_advanced.Contains(value, StringComparer.Ordinal))
+            _advanced.Add(value);
+        _advanced.Sort(StringComparer.Ordinal);
+        _advancedDraft = string.Empty;
+        _reach.Remove(value);
+        _reachErrors.Remove(value);
+        await LoadReachAsync(value);
+    }
+
+    private void RemoveAdvancedGrant(string grant)
+    {
+        if (IsReadOnly)
+            return;
+
+        _advanced.Remove(grant);
+        _reach.Remove(grant);
+        _reachErrors.Remove(grant);
+    }
+
+    private Task LoadAllReachAsync(IPermissionsApi api) =>
+        Task.WhenAll(_advanced.Select(grant => LoadReachAsync(api, grant)));
+
+    private async Task LoadReachAsync(string grant)
+    {
+        var api = await ApiClientProvider.GetApiAsync<IPermissionsApi>(_lifetime.Token);
+        await LoadReachAsync(api, grant);
+    }
+
+    private async Task LoadReachAsync(IPermissionsApi api, string grant)
+    {
+        if (_reach.ContainsKey(grant) || !RolePermissionAuthoring.TryParse(grant, out var pattern) || !_reachLoading.Add(grant))
+            return;
+
+        try
+        {
+            _reach[grant] = await api.GetReachAsync(pattern.Resource, _lifetime.Token);
+        }
+        catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _reachErrors[grant] = IdentityApiErrorMapper.Describe(exception).Message;
+        }
+        finally
+        {
+            _reachLoading.Remove(grant);
+        }
+    }
+
+    private int GetMaterializedDuplicates(string grant)
+    {
+        if (!RolePermissionAuthoring.TryParse(grant, out var wildcard))
+            return 0;
+
+        return _direct.Count(permission =>
+            RolePermissionAuthoring.TryParse(permission, out var exact) &&
+            !exact.HasWildcard &&
+            RolePermissionAuthoring.Matches(wildcard, exact.Resource, exact.Verb));
+    }
+
+    private string GetReplacement(string original) => _replacementDrafts.TryGetValue(original, out var value) ? value : string.Empty;
+
+    private void SetReplacement(string original, string? value) => _replacementDrafts[original] = value ?? string.Empty;
+
+    private void ReplaceGrant(string original)
+    {
+        _repairErrors.Remove(original);
+        var replacement = GetReplacement(original).Trim();
+        if (!RolePermissionAuthoring.IsRecognized(replacement, _catalog.Resources, out var kind))
+        {
+            _repairErrors[original] = "Replacement must be a recognized catalog permission or valid wildcard.";
+            return;
+        }
+
+        _unresolved.Remove(original);
+        if (kind == RolePermissionGrantKind.Exact)
+        {
+            if (RolePermissionAuthoring.TryParse(replacement, out var exact) && FindCoveringWildcard(exact.Resource, exact.Verb) == null)
+                _direct.Add(replacement);
+        }
+        else if (!_advanced.Contains(replacement, StringComparer.Ordinal))
+        {
+            _advanced.Add(replacement);
+            _advanced.Sort(StringComparer.Ordinal);
+        }
+
+        _replacementDrafts.Remove(original);
+    }
+
+    private void RemoveUnresolved(string original)
+    {
+        if (IsReadOnly)
+            return;
+
+        _unresolved.Remove(original);
+        _replacementDrafts.Remove(original);
+        _repairErrors.Remove(original);
+    }
+
+    private Task OnNameChanged(string value)
+    {
+        _name = value;
+        return Task.CompletedTask;
+    }
+
+    private Task OnSearchChanged(string value)
+    {
+        _search = value;
+        return Task.CompletedTask;
+    }
+
+    private Task OnTabChanged(int index)
+    {
+        _activeTab = index;
+        return Task.CompletedTask;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave || _form == null)
+            return;
+
+        await _form.Validate();
+        if (!_form.IsValid || _saving)
+            return;
+
+        _saving = true;
+        _saveError = null;
+        try
+        {
+            var permissions = RolePermissionAuthoring.NormalizePermissions(_direct.Concat(_advanced).Concat(_unresolved));
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>(_lifetime.Token);
+            if (_isCreate)
+            {
+                var created = await api.CreateAsync(new CreateRoleRequest { Name = _name.Trim(), Permissions = permissions.ToArray() }, _lifetime.Token);
+                Snackbar.Add("Role created.", Severity.Success);
+                NavigationManager.NavigateTo($"security/roles/{Uri.EscapeDataString(created.Id)}");
+            }
+            else
+            {
+                var updated = await api.UpdateAsync(RoleId!, new UpdateRoleRequest { Name = _name.Trim(), Permissions = permissions.ToArray() }, _lifetime.Token);
+                Snackbar.Add("Role updated.", Severity.Success);
+                _role = new RoleSummary { Id = updated.Id, Name = updated.Name, Permissions = updated.Permissions, TenantId = updated.TenantId };
+                _name = updated.Name;
+                LoadStoredGrants(updated.Permissions);
+            }
+        }
+        catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _saveError = IdentityApiErrorMapper.Describe(exception).Message;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void Cancel() => NavigationManager.NavigateTo("security/roles");
+
+    public ValueTask DisposeAsync()
+    {
+        _lifetime.Cancel();
+        _lifetime.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Components/RolePermissionPreview.razor
+++ b/src/modules/Elsa.Studio.Security/Components/RolePermissionPreview.razor
@@ -1,0 +1,41 @@
+@using Elsa.Studio.Security.Models
+
+<div class="role-permission-preview">
+    @if (IsGlobalRole)
+    {
+        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined" Class="role-permission-chip">
+            Global access (*)
+        </MudChip>
+    }
+    else if (Permissions.Count == 0)
+    {
+        <MudText Typo="Typo.caption">No permissions</MudText>
+    }
+    else
+    {
+        @foreach (var permission in Permissions.Take(1))
+        {
+            <MudChip T="string"
+                     Size="Size.Small"
+                     Variant="Variant.Outlined"
+                     Class="role-permission-chip"
+                     title="@permission">
+                @permission
+            </MudChip>
+        }
+
+        @if (Permissions.Count > 1)
+        {
+            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">+@(Permissions.Count - 1)</MudChip>
+        }
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public RoleSummary Role { get; set; } = default!;
+
+    private IReadOnlyList<string> Permissions =>
+        Role.Permissions?.Where(permission => !string.IsNullOrWhiteSpace(permission)).ToList() ?? [];
+
+    private bool IsGlobalRole => Permissions.Any(permission => permission == "*");
+}

--- a/src/modules/Elsa.Studio.Security/Models/IdentityApiErrorInfo.cs
+++ b/src/modules/Elsa.Studio.Security/Models/IdentityApiErrorInfo.cs
@@ -1,0 +1,16 @@
+namespace Elsa.Studio.Security.Models;
+
+/// <summary>
+/// Safe, display-ready information about a failed Identity request.
+/// </summary>
+public sealed record IdentityApiErrorInfo(
+    string Code,
+    string Message,
+    bool IsAuthorization = false,
+    bool IsNotFound = false,
+    bool IsConflict = false,
+    bool IsValidation = false)
+{
+    public static IdentityApiErrorInfo Unavailable { get; } =
+        new("unavailable", "Role administration is unavailable right now. Try again in a moment.");
+}

--- a/src/modules/Elsa.Studio.Security/Models/IdentityJsonSerializerContext.cs
+++ b/src/modules/Elsa.Studio.Security/Models/IdentityJsonSerializerContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Elsa.Studio.Security.Models;
+
+/// <summary>Trim-safe JSON metadata for structured Identity API failures.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(CoreApiErrorResponse))]
+[JsonSerializable(typeof(ValidationApiErrorResponse))]
+[JsonSerializable(typeof(RoleDeletionImpactResponse))]
+internal partial class IdentityJsonSerializerContext : JsonSerializerContext;

--- a/src/modules/Elsa.Studio.Security/Models/RolePermissionAuthoring.cs
+++ b/src/modules/Elsa.Studio.Security/Models/RolePermissionAuthoring.cs
@@ -1,0 +1,141 @@
+namespace Elsa.Studio.Security.Models;
+
+/// <summary>The kind of grant represented by a stored role permission.</summary>
+public enum RolePermissionGrantKind
+{
+    Exact,
+    Wildcard,
+    Unresolved
+}
+
+/// <summary>A parsed permission pattern used by the role authoring surface.</summary>
+public readonly record struct RolePermissionPattern(string Resource, string Verb)
+{
+    public bool IsResourceWildcard => Resource == "*";
+    public bool IsVerbWildcard => Verb == "*";
+    public bool IsSubtree => Resource.Length > 2 && Resource.EndsWith("/*", StringComparison.Ordinal);
+    public bool HasWildcard => IsResourceWildcard || IsVerbWildcard || IsSubtree;
+
+    public override string ToString() => $"{Resource}:{Verb}";
+}
+
+/// <summary>Classifies stored grants against the current Identity permission catalog.</summary>
+public static class RolePermissionAuthoring
+{
+    /// <summary>
+    /// Trims, ordinally de-duplicates, and ordinally sorts grants before sending them to Core.
+    /// Null remains an empty collection because an editor always sends the complete current grant set.
+    /// </summary>
+    public static IReadOnlyList<string> NormalizePermissions(IEnumerable<string>? permissions) =>
+        (permissions ?? [])
+            .Where(x => x != null)
+            .Select(x => x.Trim())
+            .Where(x => x.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>Parses the Core permission grammar without rejecting unfamiliar stored values.</summary>
+    public static bool TryParse(string? value, out RolePermissionPattern pattern)
+    {
+        pattern = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var trimmed = value.Trim();
+        if (trimmed == "*")
+        {
+            pattern = new("*", "*");
+            return true;
+        }
+
+        if (trimmed.Contains(',', StringComparison.Ordinal))
+            return false;
+
+        var separator = trimmed.IndexOf(':');
+        if (separator <= 0 || separator == trimmed.Length - 1)
+            return false;
+
+        var resource = trimmed[..separator];
+        var verb = trimmed[(separator + 1)..];
+        if (verb.Contains(':', StringComparison.Ordinal) || verb.Contains('/', StringComparison.Ordinal))
+            return false;
+
+        pattern = new(resource, verb);
+        return true;
+    }
+
+    /// <summary>Whether a parsed pattern is valid according to Core's wildcard placement rules.</summary>
+    public static bool IsValidPattern(RolePermissionPattern pattern)
+    {
+        if (pattern.Verb != "*" && pattern.Verb.Contains('*', StringComparison.Ordinal))
+            return false;
+
+        var first = pattern.Resource.IndexOf('*');
+        return first < 0 || (first == pattern.Resource.LastIndexOf('*') && (pattern.IsResourceWildcard || pattern.IsSubtree));
+    }
+
+    /// <summary>Whether a wildcard grant matches a concrete catalog resource and verb.</summary>
+    public static bool Matches(RolePermissionPattern grant, string resource, string verb)
+    {
+        var resourceMatches = grant.IsResourceWildcard ||
+                              string.Equals(grant.Resource, resource, StringComparison.Ordinal) ||
+                              (grant.IsSubtree &&
+                               (string.Equals(grant.Resource[..^2], resource, StringComparison.Ordinal) ||
+                                resource.StartsWith(grant.Resource[..^1], StringComparison.Ordinal)));
+        var verbMatches = grant.IsVerbWildcard || string.Equals(grant.Verb, verb, StringComparison.Ordinal);
+        return resourceMatches && verbMatches;
+    }
+
+    /// <summary>Determines whether a stored value is a recognized catalog or wildcard grant.</summary>
+    public static bool IsRecognized(
+        string? value,
+        IEnumerable<PermissionResourceDescriptor> catalog,
+        out RolePermissionGrantKind kind)
+    {
+        kind = RolePermissionGrantKind.Unresolved;
+        if (!TryParse(value, out var pattern) || !IsValidPattern(pattern))
+            return false;
+
+        if (pattern.HasWildcard)
+        {
+            kind = RolePermissionGrantKind.Wildcard;
+            return true;
+        }
+
+        var descriptor = catalog.FirstOrDefault(x => string.Equals(x.Resource, pattern.Resource, StringComparison.Ordinal));
+        if (descriptor == null || !descriptor.SupportedVerbs.Contains(pattern.Verb, StringComparer.Ordinal))
+            return false;
+
+        kind = RolePermissionGrantKind.Exact;
+        return true;
+    }
+
+    /// <summary>Returns whether a concrete catalog permission is already covered by a stored wildcard.</summary>
+    public static bool IsCoveredByWildcard(
+        string resource,
+        string verb,
+        IEnumerable<string> wildcardGrants) =>
+        wildcardGrants.Any(grant => TryParse(grant, out var pattern) &&
+                                    pattern.HasWildcard &&
+                                    IsValidPattern(pattern) &&
+                                    Matches(pattern, resource, verb));
+
+    /// <summary>Gets concrete grants for the currently displayed catalog descriptors.</summary>
+    public static IReadOnlyList<string> GetConcreteGrants(IEnumerable<PermissionResourceDescriptor> descriptors) =>
+        descriptors
+            .SelectMany(resource => resource.SupportedVerbs.Select(verb => $"{resource.Resource}:{verb}"))
+            .ToArray();
+
+    /// <summary>Gets the resources represented by a wildcard's reach response, preserving its verb pattern.</summary>
+    public static IReadOnlyList<string> GetReachedPermissions(RolePermissionPattern pattern, PermissionReachResponse? reach)
+    {
+        if (reach == null)
+            return [];
+
+        return reach.Covers
+            .Select(resource => $"{resource}:{pattern.Verb}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Pages/Role.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/Role.razor
@@ -1,0 +1,15 @@
+@page "/security/roles/new"
+@page "/security/roles/{RoleId}"
+@inherits StudioComponentBase
+
+<PageTitle>@(string.IsNullOrWhiteSpace(RoleId) ? "New role" : "Edit role")</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="py-4">
+    <RoleAdministrationAccessBoundary Context="access">
+        <RoleEditorSurface RoleId="@RoleId" Access="@access" />
+    </RoleAdministrationAccessBoundary>
+</MudContainer>
+
+@code {
+    [Parameter] public string? RoleId { get; set; }
+}

--- a/src/modules/Elsa.Studio.Security/Pages/Roles.razor
+++ b/src/modules/Elsa.Studio.Security/Pages/Roles.razor
@@ -1,16 +1,474 @@
 ﻿@page "/security/roles"
 @inherits StudioComponentBase
+@implements IAsyncDisposable
+@using Elsa.Studio.Contracts
+@using Elsa.Studio.Security.Client
+@using Elsa.Studio.Security.Services
+@inject IBackendApiClientProvider ApiClientProvider
+@inject NavigationManager NavigationManager
 
 <PageTitle>Roles</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.False">
+<style>
+    .roles-page {
+        --roles-border: var(--mud-palette-lines-default);
+        --roles-muted: var(--mud-palette-text-secondary);
+    }
+
+    .roles-toolbar {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        justify-content: space-between;
+        margin-top: 24px;
+    }
+
+    .roles-search {
+        max-width: 440px;
+        min-width: 280px;
+        width: 100%;
+    }
+
+    .roles-count {
+        align-items: center;
+        color: var(--roles-muted);
+        display: flex;
+        font-size: 0.875rem;
+        gap: 8px;
+        margin-top: 16px;
+    }
+
+    .roles-count-icon {
+        color: var(--mud-palette-primary);
+    }
+
+    .roles-desktop-list {
+        margin-top: 16px;
+    }
+
+    .roles-table {
+        border: 1px solid var(--roles-border);
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .roles-table .mud-table-head {
+        background: var(--mud-palette-background-gray);
+    }
+
+    .roles-table .mud-table-cell {
+        padding: 16px;
+        vertical-align: middle;
+    }
+
+    .roles-table .mud-table-head .mud-table-cell {
+        color: var(--roles-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+
+    .role-name {
+        font-weight: 600;
+    }
+
+    .role-id {
+        color: var(--roles-muted);
+        font-family: var(--mud-typography-default-family);
+        font-size: 0.8125rem;
+        overflow-wrap: anywhere;
+    }
+
+    .role-permission-preview {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+
+    .role-permission-chip {
+        max-width: 260px;
+    }
+
+    .role-permission-chip .mud-chip-content {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .roles-actions {
+        white-space: nowrap;
+    }
+
+    .roles-mobile-list {
+        display: none;
+        gap: 12px;
+        margin-top: 16px;
+    }
+
+    .role-card {
+        cursor: pointer;
+        padding: 16px;
+    }
+
+    .role-card-header {
+        align-items: flex-start;
+        display: flex;
+        gap: 12px;
+        justify-content: space-between;
+    }
+
+    .role-card-content {
+        min-width: 0;
+    }
+
+    .role-card-actions {
+        align-items: center;
+        display: flex;
+        gap: 4px;
+    }
+
+    .roles-state-card {
+        align-items: center;
+        border: 1px solid var(--roles-border);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        justify-content: center;
+        margin-top: 16px;
+        min-height: 220px;
+        padding: 32px 24px;
+        text-align: center;
+    }
+
+    .roles-no-pagination {
+        align-items: center;
+        border-top: 1px solid var(--roles-border);
+        color: var(--roles-muted);
+        display: flex;
+        gap: 8px;
+        padding: 12px 16px;
+    }
+
+    @@media (max-width: 959.98px) {
+        .roles-desktop-list {
+            display: none;
+        }
+
+        .roles-mobile-list {
+            display: grid;
+        }
+
+        .roles-search {
+            max-width: none;
+        }
+    }
+
+    @@media (min-width: 960px) {
+        .roles-desktop-list {
+            display: block;
+        }
+    }
+</style>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="roles-page">
     <RoleAdministrationAccessBoundary Context="access">
-        <PageHeading Text="Roles"></PageHeading>
+        <PageHeading Text="Roles" />
+
         @if (!access.CanCreate && !access.CanUpdate && !access.CanDelete)
         {
             <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
-                You can view roles, but your current sign-in cannot create, update, or delete them.
+                You can view roles, but you cannot create, edit, or delete them.
             </MudAlert>
+        }
+
+        <div class="roles-toolbar">
+            <MudTextField T="string"
+                          Value="@_search"
+                          ValueChanged="OnSearchChanged"
+                          Label="Search roles"
+                          Placeholder="Search by name, ID, or permission"
+                          Variant="Variant.Outlined"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Outlined.Search"
+                          Clearable="true"
+                          Immediate="true"
+                          Class="roles-search"
+                          aria-label="Search roles by name, ID, or permission" />
+
+            @if (access.CanCreate)
+            {
+                <MudButton Variant="Variant.Filled"
+                            Color="Color.Primary"
+                            StartIcon="@Icons.Material.Filled.Add"
+                            OnClick="NavigateToCreate"
+                            Disabled="@_navigationStarted"
+                            aria-label="Create a new role">
+                    New role
+                </MudButton>
+            }
+        </div>
+
+        @if (!_isLoading && _loadError is null)
+        {
+            <div class="roles-count" role="status" aria-live="polite">
+                <MudIcon Icon="@Icons.Material.Outlined.CheckCircle" Size="Size.Small" Class="roles-count-icon" aria-hidden="true" />
+                <span>@ResultSummary</span>
+            </div>
+        }
+
+        @if (_isLoading)
+        {
+            <MudPaper Outlined="true" Class="roles-state-card" Role="status">
+                <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="Loading roles" />
+                <MudText Typo="Typo.body2">Loading roles...</MudText>
+            </MudPaper>
+        }
+        else if (_loadError is not null)
+        {
+            <MudPaper Outlined="true" Class="roles-state-card" Role="alert">
+                <MudIcon Icon="@Icons.Material.Outlined.ErrorOutline" Color="Color.Error" Size="Size.Large" aria-hidden="true" />
+                <MudText Typo="Typo.h6">Roles could not be loaded</MudText>
+                <MudText Typo="Typo.body2">@_loadError.Message</MudText>
+                <MudButton Variant="Variant.Filled"
+                            Color="Color.Primary"
+                            OnClick="ReloadAsync"
+                            Disabled="@_isLoading"
+                            aria-label="Try loading roles again">
+                    Try again
+                </MudButton>
+            </MudPaper>
+        }
+        else if (_roles.Count == 0)
+        {
+            <MudPaper Outlined="true" Class="roles-state-card">
+                <MudIcon Icon="@Icons.Material.Outlined.Inventory2" Color="Color.Secondary" Size="Size.Large" aria-hidden="true" />
+                <MudText Typo="Typo.h6">No roles yet</MudText>
+                <MudText Typo="Typo.body2">Get started by creating your first role.</MudText>
+                @if (access.CanCreate)
+                {
+                    <MudButton Variant="Variant.Filled"
+                                Color="Color.Primary"
+                                OnClick="NavigateToCreate"
+                                Disabled="@_navigationStarted"
+                                aria-label="Create your first role">
+                        Create first role
+                    </MudButton>
+                }
+            </MudPaper>
+        }
+        else if (FilteredRoles.Count == 0)
+        {
+            <MudPaper Outlined="true" Class="roles-state-card">
+                <MudIcon Icon="@Icons.Material.Outlined.SearchOff" Color="Color.Secondary" Size="Size.Large" aria-hidden="true" />
+                <MudText Typo="Typo.h6">No matching roles</MudText>
+                <MudText Typo="Typo.body2">Try a different name, ID, or permission.</MudText>
+            </MudPaper>
+        }
+        else
+        {
+            <div class="roles-desktop-list">
+                <MudTable T="RoleSummary"
+                          Items="@FilteredRoles"
+                          Dense="true"
+                          Hover="true"
+                          Elevation="0"
+                          OnRowClick="OnRoleRowClick"
+                          RowStyle="cursor: pointer;"
+                          Class="roles-table">
+                    <HeaderContent>
+                        <MudTh>Name</MudTh>
+                        <MudTh>ID</MudTh>
+                        <MudTh>Permissions</MudTh>
+                        @if (access.CanUpdate)
+                        {
+                            <MudTh>Actions</MudTh>
+                        }
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Name">
+                            <MudText Typo="Typo.body2" Class="role-name">@context.Name</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="ID">
+                            <code class="role-id">@context.Id</code>
+                        </MudTd>
+                        <MudTd DataLabel="Permissions">
+                            <RolePermissionPreview Role="context" />
+                        </MudTd>
+                        @if (access.CanUpdate)
+                        {
+                            <MudTd DataLabel="Actions" Class="roles-actions" @onclick:stopPropagation="true">
+                                <MudButton Variant="Variant.Outlined"
+                                            Color="Color.Default"
+                                            Size="Size.Small"
+                                            OnClick="@(() => OpenRoleDetails(context))"
+                                            aria-label="@($"Edit {context.Name}")">
+                                    Edit
+                                </MudButton>
+                            </MudTd>
+                        }
+                    </RowTemplate>
+                </MudTable>
+                <div class="roles-no-pagination">
+                    <MudIcon Icon="@Icons.Material.Outlined.Info" Size="Size.Small" aria-hidden="true" />
+                    <span>All matching roles are shown. No pagination.</span>
+                </div>
+            </div>
+
+            <div class="roles-mobile-list" aria-label="Roles list">
+                @foreach (var role in FilteredRoles)
+                {
+                    <MudPaper Outlined="true"
+                              Class="role-card"
+                              Role="button"
+                              tabindex="0"
+                              @onclick="@(() => OpenRoleDetails(role))"
+                              @onkeydown="@(args => OnRoleCardKeyDown(args, role))"
+                              aria-label="@($"Open {role.Name} role details")">
+                        <div class="role-card-header">
+                            <div class="role-card-content">
+                                <MudText Typo="Typo.body1" Class="role-name">@role.Name</MudText>
+                                <code class="role-id">@role.Id</code>
+                            </div>
+                            @if (access.CanUpdate)
+                            {
+                                <div class="role-card-actions" @onclick:stopPropagation="true">
+                                    <MudIconButton Icon="@Icons.Material.Outlined.Edit"
+                                                   Size="Size.Small"
+                                                   OnClick="@(() => OpenRoleDetails(role))"
+                                                   aria-label="@($"Edit {role.Name}")" />
+                                </div>
+                            }
+                        </div>
+                        <div class="role-permission-preview mt-3">
+                            <MudText Typo="Typo.caption">Permissions</MudText>
+                            <RolePermissionPreview Role="role" />
+                        </div>
+                    </MudPaper>
+                }
+            </div>
         }
     </RoleAdministrationAccessBoundary>
 </MudContainer>
+
+@code {
+    private readonly CancellationTokenSource _loadCancellation = new();
+    private IReadOnlyList<RoleSummary> _roles = [];
+    private string _search = string.Empty;
+    private IdentityApiErrorInfo? _loadError;
+    private bool _isLoading = true;
+    private bool _navigationStarted;
+    private bool _disposed;
+
+    private IReadOnlyList<RoleSummary> FilteredRoles =>
+        string.IsNullOrWhiteSpace(_search)
+            ? _roles
+            : _roles.Where(HasSearchMatch).ToList();
+
+    private string ResultSummary
+    {
+        get
+        {
+            var count = FilteredRoles.Count;
+            var label = count == 1 ? "role" : "roles";
+            return string.IsNullOrWhiteSpace(_search)
+                ? $"{count} {label} · all loaded"
+                : $"{count} {label} · matching search";
+        }
+    }
+
+    protected override async Task OnInitializedAsync() => await LoadRolesAsync(_loadCancellation.Token);
+
+    private async Task LoadRolesAsync(CancellationToken cancellationToken)
+    {
+        if (_disposed)
+            return;
+
+        _isLoading = true;
+        _loadError = null;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var api = await ApiClientProvider.GetApiAsync<IRolesApi>(cancellationToken);
+            var response = await api.ListAsync(cancellationToken);
+            _roles = response.Roles?.ToList() ?? [];
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception) when (!_disposed)
+        {
+            _loadError = IdentityApiErrorMapper.Describe(exception);
+        }
+        finally
+        {
+            if (!_disposed)
+            {
+                _isLoading = false;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        if (_disposed || _isLoading)
+            return;
+
+        await LoadRolesAsync(_loadCancellation.Token);
+    }
+
+    private Task OnSearchChanged(string? value)
+    {
+        _search = value ?? string.Empty;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    private void NavigateToCreate()
+    {
+        if (_navigationStarted || _disposed)
+            return;
+
+        _navigationStarted = true;
+        NavigationManager.NavigateTo("/security/roles/new");
+    }
+
+    private void OnRoleRowClick(TableRowClickEventArgs<RoleSummary> args) => OpenRoleDetails(args.Item);
+
+    private void OpenRoleDetails(RoleSummary? role)
+    {
+        if (_navigationStarted || _disposed || string.IsNullOrWhiteSpace(role?.Id))
+            return;
+
+        _navigationStarted = true;
+        NavigationManager.NavigateTo($"/security/roles/{Uri.EscapeDataString(role.Id)}");
+    }
+
+    private void OnRoleCardKeyDown(KeyboardEventArgs args, RoleSummary role)
+    {
+        if (args.Key is "Enter" or " ")
+            OpenRoleDetails(role);
+    }
+
+    private bool HasSearchMatch(RoleSummary role)
+    {
+        var search = _search.Trim();
+        return role.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               role.Id.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+               (role.Permissions?.Any(permission => permission.Contains(search, StringComparison.OrdinalIgnoreCase)) ?? false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        await _loadCancellation.CancelAsync();
+        _loadCancellation.Dispose();
+    }
+}

--- a/src/modules/Elsa.Studio.Security/Services/IdentityApiErrorMapper.cs
+++ b/src/modules/Elsa.Studio.Security/Services/IdentityApiErrorMapper.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Elsa.Studio.Security.Models;
+using Refit;
+
+namespace Elsa.Studio.Security.Services;
+
+/// <summary>
+/// Maps structured Core failures without exposing raw response bodies or exception details to the UI.
+/// </summary>
+public static class IdentityApiErrorMapper
+{
+    public static IdentityApiErrorInfo Describe(Exception exception) => exception switch
+    {
+        ApiException apiException => FromApi(apiException),
+        OperationCanceledException => new("cancelled", "The request was cancelled."),
+        HttpRequestException => new("offline", "Core could not be reached. Check the connection and try again."),
+        _ => IdentityApiErrorInfo.Unavailable
+    };
+
+    private static IdentityApiErrorInfo FromApi(ApiException exception)
+    {
+        var structured = TryReadStructuredError(exception.Content);
+        var validation = TryReadValidationError(exception.Content);
+        var isAuthorization = exception.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+        var isNotFound = exception.StatusCode == HttpStatusCode.NotFound;
+        var isConflict = exception.StatusCode == HttpStatusCode.Conflict;
+        var isValidation = exception.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.UnprocessableEntity;
+
+        if (structured is { Error.Length: > 0, Message.Length: > 0 })
+            return new(structured.Error, structured.Message, isAuthorization, isNotFound, isConflict, isValidation);
+
+        if (validation is { Message.Length: > 0 })
+        {
+            var details = validation.Errors
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .SelectMany(x => x.Value)
+                .Where(x => !string.IsNullOrWhiteSpace(x));
+            var message = string.Join(" ", details);
+            return new("validation_failed", string.IsNullOrWhiteSpace(message) ? validation.Message : message,
+                isAuthorization, isNotFound, isConflict, IsValidation: true);
+        }
+
+        return exception.StatusCode switch
+        {
+            HttpStatusCode.BadRequest => new("invalid", "The request did not pass validation.", IsValidation: true),
+            HttpStatusCode.Unauthorized => new("unauthorized", "Your session has expired. Sign in again to continue.", IsAuthorization: true),
+            HttpStatusCode.Forbidden => new("forbidden", "You are not allowed to perform this role administration action.", IsAuthorization: true),
+            HttpStatusCode.NotFound => new("not_found", "The role no longer exists.", IsNotFound: true),
+            HttpStatusCode.Conflict => new("conflict", "The role or one of its dependencies changed. Refresh and review the latest state.", IsConflict: true),
+            HttpStatusCode.TooManyRequests => new("throttled", "Too many requests. Wait a moment and try again."),
+            _ => IdentityApiErrorInfo.Unavailable
+        };
+    }
+
+    private static CoreApiErrorResponse? TryReadStructuredError(string? content) =>
+        TryDeserialize(content, IdentityJsonSerializerContext.Default.CoreApiErrorResponse);
+
+    private static ValidationApiErrorResponse? TryReadValidationError(string? content) =>
+        TryDeserialize(content, IdentityJsonSerializerContext.Default.ValidationApiErrorResponse);
+
+    private static T? TryDeserialize<T>(string? content, JsonTypeInfo<T> typeInfo)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return default;
+
+        try
+        {
+            return JsonSerializer.Deserialize(content, typeInfo);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder Roles page with the approved standalone responsive list
- add shared create/edit pages with exact permissions and standalone advanced grants tabs
- preserve unresolved legacy grants for explicit repair and show unverified catalog descriptors
- normalize submitted grants without materializing wildcard-covered exact grants
- map structured Identity API errors without exposing raw response bodies

## Approved design
Uses the approved responsive mockups under `specs/010-role-permission-management/mockups/`: no tenant UI, no stepper, and separate list/details pages.

## Validation
- Security tests: 76 passed at this stack level
- Security module: .NET 8/9/10 build, 0 warnings/errors
- Server and WASM host validation is recorded on the child deletion PR after shared modal integration

Stacked on #982.