### PR TITLE
Improve StateMachine editor activity authoring UX

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -24,7 +24,13 @@
         </MudToolBar>
     </TitleContent>
     <DialogContent>
-        <MudPaper Height="655px" Width="100%" Elevation="0">
+        @if (!string.IsNullOrWhiteSpace(_validationError))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Dense="true" Class="mb-3" data-testid="code-editor-validation-error">
+                @_validationError
+            </MudAlert>
+        }
+        <MudPaper Height="@EditorHeight" Width="100%" Elevation="0">
             <StandaloneCodeEditor @ref="_monacoEditor"
                                   Id="@_monacoEditorId"
                                   ConstructionOptions="ConfigureMonacoEditor"
@@ -33,4 +39,16 @@
                                   CssClass="studio-expression-input-monaco-editor" />
         </MudPaper>
     </DialogContent>
+    <DialogActions>
+        @if (RequireExplicitApply)
+        {
+            <MudButton OnClick="Cancel">@(IsReadOnly ? Localizer["Close"] : Localizer["Cancel"])</MudButton>
+            @if (!IsReadOnly)
+            {
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Apply" data-testid="code-editor-apply">
+                    @Localizer["Apply"]
+                </MudButton>
+            }
+        }
+    </DialogActions>
 </MudDialog>

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -39,9 +39,9 @@
                                   CssClass="studio-expression-input-monaco-editor" />
         </MudPaper>
     </DialogContent>
-    <DialogActions>
-        @if (RequireExplicitApply)
-        {
+    @if (RequireExplicitApply)
+    {
+        <DialogActions>
             <MudButton OnClick="Cancel">@(IsReadOnly ? Localizer["Close"] : Localizer["Cancel"])</MudButton>
             @if (!IsReadOnly)
             {
@@ -49,6 +49,6 @@
                     @Localizer["Apply"]
                 </MudButton>
             }
-        }
-    </DialogActions>
+        </DialogActions>
+    }
 </MudDialog>

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor
@@ -7,7 +7,7 @@
     }
 </style>
 
-<MudDialog>
+<MudDialog DialogActions="@ExplicitDialogActions">
     <TitleContent>
         <MudToolBar Dense="true" Gutters="false">
             <MudStack Spacing="0">
@@ -39,16 +39,18 @@
                                   CssClass="studio-expression-input-monaco-editor" />
         </MudPaper>
     </DialogContent>
-    @if (RequireExplicitApply)
-    {
-        <DialogActions>
-            <MudButton OnClick="Cancel">@(IsReadOnly ? Localizer["Close"] : Localizer["Cancel"])</MudButton>
-            @if (!IsReadOnly)
-            {
-                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Apply" data-testid="code-editor-apply">
-                    @Localizer["Apply"]
-                </MudButton>
-            }
-        </DialogActions>
-    }
 </MudDialog>
+
+@code {
+    private RenderFragment? ExplicitDialogActions => RequireExplicitApply
+        ? @<text>
+              <MudButton OnClick="Cancel">@(IsReadOnly ? Localizer["Close"] : Localizer["Cancel"])</MudButton>
+              @if (!IsReadOnly)
+              {
+                  <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Apply" data-testid="code-editor-apply">
+                      @Localizer["Apply"]
+                  </MudButton>
+              }
+          </text>
+        : null;
+}

--- a/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/CodeEditorDialog.razor.cs
@@ -14,6 +14,7 @@ public partial class CodeEditorDialog : IDisposable
     private StandaloneCodeEditor? _monacoEditor;
     private bool _isInternalContentChange;
     private string? _lastMonacoEditorContent;
+    private string? _validationError;
 
     [Inject] private IJSRuntime JSRuntime { get; set; } = null!;
 
@@ -44,6 +45,24 @@ public partial class CodeEditorDialog : IDisposable
     /// Gets or sets the programming language syntax used by the Monaco code editor within the dialog.
     /// </summary>
     [Parameter] public string MonacoLanguage { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets whether closing the dialog should be distinct from applying the draft.
+    /// Existing expression editors retain their close-to-apply behavior by default.
+    /// </summary>
+    [Parameter] public bool RequireExplicitApply { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the editor is view-only.
+    /// </summary>
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional validator. Return an error message to keep the dialog open.
+    /// </summary>
+    [Parameter] public Func<string, string?>? Validator { get; set; }
+
+    private string EditorHeight => RequireExplicitApply ? "min(56vh, 655px)" : "655px";
 
     private async Task OnMonacoInitializedAsync()
     {
@@ -78,8 +97,8 @@ public partial class CodeEditorDialog : IDisposable
             LineDecorationsWidth = 0,
             HideCursorInOverviewRuler = true,
             GlyphMargin = false,
-            ReadOnly = false,
-            DomReadOnly = false
+            ReadOnly = IsReadOnly,
+            DomReadOnly = IsReadOnly
         };
     }
 
@@ -94,9 +113,25 @@ public partial class CodeEditorDialog : IDisposable
 
         Value = value;
         _lastMonacoEditorContent = value;
+        _validationError = null;
     }
 
-    private void OnClosedClicked() => MudDialog.Close(DialogResult.Ok(Value));
+    private void OnClosedClicked()
+    {
+        if (RequireExplicitApply)
+            MudDialog.Cancel();
+        else
+            MudDialog.Close(DialogResult.Ok(Value));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Apply()
+    {
+        _validationError = Validator?.Invoke(Value);
+        if (_validationError == null)
+            MudDialog.Close(DialogResult.Ok(Value));
+    }
 
     /// <inheritdoc />
     public void Dispose()

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
@@ -66,6 +66,9 @@
         <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\internal\state-machine-accessibility.ts"
               Link="DesignerAssets\state-machine-accessibility.ts"
               CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\Components\StateMachineCanvas.razor.css"
+              Link="DesignerAssets\StateMachineCanvas.razor.css"
+              CopyToOutputDirectory="PreserveNewest" />
         <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\internal\designer-ports.ts"
               Link="DesignerAssets\designer-ports.ts"
               CopyToOutputDirectory="PreserveNewest" />

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineEditorSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/StateMachineEditorSessionTests.cs
@@ -209,6 +209,7 @@ public class StateMachineEditorSessionTests
         Assert.Equal(canvas.Transitions[0].VisualId, edge.Id);
         Assert.Equal(canvas.States[0].VisualId, edge.Source.Cell);
         Assert.Equal(canvas.States[1].VisualId, edge.Target.Cell);
+        Assert.Equal("Approve, transition from Pending to Approved", edge.Data["accessibleName"]?.GetValue<string>());
         Assert.Single(edge.Labels);
         Assert.Single(edge.Vertices);
     }

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6DesignerModeContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6DesignerModeContractTests.cs
@@ -65,6 +65,34 @@ public sealed class X6DesignerModeContractTests
     }
 
     [Fact]
