### PR TITLE
fix: keep workflow detail timestamps in the configured time zone

### DIFF
--- a/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor.cs
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanel.razor.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text.Json;
 using Elsa.Studio.Components.DataPanelRenderers;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Localization.Time;
 using Elsa.Studio.Models;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
@@ -50,6 +50,7 @@ public partial class DataPanel : ComponentBase
     [Inject] private IClipboard Clipboard { get; set; } = null!;
     [Inject] private ISnackbar Snackbar { get; set; } = null!;
     [Inject] private IDialogService DialogService { get; set; } = null!;
+    [Inject] private ITimeFormatter TimeFormatter { get; set; } = null!;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -121,17 +122,20 @@ public partial class DataPanel : ComponentBase
 
     private string FormatTimestamp(object value, string? formatString)
     {
-        return value switch
-        {
-            DateTime dt => string.IsNullOrWhiteSpace(formatString)
-                ? dt.ToLocalTime().ToString(CultureInfo.CurrentUICulture)
-                : dt.ToLocalTime().ToString(formatString, CultureInfo.CurrentUICulture),
-            DateTimeOffset dto => string.IsNullOrWhiteSpace(formatString)
-                ? dto.ToLocalTime().ToString(CultureInfo.CurrentUICulture)
-                : dto.ToLocalTime().ToString(formatString, CultureInfo.CurrentUICulture),
-            _ => value.ToString() ?? string.Empty
-        };
+        var timestamp = GetTimestampValue(value);
+        return timestamp == null
+            ? value.ToString() ?? string.Empty
+            : TimeFormatter.Format(timestamp, string.IsNullOrWhiteSpace(formatString) ? "G" : formatString);
     }