+    public void StateMachineEdges_ExposeKeyboardAccessibleSelectionAndFocusTreatment()
+    {
+        var graphCreation = ReadAsset("create-graph.ts");
+        var accessibility = ReadAsset("state-machine-accessibility.ts");
+        var canvasCss = ReadAsset("StateMachineCanvas.razor.css");
+
+        Assert.Contains("applyStateMachineEdgeAccessibility", graphCreation, StringComparison.Ordinal);
+        Assert.Contains("graph.on('edge:added'", graphCreation, StringComparison.Ordinal);
+        Assert.Contains("graph.getEdges().forEach(edge => applyStateMachineEdgeAccessibility(graph, edge))", accessibility, StringComparison.Ordinal);
+        Assert.Contains("container.setAttribute('role', 'button')", accessibility, StringComparison.Ordinal);
+        Assert.Contains("container.setAttribute('aria-label', accessibleName)", accessibility, StringComparison.Ordinal);
+        Assert.Contains("container.setAttribute('tabindex', '0')", accessibility, StringComparison.Ordinal);
+        Assert.Contains("graph.select(edge)", accessibility, StringComparison.Ordinal);
+        Assert.Contains(".x6-edge[role=\"button\"]:focus-visible", canvasCss, StringComparison.Ordinal);
+        Assert.Contains(".x6-edge[role=\"button\"]:focus-visible > path[pointer-events=\"none\"]", canvasCss, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StateMachineEdges_UseOrthogonalRoutingWithoutManhattanFallback()
+    {
+        var graphCreation = ReadAsset("create-graph.ts");
+        var shapes = ReadAsset("state-machine-shapes.ts");
+
+        Assert.Contains("router: mode === 'stateMachine' ? 'orth' : 'manhattan'", graphCreation, StringComparison.Ordinal);
+        Assert.Contains("name: 'orth'", shapes, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GraphLifecycle_DisposesX6AndCancelsDeferredCanvasWork()
     {
         var disposal = ReadAsset("dispose-graph.ts");

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -14,7 +14,7 @@ import {arrangeSequenceGraph, moveSelectedSequenceNode, normalizeSequenceOrienta
 import {applyDesignerThemeVariables, X6DesignerTheme} from "./apply-graph-theme";
 import {createDesignerGridOptions, resolveDesignerGridOptions} from "./grid-options";
 import {ActivityShape, FlowchartEdgeShape, getDesignerModePolicy, resolveDesignerMode} from './designer-mode';
-import {applyStateMachineNodeAccessibility} from '../internal/state-machine-accessibility';
+import {applyStateMachineEdgeAccessibility, applyStateMachineNodeAccessibility} from '../internal/state-machine-accessibility';
 
 export async function createGraph(containerId: string, componentRef: DotNetComponentRef, readOnly: boolean, settings?: any): Promise<string> {
     const containerElement = document.getElementById(containerId);
@@ -60,7 +60,7 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
             useEdgeTools: () => !readOnly && modePolicy.allowsInteractiveEdges,
         },
         connecting: {
-            router: 'manhattan',
+            router: mode === 'stateMachine' ? 'orth' : 'manhattan',
             allowMulti: true,
             connector: {
                 name: 'rounded',
@@ -515,6 +515,16 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
 
         arrangeSequenceGraph(binding);
         await interop.raiseGraphUpdated();
+        return false;
+    });
+    graph.on('edge:added', async e => {
+        if (mode === 'stateMachine') {
+            const edge = e.edge || e.cell;
+            // X6 emits edge:added before its SVG view is guaranteed to be mounted.
+            // Defer one frame so the accessibility attributes land on the edge view.
+            requestAnimationFrame(() => applyStateMachineEdgeAccessibility(graph, edge));
+        }
+
         return false;
     });
     graph.on('node:removed', async e => {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/state-machine-accessibility.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/state-machine-accessibility.ts
@@ -1,23 +1,37 @@
-import {Graph, Node} from '@antv/x6';
+import {Edge, Graph, Node} from '@antv/x6';
 
 const AccessibilityMarker = 'data-elsa-state-machine-a11y';
 
 export function applyStateMachineGraphAccessibility(graph: Graph) {
     graph.getNodes().forEach(node => applyStateMachineNodeAccessibility(graph, node));
+    graph.getEdges().forEach(edge => applyStateMachineEdgeAccessibility(graph, edge));
 }
 
 export function applyStateMachineNodeAccessibility(graph: Graph, node: Node) {
-    const view = graph.findViewByCell(node);
     const accessibleName = node.getData()?.accessibleName
         ?? `${node.attr('title/text') || 'Unnamed'}, state`;
+    applyStateMachineCellAccessibility(graph, node, accessibleName, 'x6-node', () => graph.select(node));
+}
+
+export function applyStateMachineEdgeAccessibility(graph: Graph, edge: Edge) {
+    const data = edge.getData() as { accessibleName?: unknown; name?: unknown } | undefined;
+    const accessibleName = typeof data?.accessibleName === 'string' && data.accessibleName.trim()
+        ? data.accessibleName
+        : `${display(data?.name, 'Unnamed transition')}, transition from ${getEndpointName(graph, edge.getSourceCellId())} to ${getEndpointName(graph, edge.getTargetCellId())}`;
+    applyStateMachineCellAccessibility(graph, edge, accessibleName, 'x6-edge', () => graph.select(edge));
+}
+
+function applyStateMachineCellAccessibility(graph: Graph, cell: Node | Edge, accessibleName: string, className: string, selectCell: () => void) {
+    const view = graph.findViewByCell(cell);
     const container = view?.container
-        ?? graph.container.querySelector<SVGGElement>(`.x6-node[data-cell-id="${CSS.escape(node.id)}"]`);
+        ?? graph.container.querySelector<SVGGElement>(`.${className}[data-cell-id="${CSS.escape(cell.id)}"]`);
     if (!container || !accessibleName)
         return;
 
     container.setAttribute('role', 'button');
     container.setAttribute('aria-label', accessibleName);
     container.setAttribute('tabindex', '0');
+    container.setAttribute('focusable', 'true');
 
     if (container.getAttribute(AccessibilityMarker) === 'true')
         return;
@@ -29,6 +43,20 @@ export function applyStateMachineNodeAccessibility(graph: Graph, node: Node) {
             return;
 
         keyboardEvent.preventDefault();
-        graph.select(node);
+        selectCell();
     });
+}
+
+function getEndpointName(graph: Graph, cellId: string | undefined) {
+    if (!cellId)
+        return 'Unnamed state';
+
+    const cell = graph.getCellById(cellId);
+    const data = cell?.getData() as { name?: unknown } | undefined;
+    const title = cell?.attr('title/text');
+    return display(data?.name ?? title, 'Unnamed state');
+}
+
+function display(value: unknown, fallback: string) {
+    return typeof value === 'string' && value.trim() ? value : fallback;
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/state-machine-shapes.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/state-machine-shapes.ts
@@ -93,7 +93,11 @@ export function registerStateMachineShapes() {
                 },
             },
             router: {
-                name: 'manhattan',
+                // State transitions are already authored with explicit vertices and
+                // may connect through the same node boundary. Manhattan routing
+                // cannot resolve several of those paths and logs a fallback for
+                // every edge, so use the deterministic orthogonal router directly.
+                name: 'orth',
             },
         },
         true,

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/StateMachineCanvas.razor.css
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/StateMachineCanvas.razor.css
@@ -14,3 +14,13 @@
     outline: 2px solid var(--elsa-designer-selection);
     outline-offset: 3px;
 }
+
+::deep .x6-edge[role="button"]:focus-visible {
+    outline: 2px solid var(--elsa-designer-selection);
+    outline-offset: 4px;
+}
+
+::deep .x6-edge[role="button"]:focus-visible > path[pointer-events="none"] {
+    stroke: var(--elsa-designer-selection);
+    stroke-width: 3px;
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using System.Reflection;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.DiagramDesigners;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Services;
@@ -12,12 +13,29 @@ using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contexts;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace Elsa.Studio.Workflows.Tests;
 
 public class StateMachineDesignerWrapperTests
 {
+    [Theory]
+    [InlineData(false, false, "Repair the activity definition. Include a type, id, and nodeId.")]
+    [InlineData(false, true, "Edit the complete activity definition. The activity id and nodeId cannot be changed here.")]
+    [InlineData(true, false, "Review the complete activity definition.")]
+    public void ActivityJsonHelperText_DescribesTheApplicableValidationRules(bool isReadOnly, bool hasOriginalActivity, string expected)
+    {
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.IsReadOnly), isReadOnly);
+        SetPrivateField(wrapper, "Localizer", new TestLocalizer());
+
+        var originalActivity = hasOriginalActivity ? new JsonObject() : null;
+        var helperText = (string)InvokePrivate(wrapper, "GetActivityJsonHelperText", [originalActivity])!;
+
+        Assert.Equal(expected, helperText);
+    }
+
     [Fact]
     public void GetUniqueStateName_WhenRenamingToExistingStateName_ReturnsAvailableVariant()
     {
@@ -365,6 +383,14 @@ public class StateMachineDesignerWrapperTests
     {
         public bool GetNameExists(IEnumerable<JsonObject> activities, string name) => activities.Any(x => x.GetName() == name);
         public string GenerateNextName(IEnumerable<JsonObject> activities, ActivityDescriptor activityDescriptor) => name;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+
+        public LocalizedString this[string? key, params object[] arguments] =>
+            new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
     }
 
     private class ThrowingDiagramDesigner : IDiagramDesigner

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachineDesignerWrapperTests.cs
@@ -186,6 +186,38 @@ public class StateMachineDesignerWrapperTests
     }
 
     [Fact]
+    public async Task SelectTransitionActivity_SelectsArbitraryActivityWithoutOpeningANestedDesigner()
+    {
+        var root = CreateNestedSequenceStateMachine();
+        root["transitions"]![0]!["action"] = new JsonObject
+        {
+            ["id"] = "WriteLine1",
+            ["nodeId"] = "Workflow1:Machine1:WriteLine1",
+            ["name"] = "WriteLine1",
+            ["type"] = "Elsa.WriteLine",
+            ["version"] = 1,
+            ["text"] = "hello"
+        };
+        var session = CreateSession(root);
+        var wrapper = new StateMachineDesignerWrapper();
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.StateMachine), root);
+        SetPrivateField(wrapper, "_session", session);
+        SetPrivateField(wrapper, "_selectedTransitionId", session.ProjectCanvas().Transitions.Single().VisualId);
+        JsonObject? selected = null;
+        JsonObject? opened = null;
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.ActivitySelected),
+            EventCallback.Factory.Create<JsonObject>(new object(), (JsonObject activity) => selected = activity));
+        SetComponentParameter(wrapper, nameof(StateMachineDesignerWrapper.ActivityDoubleClick),
+            EventCallback.Factory.Create<JsonObject>(new object(), (JsonObject activity) => opened = activity));
+
+        await InvokePrivateAsync(wrapper, "SelectTransitionActivityAsync", "action");
+
+        Assert.Equal("WriteLine1", selected?.GetId());
+        Assert.Equal("Elsa.WriteLine", selected?.GetTypeName());
+        Assert.Null(opened);
+    }
+
+    [Fact]
     public void NestedSequenceChild_IsFoundAndUpdatedThroughItsOwningTransitionSlot()
     {
         var root = CreateNestedSequenceStateMachine();

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -3,6 +3,7 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
@@ -43,6 +44,26 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         IsBrowsable = false
     };
 
+    private readonly ActivityDescriptor _flowchart = new()
+    {
+        Name = "Flowchart",
+        DisplayName = "Flowchart",
+        TypeName = "Elsa.Flowchart",
+        Category = "Composition",
+        Description = "Runs activities as a graph.",
+        IsBrowsable = false
+    };
+
+    private readonly ActivityDescriptor _stateMachine = new()
+    {
+        Name = "StateMachine",
+        DisplayName = "State machine",
+        TypeName = "Elsa.StateMachine",
+        Category = "Composition",
+        Description = "Runs state and transition driven workflows.",
+        IsBrowsable = false
+    };
+
     private readonly ActivityDescriptor _internalActivity = new()
     {
         Name = "InternalActivity",
@@ -59,7 +80,8 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
         Services.AddSingleton<ILocalizer, TestLocalizer>();
-        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence, _internalActivity]));
+        Services.AddSingleton<IWorkflowRootActivityTemplateProvider, DefaultWorkflowRootActivityTemplateProvider>();
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence, _flowchart, _stateMachine, _internalActivity]));
         Render<MudPopoverProvider>();
         _dialogProvider = Render<MudDialogProvider>();
     }
@@ -74,8 +96,10 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
 
         _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
         _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal)).Click();
-        Assert.Equal(3, _dialogProvider.FindAll("[data-activity-type]").Count);
+        Assert.Equal(5, _dialogProvider.FindAll("[data-activity-type]").Count);
         Assert.DoesNotContain(_dialogProvider.FindAll("[data-activity-type]"), element => element.GetAttribute("data-activity-type") == _internalActivity.TypeName);
+        Assert.Contains(_dialogProvider.FindAll("[data-activity-type]"), element => element.GetAttribute("data-activity-type") == _flowchart.TypeName);
+        Assert.Contains(_dialogProvider.FindAll("[data-activity-type]"), element => element.GetAttribute("data-activity-type") == _stateMachine.TypeName);
         var search = _dialogProvider.Find("input[id*='state-machine-activity-picker']");
 
         search.Input("incoming");
@@ -116,11 +140,14 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
     }
 
     [Fact]
-    public async Task Picker_OffersSequenceAsTheProminentMultiActivityShortcut()
+    public async Task Picker_OffersDesignerBackedRootsAndRecommendsSequence()
     {
         var dialog = await ShowDialogAsync();
 
         _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-activity-type='Elsa.Sequence']")));
+        Assert.Equal(3, _dialogProvider.FindAll("[data-testid='state-machine-activity-option']").Count);
+        Assert.NotEmpty(_dialogProvider.FindAll("[data-activity-type='Elsa.Flowchart']"));
+        Assert.NotEmpty(_dialogProvider.FindAll("[data-activity-type='Elsa.StateMachine']"));
         var sequence = _dialogProvider.Find("[data-activity-type='Elsa.Sequence']");
         Assert.Contains("Recommended", sequence.TextContent);
         sequence.Click();
@@ -174,6 +201,28 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         var allActivities = _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal));
         allActivities.KeyDown("Enter");
 
+        Assert.False(dialog.Result.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Picker_SlashShortcutRefocusesSearchFromAFilterWithoutChangingTheSearchText()
+    {
+        var dialog = await ShowDialogAsync();
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        var search = _dialogProvider.Find("input[id*='state-machine-activity-picker']");
+        var allActivities = _dialogProvider.FindAll("button").Single(x => x.TextContent.Contains("All activities", StringComparison.Ordinal));
+        Assert.Equal("/", _dialogProvider.Find("[data-testid='state-machine-activity-picker']").GetAttribute("aria-keyshortcuts"));
+        var initialFocusCalls = JSInterop.Invocations.Count(x => x.Identifier.Contains("focus", StringComparison.OrdinalIgnoreCase));
+
+        allActivities.KeyDown("/");
+
+        _dialogProvider.WaitForAssertion(() =>
+        {
+            var focusCalls = JSInterop.Invocations.Count(x => x.Identifier.Contains("focus", StringComparison.OrdinalIgnoreCase));
+            Assert.True(focusCalls > initialFocusCalls);
+        });
+        Assert.Equal(string.Empty, search.GetAttribute("value"));
         Assert.False(dialog.Result.IsCompleted);
     }
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineCanvasLifecycleContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineCanvasLifecycleContractTests.cs
@@ -41,6 +41,32 @@ public sealed class StateMachineCanvasLifecycleContractTests
     }
 
     [Fact]
+    public void Wrapper_ExposesSeparateStateAndTransitionCreationMenus()
+    {
+        var wrapper = ReadAsset("StateMachineDesignerWrapper.razor");
+        const string menuStart = "<details class=\"state-machine-designer__create-menu\" name=\"state-machine-create\">";
+
+        Assert.Equal(2, wrapper.Split(menuStart, StringSplitOptions.None).Length - 1);
+        Assert.Contains("<summary>@Localizer[\"Add state\"]</summary>", wrapper, StringComparison.Ordinal);
+        Assert.Contains("<summary>@Localizer[\"Add transition\"]</summary>", wrapper, StringComparison.Ordinal);
+        Assert.DoesNotContain("<summary>@Localizer[\"Add\"]</summary>", wrapper, StringComparison.Ordinal);
+
+        var stateMenuStart = wrapper.IndexOf("<summary>@Localizer[\"Add state\"]</summary>", StringComparison.Ordinal);
+        var stateMenuEnd = wrapper.IndexOf("</details>", stateMenuStart, StringComparison.Ordinal);
+        Assert.True(stateMenuStart >= 0 && stateMenuEnd > stateMenuStart);
+        var stateMenu = wrapper[stateMenuStart..stateMenuEnd];
+        Assert.Contains("State name", stateMenu, StringComparison.Ordinal);
+        Assert.DoesNotContain("Transition name", stateMenu, StringComparison.Ordinal);
+
+        var transitionMenuStart = wrapper.IndexOf("<summary>@Localizer[\"Add transition\"]</summary>", StringComparison.Ordinal);
+        var transitionMenuEnd = wrapper.IndexOf("</details>", transitionMenuStart, StringComparison.Ordinal);
+        Assert.True(transitionMenuStart >= 0 && transitionMenuEnd > transitionMenuStart);
+        var transitionMenu = wrapper[transitionMenuStart..transitionMenuEnd];
+        Assert.Contains("Transition name", transitionMenu, StringComparison.Ordinal);
+        Assert.DoesNotContain("State name", transitionMenu, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TransitionInspector_UsesSemanticPickerCallbacksAndExcludesConditionFromActivityDrops()
     {
         var wrapper = ReadAsset("StateMachineDesignerWrapper.razor");

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -98,10 +98,12 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             .Add(component => component.State, state)
             .Add(component => component.IsInitial, true)
             .Add(component => component.IsCurrent, true)
+            .Add(component => component.SelectedActivityId, "Entry1")
             .Add(component => component.IncomingTransitionCount, 1)
             .Add(component => component.OutgoingTransitionCount, 2)
             .Add(component => component.NameChanged, value => changedName = value)
-            .Add(component => component.ActivityOpenRequested, slot => actions.Add($"open:{slot}"))
+            .Add(component => component.ActivitySelectRequested, slot => actions.Add($"select:{slot}"))
+            .Add(component => component.ActivityJsonRequested, slot => actions.Add($"json:{slot}"))
             .Add(component => component.ActivityReplaceRequested, slot => actions.Add($"replace:{slot}"))
             .Add(component => component.ActivityClearRequested, slot => actions.Add($"clear:{slot}"))
             .Add(component => component.ActivityAddRequested, slot => actions.Add($"add:{slot}"))
@@ -118,10 +120,12 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         Assert.Contains("Current", cut.Find("[aria-label='State status']").TextContent);
         Assert.Contains("2 outgoing transitions", cut.Find("[data-state-stage='active']").TextContent);
         Assert.Contains("Elsa.WriteLine", cut.Find("[data-state-stage='entry']").TextContent);
+        Assert.Equal("true", cut.Find("[data-state-stage='entry'] [data-activity-selected]").GetAttribute("data-activity-selected"));
         Assert.Contains("No exit activity configured", cut.Find("[data-state-stage='exit']").TextContent);
 
         nameInput.Change("Review");
-        cut.Find("[data-state-stage='entry'] [data-slot-action='open']").Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='select']").Click();
+        cut.Find("[data-state-stage='entry'] [data-slot-action='json']").Click();
         cut.Find("[data-state-stage='entry'] [data-slot-action='replace']").Click();
         cut.Find("[data-state-stage='entry'] [data-slot-action='clear']").Click();
         cut.Find("[data-state-stage='entry'] [data-slot-action='drop']").TriggerEvent("ondrop", new DragEventArgs());
@@ -130,7 +134,7 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
 
         Assert.Equal("Review", changedName);
         Assert.Equal("Pending", state.Name);
-        Assert.Equal(["open:entry", "replace:entry", "clear:entry", "drop:entry", "add:exit"], actions);
+        Assert.Equal(["select:entry", "json:entry", "replace:entry", "clear:entry", "drop:entry", "add:exit"], actions);
         Assert.True(viewedTransitions);
         Assert.DoesNotContain("textarea", cut.Markup, StringComparison.Ordinal);
     }
@@ -147,7 +151,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             .Add(component => component.IsReadOnly, true));
 
         Assert.True(cut.Find("input[id$='-name']").HasAttribute("disabled"));
-        Assert.Single(cut.FindAll("[data-slot-action='open']"));
+        Assert.Single(cut.FindAll("[data-slot-action='select']"));
+        Assert.Single(cut.FindAll("[data-slot-action='json']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='open']"));
         Assert.Empty(cut.FindAll("[data-slot-action='add']"));
         Assert.Empty(cut.FindAll("[data-slot-action='replace']"));
         Assert.Empty(cut.FindAll("[data-slot-action='clear']"));
@@ -190,7 +196,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         Assert.Contains("Elsa.Event", cut.Find("[data-transition-slot='trigger']").TextContent);
         Assert.Contains("Elsa.WriteLine", cut.Find("[data-transition-slot='action']").TextContent);
         Assert.Equal("always", cut.Find("[data-transition-slot='condition'] [data-condition-state]").GetAttribute("data-condition-state"));
-        Assert.NotEmpty(cut.FindAll("[data-slot-action='open']"));
+        Assert.NotEmpty(cut.FindAll("[data-slot-action='select']"));
+        Assert.NotEmpty(cut.FindAll("[data-slot-action='json']"));
+        Assert.Empty(cut.FindAll("[data-slot-action='open']"));
         Assert.NotEmpty(cut.FindAll("[data-slot-action='replace']"));
         Assert.NotEmpty(cut.FindAll("[data-slot-action='clear']"));
 