+
+    internal static DateTimeOffset? GetTimestampValue(object value) => value switch
+    {
+        // Values without a kind follow the same UTC convention as the timestamp renderer.
+        DateTime { Kind: DateTimeKind.Unspecified } dt => new DateTimeOffset(dt, TimeSpan.Zero),
+        DateTime dt => new DateTimeOffset(dt),
+        DateTimeOffset dto => dto,
+        _ => null
+    };
 
     private string FormatNumber(object value)
     {

--- a/src/framework/Elsa.Studio.Shared/Components/DataPanelRenderers/DataPanelValueRenderer.razor
+++ b/src/framework/Elsa.Studio.Shared/Components/DataPanelRenderers/DataPanelValueRenderer.razor
@@ -58,19 +58,7 @@
     {
         @if (Item is { Format: DataPanelItemFormat.Timestamp, Value: DateTime or DateTimeOffset })
         {
-            var timestampValue = Item.Value switch
-            {
-                DateTime dt => dt.Kind switch
-                {
-                    DateTimeKind.Utc => new DateTimeOffset(dt),
-                    DateTimeKind.Local => new DateTimeOffset(dt),
-                    DateTimeKind.Unspecified => new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Unspecified), TimeSpan.Zero),
-                    _ => new DateTimeOffset(dt)
-                },
-                DateTimeOffset dto => dto,
-                _ => (DateTimeOffset?)null
-            };
-            <DataPanelTimestampValue Value="@timestampValue" Format="@(Item.FormatString ?? "G")" />
+            <DataPanelTimestampValue Value="@DataPanel.GetTimestampValue(Item.Value)" Format="@(string.IsNullOrWhiteSpace(Item.FormatString) ? "G" : Item.FormatString)" />
         }
         else if (Item.Format == DataPanelItemFormat.Code)
         {

--- a/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
+++ b/src/framework/Elsa.Studio.Shared/Models/DataPanelItem.cs
@@ -14,7 +14,7 @@ namespace Elsa.Studio.Models;
 /// <param name="LabelComponent">The optional custom component to render in the label cell.</param>
 /// <param name="Value">The raw value to be formatted and displayed.</param>
 /// <param name="Format">The built-in display format to use for the value.</param>
-/// <param name="FormatString">Optional format string for built-in formatters (e.g., "yyyy-MM-dd" for timestamps).</param>
+/// <param name="FormatString">Optional format string for built-in formatters (e.g., "yyyy-MM-dd" for timestamps). Timestamps use the configured time formatter and default to "G"; DateTime values without a kind are treated as UTC.</param>
 /// <param name="ValueTemplate">Custom render fragment for complete control over value display.</param>
 /// <param name="ValueComponentType">Custom component type for reusable value renderers.</param>
 public record DataPanelItem(

--- a/src/modules/Elsa.Studio.Workflows.Tests/DataPanelTimestampTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DataPanelTimestampTests.cs
@@ -1,0 +1,96 @@
+using Bunit;
+using Elsa.Studio.Components;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Localization.Time;
+using Elsa.Studio.Localization.Time.Components;
+using Elsa.Studio.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class DataPanelTimestampTests : BunitContext, IAsyncLifetime
+{
+    private readonly ClipboardStub _clipboard = new();
+
+    public DataPanelTimestampTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IClipboard>(_clipboard);
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    public static IEnumerable<object[]> TimestampValues()
+    {
+        var instant = new DateTimeOffset(2025, 9, 2, 21, 36, 0, TimeSpan.Zero);
+        foreach (var offsetHours in new[] { 0, -4 })
+        foreach (var value in new object[] { instant, instant.ToOffset(TimeSpan.FromHours(2)), instant.UtcDateTime, instant.LocalDateTime, instant.DateTime })
+            yield return [value, offsetHours];
+    }
+
+    [Theory]
+    [MemberData(nameof(TimestampValues))]
+    public async Task TimestampDisplayAndCopyUseTheConfiguredTimeZone(object value, int offsetHours)
+    {
+        var timeZone = TimeZoneInfo.CreateCustomTimeZone("Test zone", TimeSpan.FromHours(offsetHours), "Test zone", "Test zone");
+        Services.AddSingleton<ITimeFormatter>(new DefaultTimeFormatter(new TimeZoneProviderStub(timeZone)));
+        Render<MudPopoverProvider>();
+        var item = new DataPanelItem(Label: "Created", Value: value, Format: DataPanelItemFormat.Timestamp, FormatString: "yyyy-MM-dd HH:mm:ss zzz");
+        var panel = Render<DataPanel>(parameters => parameters.Add(x => x.Data, new DataPanelModel { item }));
+        var expected = offsetHours == 0 ? "2025-09-02 21:36:00 +00:00" : "2025-09-02 17:36:00 -04:00";
+
+        Assert.Equal(expected, panel.FindComponent<Timestamp>().Markup);
+        Assert.Equal(expected, panel.Instance.GetFormattedValue(item));
+
+        await panel.FindAll("button").Last().ClickAsync(new());
+        Assert.Equal(expected, _clipboard.Text);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void DefaultAndAutoFormatsMatchTheTimestampComponent(string? format)
+    {
+        Services.AddSingleton<ITimeFormatter>(new DefaultTimeFormatter(new TimeZoneProviderStub(TimeZoneInfo.Utc)));
+        Render<MudPopoverProvider>();
+        var value = new DateTimeOffset(2025, 9, 2, 21, 36, 0, TimeSpan.Zero);
+        var item = new DataPanelItem(Label: "Updated", Value: value, Format: DataPanelItemFormat.Timestamp, FormatString: format);
+        var panel = Render<DataPanel>(parameters => parameters.Add(x => x.Data, new DataPanelModel { item }));
+        var timestamp = Render<Timestamp>(parameters => parameters.Add(x => x.Value, value));
+
+        Assert.Equal(timestamp.Markup, panel.FindComponent<Timestamp>().Markup);
+        Assert.Equal(timestamp.Markup, panel.Instance.GetFormattedValue(item));
+        Assert.Equal(timestamp.Markup, panel.Instance.GetFormattedValue(item with { Format = DataPanelItemFormat.Auto }));
+        Assert.Equal(string.Empty, panel.Instance.GetFormattedValue(item with { Value = null }));
+    }
+
+    private sealed class TimeZoneProviderStub(TimeZoneInfo timeZone) : ITimeZoneProvider
+    {
+        public TimeZoneInfo GetTimeZone() => timeZone;
+    }
+
+    private sealed class ClipboardStub : IClipboard
+    {
+        public string? Text { get; private set; }
+        public Task CopyText(string text, CancellationToken cancellationToken = default)
+        {
+            Text = text;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}


### PR DESCRIPTION
## Purpose

Keep workflow Details and journal data-panel timestamps consistent when displaying, copying, or expanding a value. Fixes #591.

## Scope

- [x] Bug fix (behavior change)

## Description

The current Details renderer already honors Studio's configured time zone, but the shared data panel still formats copy/expanded-view text with the host's local time zone. For example, a value displayed as `21:36` with Studio configured for UTC copies as `23:36 +02:00` on an Amsterdam host. Automatically formatted date values have the same inconsistency.

Route data-panel timestamp formatting through `ITimeFormatter`, sharing the existing conversion policy with the visible renderer. Preserve explicit offsets and the existing UTC interpretation of `DateTimeKind.Unspecified`. Normalize missing or blank format strings to `G` in both paths; a whitespace-only format previously threw during rendering. Document the behavior on `DataPanelItem`.

## Verification

- Existing workflow tests before the change: 135/135 passed.
- New bUnit regressions before the fix: 13/13 failed with formatting differences or the whitespace-format exception.
- Complete modified workflow suite: 148/148 passed on .NET 10.
- Focused regressions repeated with `TZ=America/New_York`: 13/13 passed.
- `Elsa.Studio.Shared` built for .NET 8, 9, and 10 with zero warnings or errors.
- Root self-review and an independent review found no blocking findings; `git diff --check` passed.

Commands:

```sh
dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj -f net10.0
TZ=America/New_York dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj --no-build --no-restore -f net10.0 --filter FullyQualifiedName~DataPanelTimestampTests
dotnet build src/framework/Elsa.Studio.Shared/Elsa.Studio.Shared.csproj --no-restore
```

Tests exercise the shared rendered DataPanel and its clipboard action, covering UTC and non-UTC configured zones, source offsets, all DateTime kinds, default/custom formats, automatic formatting, and null values. Workflow Details and journal call sites are covered through that shared component rather than full-page browser tests.

## Screenshots / Recordings

No layout changes. The timestamp and clipboard differences are verified by component assertions described above.

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated
- [x] Documentation updated
- [x] No unrelated cleanup included
- [x] Relevant tests pass