@@ -279,6 +287,28 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         Assert.Contains("JavaScript", summary.TextContent);
         Assert.Contains("context.input === true", summary.TextContent);
         Assert.Equal(source, condition.ToJsonString());
+    }
+
+    [Fact]
+    public void TransitionInspector_RendersExpressionLanguageAndValueAsDistinctElements()
+    {
+        var condition = new JsonObject
+        {
+            ["typeName"] = "Boolean",
+            ["expression"] = new JsonObject { ["type"] = "JavaScript", ["value"] = "return 1 == 1" }
+        };
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition,
+            new StateMachineTransitionEdge { From = "Pending", To = "Approved", Condition = condition }));
+
+        var summary = cut.Find("[data-testid='state-machine-transition-condition-summary']");
+        var language = summary.QuerySelector("[data-condition-language]");
+        var expression = summary.QuerySelector("[data-condition-expression]");
+
+        Assert.NotNull(language);
+        Assert.Equal("JavaScript", language!.TextContent);
+        Assert.NotNull(expression);
+        Assert.Equal("return 1 == 1", expression!.TextContent);
+        Assert.NotSame(language, expression);
     }
 
     [Fact]
@@ -400,6 +430,7 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         };
         var configuredCut = Render<StateMachineTransitionInspector>(parameters => parameters
             .Add(component => component.Transition, configured)
+            .Add(component => component.TriggerSupportsDesigner, true)
             .Add(component => component.ActivityOpenRequested, slot => slots.Add($"open:{slot}"))
             .Add(component => component.ActivityReplaceRequested, slot => slots.Add($"replace:{slot}"))
             .Add(component => component.ActivityClearRequested, slot => slots.Add($"clear:{slot}"))
@@ -434,7 +465,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
 
         Assert.Contains("WHEN", cut.Markup);
         Assert.Contains("Never", cut.Markup);
-        Assert.Equal(2, cut.FindAll("[data-slot-action='open']").Count);
+        Assert.Empty(cut.FindAll("[data-slot-action='open']"));
+        Assert.Equal(2, cut.FindAll("[data-slot-action='select']").Count);
+        Assert.Equal(2, cut.FindAll("[data-slot-action='json']").Count);
         Assert.Empty(cut.FindAll("[data-slot-action='add']"));
         Assert.Empty(cut.FindAll("[data-slot-action='replace']"));
         Assert.Empty(cut.FindAll("[data-slot-action='clear']"));
@@ -459,6 +492,8 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         var cut = Render<StateMachineTransitionInspector>(parameters => parameters
             .Add(component => component.Transition, transition)
             .Add(component => component.IsReadOnly, true)
+            .Add(component => component.TriggerSupportsDesigner, true)
+            .Add(component => component.ActionSupportsDesigner, true)
             .Add(component => component.ActivityOpenRequested, slot => opened.Add(slot))
             .Add(component => component.ActivityDropRequested, slot => dropped.Add(slot)));
 
@@ -483,7 +518,10 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             Condition = JsonValue.Create(true),
             Action = Activity("Elsa.WriteLine", "Action1", "Workflow1:Action1")
         };
-        var cut = Render<StateMachineTransitionInspector>(parameters => parameters.Add(component => component.Transition, transition));
+        var cut = Render<StateMachineTransitionInspector>(parameters => parameters
+            .Add(component => component.Transition, transition)
+            .Add(component => component.TriggerSupportsDesigner, true)
+            .Add(component => component.ActionSupportsDesigner, true));
 
         var actionButtons = cut.FindAll("[data-transition-slot] button");
         Assert.NotEmpty(actionButtons);
@@ -493,7 +531,7 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             Assert.False(string.IsNullOrWhiteSpace(button.GetAttribute("aria-label")) && string.IsNullOrWhiteSpace(button.TextContent));
         });
 
-        foreach (var action in new[] { "open", "replace", "clear" })
+        foreach (var action in new[] { "select", "open", "json", "replace", "clear" })
         {
             var triggerButton = cut.Find($"[data-transition-slot='trigger'] [data-slot-action='{action}']");
             var activityButton = cut.Find($"[data-transition-slot='action'] [data-slot-action='{action}']");

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -151,7 +151,9 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             .Add(component => component.IsReadOnly, true));
 
         Assert.True(cut.Find("input[id$='-name']").HasAttribute("disabled"));
-        Assert.Single(cut.FindAll("[data-slot-action='select']"));
+        var propertiesButton = Assert.Single(cut.FindAll("[data-slot-action='select']"));
+        Assert.Equal("View properties", propertiesButton.TextContent.Trim());
+        Assert.Equal("View entry activity properties", propertiesButton.GetAttribute("aria-label"));
         Assert.Single(cut.FindAll("[data-slot-action='json']"));
         Assert.Empty(cut.FindAll("[data-slot-action='open']"));
         Assert.Empty(cut.FindAll("[data-slot-action='add']"));
@@ -466,7 +468,11 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
         Assert.Contains("WHEN", cut.Markup);
         Assert.Contains("Never", cut.Markup);
         Assert.Empty(cut.FindAll("[data-slot-action='open']"));
-        Assert.Equal(2, cut.FindAll("[data-slot-action='select']").Count);
+        var propertiesButtons = cut.FindAll("[data-slot-action='select']");
+        Assert.Equal(2, propertiesButtons.Count);
+        Assert.All(propertiesButtons, button => Assert.Equal("View properties", button.TextContent.Trim()));
+        Assert.Equal("View trigger activity properties", propertiesButtons[0].GetAttribute("aria-label"));
+        Assert.Equal("View action activity properties", propertiesButtons[1].GetAttribute("aria-label"));
         Assert.Equal(2, cut.FindAll("[data-slot-action='json']").Count);
         Assert.Empty(cut.FindAll("[data-slot-action='add']"));
         Assert.Empty(cut.FindAll("[data-slot-action='replace']"));

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor
@@ -1,11 +1,13 @@
 @using Elsa.Api.Client.Resources.ActivityDescriptors.Models
 @namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
 
-<MudDialog Class="state-machine-activity-picker-dialog">
+<MudDialog Class="state-machine-activity-picker-dialog" DefaultFocus="DefaultFocus.None">
     <DialogContent>
         <section class="state-machine-activity-picker"
                  data-testid="state-machine-activity-picker"
-                 aria-label="@PickerHeading">
+                 aria-label="@PickerHeading"
+                 aria-keyshortcuts="/"
+                 @onkeydown="HandleGlobalKeyboardAsync">
             <header class="state-machine-activity-picker__header">
                 <p class="state-machine-activity-picker__eyebrow">@Localizer["Activity library"]</p>
                 <p class="state-machine-activity-picker__context"><strong>@ContextKicker</strong><span aria-hidden="true">·</span>@ContextDescription</p>
@@ -106,6 +108,10 @@
                                                 {
                                                     <span class="state-machine-activity-picker__recommended">@Localizer["Recommended"]</span>
                                                 }
+                                                else if (IsDesignerBackedRoot(descriptor))
+                                                {
+                                                    <span class="state-machine-activity-picker__recommended">@Localizer["Visual designer"]</span>
+                                                }
                                             </span>
                                             <span>@descriptor.TypeName</span>
                                         </span>
@@ -133,6 +139,13 @@
                                 <div class="state-machine-activity-picker__note" role="note">
                                     <strong>@Localizer["Runs multiple activities"]</strong>
                                     <span>@Localizer["After adding Sequence, open it to arrange its child activities."]</span>
+                                </div>
+                            }
+                            else if (IsDesignerBackedRoot(_selectedDescriptor))
+                            {
+                                <div class="state-machine-activity-picker__note" role="note">
+                                    <strong>@Localizer["Includes a visual designer"]</strong>
+                                    <span>@Localizer["After adding it, use Open designer to configure its internal workflow."]</span>
                                 </div>
                             }
                         }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
@@ -18,6 +18,7 @@ public partial class StateMachineActivityPickerDialog
     private const string AllSection = "all";
     private readonly string _id = $"state-machine-activity-picker-{Guid.NewGuid():N}";
     private IReadOnlyList<ActivityDescriptor> _descriptors = [];
+    private IReadOnlySet<string> _rootActivityTypeNames = new HashSet<string>(StringComparer.Ordinal);
     private string _searchText = string.Empty;
     private string _selectedSection = SuggestedSection;
     private ActivityDescriptor? _selectedDescriptor;
@@ -28,6 +29,7 @@ public partial class StateMachineActivityPickerDialog
 
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
+    [Inject] private IWorkflowRootActivityTemplateProvider RootActivityTemplateProvider { get; set; } = null!;
     [Inject] private ILocalizer Localizer { get; set; } = null!;
 
     [Parameter] public string SlotName { get; set; } = "action";
@@ -64,9 +66,13 @@ public partial class StateMachineActivityPickerDialog
     };
 
     private IReadOnlyList<ActivityDescriptor> SuggestedDescriptors =>
-        string.Equals(SlotName, "trigger", StringComparison.OrdinalIgnoreCase) || SequenceDescriptor == null
+        string.Equals(SlotName, "trigger", StringComparison.OrdinalIgnoreCase)
             ? []
-            : [SequenceDescriptor];
+            : _descriptors
+                .Where(IsDesignerBackedRoot)
+                .OrderBy(x => ReferenceEquals(x, SequenceDescriptor) ? 0 : 1)
+                .ThenBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
     private IReadOnlyList<ActivityDescriptor> RecentDescriptors => RecentActivityTypes
         .Select(type => _descriptors.FirstOrDefault(x => string.Equals(x.TypeName, type, StringComparison.Ordinal)))
@@ -119,12 +125,13 @@ public partial class StateMachineActivityPickerDialog
             await ActivityRegistry.EnsureLoadedAsync();
             var allDescriptors = ActivityRegistry.List().ToList();
             var browsableDescriptors = ActivityRegistry.ListBrowsable().ToList();
-            var sequence = allDescriptors.FirstOrDefault(x => string.Equals(x.TypeName, "Elsa.Sequence", StringComparison.Ordinal))
-                           ?? ActivityRegistry.Find("Elsa.Sequence");
-            if (sequence != null && browsableDescriptors.All(x => !string.Equals(x.TypeName, sequence.TypeName, StringComparison.Ordinal)))
-                browsableDescriptors.Add(sequence);
+            _rootActivityTypeNames = RootActivityTemplateProvider.List()
+                .Select(x => x.Key)
+                .ToHashSet(StringComparer.Ordinal);
+            var designerBackedRoots = allDescriptors.Where(x => _rootActivityTypeNames.Contains(x.TypeName));
 
             _descriptors = browsableDescriptors
+                .Concat(designerBackedRoots)
                 .DistinctBy(x => x.TypeName, StringComparer.Ordinal)
                 .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
@@ -145,11 +152,14 @@ public partial class StateMachineActivityPickerDialog
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!_focusSearch || _isLoading || _loadError != null)
+        if (_isLoading || _loadError != null)
             return;
 
-        _focusSearch = false;
-        await _searchInput.FocusAsync();
+        if (_focusSearch)
+        {
+            _focusSearch = false;
+            await _searchInput.FocusAsync();
+        }
     }
 
     private void OnSearchInput(ChangeEventArgs args)
@@ -182,12 +192,6 @@ public partial class StateMachineActivityPickerDialog
 
     private Task HandleKeyboardAsync(KeyboardEventArgs args)
     {
-        if (args.Key == "/")
-        {
-            _focusSearch = true;
-            return InvokeAsync(StateHasChanged);
-        }
-
         var results = VisibleDescriptors;
         if (results.Count == 0)
             return Task.CompletedTask;
@@ -206,6 +210,15 @@ public partial class StateMachineActivityPickerDialog
         }
 
         return Task.CompletedTask;
+    }
+
+    private Task HandleGlobalKeyboardAsync(KeyboardEventArgs args)
+    {
+        if (args.Key != "/")
+            return Task.CompletedTask;
+
+        _focusSearch = true;
+        return InvokeAsync(StateHasChanged);
     }
 
     private void EnsureSelection()
@@ -232,6 +245,7 @@ public partial class StateMachineActivityPickerDialog
         value?.Contains(search, StringComparison.OrdinalIgnoreCase) == true;
 
     private string GetDisplayName(ActivityDescriptor descriptor) => Localizer[descriptor.DisplayName ?? descriptor.Name].Value;
+    private bool IsDesignerBackedRoot(ActivityDescriptor descriptor) => _rootActivityTypeNames.Contains(descriptor.TypeName);
     private string GetCategory(ActivityDescriptor descriptor) => string.IsNullOrWhiteSpace(descriptor.Category) ? Localizer["Other"] : Localizer[descriptor.Category];
     private string GetResultId(ActivityDescriptor descriptor) => $"{_id}-activity-{SanitizeId(descriptor.TypeName)}";
     private static string SanitizeId(string value) => new(value.Select(character => char.IsLetterOrDigit(character) ? character : '-').ToArray());

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
@@ -62,9 +62,9 @@
                             class="state-machine-activity-slot__button state-machine-activity-slot__button--primary"
                             data-slot-action="select"
                             aria-pressed="@IsSelected"
-                            aria-label="@Localizer[$"Edit {SlotName} activity properties"]"
+                            aria-label="@Localizer[$"{(IsReadOnly ? "View" : "Edit")} {SlotName} activity properties"]"
                             @onclick="RequestSelectAsync">
-                        @Localizer["Edit properties"]
+                        @(IsReadOnly ? Localizer["View properties"] : Localizer["Edit properties"])
                     </button>
                     @if (SupportsDesigner)
                     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor
@@ -31,9 +31,10 @@
     }
     else
     {
-        <div class="@(Presentation.State == StateMachineActivityState.Malformed ? "state-machine-activity-slot__card state-machine-activity-slot__card--invalid" : "state-machine-activity-slot__card")"
+        <div class="@CardClass"
              data-testid="@($"{TestIdPrefix}-{SlotName}-activity")"
-             data-activity-state="@Presentation.State.ToString().ToLowerInvariant()">
+             data-activity-state="@Presentation.State.ToString().ToLowerInvariant()"
+             data-activity-selected="@IsSelected.ToString().ToLowerInvariant()">
             <div class="state-machine-activity-slot__copy">
                 <strong>@Presentation.Title</strong>
                 <span>@Presentation.Detail</span>
@@ -54,38 +55,53 @@
                 </details>
             }
 
-            @if (Presentation.State != StateMachineActivityState.Malformed || !IsReadOnly)
-            {
-                <div class="state-machine-activity-slot__actions">
-                    @if (Presentation.State != StateMachineActivityState.Malformed)
+            <div class="state-machine-activity-slot__actions">
+                @if (Presentation.State != StateMachineActivityState.Malformed)
+                {
+                    <button type="button"
+                            class="state-machine-activity-slot__button state-machine-activity-slot__button--primary"
+                            data-slot-action="select"
+                            aria-pressed="@IsSelected"
+                            aria-label="@Localizer[$"Edit {SlotName} activity properties"]"
+                            @onclick="RequestSelectAsync">
+                        @Localizer["Edit properties"]
+                    </button>
+                    @if (SupportsDesigner)
                     {
                         <button type="button"
                                 class="state-machine-activity-slot__button"
                                 data-slot-action="open"
-                                aria-label="@Localizer[$"Open {SlotName} activity"]"
+                                aria-label="@Localizer[$"Open {SlotName} activity designer"]"
                                 @onclick="RequestOpenAsync">
-                            @Localizer["Open"]
+                            @Localizer["Open designer"]
                         </button>
                     }
-                    @if (!IsReadOnly)
-                    {
-                        <button type="button"
-                                class="state-machine-activity-slot__button"
-                                data-slot-action="replace"
-                                aria-label="@Localizer[$"Replace {SlotName} activity"]"
-                                @onclick="RequestReplaceAsync">
-                            @Localizer["Replace"]
-                        </button>
-                        <button type="button"
-                                class="state-machine-activity-slot__button state-machine-activity-slot__button--subtle"
-                                data-slot-action="clear"
-                                aria-label="@Localizer[$"Clear {SlotName} activity"]"
-                                @onclick="RequestClearAsync">
-                            @Localizer["Clear"]
-                        </button>
-                    }
-                </div>
-            }
+                }
+                <button type="button"
+                        class="state-machine-activity-slot__button"
+                        data-slot-action="json"
+                        aria-label="@Localizer[$"{(IsReadOnly ? "View" : "Edit")} {SlotName} activity JSON"]"
+                        @onclick="RequestJsonAsync">
+                    @(IsReadOnly ? Localizer["View JSON"] : Localizer["Edit JSON"])
+                </button>
+                @if (!IsReadOnly)
+                {
+                    <button type="button"
+                            class="state-machine-activity-slot__button"
+                            data-slot-action="replace"
+                            aria-label="@Localizer[$"Replace {SlotName} activity"]"
+                            @onclick="RequestReplaceAsync">
+                        @Localizer["Replace"]
+                    </button>
+                    <button type="button"
+                            class="state-machine-activity-slot__button state-machine-activity-slot__button--subtle"
+                            data-slot-action="clear"
+                            aria-label="@Localizer[$"Clear {SlotName} activity"]"
+                            @onclick="RequestClearAsync">
+                        @Localizer["Clear"]
+                    </button>
+                }
+            </div>
         </div>
     }
 </div>
@@ -98,13 +114,23 @@
     [Parameter, EditorRequired] public string EmptyDescription { get; set; } = null!;
     [Parameter, EditorRequired] public string AddLabel { get; set; } = null!;
     [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public bool IsSelected { get; set; }
+    [Parameter] public bool SupportsDesigner { get; set; }
     [Parameter] public EventCallback<string> AddRequested { get; set; }
+    [Parameter] public EventCallback<string> SelectRequested { get; set; }
     [Parameter] public EventCallback<string> OpenRequested { get; set; }
+    [Parameter] public EventCallback<string> JsonRequested { get; set; }
     [Parameter] public EventCallback<string> ReplaceRequested { get; set; }
     [Parameter] public EventCallback<string> ClearRequested { get; set; }
     [Parameter] public EventCallback<string> DropRequested { get; set; }
 
     private StateMachineActivityPresentation Presentation => StateMachineActivityPresentation.Describe(Value, Localizer);
+    private string CardClass => string.Join(" ", new[]
+    {
+        "state-machine-activity-slot__card",
+        Presentation.State == StateMachineActivityState.Malformed ? "state-machine-activity-slot__card--invalid" : null,
+        IsSelected ? "state-machine-activity-slot__card--selected" : null
+    }.Where(x => x != null));
     private EventCallback<DragEventArgs> DragOverCallback => IsReadOnly
         ? default
         : EventCallback.Factory.Create<DragEventArgs>(this, _ => Task.CompletedTask);
@@ -113,7 +139,9 @@
         : EventCallback.Factory.Create<DragEventArgs>(this, _ => RequestDropAsync());
 
     private Task RequestAddAsync() => AddRequested.InvokeAsync(SlotName);
+    private Task RequestSelectAsync() => SelectRequested.InvokeAsync(SlotName);
     private Task RequestOpenAsync() => OpenRequested.InvokeAsync(SlotName);
+    private Task RequestJsonAsync() => JsonRequested.InvokeAsync(SlotName);
     private Task RequestReplaceAsync() => ReplaceRequested.InvokeAsync(SlotName);
     private Task RequestClearAsync() => ClearRequested.InvokeAsync(SlotName);
     private Task RequestDropAsync() => IsReadOnly ? Task.CompletedTask : DropRequested.InvokeAsync(SlotName);

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivitySlot.razor.css
@@ -45,6 +45,15 @@
   align-items: start;
   gap: 0.625rem;
   min-width: 0;
+  margin: -0.375rem;
+  padding: 0.375rem;
+  border: 1px solid transparent;
+  border-radius: var(--mud-default-borderradius);
+}
+
+.state-machine-activity-slot__card--selected {
+  border-color: var(--mud-palette-primary);
+  background: color-mix(in srgb, var(--mud-palette-primary) 7%, transparent);
 }
 
 .state-machine-activity-slot__copy {
@@ -83,6 +92,10 @@
 
 .state-machine-activity-slot__button--subtle {
   color: var(--mud-palette-text-secondary);
+}
+
+.state-machine-activity-slot__button--primary {
+  background: color-mix(in srgb, var(--mud-palette-primary) 10%, transparent);
 }
 
 .state-machine-activity-slot__button:focus-visible,

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineStateInspector.razor
@@ -1,3 +1,6 @@
+@using System.Text.Json.Nodes
+@using Elsa.Api.Client.Extensions
+@using Elsa.Studio.Workflows.Designer
 @using Elsa.Studio.Workflows.Designer.Models
 @using Elsa.Studio.Localization
 @namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation
@@ -59,8 +62,12 @@
                                               EmptyDescription="@Localizer["Nothing runs when this state becomes active."]"
                                               AddLabel="@Localizer["Add activity"]"
                                               IsReadOnly="@IsReadOnly"
+                                              IsSelected="@IsActivitySelected(State.Entry)"
+                                              SupportsDesigner="@EntrySupportsDesigner"
                                               AddRequested="RequestActivityAddAsync"
+                                              SelectRequested="RequestActivitySelectAsync"
                                               OpenRequested="RequestActivityOpenAsync"
+                                              JsonRequested="RequestActivityJsonAsync"
                                               ReplaceRequested="RequestActivityReplaceAsync"
                                               ClearRequested="RequestActivityClearAsync"
                                               DropRequested="RequestActivityDropAsync" />
@@ -113,8 +120,12 @@
                                               EmptyDescription="@Localizer["Nothing runs before this state is left."]"
                                               AddLabel="@Localizer["Add activity"]"
                                               IsReadOnly="@IsReadOnly"
+                                              IsSelected="@IsActivitySelected(State.Exit)"
+                                              SupportsDesigner="@ExitSupportsDesigner"
                                               AddRequested="RequestActivityAddAsync"
+                                              SelectRequested="RequestActivitySelectAsync"
                                               OpenRequested="RequestActivityOpenAsync"
+                                              JsonRequested="RequestActivityJsonAsync"
                                               ReplaceRequested="RequestActivityReplaceAsync"
                                               ClearRequested="RequestActivityClearAsync"
                                               DropRequested="RequestActivityDropAsync" />
@@ -167,12 +178,17 @@
     [Parameter] public bool IsReadOnly { get; set; }
     [Parameter] public bool IsInitial { get; set; }
     [Parameter] public bool IsCurrent { get; set; }
+    [Parameter] public string? SelectedActivityId { get; set; }
+    [Parameter] public bool EntrySupportsDesigner { get; set; }
+    [Parameter] public bool ExitSupportsDesigner { get; set; }
     [Parameter] public int IncomingTransitionCount { get; set; }
     [Parameter] public int OutgoingTransitionCount { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
     [Parameter] public EventCallback<string> NameChanged { get; set; }
     [Parameter] public EventCallback<string> ActivityAddRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivitySelectRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityOpenRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityJsonRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityReplaceRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityClearRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityDropRequested { get; set; }
@@ -190,8 +206,12 @@
 
     private Task ChangeNameAsync(ChangeEventArgs args) => NameChanged.InvokeAsync(args.Value?.ToString() ?? "");
     private Task RequestActivityAddAsync(string slotName) => ActivityAddRequested.InvokeAsync(slotName);
+    private Task RequestActivitySelectAsync(string slotName) => ActivitySelectRequested.InvokeAsync(slotName);
     private Task RequestActivityOpenAsync(string slotName) => ActivityOpenRequested.InvokeAsync(slotName);
+    private Task RequestActivityJsonAsync(string slotName) => ActivityJsonRequested.InvokeAsync(slotName);
     private Task RequestActivityReplaceAsync(string slotName) => ActivityReplaceRequested.InvokeAsync(slotName);
     private Task RequestActivityClearAsync(string slotName) => ActivityClearRequested.InvokeAsync(slotName);
     private Task RequestActivityDropAsync(string slotName) => ActivityDropRequested.InvokeAsync(slotName);
+    private bool IsActivitySelected(JsonNode? activity) => activity is JsonObject obj &&
+        (string.Equals(obj.GetId(), SelectedActivityId, StringComparison.Ordinal) || string.Equals(obj.GetNodeId(), SelectedActivityId, StringComparison.Ordinal));
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor
@@ -44,8 +44,12 @@
                                               EmptyDescription="@Localizer["This transition evaluates immediately after source entry."]"
                                               AddLabel="@Localizer["Add trigger"]"
                                               IsReadOnly="@IsReadOnly"
+                                              IsSelected="@IsActivitySelected(Transition.Trigger)"
+                                              SupportsDesigner="@TriggerSupportsDesigner"
                                               AddRequested="RequestActivityAddAsync"
+                                              SelectRequested="RequestActivitySelectAsync"
                                               OpenRequested="RequestActivityOpenAsync"
+                                              JsonRequested="RequestActivityJsonAsync"
                                               ReplaceRequested="RequestActivityReplaceAsync"
                                               ClearRequested="RequestActivityClearAsync"
                                               DropRequested="RequestActivityDropAsync" />
@@ -73,7 +77,46 @@
                             </button>
                         }
                     </div>
-                    @RenderCondition(Transition.Condition)
+                    @{
+                        var condition = DescribeCondition(Transition.Condition);
+                    }
+                    <div class="@(condition.State is ConditionState.Never or ConditionState.Malformed
+                                      ? "state-machine-transition-inspector__condition state-machine-transition-inspector__condition--warning"
+                                      : "state-machine-transition-inspector__condition")"
+                         data-condition-state="@condition.State.ToString().ToLowerInvariant()"
+                         data-testid="state-machine-transition-condition-summary">
+                        @if (condition.State == ConditionState.Expression)
+                        {
+                            <dl class="state-machine-transition-inspector__condition-expression">
+                                <div>
+                                    <dt>@Localizer["Language"]</dt>
+                                    <dd data-condition-language>@condition.Title</dd>
+                                </div>
+                                <div>
+                                    <dt>@Localizer["Expression"]</dt>
+                                    <dd data-condition-expression><code>@condition.Detail</code></dd>
+                                </div>
+                            </dl>
+                        }
+                        else
+                        {
+                            <strong>@condition.Title</strong>
+                            <span>@condition.Detail</span>
+                        }
+
+                        @if (!string.IsNullOrWhiteSpace(condition.Warning))
+                        {
+                            <p class="state-machine-transition-inspector__slot-warning" role="status">@condition.Warning</p>
+                        }
+
+                        @if (!string.IsNullOrWhiteSpace(condition.RawDefinition))
+                        {
+                            <details class="state-machine-transition-inspector__definition">
+                                <summary>@Localizer["View definition"]</summary>
+                                <pre data-testid="state-machine-transition-condition-definition">@condition.RawDefinition</pre>
+                            </details>
+                        }
+                    </div>
                 </div>
             </section>
 
@@ -96,8 +139,12 @@
                                               EmptyDescription="@Localizer["No activity runs between source exit and the target state."]"
                                               AddLabel="@Localizer["Add action"]"
                                               IsReadOnly="@IsReadOnly"
+                                              IsSelected="@IsActivitySelected(Transition.Action)"
+                                              SupportsDesigner="@ActionSupportsDesigner"
                                               AddRequested="RequestActivityAddAsync"
+                                              SelectRequested="RequestActivitySelectAsync"
                                               OpenRequested="RequestActivityOpenAsync"
+                                              JsonRequested="RequestActivityJsonAsync"
                                               ReplaceRequested="RequestActivityReplaceAsync"
                                               ClearRequested="RequestActivityClearAsync"
                                               DropRequested="RequestActivityDropAsync" />

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Models;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 
@@ -15,6 +15,9 @@ public partial class StateMachineTransitionInspector
     [Parameter] public StateMachineTransitionEdge? Transition { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineStateNode> States { get; set; } = [];
     [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public string? SelectedActivityId { get; set; }
+    [Parameter] public bool TriggerSupportsDesigner { get; set; }
+    [Parameter] public bool ActionSupportsDesigner { get; set; }
     [Parameter] public IReadOnlyCollection<StateMachineValidationIssue> ValidationIssues { get; set; } = [];
     [Parameter] public IReadOnlyCollection<string> KnownExpressionProviderTypes { get; set; } = DefaultKnownExpressionProviderTypes;
     [Parameter] public EventCallback<string?> NameChanged { get; set; }
@@ -29,7 +32,9 @@ public partial class StateMachineTransitionInspector
     [Parameter] public EventCallback<string> SlotDropRequested { get; set; }
 
     [Parameter] public EventCallback<string> ActivityAddRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivitySelectRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityOpenRequested { get; set; }
+    [Parameter] public EventCallback<string> ActivityJsonRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityReplaceRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityClearRequested { get; set; }
     [Parameter] public EventCallback<string> ActivityDropRequested { get; set; }
@@ -54,7 +59,9 @@ public partial class StateMachineTransitionInspector
     private Task RequestConditionEditAsync() => ConditionEditRequested.InvokeAsync("condition");
 
     private Task RequestActivityAddAsync(string slotName) => ActivityAddRequested.InvokeAsync(slotName);
+    private Task RequestActivitySelectAsync(string slotName) => ActivitySelectRequested.InvokeAsync(slotName);
     private Task RequestActivityOpenAsync(string slotName) => ActivityOpenRequested.InvokeAsync(slotName);
+    private Task RequestActivityJsonAsync(string slotName) => ActivityJsonRequested.InvokeAsync(slotName);
     private Task RequestActivityReplaceAsync(string slotName) => ActivityReplaceRequested.InvokeAsync(slotName);
 
     private Task RequestActivityClearAsync(string slotName) => ActivityClearRequested.HasDelegate
@@ -71,49 +78,8 @@ public partial class StateMachineTransitionInspector
         return string.IsNullOrWhiteSpace(text) ? null : text;
     }
 
-    private RenderFragment RenderCondition(JsonNode? value) => builder =>
-    {
-        var condition = DescribeCondition(value);
-        var sequence = 0;
-
-        builder.OpenElement(sequence++, "div");
-        builder.AddAttribute(sequence++, "class", condition.State is ConditionState.Never or ConditionState.Malformed
-            ? "state-machine-transition-inspector__condition state-machine-transition-inspector__condition--warning"
-            : "state-machine-transition-inspector__condition");
-        builder.AddAttribute(sequence++, "data-condition-state", condition.State.ToString().ToLowerInvariant());
-        builder.AddAttribute(sequence++, "data-testid", "state-machine-transition-condition-summary");
-        builder.OpenElement(sequence++, "strong");
-        builder.AddContent(sequence++, condition.Title);
-        builder.CloseElement();
-        builder.OpenElement(sequence++, "span");
-        builder.AddContent(sequence++, condition.Detail);
-        builder.CloseElement();
-
-        if (!string.IsNullOrWhiteSpace(condition.Warning))
-        {
-            builder.OpenElement(sequence++, "p");
-            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__slot-warning");
-            builder.AddAttribute(sequence++, "role", "status");
-            builder.AddContent(sequence++, condition.Warning);
-            builder.CloseElement();
-        }
-
-        if (!string.IsNullOrWhiteSpace(condition.RawDefinition))
-        {
-            builder.OpenElement(sequence++, "details");
-            builder.AddAttribute(sequence++, "class", "state-machine-transition-inspector__definition");
-            builder.OpenElement(sequence++, "summary");
-            builder.AddContent(sequence++, Localizer["View definition"]);
-            builder.CloseElement();
-            builder.OpenElement(sequence++, "pre");
-            builder.AddAttribute(sequence++, "data-testid", "state-machine-transition-condition-definition");
-            builder.AddContent(sequence++, condition.RawDefinition);
-            builder.CloseElement();
-            builder.CloseElement();
-        }
-
-        builder.CloseElement();
-    };
+    private bool IsActivitySelected(JsonNode? activity) => activity is JsonObject obj &&
+        (string.Equals(obj.GetId(), SelectedActivityId, StringComparison.Ordinal) || string.Equals(obj.GetNodeId(), SelectedActivityId, StringComparison.Ordinal));
 
     private ConditionPresentation DescribeCondition(JsonNode? value)
     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineTransitionInspector.razor.css
@@ -138,6 +138,53 @@
   font-weight: 600;
 }
 
+.state-machine-transition-inspector__condition-expression {
+  display: grid;
+  gap: 0.625rem;
+  min-width: 0;
+  margin: 0;
+}
+
+.state-machine-transition-inspector__condition-expression > div {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.state-machine-transition-inspector__condition-expression dt {
+  color: var(--mud-palette-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.state-machine-transition-inspector__condition-expression dd {
+  min-width: 0;
+  margin: 0;
+}
+
+.state-machine-transition-inspector__condition-expression dd[data-condition-language] {
+  color: var(--mud-palette-primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.state-machine-transition-inspector__condition-expression dd[data-condition-expression] code {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: var(--mud-default-borderradius);
+  background: var(--mud-palette-background-grey);
+  color: var(--mud-palette-text-primary);
+  font-family: monospace;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .state-machine-transition-inspector__button {
   min-height: 2.25rem;
   padding: 0.375rem 0.625rem;

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor
@@ -25,18 +25,22 @@
 
             @if (!IsReadOnly)
             {
-                <details class="state-machine-designer__create-menu">
-                    <summary>@Localizer["Add"]</summary>
+                <details class="state-machine-designer__create-menu" name="state-machine-create">
+                    <summary>@Localizer["Add state"]</summary>
                     <div class="state-machine-designer__create-popover">
                         <label>
                             <span>@Localizer["State name"]</span>
                             <input class="state-machine-designer__control" @bind="_newStateName" />
                         </label>
                         <button type="button" class="state-machine-designer__button state-machine-designer__button--primary" @onclick="AddStateAsync">@Localizer["Add state"]</button>
+                    </div>
+                </details>
 
-                        @if (_session.Graph.States.Count > 0)
-                        {
-                            <hr />
+                <details class="state-machine-designer__create-menu" name="state-machine-create">
+                    <summary>@Localizer["Add transition"]</summary>
+                    @if (_session.Graph.States.Count > 0)
+                    {
+                        <div class="state-machine-designer__create-popover">
                             <label>
                                 <span>@Localizer["Transition name"]</span>
                                 <input class="state-machine-designer__control" @bind="_newTransitionName" />
@@ -60,8 +64,14 @@
                                 </select>
                             </label>
                             <button type="button" class="state-machine-designer__button state-machine-designer__button--primary" @onclick="AddTransitionAsync">@Localizer["Add transition"]</button>
-                        }
-                    </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="state-machine-designer__create-popover state-machine-designer__create-popover--empty">
+                            <span>@Localizer["Add a state before adding a transition."]</span>
+                        </div>
+                    }
                 </details>
             }
         </header>
@@ -149,9 +159,14 @@
                                                 IncomingTransitionCount="@GetSelectedStateIncomingTransitionCount()"
                                                 OutgoingTransitionCount="@GetSelectedStateOutgoingTransitionCount()"
                                                 ValidationIssues="@GetSelectedStateIssues()"
+                                                SelectedActivityId="@_selectedActivityId"
+                                                EntrySupportsDesigner="@HasDiagramDesigner(SelectedState.Entry)"
+                                                ExitSupportsDesigner="@HasDiagramDesigner(SelectedState.Exit)"
                                                 NameChanged="RenameSelectedStateAsync"
                                                 ActivityAddRequested="AddStateActivityAsync"
+                                                ActivitySelectRequested="SelectStateActivityAsync"
                                                 ActivityOpenRequested="OpenStateActivityAsync"
+                                                ActivityJsonRequested="OpenStateActivityJsonAsync"
                                                 ActivityReplaceRequested="ReplaceStateActivityAsync"
                                                 ActivityClearRequested="ClearStateSlotAsync"
                                                 ActivityDropRequested="OnStateSlotDropAsync"
@@ -165,12 +180,17 @@
                                                      KnownExpressionProviderTypes="@_knownExpressionProviderTypes"
                                                      IsReadOnly="@IsReadOnly"
                                                      ValidationIssues="@GetSelectedTransitionIssues()"
+                                                     SelectedActivityId="@_selectedActivityId"
+                                                     TriggerSupportsDesigner="@HasDiagramDesigner(SelectedTransition.Trigger)"
+                                                     ActionSupportsDesigner="@HasDiagramDesigner(SelectedTransition.Action)"
                                                      NameChanged="SetTransitionNameAsync"
                                                      DisplayNameChanged="SetTransitionDisplayNameAsync"
                                                      FromChanged="SetTransitionFromAsync"
                                                      ToChanged="SetTransitionToAsync"
                                                      ActivityAddRequested="AddTransitionActivityAsync"
+                                                     ActivitySelectRequested="SelectTransitionActivityAsync"
                                                      ActivityOpenRequested="OpenTransitionActivityAsync"
+                                                     ActivityJsonRequested="OpenTransitionActivityJsonAsync"
                                                      ActivityReplaceRequested="ReplaceTransitionActivityAsync"
                                                      ActivityClearRequested="ClearTransitionSlotAsync"
                                                      ActivityDropRequested="OnTransitionSlotDropAsync"

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Components;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Components;
@@ -12,6 +13,7 @@ using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Models;
+using Elsa.Studio.Workflows.UI.Contracts;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
@@ -58,6 +60,7 @@ public partial class StateMachineDesignerWrapper
     [Inject] private IStateMachineMapper StateMachineMapper { get; set; } = null!;
     [Inject] private StateMachineValidator StateMachineValidator { get; set; } = null!;
     [Inject] private IDialogService DialogService { get; set; } = null!;
+    [Inject] private IDiagramDesignerService DiagramDesignerService { get; set; } = null!;
     [Inject] private IExpressionService ExpressionService { get; set; } = null!;
 
     private StateMachineStateNode? SelectedState =>
@@ -306,6 +309,14 @@ public partial class StateMachineDesignerWrapper
 
     private Task ReplaceStateActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, true, true);
 
+    private Task SelectStateActivityAsync(string slotName)
+    {
+        if (_session == null || _selectedStateId == null || !IsStateActivitySlot(slotName) || SelectedState is not { } state)
+            return Task.CompletedTask;
+
+        return SelectActivityForPropertiesAsync(GetStateSlot(state, slotName), slotName);
+    }
+
     private async Task OpenStateActivityAsync(string slotName)
     {
         if (_session == null || _selectedStateId == null || !IsStateActivitySlot(slotName) || SelectedState is not { } state)
@@ -320,6 +331,23 @@ public partial class StateMachineDesignerWrapper
     private Task AddTransitionActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, false, false);
 
     private Task ReplaceTransitionActivityAsync(string slotName) => OpenActivityPickerAsync(slotName, true, false);
+
+    private Task SelectTransitionActivityAsync(string slotName)
+    {
+        if (_session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || SelectedTransition is not { } transition)
+            return Task.CompletedTask;
+
+        return SelectActivityForPropertiesAsync(GetTransitionSlot(transition, slotName), slotName);
+    }
+
+    private async Task SelectActivityForPropertiesAsync(JsonNode? slot, string slotName)
+    {
+        if (slot is not JsonObject activity || !activity.IsActivity())
+            return;
+
+        _selectedSlotName = slotName;
+        await SelectSlotActivityForPropertiesAsync(activity);
+    }
 
     private async Task OpenTransitionActivityAsync(string slotName)
     {
@@ -340,6 +368,111 @@ public partial class StateMachineDesignerWrapper
         // Sequence as well as any other current or future composite activity.
         if (ActivityDoubleClick.HasDelegate)
             await ActivityDoubleClick.InvokeAsync(activity);
+    }
+
+    private Task OpenStateActivityJsonAsync(string slotName)
+    {
+        if (_session == null || _selectedStateId == null || !IsStateActivitySlot(slotName) || SelectedState is not { } state)
+            return Task.CompletedTask;
+
+        var stateId = _selectedStateId;
+        return OpenActivityJsonEditorAsync(slotName, GetStateSlot(state, slotName), value => ApplyEditedStateActivityJsonAsync(stateId, slotName, value));
+    }
+
+    private Task OpenTransitionActivityJsonAsync(string slotName)
+    {
+        if (_session == null || _selectedTransitionId == null || !IsTransitionActivitySlot(slotName) || SelectedTransition is not { } transition)
+            return Task.CompletedTask;
+
+        var transitionId = _selectedTransitionId;
+        return OpenActivityJsonEditorAsync(slotName, GetTransitionSlot(transition, slotName), value => ApplyEditedTransitionActivityJsonAsync(transitionId, slotName, value));
+    }
+
+    private async Task OpenActivityJsonEditorAsync(string slotName, JsonNode? slot, Func<string, Task> applyAsync)
+    {
+        if (slot == null)
+            return;
+
+        var originalActivity = slot is JsonObject obj && obj.IsActivity() ? obj : null;
+        var label = IsReadOnly ? Localizer["View {0} activity JSON", slotName] : Localizer["Edit {0} activity JSON", slotName];
+        var helperText = IsReadOnly
+            ? Localizer["Review the complete activity definition."]
+            : Localizer["Edit the complete activity definition. Activity identity must remain unchanged."];
+        var parameters = new DialogParameters<CodeEditorDialog>
+        {
+            { x => x.Label, label },
+            { x => x.HelperText, helperText },
+            { x => x.Value, StateMachinePresentationFormatter.JsonSlot(slot) },
+            { x => x.LanguageLabel, Localizer["JSON"] },
+            { x => x.MonacoLanguage, "json" },
+            { x => x.RequireExplicitApply, true },
+            { x => x.IsReadOnly, IsReadOnly },
+            { x => x.Validator, (Func<string, string?>)(value => ValidateActivityJson(value, originalActivity)) }
+        };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Large,
+            Position = DialogPosition.Center
+        };
+        var dialog = await DialogService.ShowAsync<CodeEditorDialog>(label, parameters, options);
+        var result = await dialog.Result;
+
+        if (IsReadOnly || result is not { Canceled: false, Data: string value })
+            return;
+
+        await applyAsync(value);
+    }
+
+    private async Task ApplyEditedStateActivityJsonAsync(string stateId, string slotName, string value)
+    {
+        if (IsReadOnly || _session == null || TryGetState(stateId) == null)
+            return;
+
+        _selectedStateId = stateId;
+        _session.SetStateSlot(stateId, ParseStateSlot(slotName), JsonNode.Parse(value));
+        await ApplySessionChangesAndRefreshSlotAsync(slotName, true);
+    }
+
+    private async Task ApplyEditedTransitionActivityJsonAsync(string transitionId, string slotName, string value)
+    {
+        if (IsReadOnly || _session == null || TryGetTransition(transitionId) == null)
+            return;
+
+        _selectedTransitionId = transitionId;
+        _session.SetTransitionSlot(transitionId, ParseTransitionSlot(slotName), JsonNode.Parse(value));
+        await ApplySessionChangesAndRefreshSlotAsync(slotName, true);
+    }
+
+    private string? ValidateActivityJson(string value, JsonObject? originalActivity)
+    {
+        JsonNode? parsed;
+        try
+        {
+            parsed = JsonNode.Parse(value);
+        }
+        catch (JsonException exception)
+        {
+            return Localizer[
+                "Invalid JSON at line {0}, column {1}. Check the highlighted syntax and try again.",
+                (exception.LineNumber ?? 0) + 1,
+                (exception.BytePositionInLine ?? 0) + 1];
+        }
+
+        if (parsed is not JsonObject activity)
+            return Localizer["The activity definition must be a JSON object."];
+        if (!activity.IsActivity())
+            return Localizer["The activity definition must include a type."];
+        if (string.IsNullOrWhiteSpace(activity.GetId()) || string.IsNullOrWhiteSpace(activity.GetNodeId()))
+            return Localizer["The activity definition must include an id and nodeId."];
+
+        if (originalActivity != null &&
+            (!string.Equals(activity.GetId(), originalActivity.GetId(), StringComparison.Ordinal) ||
+             !string.Equals(activity.GetNodeId(), originalActivity.GetNodeId(), StringComparison.Ordinal)))
+            return Localizer["The activity id and nodeId cannot be changed here."];
+
+        return null;
     }
 
     private async Task OpenActivityPickerAsync(string slotName, bool replacing, bool isStateSlot)
@@ -463,6 +596,9 @@ public partial class StateMachineDesignerWrapper
     private static bool IsStateActivitySlot(string slotName) =>
         string.Equals(slotName, "entry", StringComparison.Ordinal) ||
         string.Equals(slotName, "exit", StringComparison.Ordinal);
+
+    private bool HasDiagramDesigner(JsonNode? slot) => slot is JsonObject activity &&
+        activity.IsActivity() && DiagramDesignerService.HasDiagramDesigner(activity);
 
     private void RememberRecentActivity(string activityType)
     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.cs
@@ -395,9 +395,7 @@ public partial class StateMachineDesignerWrapper
 
         var originalActivity = slot is JsonObject obj && obj.IsActivity() ? obj : null;
         var label = IsReadOnly ? Localizer["View {0} activity JSON", slotName] : Localizer["Edit {0} activity JSON", slotName];
-        var helperText = IsReadOnly
-            ? Localizer["Review the complete activity definition."]
-            : Localizer["Edit the complete activity definition. Activity identity must remain unchanged."];
+        var helperText = GetActivityJsonHelperText(originalActivity);
         var parameters = new DialogParameters<CodeEditorDialog>
         {
             { x => x.Label, label },
@@ -423,6 +421,16 @@ public partial class StateMachineDesignerWrapper
             return;
 
         await applyAsync(value);
+    }
+
+    private string GetActivityJsonHelperText(JsonObject? originalActivity)
+    {
+        if (IsReadOnly)
+            return Localizer["Review the complete activity definition."];
+
+        return originalActivity == null
+            ? Localizer["Repair the activity definition. Include a type, id, and nodeId."]
+            : Localizer["Edit the complete activity definition. The activity id and nodeId cannot be changed here."];
     }
 
     private async Task ApplyEditedStateActivityJsonAsync(string stateId, string slotName, string value)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.css
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/StateMachineDesignerWrapper.razor.css
@@ -111,19 +111,17 @@
     box-shadow: var(--mud-elevation-8);
 }
 
+.state-machine-designer__create-popover--empty {
+    color: var(--mud-palette-text-secondary);
+    font-size: .75rem;
+}
+
 .state-machine-designer__create-popover label,
 .state-machine-designer__configuration label {
     display: grid;
     gap: .25rem;
     color: var(--mud-palette-text-secondary);
     font-size: .75rem;
-}
-
-.state-machine-designer__create-popover hr {
-    width: 100%;
-    margin: 0;
-    border: 0;
-    border-top: 1px solid var(--mud-palette-lines-default);
 }
 
 .state-machine-designer__configuration {


### PR DESCRIPTION
## Summary

- redesign the StateMachine state and transition inspectors around clear WF4-inspired authoring stages
- let embedded activities use the standard activity properties panel and provide a validated full-size JSON editor
- expose Flowchart, Sequence, and State Machine as supported composite activity choices
- improve StateMachine canvas routing, keyboard accessibility, focus styling, and add-state/add-transition actions

## Verification

- dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj -f net10.0 --no-restore --verbosity minimal (124 passed)
- dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj -f net10.0 --no-restore --verbosity minimal (70 passed)
- npm run build in src/modules/Elsa.Studio.Workflows.Designer/ClientLib
- dotnet build src/hosts/Elsa.Studio.Host.Server/Elsa.Studio.Host.Server.csproj -f net10.0 --no-restore --verbosity minimal
- browser walkthrough covering activity selection, standard property editing, JSON validation and cancellation, and composite activity choices

No Elsa Core runtime change was required.