### PR TITLE
fix: preserve workflow metadata during rapid input changes

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionEditorParameterLifecycleTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionEditorParameterLifecycleTests.cs
@@ -116,6 +116,27 @@ public sealed class WorkflowDefinitionEditorParameterLifecycleTests
     }
 
     [Fact]
+    public async Task WorkflowDefinitionEditorCoalescesSameDefinitionLoadsWhileTheCurrentLoadIsPending()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var pendingLoad = service.EnqueueFind();
+        var cut = RenderOuterEditor(context, "definition-a");
+
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-a"));
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-a"));
+
+        Assert.Equal(1, service.FindByDefinitionIdCallCount);
+
+        var definition = CreateDefinition("definition a", "version-a");
+        definition.DefinitionId = "definition-a";
+        pendingLoad.SetResult(definition);
+
+        cut.WaitForAssertion(() => Assert.Same(definition, cut.Instance.GetSelectedWorkflowDefinitionVersion()));
+        Assert.Equal(1, service.FindByDefinitionIdCallCount);
+    }
+
+    [Fact]
     public async Task WorkflowDefinitionEditorKeepsTheLatestOutOfOrderDefinitionLoad()
     {
         await using var context = CreateContext();
@@ -141,6 +162,50 @@ public sealed class WorkflowDefinitionEditorParameterLifecycleTests
         secondLoad.SetResult(CreateDefinition("stale definition b", "version-b-old"));
         cut.WaitForState(() => cut.RenderCount > renderCount, TimeSpan.FromSeconds(5));
         Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
+        Assert.Equal(3, service.FindByDefinitionIdCallCount);
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionEditorIgnoresFailureFromAnObsoleteDefinitionLoad()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var firstLoad = service.EnqueueFind();
+        var cut = RenderOuterEditor(context, "definition-a");
+        var secondLoad = service.EnqueueFind();
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b"));
+
+        var latestDefinition = CreateDefinition("latest definition b", "version-b-latest");
+        latestDefinition.DefinitionId = "definition-b";
+        secondLoad.SetResult(latestDefinition);
+        cut.WaitForAssertion(() => Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion()));
+
+        var renderCount = cut.RenderCount;
+        firstLoad.SetException(new InvalidOperationException("obsolete definition load failed"));
+        cut.WaitForState(() => cut.RenderCount > renderCount, TimeSpan.FromSeconds(5));
+
+        Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionEditorPropagatesCurrentLoadFailureAndRetriesAfterFailure()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var cut = RenderOuterEditor(context, "definition-a");
+        service.FindException = new InvalidOperationException("current definition load failed");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b")));
+
+        Assert.Equal("current definition load failed", exception.Message);
+
+        service.FindException = null;
+        var recoveredDefinition = CreateDefinition("recovered", "version-b");
+        recoveredDefinition.DefinitionId = "definition-b";
+        service.FindResultFactory = _ => recoveredDefinition;
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b"));
+
+        Assert.Same(recoveredDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
         Assert.Equal(3, service.FindByDefinitionIdCallCount);
     }
 
@@ -327,6 +392,7 @@ public sealed class WorkflowDefinitionEditorParameterLifecycleTests
 
         public int FindByDefinitionIdCallCount { get; private set; }
         public Func<string, WorkflowDefinition?> FindResultFactory { get; set; } = definitionId => CreateDefinition("loaded", definitionId);
+        public Exception? FindException { get; set; }
 
         public TaskCompletionSource<WorkflowDefinition?> EnqueueFind()
         {
@@ -343,6 +409,9 @@ public sealed class WorkflowDefinitionEditorParameterLifecycleTests
                 var definitionId = (string)args![0]!;
                 if (_pendingFinds.TryDequeue(out var pending))
                     return pending.Task;
+
+                if (FindException != null)
+                    return Task.FromException<WorkflowDefinition?>(FindException);
 
                 return Task.FromResult(FindResultFactory(definitionId));
             }

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionEditorParameterLifecycleTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionEditorParameterLifecycleTests.cs
@@ -1,0 +1,414 @@
+using System.Reflection;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+using MetadataComponent = Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Properties.Sections.Metadata.Metadata;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class WorkflowDefinitionEditorParameterLifecycleTests
+{
+    [Fact]
+    public async Task WorkspacePreservesInternalSelectionWhenIncomingParametersAreUnchanged()
+    {
+        await using var context = CreateContext();
+        var initialDefinition = CreateDefinition("initial", "version-1");
+        var selectedDefinition = CreateDefinition("selected", "version-0");
+        var cut = RenderWorkspace(context, initialDefinition, initialDefinition);
+
+        await cut.InvokeAsync(() => cut.Instance.DisplayWorkflowDefinitionVersionAsync(selectedDefinition));
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, initialDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, initialDefinition));
+
+        Assert.Same(selectedDefinition, cut.Instance.GetSelectedDefinition());
+    }
+
+    [Fact]
+    public async Task WorkspaceReloadSignalRehydratesMetadataOnlyForANewIncomingReference()
+    {
+        await using var context = CreateContext();
+        var initialDefinition = CreateDefinition("initial", "version-1");
+        var cut = RenderWorkspace(context, initialDefinition, initialDefinition);
+        var metadata = cut.FindComponent<MetadataComponent>();
+        var fields = metadata.FindComponents<MudTextField<string>>();
+        var nameInput = fields[0].Find("input");
+        var descriptionInput = fields[1].Find("textarea");
+
+        await nameInput.InputAsync("validated name");
+        await nameInput.BlurAsync();
+        await descriptionInput.InputAsync("draft description");
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, initialDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, initialDefinition));
+
+        Assert.Equal("validated name", cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Equal("draft description", cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
+
+        var replacementDefinition = CreateDefinition("replacement name", "version-1");
+        replacementDefinition.Description = "replacement description";
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, replacementDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, replacementDefinition));
+
+        fields = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>();
+        Assert.Equal("replacement name", fields[0].Find("input").GetAttribute("value"));
+        Assert.Equal("replacement description", fields[1].Find("textarea").GetAttribute("value"));
+        Assert.Equal("replacement name", replacementDefinition.Name);
+        Assert.Equal("replacement description", replacementDefinition.Description);
+    }
+
+    [Fact]
+    public async Task WorkspaceAppliesNewSameVersionIncomingReference()
+    {
+        await using var context = CreateContext();
+        var initialDefinition = CreateDefinition("initial", "version-1");
+        var replacementDefinition = CreateDefinition("replacement", "version-1");
+        var cut = RenderWorkspace(context, initialDefinition, initialDefinition);
+        var editor = cut.FindComponent<WorkflowEditor>().Instance;
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, replacementDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, replacementDefinition));
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, replacementDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, replacementDefinition));
+
+        Assert.Same(replacementDefinition, cut.Instance.GetSelectedDefinition());
+        Assert.Same(replacementDefinition, editor.WorkflowDefinition);
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionEditorDoesNotRefetchWhenDefinitionIdIsUnchanged()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var cut = RenderOuterEditor(context, "definition-1");
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-1"));
+
+        Assert.Equal(1, service.FindByDefinitionIdCallCount);
+
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-2"));
+
+        Assert.Equal(2, service.FindByDefinitionIdCallCount);
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionEditorKeepsTheLatestOutOfOrderDefinitionLoad()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var firstLoad = service.EnqueueFind();
+        var cut = RenderOuterEditor(context, "definition-a");
+        var secondLoad = service.EnqueueFind();
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b"));
+        var latestLoad = service.EnqueueFind();
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-a"));
+
+        var latestDefinition = CreateDefinition("latest definition a", "version-a-latest");
+        latestLoad.SetResult(latestDefinition);
+
+        cut.WaitForAssertion(() => Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion()));
+
+        var renderCount = cut.RenderCount;
+        firstLoad.SetResult(CreateDefinition("stale definition a", "version-a-old"));
+        cut.WaitForState(() => cut.RenderCount > renderCount, TimeSpan.FromSeconds(5));
+        Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
+
+        renderCount = cut.RenderCount;
+        secondLoad.SetResult(CreateDefinition("stale definition b", "version-b-old"));
+        cut.WaitForState(() => cut.RenderCount > renderCount, TimeSpan.FromSeconds(5));
+        Assert.Same(latestDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
+        Assert.Equal(3, service.FindByDefinitionIdCallCount);
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionEditorClearsAWorkflowWhenLatestLoadReturnsNullAndRetriesIt()
+    {
+        await using var context = CreateContext();
+        var service = AddWorkflowDefinitionServiceProxy(context);
+        var loadedDefinition = CreateDefinition("loaded", "version-1");
+        service.FindResultFactory = _ => loadedDefinition;
+        var cut = RenderOuterEditor(context, "definition-a");
+
+        service.FindResultFactory = _ => null;
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b"));
+        Assert.Null(cut.Instance.GetSelectedWorkflowDefinitionVersion());
+
+        var recoveredDefinition = CreateDefinition("recovered", "version-b");
+        service.FindResultFactory = _ => recoveredDefinition;
+        cut.Render(parameters => parameters.Add(x => x.DefinitionId, "definition-b"));
+
+        Assert.Same(recoveredDefinition, cut.Instance.GetSelectedWorkflowDefinitionVersion());
+        Assert.Equal(3, service.FindByDefinitionIdCallCount);
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddLogging();
+        context.Services.AddMudServices();
+        context.Services.AddCoreInternal();
+        context.Services.AddRemoteBackend();
+        context.Services.AddWorkflowsModule();
+        context.Services.AddSingleton<ILocalizer, TestLocalizer>();
+        var editorService = new DelayedWorkflowDefinitionEditorService();
+        context.Services.AddSingleton(editorService);
+        context.Services.AddSingleton<IWorkflowDefinitionEditorService>(editorService);
+        var workflowDefinitionService = DispatchProxy.Create<IWorkflowDefinitionService, WorkflowDefinitionServiceProxy>();
+        context.Services.AddSingleton(workflowDefinitionService);
+        context.Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+        context.Services.AddSingleton<IActivityPickerComponentProvider, EmptyActivityPickerComponentProvider>();
+        context.ComponentFactories.Add<WorkflowEditor, TestWorkflowEditor>();
+        context.ComponentFactories.Add<CodeView, TestCodeView>();
+        context.ComponentFactories.Add<WorkflowProperties, TestWorkflowProperties>();
+        return context;
+    }
+
+    private static IRenderedComponent<WorkflowDefinitionWorkspace> RenderWorkspace(BunitContext context, WorkflowDefinition workflowDefinition, WorkflowDefinition selectedWorkflowDefinition) =>
+        RenderWithPopoverProvider(context, () => context.Render<WorkflowDefinitionWorkspace>(parameters => parameters
+            .Add(x => x.WorkflowDefinition, workflowDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, selectedWorkflowDefinition)));
+
+    private static IRenderedComponent<WorkflowDefinitionEditor> RenderOuterEditor(BunitContext context, string definitionId) =>
+        RenderWithPopoverProvider(context, () => context.Render<WorkflowDefinitionEditor>(parameters => parameters.Add(x => x.DefinitionId, definitionId)));
+
+    private static T RenderWithPopoverProvider<T>(BunitContext context, Func<T> render)
+    {
+        context.Render<MudPopoverProvider>();
+        return render();
+    }
+
+    private static WorkflowDefinitionServiceProxy AddWorkflowDefinitionServiceProxy(BunitContext context)
+    {
+        var service = DispatchProxy.Create<IWorkflowDefinitionService, WorkflowDefinitionServiceProxy>();
+        context.Services.AddSingleton(service);
+        return (WorkflowDefinitionServiceProxy)(object)service;
+    }
+
+    private static WorkflowDefinition CreateDefinition(string name, string versionId) => new()
+    {
+        Id = versionId,
+        DefinitionId = "definition-1",
+        Name = name,
+        Description = $"{name} description",
+        IsLatest = true,
+        Links = [new(string.Empty, "publish", string.Empty)]
+    };
+
+    [Fact]
+    public async Task WorkspaceReplacementRejectsAnInFlightSaveResponse()
+    {
+        await using var context = CreateContext();
+        var initialDefinition = CreateDefinition("initial", "version-1");
+        var replacementDefinition = CreateDefinition("replacement", "version-1");
+        var cut = RenderWorkspace(context, initialDefinition, initialDefinition);
+        var editor = cut.FindComponent<WorkflowEditor>().Instance;
+        var saveTask = InvokeSaveAsync(editor);
+        var pendingSave = await context.Services.GetRequiredService<DelayedWorkflowDefinitionEditorService>().SaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, replacementDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, replacementDefinition));
+        await pendingSave.CompleteSuccessAsync(CreateDefinition("stale response", "version-1"));
+        await saveTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(replacementDefinition, editor.WorkflowDefinition);
+        Assert.Same(replacementDefinition, cut.Instance.GetSelectedDefinition());
+    }
+
+    [Fact]
+    public async Task WorkspaceReplacementRejectsAnInFlightRetractResponse()
+    {
+        await using var context = CreateContext();
+        var initialDefinition = CreateDefinition("initial", "version-1");
+        var replacementDefinition = CreateDefinition("replacement", "version-1");
+        var cut = RenderWorkspace(context, initialDefinition, initialDefinition);
+        var editor = cut.FindComponent<WorkflowEditor>().Instance;
+        var retractTask = InvokeRetractAsync(editor);
+        var pendingRetract = await context.Services.GetRequiredService<DelayedWorkflowDefinitionEditorService>().RetractStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, replacementDefinition)
+            .Add(x => x.SelectedWorkflowDefinition, replacementDefinition));
+        await pendingRetract.CompleteSuccessAsync(CreateDefinition("stale response", "version-1"));
+        await retractTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(replacementDefinition, editor.WorkflowDefinition);
+        Assert.Same(replacementDefinition, cut.Instance.GetSelectedDefinition());
+    }
+
+    private static Task InvokeSaveAsync(WorkflowEditor editor)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("SaveChangesAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, new object?[] { false, false, false, null, null, null })!;
+    }
+
+    private static Task InvokeRetractAsync(WorkflowEditor editor)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("RetractAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, new object?[] { null, null })!;
+    }
+
+    private sealed class TestWorkflowEditor : WorkflowEditor
+    {
+        protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private sealed class TestCodeView : CodeView
+    {
+        protected override void OnInitialized()
+        {
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private sealed class TestWorkflowProperties : WorkflowProperties
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<MetadataComponent>(0);
+            builder.AddAttribute(1, nameof(MetadataComponent.WorkflowDefinition), WorkflowDefinition);
+            builder.AddAttribute(2, nameof(MetadataComponent.WorkflowDefinitionUpdated), WorkflowDefinitionUpdated);
+            builder.CloseComponent();
+        }
+    }
+
+    private sealed class EmptyActivityPickerComponentProvider : IActivityPickerComponentProvider
+    {
+        public RenderFragment GetActivityPickerComponent() => _ => { };
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = null) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+
+    private class WorkflowDefinitionServiceProxy : DispatchProxy
+    {
+        private readonly Queue<TaskCompletionSource<WorkflowDefinition?>> _pendingFinds = new();
+
+        public int FindByDefinitionIdCallCount { get; private set; }
+        public Func<string, WorkflowDefinition?> FindResultFactory { get; set; } = definitionId => CreateDefinition("loaded", definitionId);
+
+        public TaskCompletionSource<WorkflowDefinition?> EnqueueFind()
+        {
+            var pending = NewCompletionSource<WorkflowDefinition?>();
+            _pendingFinds.Enqueue(pending);
+            return pending;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IWorkflowDefinitionService.FindByDefinitionIdAsync))
+            {
+                FindByDefinitionIdCallCount++;
+                var definitionId = (string)args![0]!;
+                if (_pendingFinds.TryDequeue(out var pending))
+                    return pending.Task;
+
+                return Task.FromResult(FindResultFactory(definitionId));
+            }
+
+            if (targetMethod?.Name == nameof(IWorkflowDefinitionService.GetIsNameUniqueAsync))
+                return Task.FromResult(true);
+
+            throw new InvalidOperationException($"Unexpected call to {targetMethod?.Name}.");
+        }
+    }
+
+    private sealed class DelayedWorkflowDefinitionEditorService : IWorkflowDefinitionEditorService
+    {
+        public TaskCompletionSource<PendingSave> SaveStarted { get; } = NewCompletionSource<PendingSave>();
+        public TaskCompletionSource<PendingRetract> RetractStarted { get; } = NewCompletionSource<PendingRetract>();
+
+        public Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(WorkflowDefinition workflowDefinition, bool publish, Func<WorkflowDefinition, Task>? workflowSavedCallback = null, CancellationToken cancellationToken = default)
+        {
+            var pending = new PendingSave(workflowSavedCallback);
+            SaveStarted.TrySetResult(pending);
+            return pending.Completion.Task;
+        }
+
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowPublishedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowRetractedCallback = null, CancellationToken cancellationToken = default)
+        {
+            var pending = new PendingRetract(workflowRetractedCallback);
+            RetractStarted.TrySetResult(pending);
+            return pending.Completion.Task;
+        }
+
+        public Task<FileDownload> ExportAsync(WorkflowDefinition workflowDefinition, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class PendingSave(Func<WorkflowDefinition, Task>? callback)
+    {
+        public TaskCompletionSource<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> Completion { get; } = NewCompletionSource<Result<SaveWorkflowDefinitionResponse, ValidationErrors>>();
+
+        public async Task CompleteSuccessAsync(WorkflowDefinition definition)
+        {
+            if (callback != null)
+                await callback(definition);
+
+            Completion.TrySetResult(new(new SaveWorkflowDefinitionResponse(definition, false, 0)));
+        }
+    }
+
+    private sealed class PendingRetract(Func<WorkflowDefinition, Task>? callback)
+    {
+        public TaskCompletionSource<Result<WorkflowDefinition, ValidationErrors>> Completion { get; } = NewCompletionSource<Result<WorkflowDefinition, ValidationErrors>>();
+
+        public async Task CompleteSuccessAsync(WorkflowDefinition definition)
+        {
+            if (callback != null)
+                await callback(definition);
+
+            Completion.TrySetResult(new(definition));
+        }
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private static TaskCompletionSource<T> NewCompletionSource<T>() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
@@ -537,7 +537,7 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         validation.Result.SetResult(true);
         await blurTask;
 
-        var editor = new WorkflowEditor();
+        using var editor = new WorkflowEditor();
         typeof(WorkflowEditor).GetProperty("Mediator", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(editor, new NoOpMediator());
 
@@ -553,29 +553,63 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         };
 #pragma warning restore BL0005
 
-        try
-        {
-            // The importer invokes this callback before publishing ImportedWorkflowDefinition.
-            await editor.SetImportedWorkflowDefinitionAsync(importedDefinition);
+        // The importer invokes this callback before publishing ImportedWorkflowDefinition.
+        await editor.SetImportedWorkflowDefinitionAsync(importedDefinition);
 
-            var fields = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>();
-            Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
-            Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
+        var fields = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>();
+        Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
+        Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
 
-            // The notification is the same import object and must not reset the form a second time.
-            await ((INotificationHandler<ImportedWorkflowDefinition>)editor)
-                .HandleAsync(new ImportedWorkflowDefinition(importedDefinition), CancellationToken.None);
+        // The notification is the same import object and must not reset the form a second time.
+        await ((INotificationHandler<ImportedWorkflowDefinition>)editor)
+            .HandleAsync(new ImportedWorkflowDefinition(importedDefinition), CancellationToken.None);
 
-            Assert.Equal(1, reloadCount);
-            Assert.Equal("imported name", importedDefinition.Name);
-            Assert.Equal("imported description", importedDefinition.Description);
-            Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
-            Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
-        }
-        finally
-        {
-            editor.Dispose();
-        }
+        Assert.Equal(1, reloadCount);
+        Assert.Equal("imported name", importedDefinition.Name);
+        Assert.Equal("imported description", importedDefinition.Description);
+        Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
+        Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task ObsoleteQueuedSavePayloadDoesNotTouchTheRendererOrCallbacks()
+    {
+        using var editor = new WorkflowEditor();
+        var editorService = new RecordingWorkflowDefinitionEditorService();
+        typeof(WorkflowEditor).GetProperty("Mediator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(editor, new NoOpMediator());
+        typeof(WorkflowEditor).GetProperty("WorkflowDefinitionEditorService", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(editor, editorService);
+
+        editor.InvalidateWorkflowDefinitionOperations();
+
+        var successInvoked = false;
+        var failureInvoked = false;
+        var saveMethod = typeof(WorkflowEditor).GetMethod("SaveChangesAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var saveTask = (Task)saveMethod.Invoke(editor,
+            new object?[]
+            {
+                false,
+                false,
+                false,
+                (Func<SaveWorkflowDefinitionResponse, Task>)(_ =>
+                {
+                    successInvoked = true;
+                    return Task.CompletedTask;
+                }),
+                (Func<ValidationErrors, Task>)(_ =>
+                {
+                    failureInvoked = true;
+                    return Task.CompletedTask;
+                }),
+                0L
+            })!;
+
+        await saveTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(successInvoked);
+        Assert.False(failureInvoked);
+        Assert.Equal(0, editorService.SaveCallCount);
     }
 
     private IRenderedComponent<MetadataComponent> RenderMetadata(WorkflowDefinition definition, List<(string? Name, string? Description)> callbackValues, Func<WorkflowDefinition>? currentDefinition = null) =>
@@ -647,6 +681,21 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingWorkflowDefinitionEditorService : IWorkflowDefinitionEditorService
+    {
+        public int SaveCallCount { get; private set; }
+
+        public Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(WorkflowDefinition workflowDefinition, bool publish, Func<WorkflowDefinition, Task>? workflowSavedCallback = null, CancellationToken cancellationToken = default)
+        {
+            SaveCallCount++;
+            throw new InvalidOperationException("The obsolete save payload reached the editor service.");
+        }
+
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowPublishedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowRetractedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportAsync(WorkflowDefinition workflowDefinition, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 
     private sealed class NoOpMediator : IMediator

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
@@ -4,8 +4,11 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Notifications;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -14,6 +17,7 @@ using Microsoft.Extensions.Localization;
 using MudBlazor;
 using MudBlazor.Services;
 using Refit;
+using System.Reflection;
 using Xunit;
 
 using MetadataComponent = Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Properties.Sections.Metadata.Metadata;
@@ -508,6 +512,72 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         Assert.Equal("code view description", fields[1].Find("textarea").GetAttribute("value"));
     }
 
+    [Fact]
+    public async Task ImportCallbackSignalsMetadataReloadBeforeItsDuplicateNotification()
+    {
+        var initialDefinition = CreateDefinition();
+        var importedDefinition = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "imported name",
+            Description = "imported description"
+        };
+        var reloadVersion = 0L;
+        var reloadCount = 0;
+        var cut = Render<MetadataHost>(parameters => parameters
+            .Add(x => x.WorkflowDefinition, initialDefinition)
+            .Add(x => x.ReloadVersion, reloadVersion));
+        var nameInput = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("submitted name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var blurTask = nameInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        var editor = new WorkflowEditor();
+        typeof(WorkflowEditor).GetProperty("Mediator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(editor, new NoOpMediator());
+
+#pragma warning disable BL0005 // The callback is configured directly to exercise the replacement boundary.
+        editor.WorkflowDefinitionReloaded = () =>
+        {
+            reloadCount++;
+            reloadVersion++;
+            cut.Render(parameters => parameters
+                .Add(x => x.WorkflowDefinition, importedDefinition)
+                .Add(x => x.ReloadVersion, reloadVersion));
+            return Task.CompletedTask;
+        };
+#pragma warning restore BL0005
+
+        try
+        {
+            // The importer invokes this callback before publishing ImportedWorkflowDefinition.
+            await editor.SetImportedWorkflowDefinitionAsync(importedDefinition);
+
+            var fields = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>();
+            Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
+            Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
+
+            // The notification is the same import object and must not reset the form a second time.
+            await ((INotificationHandler<ImportedWorkflowDefinition>)editor)
+                .HandleAsync(new ImportedWorkflowDefinition(importedDefinition), CancellationToken.None);
+
+            Assert.Equal(1, reloadCount);
+            Assert.Equal("imported name", importedDefinition.Name);
+            Assert.Equal("imported description", importedDefinition.Description);
+            Assert.Equal("imported name", fields[0].Find("input").GetAttribute("value"));
+            Assert.Equal("imported description", fields[1].Find("textarea").GetAttribute("value"));
+        }
+        finally
+        {
+            editor.Dispose();
+        }
+    }
+
     private IRenderedComponent<MetadataComponent> RenderMetadata(WorkflowDefinition definition, List<(string? Name, string? Description)> callbackValues, Func<WorkflowDefinition>? currentDefinition = null) =>
         Render<MetadataComponent>(parameters => parameters
             .Add(x => x.WorkflowDefinition, definition)
@@ -577,6 +647,28 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class NoOpMediator : IMediator
+    {
+        public void Subscribe<TNotification, THandler>(THandler handler)
+            where TNotification : INotification
+            where THandler : INotificationHandler<TNotification>
+        {
+        }
+
+        public void Unsubscribe<TNotification, THandler>(THandler handler)
+            where TNotification : INotification
+            where THandler : INotificationHandler<TNotification>
+        {
+        }
+
+        public void Unsubscribe(INotificationHandler handler)
+        {
+        }
+
+        public Task NotifyAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification => Task.CompletedTask;
     }
 
     private sealed class TestLocalizer : ILocalizer

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
@@ -8,6 +8,7 @@ using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
@@ -106,15 +107,16 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
 
         secondValidation.Result.SetResult(true);
         await secondBlurTask;
-        firstValidation.Result.SetResult(true);
+        firstValidation.Result.SetResult(false);
         await firstBlurTask;
 
         Assert.Equal("edited name", definition.Name);
         Assert.Equal("edited description", definition.Description);
         Assert.Equal("edited name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
         Assert.Equal("edited description", cut.FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
-        Assert.Equal(2, callbackValues.Count);
+        Assert.Single(callbackValues);
         Assert.Equal(("edited name", "edited description"), callbackValues[^1]);
+        Assert.DoesNotContain("A workflow with this name already exists.", cut.Markup);
     }
 
     [Fact]
@@ -221,6 +223,7 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
 
         Assert.Equal("initial name", definition.Name);
         Assert.Empty(callbackValues);
+        Assert.Contains("A workflow with this name already exists.", cut.Markup);
     }
 
     [Fact]
@@ -468,6 +471,43 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
         Assert.Equal("replacement description", fields[1].Find("textarea").GetAttribute("value"));
     }
 
+    [Fact]
+    public async Task ExplicitSameVersionReloadAppliesCodeViewMetadataAfterAnEarlierCommit()
+    {
+        var initialDefinition = CreateDefinition();
+        var codeViewDefinition = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "code view name",
+            Description = "code view description"
+        };
+        var cut = Render<MetadataHost>(parameters => parameters
+            .Add(x => x.WorkflowDefinition, initialDefinition)
+            .Add(x => x.ReloadVersion, 0));
+        var metadata = cut.FindComponent<MetadataComponent>();
+        var nameInput = metadata.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("submitted name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var blurTask = nameInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        // The workspace reload signal can be observed before the replacement object reaches this child.
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, initialDefinition)
+            .Add(x => x.ReloadVersion, 1));
+        cut.Render(parameters => parameters
+            .Add(x => x.WorkflowDefinition, codeViewDefinition)
+            .Add(x => x.ReloadVersion, 1));
+
+        var fields = cut.FindComponent<MetadataComponent>().FindComponents<MudTextField<string>>();
+        Assert.Equal("code view name", fields[0].Find("input").GetAttribute("value"));
+        Assert.Equal("code view description", fields[1].Find("textarea").GetAttribute("value"));
+    }
+
     private IRenderedComponent<MetadataComponent> RenderMetadata(WorkflowDefinition definition, List<(string? Name, string? Description)> callbackValues, Func<WorkflowDefinition>? currentDefinition = null) =>
         Render<MetadataComponent>(parameters => parameters
             .Add(x => x.WorkflowDefinition, definition)
@@ -543,5 +583,25 @@ public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifeti
     {
         public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
         public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class MetadataHost : ComponentBase
+    {
+        [Parameter] public WorkflowDefinition WorkflowDefinition { get; set; } = default!;
+        [Parameter] public long ReloadVersion { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<CascadingValue<long>>(0);
+            builder.AddAttribute(1, nameof(CascadingValue<long>.Name), "WorkflowDefinitionReloadVersion");
+            builder.AddAttribute(2, nameof(CascadingValue<long>.Value), ReloadVersion);
+            builder.AddAttribute(3, nameof(CascadingValue<long>.ChildContent), (RenderFragment)(childBuilder =>
+            {
+                childBuilder.OpenComponent<MetadataComponent>(0);
+                childBuilder.AddAttribute(1, nameof(MetadataComponent.WorkflowDefinition), WorkflowDefinition);
+                childBuilder.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowDefinitionMetadataTests.cs
@@ -1,0 +1,547 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Refit;
+using Xunit;
+
+using MetadataComponent = Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.Properties.Sections.Metadata.Metadata;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class WorkflowDefinitionMetadataTests : BunitContext, IAsyncLifetime
+{
+    private readonly ControlledWorkflowDefinitionService _workflowDefinitionService = new();
+
+    public WorkflowDefinitionMetadataTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IWorkflowDefinitionService>(_workflowDefinitionService);
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task DescriptionEditSurvivesRerenderWhileNameBlurValidationIsPending()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var fields = cut.FindComponents<MudTextField<string>>();
+        var nameInput = fields[0].Find("input");
+        var descriptionInput = fields[1].Find("textarea");
+
+        await descriptionInput.InputAsync("edited description");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+
+        var blurTask = nameInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, definition));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        Assert.Equal("edited description", definition.Description);
+        Assert.Equal("edited description", callbackValues.Single().Description);
+        Assert.Equal("edited description", cut.FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task NameEditSurvivesRerenderWhileDescriptionBlurValidationIsPending()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var fields = cut.FindComponents<MudTextField<string>>();
+        var nameInput = fields[0].Find("input");
+        var descriptionInput = fields[1].Find("textarea");
+
+        await nameInput.InputAsync("edited name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+
+        var blurTask = descriptionInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, definition));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        Assert.Equal("edited name", definition.Name);
+        Assert.Equal("edited name", callbackValues.Single().Name);
+        Assert.Equal("edited name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task OverlappingBlurValidationsKeepTheLatestMetadataAfterOutOfOrderCompletion()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var fields = cut.FindComponents<MudTextField<string>>();
+        var nameInput = fields[0].Find("input");
+        var descriptionInput = fields[1].Find("textarea");
+
+        await nameInput.InputAsync("edited name");
+        await descriptionInput.InputAsync("edited description");
+        var firstValidation = _workflowDefinitionService.EnqueueValidation();
+        var secondValidation = _workflowDefinitionService.EnqueueValidation();
+
+        var firstBlurTask = nameInput.BlurAsync();
+        await firstValidation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondBlurTask = descriptionInput.BlurAsync();
+        await secondValidation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        secondValidation.Result.SetResult(true);
+        await secondBlurTask;
+        firstValidation.Result.SetResult(true);
+        await firstBlurTask;
+
+        Assert.Equal("edited name", definition.Name);
+        Assert.Equal("edited description", definition.Description);
+        Assert.Equal("edited name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Equal("edited description", cut.FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
+        Assert.Equal(2, callbackValues.Count);
+        Assert.Equal(("edited name", "edited description"), callbackValues[^1]);
+    }
+
+    [Fact]
+    public async Task StaleValidationDoesNotCommitANameEditedAfterValidationStarted()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("name A");
+        var firstValidation = _workflowDefinitionService.EnqueueValidation();
+        var firstBlurTask = nameInput.BlurAsync();
+        await firstValidation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await nameInput.InputAsync("name B");
+        var secondValidation = _workflowDefinitionService.EnqueueValidation();
+        var secondBlurTask = nameInput.BlurAsync();
+        await secondValidation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        firstValidation.Result.SetResult(false);
+        await firstBlurTask;
+
+        Assert.Equal("initial name", definition.Name);
+        Assert.Equal("name A", firstValidation.Name);
+
+        secondValidation.Result.SetResult(true);
+        await secondBlurTask;
+
+        Assert.Equal("name B", definition.Name);
+        Assert.Equal("name B", callbackValues.Single().Name);
+        Assert.Equal("name B", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Equal("name B", secondValidation.Name);
+    }
+
+    [Fact]
+    public async Task PendingValidationCommitsToTheLatestSameVersionSaveResponse()
+    {
+        var initialDefinition = CreateDefinition();
+        var saveResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "older server name",
+            Description = "older server description"
+        };
+        var currentDefinition = initialDefinition;
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues, () => currentDefinition);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("local name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var blurTask = nameInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        currentDefinition = saveResponse;
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, saveResponse));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        Assert.Equal("initial name", initialDefinition.Name);
+        Assert.Equal("local name", saveResponse.Name);
+        Assert.Equal("local name", callbackValues.Single().Name);
+    }
+
+    [Fact]
+    public async Task FormSubmissionCommitsTheCurrentMetadataAfterAsyncValidation()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("submitted name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        Assert.Equal("submitted name", definition.Name);
+        Assert.Equal("submitted name", callbackValues.Single().Name);
+    }
+
+    [Fact]
+    public async Task FormSubmissionDoesNotCommitWhileValidationIsPendingOrWhenItFails()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("invalid name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("initial name", definition.Name);
+        Assert.Empty(callbackValues);
+
+        validation.Result.SetResult(false);
+        await submitTask;
+
+        Assert.Equal("initial name", definition.Name);
+        Assert.Empty(callbackValues);
+    }
+
+    [Fact]
+    public async Task FormSubmissionDoesNotCommitANameChangedWhileItsValidationIsPending()
+    {
+        var definition = CreateDefinition();
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(definition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("name A");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await nameInput.InputAsync("name B");
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        Assert.Equal("initial name", definition.Name);
+        Assert.Empty(callbackValues);
+        Assert.Equal("name B", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task FormSubmissionFromAnOldWorkflowVersionCannotCommitIntoTheReplacement()
+    {
+        var initialDefinition = CreateDefinition();
+        var replacementDefinition = new WorkflowDefinition
+        {
+            Id = "version-2",
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "replacement name",
+            Description = "replacement description"
+        };
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("old version name");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, replacementDefinition));
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        Assert.Equal("initial name", initialDefinition.Name);
+        Assert.Equal("replacement name", replacementDefinition.Name);
+        Assert.Empty(callbackValues);
+    }
+
+    [Fact]
+    public async Task ValidationFromAnOldWorkflowVersionCannotCommitIntoTheReplacement()
+    {
+        var initialDefinition = CreateDefinition();
+        var replacementDefinition = new WorkflowDefinition
+        {
+            Id = "version-2",
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "replacement name",
+            Description = "replacement description"
+        };
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("edited old version");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var blurTask = nameInput.BlurAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, replacementDefinition));
+        validation.Result.SetResult(true);
+        await blurTask;
+
+        Assert.Equal("initial name", initialDefinition.Name);
+        Assert.Equal("replacement name", replacementDefinition.Name);
+        Assert.Empty(callbackValues);
+        Assert.Equal("replacement name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void AStaleSameVersionSaveResponseDoesNotOverwriteLocalMetadata()
+    {
+        var initialDefinition = CreateDefinition();
+        var saveResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "older server name",
+            Description = "older server description"
+        };
+        var cut = RenderMetadata(initialDefinition, []);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+        var descriptionInput = cut.FindComponents<MudTextField<string>>()[1].Find("textarea");
+
+        nameInput.Input("local name");
+        descriptionInput.Input("local description");
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, saveResponse));
+
+        Assert.Equal("local name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Equal("local description", cut.FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task OlderSameVersionSaveResponseDoesNotOverwriteSubmittedLocalMetadata()
+    {
+        var initialDefinition = CreateDefinition();
+        var saveResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "older server name",
+            Description = "older server description"
+        };
+        var currentDefinition = initialDefinition;
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues, () => currentDefinition);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+        var descriptionInput = cut.FindComponents<MudTextField<string>>()[1].Find("textarea");
+
+        await nameInput.InputAsync("submitted local name");
+        await descriptionInput.InputAsync("submitted local description");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        Assert.Equal("submitted local name", initialDefinition.Name);
+        Assert.Equal("submitted local description", initialDefinition.Description);
+
+        currentDefinition = saveResponse;
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, saveResponse));
+
+        Assert.Equal("submitted local name", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Equal("submitted local description", cut.FindComponents<MudTextField<string>>()[1].Find("textarea").GetAttribute("value"));
+        Assert.Equal("submitted local name", saveResponse.Name);
+        Assert.Equal("submitted local description", saveResponse.Description);
+        Assert.Single(callbackValues);
+    }
+
+    [Fact]
+    public async Task OlderSameVersionSaveResponseDoesNotCommitAnUnvalidatedEdit()
+    {
+        var initialDefinition = CreateDefinition();
+        var saveResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "older server name",
+            Description = "older server description"
+        };
+        var currentDefinition = initialDefinition;
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues, () => currentDefinition);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("submitted name A");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        await nameInput.InputAsync("unvalidated name B");
+        currentDefinition = saveResponse;
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, saveResponse));
+
+        Assert.Equal("submitted name A", saveResponse.Name);
+        Assert.Equal("unvalidated name B", cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Single(callbackValues);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task MatchingSaveResponseKeepsLaterUnvalidatedEditAndRejectsAnOlderResponse(bool editAfterAcknowledgement)
+    {
+        var initialDefinition = CreateDefinition();
+        var matchingResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "submitted name A",
+            Description = initialDefinition.Description
+        };
+        var olderResponse = new WorkflowDefinition
+        {
+            Id = initialDefinition.Id,
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "older server name",
+            Description = "older server description"
+        };
+        var currentDefinition = initialDefinition;
+        var callbackValues = new List<(string? Name, string? Description)>();
+        var cut = RenderMetadata(initialDefinition, callbackValues, () => currentDefinition);
+        var nameInput = cut.FindComponents<MudTextField<string>>()[0].Find("input");
+
+        await nameInput.InputAsync("submitted name A");
+        var validation = _workflowDefinitionService.EnqueueValidation();
+        var submitTask = cut.Find("form").SubmitAsync();
+        await validation.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        validation.Result.SetResult(true);
+        await submitTask;
+
+        if (editAfterAcknowledgement)
+            await nameInput.InputAsync("unvalidated name B");
+
+        currentDefinition = matchingResponse;
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, matchingResponse));
+
+        Assert.Equal("submitted name A", matchingResponse.Name);
+        Assert.Equal(editAfterAcknowledgement ? "unvalidated name B" : "submitted name A",
+            cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+
+        currentDefinition = olderResponse;
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, olderResponse));
+
+        Assert.Equal("submitted name A", olderResponse.Name);
+        Assert.Equal(editAfterAcknowledgement ? "unvalidated name B" : "submitted name A",
+            cut.FindComponents<MudTextField<string>>()[0].Find("input").GetAttribute("value"));
+        Assert.Single(callbackValues);
+    }
+
+    [Fact]
+    public void ReplacingTheWorkflowDefinitionReloadsTheMetadataModel()
+    {
+        var initialDefinition = CreateDefinition();
+        var replacementDefinition = new WorkflowDefinition
+        {
+            Id = "version-2",
+            DefinitionId = initialDefinition.DefinitionId,
+            Name = "replacement name",
+            Description = "replacement description"
+        };
+        var cut = RenderMetadata(initialDefinition, []);
+
+        cut.Render(parameters => parameters.Add(x => x.WorkflowDefinition, replacementDefinition));
+
+        var fields = cut.FindComponents<MudTextField<string>>();
+        Assert.Equal("replacement name", fields[0].Find("input").GetAttribute("value"));
+        Assert.Equal("replacement description", fields[1].Find("textarea").GetAttribute("value"));
+    }
+
+    private IRenderedComponent<MetadataComponent> RenderMetadata(WorkflowDefinition definition, List<(string? Name, string? Description)> callbackValues, Func<WorkflowDefinition>? currentDefinition = null) =>
+        Render<MetadataComponent>(parameters => parameters
+            .Add(x => x.WorkflowDefinition, definition)
+            .Add(x => x.WorkflowDefinitionUpdated, () =>
+            {
+                var callbackDefinition = currentDefinition?.Invoke() ?? definition;
+                callbackValues.Add((callbackDefinition.Name, callbackDefinition.Description));
+                return Task.CompletedTask;
+            }));
+
+    private static WorkflowDefinition CreateDefinition() => new()
+    {
+        Id = "version-1",
+        DefinitionId = "definition-1",
+        Name = "initial name",
+        Description = "initial description"
+    };
+
+    private sealed class ControlledWorkflowDefinitionService : IWorkflowDefinitionService
+    {
+        private readonly Queue<PendingValidation> _pendingValidations = new();
+
+        public PendingValidation EnqueueValidation()
+        {
+            var validation = new PendingValidation();
+            lock (_pendingValidations)
+                _pendingValidations.Enqueue(validation);
+            return validation;
+        }
+
+        public async Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default)
+        {
+            PendingValidation validation;
+            lock (_pendingValidations)
+                validation = _pendingValidations.Dequeue();
+
+            validation.Name = name;
+            validation.Started.TrySetResult(true);
+            return await validation.Result.Task.WaitAsync(cancellationToken);
+        }
+
+        public sealed class PendingValidation
+        {
+            public string? Name { get; set; }
+            public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource<bool> Result { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorLifecycleTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorLifecycleTests.cs
@@ -1,0 +1,295 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.DomInterop.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class WorkflowEditorLifecycleTests : BunitContext, IAsyncLifetime
+{
+    private readonly DelayedWorkflowDefinitionEditorService _editorService = new();
+    private readonly RecordingUserMessageService _userMessageService = new();
+
+    public WorkflowEditorLifecycleTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddRemoteBackend();
+        Services.AddWorkflowsModule();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IWorkflowDefinitionEditorService>(_editorService);
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+        Services.AddSingleton<IDomAccessor, NoOpDomAccessor>();
+        Services.AddSingleton(_userMessageService);
+        Services.AddSingleton<IUserMessageService>(_userMessageService);
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task SaveSuccessCompletedAfterInvalidationDoesNotReplaceOrInvokeSuccess()
+    {
+        var originalDefinition = CreateDefinition("initial");
+        var replacementCount = 0;
+        var cut = RenderEditor(originalDefinition, () =>
+        {
+            replacementCount++;
+            return Task.CompletedTask;
+        });
+        var successCount = 0;
+
+        var saveTask = InvokeSaveAsync(cut.Instance, _ =>
+        {
+            successCount++;
+            return Task.CompletedTask;
+        }, null);
+        var pendingSave = await _editorService.SaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Instance.InvalidateWorkflowDefinitionOperations();
+        await pendingSave.CompleteSuccessAsync(CreateDefinition("server response"));
+        await saveTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(originalDefinition, cut.Instance.WorkflowDefinition);
+        Assert.True(pendingSave.CallbackInvoked);
+        Assert.Equal(0, replacementCount);
+        Assert.Equal(0, successCount);
+    }
+
+    [Fact]
+    public async Task SaveFailureCompletedAfterInvalidationDoesNotInvokeFailure()
+    {
+        var originalDefinition = CreateDefinition("initial");
+        var cut = RenderEditor(originalDefinition, () => Task.CompletedTask);
+        var failureCount = 0;
+
+        var saveTask = InvokeSaveAsync(cut.Instance, null, _ =>
+        {
+            failureCount++;
+            return Task.CompletedTask;
+        });
+        var pendingSave = await _editorService.SaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Instance.InvalidateWorkflowDefinitionOperations();
+        pendingSave.CompleteFailure();
+        await saveTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, failureCount);
+        Assert.Equal(0, _userMessageService.MessageCount);
+    }
+
+    [Fact]
+    public async Task RetractSuccessCompletedAfterInvalidationDoesNotReplaceOrInvokeSuccess()
+    {
+        var originalDefinition = CreateDefinition("initial");
+        var replacementCount = 0;
+        var cut = RenderEditor(originalDefinition, () =>
+        {
+            replacementCount++;
+            return Task.CompletedTask;
+        });
+        var successCount = 0;
+
+        var retractTask = InvokeRetractAsync(cut.Instance, () =>
+        {
+            successCount++;
+            return Task.CompletedTask;
+        }, null);
+        var pendingRetract = await _editorService.RetractStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Instance.InvalidateWorkflowDefinitionOperations();
+        await pendingRetract.CompleteSuccessAsync(CreateDefinition("retracted response"));
+        await retractTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(originalDefinition, cut.Instance.WorkflowDefinition);
+        Assert.True(pendingRetract.CallbackInvoked);
+        Assert.Equal(0, replacementCount);
+        Assert.Equal(0, successCount);
+    }
+
+    [Fact]
+    public async Task RetractFailureCompletedAfterInvalidationDoesNotInvokeFailure()
+    {
+        var originalDefinition = CreateDefinition("initial");
+        var cut = RenderEditor(originalDefinition, () => Task.CompletedTask);
+        var failureCount = 0;
+
+        var retractTask = InvokeRetractAsync(cut.Instance, null, _ =>
+        {
+            failureCount++;
+            return Task.CompletedTask;
+        });
+        var pendingRetract = await _editorService.RetractStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cut.Instance.InvalidateWorkflowDefinitionOperations();
+        pendingRetract.CompleteFailure();
+        await retractTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, failureCount);
+    }
+
+    private IRenderedComponent<WorkflowEditor> RenderEditor(WorkflowDefinition definition, Func<Task> workflowDefinitionUpdated)
+    {
+        ComponentFactories.Add<DiagramDesignerWrapper, TestDiagramDesignerWrapper>();
+        ComponentFactories.Add<ActivityPropertiesPanel, TestActivityPropertiesPanel>();
+        return Render<WorkflowEditor>(parameters => parameters
+            .Add(x => x.WorkflowDefinition, definition)
+            .Add(x => x.WorkflowDefinitionUpdated, workflowDefinitionUpdated));
+    }
+
+    private static Task InvokeSaveAsync(WorkflowEditor editor, Func<SaveWorkflowDefinitionResponse, Task>? onSuccess, Func<ValidationErrors, Task>? onFailure)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("SaveChangesAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, new object?[] { false, false, false, onSuccess, onFailure, null })!;
+    }
+
+    private static Task InvokeRetractAsync(WorkflowEditor editor, Func<Task>? onSuccess, Func<ValidationErrors, Task>? onFailure)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("RetractAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, new object?[] { onSuccess, onFailure })!;
+    }
+
+    private static WorkflowDefinition CreateDefinition(string name) => new()
+    {
+        Id = "version-1",
+        DefinitionId = "definition-1",
+        Name = name,
+        Description = "description"
+    };
+
+    private sealed class DelayedWorkflowDefinitionEditorService : IWorkflowDefinitionEditorService
+    {
+        public TaskCompletionSource<PendingSave> SaveStarted { get; } = NewCompletionSource<PendingSave>();
+        public TaskCompletionSource<PendingRetract> RetractStarted { get; } = NewCompletionSource<PendingRetract>();
+
+        public Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(WorkflowDefinition workflowDefinition, bool publish, Func<WorkflowDefinition, Task>? workflowSavedCallback = null, CancellationToken cancellationToken = default)
+        {
+            var pending = new PendingSave(workflowSavedCallback);
+            SaveStarted.TrySetResult(pending);
+            return pending.Completion.Task;
+        }
+
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowPublishedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowRetractedCallback = null, CancellationToken cancellationToken = default)
+        {
+            var pending = new PendingRetract(workflowRetractedCallback);
+            RetractStarted.TrySetResult(pending);
+            return pending.Completion.Task;
+        }
+
+        public Task<FileDownload> ExportAsync(WorkflowDefinition workflowDefinition, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class PendingSave(Func<WorkflowDefinition, Task>? callback)
+    {
+        public TaskCompletionSource<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> Completion { get; } = NewCompletionSource<Result<SaveWorkflowDefinitionResponse, ValidationErrors>>();
+        public bool CallbackInvoked { get; private set; }
+
+        public async Task CompleteSuccessAsync(WorkflowDefinition definition)
+        {
+            if (callback != null)
+            {
+                CallbackInvoked = true;
+                await callback(definition);
+            }
+
+            Completion.TrySetResult(new(new SaveWorkflowDefinitionResponse(definition, false, 0)));
+        }
+
+        public void CompleteFailure() => Completion.TrySetResult(new(new ValidationErrors([new("save failed")])));
+    }
+
+    private sealed class PendingRetract(Func<WorkflowDefinition, Task>? callback)
+    {
+        public TaskCompletionSource<Result<WorkflowDefinition, ValidationErrors>> Completion { get; } = NewCompletionSource<Result<WorkflowDefinition, ValidationErrors>>();
+        public bool CallbackInvoked { get; private set; }
+
+        public async Task CompleteSuccessAsync(WorkflowDefinition definition)
+        {
+            if (callback != null)
+            {
+                CallbackInvoked = true;
+                await callback(definition);
+            }
+
+            Completion.TrySetResult(new(definition));
+        }
+
+        public void CompleteFailure() => Completion.TrySetResult(new(new ValidationErrors([new("retract failed")])));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = null) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class NoOpDomAccessor : IDomAccessor
+    {
+        public Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(new DomRect());
+        public Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(0d);
+        public Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingUserMessageService : IUserMessageService
+    {
+        public int MessageCount { get; private set; }
+        public void ShowSnackbarTextMessage(string message, Severity severity = Severity.Normal, Action<SnackbarOptions>? snackbarOptions = null) => MessageCount++;
+        public void ShowSnackbarTextMessage(IEnumerable<string> messages, Severity severity = Severity.Normal, Action<SnackbarOptions>? snackbarOptions = null) => MessageCount++;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class TestDiagramDesignerWrapper : DiagramDesignerWrapper
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private sealed class TestActivityPropertiesPanel : ActivityPropertiesPanel
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private static TaskCompletionSource<T> NewCompletionSource<T>() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorLifecycleTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorLifecycleTests.cs
@@ -1,7 +1,9 @@
 using Bunit;
+using System.Text.Json.Nodes;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.DomInterop.Models;
@@ -16,6 +18,8 @@ using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contracts;
+using Elsa.Studio.Workflows.UI.Contexts;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -76,6 +80,135 @@ public sealed class WorkflowEditorLifecycleTests : BunitContext, IAsyncLifetime
         Assert.True(pendingSave.CallbackInvoked);
         Assert.Equal(0, replacementCount);
         Assert.Equal(0, successCount);
+    }
+
+    [Fact]
+    public async Task DiagramLoadCompletionLeavesTheLatestWorkflowSelected()
+    {
+        var activityVisitor = new DelayedActivityVisitor();
+        Services.AddSingleton<IActivityVisitor>(activityVisitor);
+        Services.AddSingleton<IDiagramDesignerService, TestDiagramDesignerService>();
+
+        var initialDefinition = CreateDefinition("initial");
+        var firstDefinition = CreateDefinition("first");
+        var secondDefinition = CreateDefinition("second");
+        var firstLoad = activityVisitor.Enqueue();
+        var cut = RenderEditor(initialDefinition, () => Task.CompletedTask);
+
+        Task? firstTask = null;
+        await cut.InvokeAsync(() =>
+        {
+            SetWorkflowDefinition(cut.Instance, firstDefinition);
+            firstTask = InvokeOnParametersSetAsync(cut.Instance);
+        });
+        await firstLoad.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondLoad = activityVisitor.Enqueue();
+        Task? secondTask = null;
+        await cut.InvokeAsync(() =>
+        {
+            SetWorkflowDefinition(cut.Instance, secondDefinition);
+            secondTask = InvokeOnParametersSetAsync(cut.Instance);
+        });
+
+        if (secondLoad.Started.Task.IsCompleted)
+        {
+            await cut.InvokeAsync(secondLoad.Complete);
+            await secondTask!.WaitAsync(TimeSpan.FromSeconds(5));
+            await cut.InvokeAsync(firstLoad.Complete);
+        }
+        else
+        {
+            await cut.InvokeAsync(firstLoad.Complete);
+            await secondLoad.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await cut.InvokeAsync(secondLoad.Complete);
+        }
+
+        await firstTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondTask!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var diagram = cut.FindComponent<DiagramDesignerWrapper>().Instance;
+        var activityGraph = await diagram.GetActivityGraphAsync();
+        Assert.Same(secondDefinition.Root, diagram.Activity);
+        Assert.Same(secondDefinition.Root, activityGraph.Activity);
+        Assert.Equal(secondDefinition.Root!["id"]!.GetValue<string>(), cut.Instance.SelectedActivityId);
+    }
+
+    [Fact]
+    public async Task ObsoleteDiagramLoadFailureDoesNotPreventTheLatestLoad()
+    {
+        var activityVisitor = new DelayedActivityVisitor();
+        Services.AddSingleton<IActivityVisitor>(activityVisitor);
+        Services.AddSingleton<IDiagramDesignerService, TestDiagramDesignerService>();
+
+        var initialDefinition = CreateDefinition("initial");
+        var firstDefinition = CreateDefinition("first");
+        var secondDefinition = CreateDefinition("second");
+        var firstLoad = activityVisitor.Enqueue();
+        var cut = RenderEditor(initialDefinition, () => Task.CompletedTask);
+
+        Task? firstTask = null;
+        await cut.InvokeAsync(() =>
+        {
+            SetWorkflowDefinition(cut.Instance, firstDefinition);
+            firstTask = InvokeOnParametersSetAsync(cut.Instance);
+        });
+        await firstLoad.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondLoad = activityVisitor.Enqueue();
+        Task? secondTask = null;
+        await cut.InvokeAsync(() =>
+        {
+            SetWorkflowDefinition(cut.Instance, secondDefinition);
+            secondTask = InvokeOnParametersSetAsync(cut.Instance);
+        });
+
+        firstLoad.Fail(new InvalidOperationException("obsolete diagram load"));
+        await firstTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondLoad.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        secondLoad.Complete();
+        await secondTask!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var diagram = cut.FindComponent<DiagramDesignerWrapper>().Instance;
+        var activityGraph = await diagram.GetActivityGraphAsync();
+        Assert.Same(secondDefinition.Root, diagram.Activity);
+        Assert.Same(secondDefinition.Root, activityGraph.Activity);
+    }
+
+    [Fact]
+    public async Task OlderForegroundSaveCannotClearAConcurrentProgressOwner()
+    {
+        var originalDefinition = CreateDefinition("initial");
+        var cut = RenderEditor(originalDefinition, () => Task.CompletedTask);
+        var firstSaveTask = InvokeSaveWithLoaderAsync(cut.Instance);
+        var firstSave = await _editorService.SaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondSaveTask = InvokeSaveWithLoaderAsync(cut.Instance);
+        var secondSave = await _editorService.SecondSaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(GetIsProgressing(cut.Instance));
+
+        await firstSave.CompleteSuccessAsync(CreateDefinition("first response"));
+        await firstSaveTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(GetIsProgressing(cut.Instance));
+
+        await secondSave.CompleteSuccessAsync(CreateDefinition("second response"));
+        await secondSaveTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(GetIsProgressing(cut.Instance));
+    }
+
+    [Fact]
+    public async Task ObsoleteForegroundSaveCompletionAfterDisposeDoesNotRender()
+    {
+        var cut = RenderEditor(CreateDefinition("initial"), () => Task.CompletedTask);
+        var saveTask = InvokeSaveWithLoaderAsync(cut.Instance);
+        var pendingSave = await _editorService.SaveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var renderCount = cut.RenderCount;
+
+        cut.Instance.Dispose();
+        await pendingSave.CompleteSuccessAsync(CreateDefinition("server response"));
+        await saveTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(renderCount, cut.RenderCount);
     }
 
     [Fact]
@@ -165,6 +298,29 @@ public sealed class WorkflowEditorLifecycleTests : BunitContext, IAsyncLifetime
         return (Task)method.Invoke(editor, new object?[] { false, false, false, onSuccess, onFailure, null })!;
     }
 
+    private static Task InvokeSaveWithLoaderAsync(WorkflowEditor editor)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("SaveChangesAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, new object?[] { false, true, false, null, null, null })!;
+    }
+
+    private static Task InvokeOnParametersSetAsync(WorkflowEditor editor)
+    {
+        var method = typeof(WorkflowEditor).GetMethod("OnParametersSetAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(editor, null)!;
+    }
+
+    private static void SetWorkflowDefinition(WorkflowEditor editor, WorkflowDefinition definition)
+    {
+        typeof(WorkflowEditor).GetProperty(nameof(WorkflowEditor.WorkflowDefinition))!.SetValue(editor, definition);
+    }
+
+    private static bool GetIsProgressing(WorkflowEditor editor)
+    {
+        var property = typeof(WorkflowEditorComponentBase).GetProperty("IsProgressing", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (bool)property.GetValue(editor)!;
+    }
+
     private static Task InvokeRetractAsync(WorkflowEditor editor, Func<Task>? onSuccess, Func<ValidationErrors, Task>? onFailure)
     {
         var method = typeof(WorkflowEditor).GetMethod("RetractAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
@@ -176,18 +332,27 @@ public sealed class WorkflowEditorLifecycleTests : BunitContext, IAsyncLifetime
         Id = "version-1",
         DefinitionId = "definition-1",
         Name = name,
-        Description = "description"
+        Description = "description",
+        Root = new JsonObject
+        {
+            ["id"] = $"{name}-root",
+            ["nodeId"] = $"{name}-root",
+            ["typeName"] = "Elsa.Workflow",
+            ["version"] = 1
+        }
     };
 
     private sealed class DelayedWorkflowDefinitionEditorService : IWorkflowDefinitionEditorService
     {
         public TaskCompletionSource<PendingSave> SaveStarted { get; } = NewCompletionSource<PendingSave>();
+        public TaskCompletionSource<PendingSave> SecondSaveStarted { get; } = NewCompletionSource<PendingSave>();
         public TaskCompletionSource<PendingRetract> RetractStarted { get; } = NewCompletionSource<PendingRetract>();
 
         public Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(WorkflowDefinition workflowDefinition, bool publish, Func<WorkflowDefinition, Task>? workflowSavedCallback = null, CancellationToken cancellationToken = default)
         {
             var pending = new PendingSave(workflowSavedCallback);
-            SaveStarted.TrySetResult(pending);
+            if (!SaveStarted.TrySetResult(pending))
+                SecondSaveStarted.TrySetResult(pending);
             return pending.Completion.Task;
         }
 
@@ -289,6 +454,53 @@ public sealed class WorkflowEditorLifecycleTests : BunitContext, IAsyncLifetime
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
         }
+    }
+
+    private sealed class DelayedActivityVisitor : IActivityVisitor
+    {
+        private readonly Queue<PendingVisit> _pending = new();
+
+        public PendingVisit Enqueue()
+        {
+            var pending = new PendingVisit();
+            _pending.Enqueue(pending);
+            return pending;
+        }
+
+        public Task<ActivityNode> VisitAsync(JsonObject activity, CancellationToken cancellationToken = default)
+        {
+            if (!_pending.TryDequeue(out var pending))
+                return Task.FromResult(new ActivityNode(activity));
+
+            pending.Started.TrySetResult(activity);
+            return pending.Completion.Task;
+        }
+    }
+
+    private sealed class PendingVisit
+    {
+        public TaskCompletionSource<JsonObject> Started { get; } = NewCompletionSource<JsonObject>();
+        public TaskCompletionSource<ActivityNode> Completion { get; } = NewCompletionSource<ActivityNode>();
+
+        public void Complete() => Completion.TrySetResult(new ActivityNode(Started.Task.Result));
+
+        public void Fail(Exception exception) => Completion.TrySetException(exception);
+    }
+
+    private sealed class TestDiagramDesignerService : IDiagramDesignerService
+    {
+        public bool HasDiagramDesigner(JsonObject activity) => true;
+        public IDiagramDesigner GetDiagramDesigner(JsonObject activity) => new TestDiagramDesigner();
+    }
+
+    private sealed class TestDiagramDesigner : IDiagramDesigner
+    {
+        public Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap) => Task.CompletedTask;
+        public Task UpdateActivityAsync(string id, JsonObject activity) => Task.CompletedTask;
+        public Task UpdateActivityStatsAsync(string id, ActivityStats stats) => Task.CompletedTask;
+        public Task SelectActivityAsync(string id) => Task.CompletedTask;
+        public Task<JsonObject> ReadRootActivityAsync() => Task.FromResult(new JsonObject());
+        public RenderFragment DisplayDesigner(DisplayContext context) => _ => { };
     }
 
     private static TaskCompletionSource<T> NewCompletionSource<T>() => new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -56,6 +56,7 @@
                                             @bind-AutoSave="_autoSave"
                                             WorkflowDefinition="_selectedWorkflowDefinition"
                                             WorkflowDefinitionUpdated="OnWorkflowDefinitionUpdated"
+                                            WorkflowDefinitionReloaded="OnWorkflowDefinitionReloaded"
                                             WorkflowDefinitionExecuted="WorkflowDefinitionExecuted"
                                             ActivitySelected="ActivitySelected" />
                         }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor
@@ -30,8 +30,9 @@
     }
 </style>
 
-<CascadingValue Value="this">
-    <RadzenSplitter Orientation="Orientation.Horizontal" Style="height:100%;">
+<CascadingValue Name="WorkflowDefinitionReloadVersion" Value="_workflowDefinitionReloadVersion">
+    <CascadingValue Value="this">
+        <RadzenSplitter Orientation="Orientation.Horizontal" Style="height:100%;">
         <RadzenSplitterPane Size="65%" Class="pane-left">
             @if (_selectedWorkflowDefinition != null)
             {
@@ -89,5 +90,6 @@
                     WorkflowDefinitionUpdated="OnWorkflowDefinitionPropsUpdated"/>
             }
         </RadzenSplitterPane>
-    </RadzenSplitter>
+        </RadzenSplitter>
+    </CascadingValue>
 </CascadingValue>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -21,6 +21,8 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     private MudDynamicTabs _dynamicTabs = null!;
     private WorkflowDefinition? _workflowDefinition = null!;
     private WorkflowDefinition? _selectedWorkflowDefinition = null!;
+    private WorkflowDefinition? _lastIncomingWorkflowDefinition;
+    private WorkflowDefinition? _lastIncomingSelectedWorkflowDefinition;
     private long _workflowDefinitionReloadVersion;
     private WorkflowEditor WorkflowEditor { get; set; } = null!;
     private CodeView CodeView { get; set; } = null!;
@@ -66,18 +68,31 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     {
         _autoSave = WorkflowDefinitionOptions.Value.AutoSaveChangesByDefault;
         _autoApply = WorkflowDefinitionOptions.Value.AutoApplyCodeViewChangesByDefault;
+        _lastIncomingWorkflowDefinition = WorkflowDefinition;
+        _lastIncomingSelectedWorkflowDefinition = SelectedWorkflowDefinition;
         _workflowDefinition = WorkflowDefinition;
-        _selectedWorkflowDefinition = SelectedWorkflowDefinition;
+        _selectedWorkflowDefinition = SelectedWorkflowDefinition ?? _workflowDefinition;
     }
 
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
-        _workflowDefinition = WorkflowDefinition;
-        _selectedWorkflowDefinition = SelectedWorkflowDefinition;
+        var isNewWorkflowDefinition = !ReferenceEquals(_lastIncomingWorkflowDefinition, WorkflowDefinition);
+        var isNewSelectedWorkflowDefinition = !ReferenceEquals(_lastIncomingSelectedWorkflowDefinition, SelectedWorkflowDefinition);
+        _lastIncomingWorkflowDefinition = WorkflowDefinition;
+        _lastIncomingSelectedWorkflowDefinition = SelectedWorkflowDefinition;
 
-        if (_selectedWorkflowDefinition == null)
-            _selectedWorkflowDefinition = _workflowDefinition;
+        if (!isNewWorkflowDefinition && !isNewSelectedWorkflowDefinition)
+            return;
+
+        if (WorkflowEditor != null)
+            WorkflowEditor.InvalidateWorkflowDefinitionOperations();
+
+        if (isNewWorkflowDefinition)
+            _workflowDefinition = WorkflowDefinition;
+
+        _selectedWorkflowDefinition = SelectedWorkflowDefinition ?? _workflowDefinition;
+        _workflowDefinitionReloadVersion++;
     }
 
     /// Displays the specified workflow definition version.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -86,6 +86,9 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
         if (_selectedWorkflowDefinition == workflowDefinition)
             return;
 
+        if (WorkflowEditor != null)
+            WorkflowEditor.InvalidateWorkflowDefinitionOperations();
+
         _workflowDefinitionReloadVersion++;
         _selectedWorkflowDefinition = workflowDefinition;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -134,13 +134,17 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
         await InvokeAsync(StateHasChanged);
     }
 
+    private async Task OnWorkflowDefinitionReloaded()
+    {
+        _workflowDefinitionReloadVersion++;
+        await OnWorkflowDefinitionUpdated();
+    }
+
     private async Task OnApplyWorkflowDefinition(WorkflowDefinition deserialized)
     {
         var incomingJson = JsonSerializer.Serialize(deserialized, new JsonSerializerOptions { WriteIndented = true });
         if (string.Equals(WorkflowDefinitionSerialized, incomingJson, StringComparison.Ordinal))
             return;
-
-        _workflowDefinitionReloadVersion++;
 
         if (WorkflowEditor != null)
             await WorkflowEditor.ApplyWorkflowDefinitionAsync(deserialized);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionWorkspace.razor.cs
@@ -21,6 +21,7 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
     private MudDynamicTabs _dynamicTabs = null!;
     private WorkflowDefinition? _workflowDefinition = null!;
     private WorkflowDefinition? _selectedWorkflowDefinition = null!;
+    private long _workflowDefinitionReloadVersion;
     private WorkflowEditor WorkflowEditor { get; set; } = null!;
     private CodeView CodeView { get; set; } = null!;
 
@@ -85,6 +86,7 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
         if (_selectedWorkflowDefinition == workflowDefinition)
             return;
 
+        _workflowDefinitionReloadVersion++;
         _selectedWorkflowDefinition = workflowDefinition;
 
         if (workflowDefinition.IsLatest)
@@ -137,6 +139,8 @@ public partial class WorkflowDefinitionWorkspace : IWorkspace
         var incomingJson = JsonSerializer.Serialize(deserialized, new JsonSerializerOptions { WriteIndented = true });
         if (string.Equals(WorkflowDefinitionSerialized, incomingJson, StringComparison.Ordinal))
             return;
+
+        _workflowDefinitionReloadVersion++;
 
         if (WorkflowEditor != null)
             await WorkflowEditor.ApplyWorkflowDefinitionAsync(deserialized);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -37,7 +37,7 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
 /// A component that allows the user to edit a workflow definition.
 public partial class WorkflowEditor : WorkflowEditorComponentBase, INotificationHandler<ImportedWorkflowDefinition>, IDisposable
 {
-    private readonly RateLimitedFunc<bool, Task> _rateLimitedSaveChangesAsync;
+    private readonly RateLimitedFunc<(bool ReadDiagram, long WorkflowDefinitionGeneration), Task> _rateLimitedSaveChangesAsync;
     private bool _isDirty;
     private WorkflowDefinition? _lastImportedWorkflowDefinition;
     private long _workflowDefinitionGeneration;
@@ -48,7 +48,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc />
     public WorkflowEditor()
     {
-        _rateLimitedSaveChangesAsync = Debouncer.Debounce<bool, Task>(readDiagram => SaveChangesAsync(readDiagram, false, false), TimeSpan.FromMilliseconds(500));
+        _rateLimitedSaveChangesAsync = Debouncer.Debounce<(bool ReadDiagram, long WorkflowDefinitionGeneration), Task>(
+            request => SaveChangesAsync(request.ReadDiagram, false, false, workflowDefinitionGeneration: request.WorkflowDefinitionGeneration),
+            TimeSpan.FromMilliseconds(500));
     }
 
     /// Gets or sets the drag and drop manager via property injection.
@@ -186,20 +188,25 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc />
     public void Dispose()
     {
+        _workflowDefinitionGeneration++;
         Mediator.Unsubscribe(this);
         _rateLimitedSaveChangesAsync.Dispose();
     }    
 
+    /// Invalidates asynchronous operations that belong to the current workflow definition.
+    public void InvalidateWorkflowDefinitionOperations() => _workflowDefinitionGeneration++;
+
     private async Task HandleChangesAsync(bool readDiagram, bool force = false)
     {
+        var workflowDefinitionGeneration = _workflowDefinitionGeneration;
         _isDirty = true;
         await InvokeAsync(StateHasChanged);
 
         if (AutoSave)
             if (force)
-                await SaveChangesAsync(readDiagram, showLoader: false, publish: false);
+                await SaveChangesAsync(readDiagram, showLoader: false, publish: false, workflowDefinitionGeneration: workflowDefinitionGeneration);
             else
-                await SaveChangesRateLimitedAsync(readDiagram);
+                await SaveChangesRateLimitedAsync(readDiagram, workflowDefinitionGeneration);
     }
 
     private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(bool readDiagram, bool publish, long workflowDefinitionGeneration)
@@ -244,6 +251,10 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
             if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
                 await SetWorkflowDefinitionAsync(definition);
         });
+
+        if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+            return;
+
         await result.OnSuccessAsync(async _ =>
         {
             if (onSuccess != null) await onSuccess();
@@ -255,14 +266,17 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         });
     }
 
-    private async Task SaveChangesRateLimitedAsync(bool readDiagram)
+    private async Task SaveChangesRateLimitedAsync(bool readDiagram, long workflowDefinitionGeneration)
     {
-        await _rateLimitedSaveChangesAsync!.InvokeAsync(readDiagram);
+        await _rateLimitedSaveChangesAsync!.InvokeAsync((readDiagram, workflowDefinitionGeneration));
     }
 
-    private async Task SaveChangesAsync(bool readDiagram, bool showLoader, bool publish, Func<SaveWorkflowDefinitionResponse, Task>? onSuccess = null, Func<ValidationErrors, Task>? onFailure = null)
+    private async Task SaveChangesAsync(bool readDiagram, bool showLoader, bool publish, Func<SaveWorkflowDefinitionResponse, Task>? onSuccess = null, Func<ValidationErrors, Task>? onFailure = null, long? workflowDefinitionGeneration = null)
     {
-        var workflowDefinitionGeneration = _workflowDefinitionGeneration;
+        var expectedWorkflowDefinitionGeneration = workflowDefinitionGeneration ?? _workflowDefinitionGeneration;
+
+        if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+            return;
 
         await InvokeAsync(() =>
         {
@@ -277,13 +291,17 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         // Therefore, we need to wrap this in a try/catch block.
         try
         {
-            if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+            if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
                 return;
 
-            var result = await SaveAsync(readDiagram, publish, workflowDefinitionGeneration);
+            var result = await SaveAsync(readDiagram, publish, expectedWorkflowDefinitionGeneration);
+
+            if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+                return;
+
             await result.OnSuccessAsync(async response =>
             {
-                if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+                if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
                     return;
 
                 var currentSelectedActivityId = SelectedActivityId;
@@ -321,8 +339,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 options => options.VisibleStateDuration = 5000
             );
         }
-        catch (OperationCanceledException) when (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+        catch (OperationCanceledException) when (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
         {
+            Logger.LogDebug("Skipped obsolete workflow save after the workflow definition changed.");
         }
         finally
         {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -39,6 +39,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 {
     private readonly RateLimitedFunc<bool, Task> _rateLimitedSaveChangesAsync;
     private bool _isDirty;
+    private WorkflowDefinition? _lastImportedWorkflowDefinition;
+    private long _workflowDefinitionGeneration;
     private RadzenSplitterPane _activityPropertiesPane = null!;
     private int _activityPropertiesPaneHeight = 300;
     private DiagramDesignerWrapper _diagramDesigner = null!;
@@ -57,6 +59,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     /// Gets or sets a callback invoked when the workflow definition is updated.
     [Parameter] public Func<Task>? WorkflowDefinitionUpdated { get; set; }
+
+    /// Gets or sets a callback invoked when an external workflow definition replaces the current definition.
+    [Parameter] public Func<Task>? WorkflowDefinitionReloaded { get; set; }
 
     /// Gets or sets the event triggered when an activity is selected.
     [Parameter] public Func<JsonObject, Task>? ActivitySelected { get; set; }
@@ -124,7 +129,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <param name="workflowDefinition">The workflow definition to apply. Cannot be null.</param>
     public async Task ApplyWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition)
     {
-        await SetWorkflowDefinitionAsync(workflowDefinition);
+        await SetWorkflowDefinitionAsync(workflowDefinition, true);
         await HandleChangesAsync(false, true);
     }
 
@@ -154,6 +159,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         if (WorkflowDefinition == _workflowDefinition)
             return;
+
+        if (_workflowDefinition != null && !IsSameWorkflowVersion(_workflowDefinition, WorkflowDefinition))
+            _workflowDefinitionGeneration++;
 
         _workflowDefinition = WorkflowDefinition;
 
@@ -194,20 +202,31 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 await SaveChangesRateLimitedAsync(readDiagram);
     }
 
-    private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(bool readDiagram, bool publish)
+    private async Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(bool readDiagram, bool publish, long workflowDefinitionGeneration)
     {
         var workflowDefinition = _workflowDefinition ?? new WorkflowDefinition();
 
         if (readDiagram)
         {
             var root = await _diagramDesigner.GetActivityAsync();
+
+            if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+                throw new OperationCanceledException();
+
             workflowDefinition.Root = root;
         }
 
-        var result = await WorkflowDefinitionEditorService.SaveAsync(workflowDefinition, publish, async definition => await SetWorkflowDefinitionAsync(definition));
+        var result = await WorkflowDefinitionEditorService.SaveAsync(workflowDefinition, publish, async definition =>
+        {
+            if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
+                await SetWorkflowDefinitionAsync(definition);
+        });
 
-        _isDirty = false;
-        await InvokeAsync(StateHasChanged);
+        if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
+        {
+            _isDirty = false;
+            await InvokeAsync(StateHasChanged);
+        }
 
         return result;
     }
@@ -219,7 +238,12 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task RetractAsync(Func<Task>? onSuccess = null, Func<ValidationErrors, Task>? onFailure = null)
     {
-        var result = await WorkflowDefinitionEditorService.RetractAsync(_workflowDefinition!, async definition => await SetWorkflowDefinitionAsync(definition));
+        var workflowDefinitionGeneration = _workflowDefinitionGeneration;
+        var result = await WorkflowDefinitionEditorService.RetractAsync(_workflowDefinition!, async definition =>
+        {
+            if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
+                await SetWorkflowDefinitionAsync(definition);
+        });
         await result.OnSuccessAsync(async _ =>
         {
             if (onSuccess != null) await onSuccess();
@@ -238,6 +262,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task SaveChangesAsync(bool readDiagram, bool showLoader, bool publish, Func<SaveWorkflowDefinitionResponse, Task>? onSuccess = null, Func<ValidationErrors, Task>? onFailure = null)
     {
+        var workflowDefinitionGeneration = _workflowDefinitionGeneration;
+
         await InvokeAsync(() =>
         {
             if (showLoader)
@@ -251,9 +277,15 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         // Therefore, we need to wrap this in a try/catch block.
         try
         {
-            var result = await SaveAsync(readDiagram, publish);
+            if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+                return;
+
+            var result = await SaveAsync(readDiagram, publish, workflowDefinitionGeneration);
             await result.OnSuccessAsync(async response =>
             {
+                if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+                    return;
+
                 var currentSelectedActivityId = SelectedActivityId;
 
                 await SetWorkflowDefinitionAsync(response.WorkflowDefinition);
@@ -289,6 +321,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 options => options.VisibleStateDuration = 5000
             );
         }
+        catch (OperationCanceledException) when (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+        {
+        }
         finally
         {
             if (showLoader)
@@ -307,11 +342,32 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task SetWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition)
+    private async Task SetWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition, bool isExternalReplacement = false)
     {
+        if (isExternalReplacement)
+            _workflowDefinitionGeneration++;
+
         _workflowDefinition = WorkflowDefinition = workflowDefinition;
-        if (WorkflowDefinitionUpdated != null) await WorkflowDefinitionUpdated();
+        if (isExternalReplacement && WorkflowDefinitionReloaded != null)
+            await WorkflowDefinitionReloaded();
+        else if (WorkflowDefinitionUpdated != null)
+            await WorkflowDefinitionUpdated();
     }
+
+    internal async Task SetImportedWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition)
+    {
+        var isNewImport = !ReferenceEquals(_lastImportedWorkflowDefinition, workflowDefinition);
+        _lastImportedWorkflowDefinition = workflowDefinition;
+        await SetWorkflowDefinitionAsync(workflowDefinition, isNewImport);
+
+        if (isNewImport && workflowDefinition.Root != null)
+            await _diagramDesigner.LoadActivityAsync(workflowDefinition.Root);
+    }
+
+    private static bool IsSameWorkflowVersion(WorkflowDefinition? first, WorkflowDefinition? second) =>
+        first != null && second != null &&
+        string.Equals(first.DefinitionId, second.DefinitionId, StringComparison.Ordinal) &&
+        string.Equals(first.Id, second.Id, StringComparison.Ordinal);
 
     private async Task<WorkflowDefinition?> GetWorkflowDefinitionSnapshotAsync()
     {
@@ -488,9 +544,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     
     async Task INotificationHandler<ImportedWorkflowDefinition>.HandleAsync(ImportedWorkflowDefinition notification, CancellationToken cancellationToken)
     {
-        var definition = notification.WorkflowDefinition;
-        await SetWorkflowDefinitionAsync(definition);
-        await _diagramDesigner.LoadActivityAsync(definition.Root);
+        await SetImportedWorkflowDefinitionAsync(notification.WorkflowDefinition);
     }
 
     private async Task ImportFilesAsync(IReadOnlyList<IBrowserFile> files)
@@ -504,8 +558,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
             DefinitionId = WorkflowDefinition?.DefinitionId,
             ImportedCallback = async definition =>
             {
-                await SetWorkflowDefinitionAsync(definition);
-                await _diagramDesigner.LoadActivityAsync(definition.Root);
+                await SetImportedWorkflowDefinitionAsync(definition);
             },
             ErrorCallback = ex =>
             {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -320,13 +320,13 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
             if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
                 return;
 
-            if (progressOperationOwner.HasValue)
+            if (progressOperationOwner is { } progressOwner)
             {
                 try
                 {
                     await InvokeAsync(() =>
                     {
-                        if (!IsCurrentProgressOperation(expectedWorkflowDefinitionGeneration, progressOperationOwner.Value))
+                        if (!IsCurrentProgressOperation(expectedWorkflowDefinitionGeneration, progressOwner))
                             return;
 
                         IsProgressing = true;
@@ -416,8 +416,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         }
         finally
         {
-            if (progressOperationOwner.HasValue)
-                await CompleteProgressOperationAsync(expectedWorkflowDefinitionGeneration, progressOperationOwner.Value);
+            if (progressOperationOwner is { } progressOwner)
+                await CompleteProgressOperationAsync(expectedWorkflowDefinitionGeneration, progressOwner);
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -159,11 +159,10 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
-        if (WorkflowDefinition == _workflowDefinition)
+        if (ReferenceEquals(WorkflowDefinition, _workflowDefinition))
             return;
 
-        if (_workflowDefinition != null && !IsSameWorkflowVersion(_workflowDefinition, WorkflowDefinition))
-            _workflowDefinitionGeneration++;
+        _workflowDefinitionGeneration++;
 
         _workflowDefinition = WorkflowDefinition;
 
@@ -382,11 +381,6 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         if (isNewImport && workflowDefinition.Root != null)
             await _diagramDesigner.LoadActivityAsync(workflowDefinition.Root);
     }
-
-    private static bool IsSameWorkflowVersion(WorkflowDefinition? first, WorkflowDefinition? second) =>
-        first != null && second != null &&
-        string.Equals(first.DefinitionId, second.DefinitionId, StringComparison.Ordinal) &&
-        string.Equals(first.Id, second.Id, StringComparison.Ordinal);
 
     private async Task<WorkflowDefinition?> GetWorkflowDefinitionSnapshotAsync()
     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -39,8 +39,11 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 {
     private readonly RateLimitedFunc<(bool ReadDiagram, long WorkflowDefinitionGeneration), Task> _rateLimitedSaveChangesAsync;
     private bool _isDirty;
+    private bool _disposed;
     private WorkflowDefinition? _lastImportedWorkflowDefinition;
     private long _workflowDefinitionGeneration;
+    private long _progressOperationSequence;
+    private long? _progressOperationOwner;
     private RadzenSplitterPane _activityPropertiesPane = null!;
     private int _activityPropertiesPaneHeight = 300;
     private DiagramDesignerWrapper _diagramDesigner = null!;
@@ -159,18 +162,33 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
+        if (_disposed)
+            return;
+
         if (ReferenceEquals(WorkflowDefinition, _workflowDefinition))
             return;
 
-        _workflowDefinitionGeneration++;
+        InvalidateWorkflowDefinitionOperations();
 
-        _workflowDefinition = WorkflowDefinition;
+        var workflowDefinition = _workflowDefinition = WorkflowDefinition;
+        var expectedWorkflowDefinitionGeneration = _workflowDefinitionGeneration;
 
-        if (_workflowDefinition?.Root == null)
+        if (workflowDefinition?.Root == null)
             return;
 
-        await _diagramDesigner.LoadActivityAsync(_workflowDefinition!.Root);
-        await SelectActivityAsync(_workflowDefinition.Root);
+        try
+        {
+            await _diagramDesigner.LoadActivityAsync(workflowDefinition.Root);
+        }
+        catch (Exception) when (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration) || !ReferenceEquals(_workflowDefinition, workflowDefinition))
+        {
+            return;
+        }
+
+        if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration) || !ReferenceEquals(_workflowDefinition, workflowDefinition))
+            return;
+
+        await SelectActivityAsync(workflowDefinition.Root);
     }
 
     /// <inheritdoc />
@@ -187,13 +205,29 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc />
     public void Dispose()
     {
+        DisposeCore();
+    }
+
+    private void DisposeCore()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _workflowDefinitionGeneration++;
+        _progressOperationOwner = null;
+        IsProgressing = false;
         Mediator.Unsubscribe(this);
         _rateLimitedSaveChangesAsync.Dispose();
-    }    
+    }
 
     /// Invalidates asynchronous operations that belong to the current workflow definition.
-    public void InvalidateWorkflowDefinitionOperations() => _workflowDefinitionGeneration++;
+    public void InvalidateWorkflowDefinitionOperations()
+    {
+        _workflowDefinitionGeneration++;
+        _progressOperationOwner = null;
+        IsProgressing = false;
+    }
 
     private async Task HandleChangesAsync(bool readDiagram, bool force = false)
     {
@@ -216,7 +250,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         {
             var root = await _diagramDesigner.GetActivityAsync();
 
-            if (workflowDefinitionGeneration != _workflowDefinitionGeneration)
+            if (!IsCurrentWorkflowOperation(workflowDefinitionGeneration))
                 throw new OperationCanceledException();
 
             workflowDefinition.Root = root;
@@ -224,11 +258,11 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
         var result = await WorkflowDefinitionEditorService.SaveAsync(workflowDefinition, publish, async definition =>
         {
-            if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
+            if (IsCurrentWorkflowOperation(workflowDefinitionGeneration))
                 await SetWorkflowDefinitionAsync(definition);
         });
 
-        if (workflowDefinitionGeneration == _workflowDefinitionGeneration)
+        if (IsCurrentWorkflowOperation(workflowDefinitionGeneration))
         {
             _isDirty = false;
             await InvokeAsync(StateHasChanged);
@@ -274,45 +308,77 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         var expectedWorkflowDefinitionGeneration = workflowDefinitionGeneration ?? _workflowDefinitionGeneration;
 
-        if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+        if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
             return;
 
-        await InvokeAsync(() =>
-        {
-            if (showLoader)
-            {
-                IsProgressing = true;
-                StateHasChanged();
-            }
-        });
+        var progressOperationOwner = showLoader ? BeginProgressOperation() : null;
 
         // Because this method is rate-limited, it's possible that the designer has been disposed of since the last invocation.
         // Therefore, we need to wrap this in a try/catch block.
         try
         {
-            if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+            if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                return;
+
+            if (progressOperationOwner.HasValue)
+            {
+                try
+                {
+                    await InvokeAsync(() =>
+                    {
+                        if (!IsCurrentProgressOperation(expectedWorkflowDefinitionGeneration, progressOperationOwner.Value))
+                            return;
+
+                        IsProgressing = true;
+                        StateHasChanged();
+                    });
+                }
+                catch (ObjectDisposedException) when (_disposed)
+                {
+                    return;
+                }
+                catch (InvalidOperationException) when (_disposed)
+                {
+                    return;
+                }
+            }
+
+            if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
                 return;
 
             var result = await SaveAsync(readDiagram, publish, expectedWorkflowDefinitionGeneration);
 
-            if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+            if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
                 return;
 
             await result.OnSuccessAsync(async response =>
             {
-                if (expectedWorkflowDefinitionGeneration != _workflowDefinitionGeneration)
+                if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
                     return;
 
                 var currentSelectedActivityId = SelectedActivityId;
 
                 await SetWorkflowDefinitionAsync(response.WorkflowDefinition);
 
+                if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                    return;
+
                 if (!string.IsNullOrEmpty(currentSelectedActivityId))
                 {
                     await RefreshSelectedActivityAsync(currentSelectedActivityId);
+
+                    if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                        return;
                 }
 
-                await InvokeAsync(StateHasChanged);
+                await InvokeAsync(() =>
+                {
+                    if (IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                        StateHasChanged();
+                });
+
+                if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                    return;
 
                 if (onSuccess != null)
                     await onSuccess(response);
@@ -321,6 +387,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
             await result.OnFailedAsync(errors =>
             {
+                if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                    return Task.CompletedTask;
+
                 onFailure?.Invoke(errors);
                 UserMessageService.ShowSnackbarTextMessage(
                     errors.Errors.Select(x => x.ErrorMessage),
@@ -332,6 +401,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         }
         catch (DiagramDesignerValidationException e)
         {
+            if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
+                return;
+
             UserMessageService.ShowSnackbarTextMessage(
                 e.Message,
                 Severity.Error,
@@ -344,11 +416,55 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         }
         finally
         {
-            if (showLoader)
+            if (progressOperationOwner.HasValue)
+                await CompleteProgressOperationAsync(expectedWorkflowDefinitionGeneration, progressOperationOwner.Value);
+        }
+    }
+
+    private long? BeginProgressOperation() => _progressOperationOwner = ++_progressOperationSequence;
+
+    private bool IsCurrentWorkflowOperation(long workflowDefinitionGeneration) => !_disposed && workflowDefinitionGeneration == _workflowDefinitionGeneration;
+
+    private bool IsCurrentProgressOperation(long workflowDefinitionGeneration, long progressOperationOwner) =>
+        IsCurrentWorkflowOperation(workflowDefinitionGeneration) && _progressOperationOwner == progressOperationOwner;
+
+    private async Task CompleteProgressOperationAsync(long workflowDefinitionGeneration, long progressOperationOwner)
+    {
+        if (_disposed)
+        {
+            if (_progressOperationOwner == progressOperationOwner)
+                _progressOperationOwner = null;
+
+            return;
+        }
+
+        try
+        {
+            await InvokeAsync(() =>
             {
+                if (_progressOperationOwner != progressOperationOwner)
+                    return;
+
+                _progressOperationOwner = null;
                 IsProgressing = false;
-                await InvokeAsync(StateHasChanged);
-            }
+
+                if (IsCurrentWorkflowOperation(workflowDefinitionGeneration))
+                    StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException) when (_disposed)
+        {
+            if (_progressOperationOwner == progressOperationOwner)
+                _progressOperationOwner = null;
+
+            Logger.LogDebug("Skipped obsolete workflow progress cleanup after editor disposal.");
+        }
+        catch (InvalidOperationException) when (_disposed)
+        {
+            if (_progressOperationOwner == progressOperationOwner)
+                _progressOperationOwner = null;
+
+            Logger.LogDebug("Skipped obsolete workflow progress cleanup after editor disposal.");
         }
     }
 
@@ -363,7 +479,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     private async Task SetWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition, bool isExternalReplacement = false)
     {
         if (isExternalReplacement)
-            _workflowDefinitionGeneration++;
+            InvalidateWorkflowDefinitionOperations();
 
         _workflowDefinition = WorkflowDefinition = workflowDefinition;
         if (isExternalReplacement && WorkflowDefinitionReloaded != null)
@@ -615,6 +731,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
+        DisposeCore();
+
         if (_dotNetRef != null)
         {
             await JSRuntime.InvokeVoidAsync("editorHotkeys.dispose", _dotNetRef);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
@@ -7,7 +7,6 @@
 <div>
     <MudText Typo="Typo.overline">@Localizer["Metadata"]</MudText>
     <EditForm @key="_editContext" EditContext="@_editContext" OnSubmit="OnSubmit">
-        <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator"/>
         <MudStack>
             <MudTextField T="string" Label="@Localizer["Name"]" Value="@_model.Name" ValueChanged="OnNameChanged" For="@(() => _model.Name)" HelperText="@Localizer["The name of the workflow."]" OnBlur="ValidateForm" Immediate="true" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
             <MarkdownTextArea Label="@Localizer["Description"]" Value="@_model.Description" ValueChanged="OnDescriptionChanged" For="@(() => _model.Description)" HelperText="@Localizer["A brief description of the workflow."]" OnBlur="ValidateForm" IsReadOnly="IsReadOnly" />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor
@@ -6,11 +6,11 @@
 
 <div>
     <MudText Typo="Typo.overline">@Localizer["Metadata"]</MudText>
-    <EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit">
+    <EditForm @key="_editContext" EditContext="@_editContext" OnSubmit="OnSubmit">
         <FluentValidationValidator @ref="_fluentValidationValidator" Validator="_validator"/>
         <MudStack>
-            <MudTextField T="string" Label="@Localizer["Name"]" @bind-Value="@_model.Name" For="@(() => _model.Name)" HelperText="@Localizer["The name of the workflow."]" OnBlur="ValidateForm" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
-            <MarkdownTextArea Label="@Localizer["Description"]" @bind-Value="@_model.Description" For="@(() => _model.Description)" HelperText="@Localizer["A brief description of the workflow."]" OnBlur="ValidateForm" IsReadOnly="IsReadOnly" />
+            <MudTextField T="string" Label="@Localizer["Name"]" Value="@_model.Name" ValueChanged="OnNameChanged" For="@(() => _model.Name)" HelperText="@Localizer["The name of the workflow."]" OnBlur="ValidateForm" Immediate="true" Required="true" Variant="Variant.Outlined" Margin="Margin.Dense" ReadOnly="IsReadOnly" Disabled="IsReadOnly"></MudTextField>
+            <MarkdownTextArea Label="@Localizer["Description"]" Value="@_model.Description" ValueChanged="OnDescriptionChanged" For="@(() => _model.Description)" HelperText="@Localizer["A brief description of the workflow."]" OnBlur="ValidateForm" IsReadOnly="IsReadOnly" />
         </MudStack>
     </EditForm>
 </div>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor.cs
@@ -1,8 +1,10 @@
-using Blazored.FluentValidation;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.Validators;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 
@@ -14,9 +16,9 @@ namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.W
 public partial class Metadata
 {
     private readonly WorkflowMetadataModel _model = new();
-    private FluentValidationValidator _fluentValidationValidator = default!;
     private WorkflowPropertiesModelValidator _validator = default!;
     private EditContext _editContext = default!;
+    private ValidationMessageStore _validationMessages = default!;
     private WorkflowDefinition? _boundWorkflowDefinition;
     private string? _lastLoadedName;
     private string? _lastLoadedDescription;
@@ -24,7 +26,9 @@ public partial class Metadata
     private string? _lastCommittedDescription;
     private long _editVersion;
     private long _workflowVersion;
+    private long _validationVersion;
     private bool _hasCommittedMetadata;
+    private long _lastWorkflowDefinitionReloadVersion;
 
     /// <summary>
     /// Gets or sets the workflow definition.
@@ -36,13 +40,22 @@ public partial class Metadata
     /// </summary>
     [Parameter] public EventCallback WorkflowDefinitionUpdated { get; set; }
     [CascadingParameter] private IWorkspace? Workspace { get; set; }
+    [CascadingParameter(Name = "WorkflowDefinitionReloadVersion")]
+    private long WorkflowDefinitionReloadVersion { get; set; }
+    [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;
     
     private bool IsReadOnly => Workspace?.IsReadOnly ?? false;
 
     /// <inheritdoc />
+    protected override void OnInitialized() => _validator = new(WorkflowDefinitionService, Localizer);
+
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
-        if (ReferenceEquals(_boundWorkflowDefinition, WorkflowDefinition))
+        var isExplicitReload = WorkflowDefinitionReloadVersion != _lastWorkflowDefinitionReloadVersion;
+        _lastWorkflowDefinitionReloadVersion = WorkflowDefinitionReloadVersion;
+
+        if (!isExplicitReload && ReferenceEquals(_boundWorkflowDefinition, WorkflowDefinition))
             return;
 
         var isSameWorkflowVersion = IsSameWorkflowVersion(_boundWorkflowDefinition, WorkflowDefinition);
@@ -50,7 +63,7 @@ public partial class Metadata
         // A save response creates a new object for the same workflow version. Keep local edits and
         // committed metadata across same-version responses, and use a different version as the
         // explicit reload boundary.
-        if (isSameWorkflowVersion && (HasLocalChanges || _hasCommittedMetadata))
+        if (!isExplicitReload && isSameWorkflowVersion && (HasLocalChanges || _hasCommittedMetadata))
         {
             // The editor can receive an older save response after this form has already committed a
             // newer local value. Keep the parent object aligned with the last validated submission;
@@ -73,10 +86,12 @@ public partial class Metadata
         _model.Description = WorkflowDefinition.Description;
         _model.Name = WorkflowDefinition.Name;
         _editContext = new EditContext(_model);
+        _validationMessages = new ValidationMessageStore(_editContext);
         _lastLoadedName = WorkflowDefinition.Name;
         _lastLoadedDescription = WorkflowDefinition.Description;
         _editVersion++;
         _workflowVersion++;
+        _validationVersion++;
         _hasCommittedMetadata = false;
         _lastCommittedName = null;
         _lastCommittedDescription = null;
@@ -91,13 +106,18 @@ public partial class Metadata
         var workflowVersion = _workflowVersion;
         var editVersion = _editVersion;
         var workflowDefinition = WorkflowDefinition;
-        var validator = _fluentValidationValidator;
+        var validationVersion = ++_validationVersion;
 
-        if (!await validator.ValidateAsync())
+        var result = await _validator.ValidateAsync(_model);
+
+        if (validationVersion != _validationVersion ||
+            workflowVersion != _workflowVersion || editVersion != _editVersion ||
+            !IsSameWorkflowVersion(workflowDefinition, WorkflowDefinition))
             return;
 
-        if (workflowVersion != _workflowVersion || editVersion != _editVersion ||
-            !IsSameWorkflowVersion(workflowDefinition, WorkflowDefinition))
+        PublishValidationResult(result);
+
+        if (!result.IsValid)
             return;
 
         await CommitAsync(workflowVersion, editVersion, workflowDefinition);
@@ -110,6 +130,8 @@ public partial class Metadata
 
         _model.Name = value;
         _editVersion++;
+        _validationVersion++;
+        ClearValidationMessages(nameof(WorkflowMetadataModel.Name));
         return Task.CompletedTask;
     }
 
@@ -120,6 +142,8 @@ public partial class Metadata
 
         _model.Description = value;
         _editVersion++;
+        _validationVersion++;
+        ClearValidationMessages(nameof(WorkflowMetadataModel.Description));
         return Task.CompletedTask;
     }
 
@@ -143,6 +167,25 @@ public partial class Metadata
 
     private bool HasLocalChanges => !string.Equals(_model.Name, _lastLoadedName, StringComparison.Ordinal) ||
                                     !string.Equals(_model.Description, _lastLoadedDescription, StringComparison.Ordinal);
+
+    private void ClearValidationMessages(string fieldName)
+    {
+        _validationMessages.Clear(new FieldIdentifier(_model, fieldName));
+        _editContext.NotifyValidationStateChanged();
+    }
+
+    private void PublishValidationResult(ValidationResult result)
+    {
+        _validationMessages.Clear();
+
+        foreach (var error in result.Errors)
+        {
+            var fieldIdentifier = new FieldIdentifier(_model, error.PropertyName);
+            _validationMessages.Add(fieldIdentifier, error.ErrorMessage);
+        }
+
+        _editContext.NotifyValidationStateChanged();
+    }
 
     private bool HasMatchingCommittedMetadata(WorkflowDefinition definition) =>
         _hasCommittedMetadata &&

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/Properties/Sections/Metadata/Metadata.razor.cs
@@ -17,6 +17,14 @@ public partial class Metadata
     private FluentValidationValidator _fluentValidationValidator = default!;
     private WorkflowPropertiesModelValidator _validator = default!;
     private EditContext _editContext = default!;
+    private WorkflowDefinition? _boundWorkflowDefinition;
+    private string? _lastLoadedName;
+    private string? _lastLoadedDescription;
+    private string? _lastCommittedName;
+    private string? _lastCommittedDescription;
+    private long _editVersion;
+    private long _workflowVersion;
+    private bool _hasCommittedMetadata;
 
     /// <summary>
     /// Gets or sets the workflow definition.
@@ -34,26 +42,115 @@ public partial class Metadata
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
+        if (ReferenceEquals(_boundWorkflowDefinition, WorkflowDefinition))
+            return;
+
+        var isSameWorkflowVersion = IsSameWorkflowVersion(_boundWorkflowDefinition, WorkflowDefinition);
+
+        // A save response creates a new object for the same workflow version. Keep local edits and
+        // committed metadata across same-version responses, and use a different version as the
+        // explicit reload boundary.
+        if (isSameWorkflowVersion && (HasLocalChanges || _hasCommittedMetadata))
+        {
+            // The editor can receive an older save response after this form has already committed a
+            // newer local value. Keep the parent object aligned with the last validated submission;
+            // later edits may still be unvalidated.
+            if (_hasCommittedMetadata && !HasMatchingCommittedMetadata(WorkflowDefinition))
+            {
+                WorkflowDefinition.Name = _lastCommittedName;
+                WorkflowDefinition.Description = _lastCommittedDescription;
+            }
+
+            _boundWorkflowDefinition = WorkflowDefinition;
+            _lastLoadedName = WorkflowDefinition.Name;
+            _lastLoadedDescription = WorkflowDefinition.Description;
+
+            return;
+        }
+
+        _boundWorkflowDefinition = WorkflowDefinition;
         _model.DefinitionId = WorkflowDefinition.DefinitionId;
         _model.Description = WorkflowDefinition.Description;
         _model.Name = WorkflowDefinition.Name;
         _editContext = new EditContext(_model);
+        _lastLoadedName = WorkflowDefinition.Name;
+        _lastLoadedDescription = WorkflowDefinition.Description;
+        _editVersion++;
+        _workflowVersion++;
+        _hasCommittedMetadata = false;
+        _lastCommittedName = null;
+        _lastCommittedDescription = null;
     }
 
-    private async Task ValidateForm()
+    private Task ValidateForm() => ValidateAndCommitAsync();
+
+    private Task OnSubmit(EditContext _) => ValidateAndCommitAsync();
+
+    private async Task ValidateAndCommitAsync()
     {
-        if (!await _fluentValidationValidator.ValidateAsync())
+        var workflowVersion = _workflowVersion;
+        var editVersion = _editVersion;
+        var workflowDefinition = WorkflowDefinition;
+        var validator = _fluentValidationValidator;
+
+        if (!await validator.ValidateAsync())
             return;
 
-        await OnValidSubmit();
+        if (workflowVersion != _workflowVersion || editVersion != _editVersion ||
+            !IsSameWorkflowVersion(workflowDefinition, WorkflowDefinition))
+            return;
+
+        await CommitAsync(workflowVersion, editVersion, workflowDefinition);
     }
 
-    private async Task OnValidSubmit()
+    private Task OnNameChanged(string value)
     {
+        if (string.Equals(_model.Name, value, StringComparison.Ordinal))
+            return Task.CompletedTask;
+
+        _model.Name = value;
+        _editVersion++;
+        return Task.CompletedTask;
+    }
+
+    private Task OnDescriptionChanged(string value)
+    {
+        if (string.Equals(_model.Description, value, StringComparison.Ordinal))
+            return Task.CompletedTask;
+
+        _model.Description = value;
+        _editVersion++;
+        return Task.CompletedTask;
+    }
+
+    private async Task CommitAsync(long workflowVersion, long editVersion, WorkflowDefinition workflowDefinition)
+    {
+        if (workflowVersion != _workflowVersion || editVersion != _editVersion ||
+            !IsSameWorkflowVersion(workflowDefinition, WorkflowDefinition))
+            return;
+
         WorkflowDefinition.Description = _model.Description;
         WorkflowDefinition.Name = _model.Name;
+        _lastLoadedName = _model.Name;
+        _lastLoadedDescription = _model.Description;
+        _lastCommittedName = _model.Name;
+        _lastCommittedDescription = _model.Description;
+        _hasCommittedMetadata = true;
 
         if (WorkflowDefinitionUpdated.HasDelegate)
             await WorkflowDefinitionUpdated.InvokeAsync();
     }
+
+    private bool HasLocalChanges => !string.Equals(_model.Name, _lastLoadedName, StringComparison.Ordinal) ||
+                                    !string.Equals(_model.Description, _lastLoadedDescription, StringComparison.Ordinal);
+
+    private bool HasMatchingCommittedMetadata(WorkflowDefinition definition) =>
+        _hasCommittedMetadata &&
+        string.Equals(_lastCommittedName, definition.Name, StringComparison.Ordinal) &&
+        string.Equals(_lastCommittedDescription, definition.Description, StringComparison.Ordinal);
+
+    private static bool IsSameWorkflowVersion(WorkflowDefinition? first, WorkflowDefinition? second) =>
+        first != null && second != null &&
+        string.Equals(first.DefinitionId, second.DefinitionId, StringComparison.Ordinal) &&
+        string.Equals(first.Id, second.Id, StringComparison.Ordinal);
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -36,6 +36,8 @@
     private WorkflowDefinition? _workflowDefinition;
     private string? _loadedDefinitionId;
     private long _definitionLoadGeneration;
+    private Task<WorkflowDefinition?>? _pendingDefinitionLoad;
+    private string? _pendingDefinitionLoadId;
     private WorkflowDefinitionWorkspace WorkflowDefinitionWorkspace { get; set; } = null!;
 
     /// The ID of the workflow definition to load.
@@ -71,15 +73,40 @@
             return;
 
         var requestedDefinitionId = DefinitionId;
-        var definitionLoadGeneration = ++_definitionLoadGeneration;
-        var workflowDefinition = await WorkflowDefinitionService.FindByDefinitionIdAsync(requestedDefinitionId, VersionOptions.Latest);
+        var definitionLoadGeneration = _definitionLoadGeneration;
+        var definitionLoad = _pendingDefinitionLoad;
 
-        if (definitionLoadGeneration != _definitionLoadGeneration || !string.Equals(requestedDefinitionId, DefinitionId, StringComparison.Ordinal))
+        if (definitionLoad == null || !string.Equals(_pendingDefinitionLoadId, requestedDefinitionId, StringComparison.Ordinal))
+        {
+            definitionLoadGeneration = ++_definitionLoadGeneration;
+            definitionLoad = WorkflowDefinitionService.FindByDefinitionIdAsync(requestedDefinitionId, VersionOptions.Latest);
+            _pendingDefinitionLoad = definitionLoad;
+            _pendingDefinitionLoadId = requestedDefinitionId;
+        }
+
+        try
+        {
+            var workflowDefinition = await definitionLoad;
+
+            if (definitionLoadGeneration != _definitionLoadGeneration || !string.Equals(requestedDefinitionId, DefinitionId, StringComparison.Ordinal))
+                return;
+
+            _workflowDefinition = workflowDefinition;
+
+            if (workflowDefinition != null)
+                _loadedDefinitionId = requestedDefinitionId;
+        }
+        catch (Exception) when (definitionLoadGeneration != _definitionLoadGeneration || !string.Equals(requestedDefinitionId, DefinitionId, StringComparison.Ordinal))
+        {
             return;
-
-        _workflowDefinition = workflowDefinition;
-
-        if (workflowDefinition != null)
-            _loadedDefinitionId = requestedDefinitionId;
+        }
+        finally
+        {
+            if (ReferenceEquals(_pendingDefinitionLoad, definitionLoad))
+            {
+                _pendingDefinitionLoad = null;
+                _pendingDefinitionLoadId = null;
+            }
+        }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/WorkflowDefinitionEditor.razor
@@ -34,6 +34,8 @@
 {
     private readonly DragDropManager _dragDropManager = new();
     private WorkflowDefinition? _workflowDefinition;
+    private string? _loadedDefinitionId;
+    private long _definitionLoadGeneration;
     private WorkflowDefinitionWorkspace WorkflowDefinitionWorkspace { get; set; } = null!;
 
     /// The ID of the workflow definition to load.
@@ -65,6 +67,19 @@
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
-        _workflowDefinition = await WorkflowDefinitionService.FindByDefinitionIdAsync(DefinitionId, VersionOptions.Latest);
+        if (string.Equals(_loadedDefinitionId, DefinitionId, StringComparison.Ordinal) && _workflowDefinition != null)
+            return;
+
+        var requestedDefinitionId = DefinitionId;
+        var definitionLoadGeneration = ++_definitionLoadGeneration;
+        var workflowDefinition = await WorkflowDefinitionService.FindByDefinitionIdAsync(requestedDefinitionId, VersionOptions.Latest);
+
+        if (definitionLoadGeneration != _definitionLoadGeneration || !string.Equals(requestedDefinitionId, DefinitionId, StringComparison.Ordinal))
+            return;
+
+        _workflowDefinition = workflowDefinition;
+
+        if (workflowDefinition != null)
+            _loadedDefinitionId = requestedDefinitionId;
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -15,6 +15,7 @@ using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Humanizer;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using MudBlazor;
 
 namespace Elsa.Studio.Workflows.Shared.Components;
@@ -24,6 +25,8 @@ public partial class DiagramDesignerWrapper
 {
     private const string SelfDesignerPortName = "__self";
     private IDiagramDesigner? _diagramDesigner;
+    private readonly object _loadActivityLock = new();
+    private Task _loadActivityTask = Task.CompletedTask;
     private Stack<ActivityPathSegment> _pathSegments = new();
     private JsonObject? _currentContainerActivity;
     private List<BreadcrumbItem> _breadcrumbItems = new();
@@ -91,6 +94,9 @@ public partial class DiagramDesignerWrapper
 
     [Inject]
     private IActivityRegistry ActivityRegistry { get; set; } = null!;
+
+    [Inject]
+    private ILogger<DiagramDesignerWrapper> Logger { get; set; } = null!;
 
     [Inject]
     private IIdentityGenerator IdentityGenerator { get; set; } = null!;
@@ -221,7 +227,48 @@ public partial class DiagramDesignerWrapper
 
     /// Loads the specified activity into the designer.
     /// <param name="activity">The activity to load.</param>
-    public async Task LoadActivityAsync(JsonObject activity)
+    public Task LoadActivityAsync(JsonObject activity)
+    {
+        Task previousLoad;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        lock (_loadActivityLock)
+        {
+            previousLoad = _loadActivityTask;
+            _loadActivityTask = completion.Task;
+        }
+
+        _ = RunActivityLoadAsync(previousLoad, activity, completion);
+        return completion.Task;
+    }
+
+    private async Task RunActivityLoadAsync(Task previousLoad, JsonObject activity, TaskCompletionSource completion)
+    {
+        try
+        {
+            try
+            {
+                await previousLoad;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "A previous diagram load failed; continuing with the newer load.");
+            }
+
+            await LoadActivityCoreAsync(activity);
+            completion.TrySetResult();
+        }
+        catch (OperationCanceledException ex)
+        {
+            completion.TrySetCanceled(ex.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task LoadActivityCoreAsync(JsonObject activity)
     {
         Activity = activity;
         _diagramDesigner = DiagramDesignerService.GetDiagramDesigner(activity);


### PR DESCRIPTION
## Purpose

Preserve workflow Name and Description when users switch inputs quickly or delayed validation/save responses rerender the metadata form. Form submission now waits for asynchronous name validation before updating the workflow.

Fixes #945.

## Scope

- [x] Bug fix (behavior change)

## Description

### Problem

The form recreated its edit context and copied both values from the workflow on every parameter update. A rerender during a blur validation could restore the old value. Enter also used the synchronous EditForm validation path even though name uniqueness is asynchronous. Older autosave responses could overwrite more recent submitted metadata.

### Solution

Update Name on input and keep the metadata model and edit context stable. Blur and submission await validation, and only the current validation request can publish errors or commit values. Keep live input separate from the last validated submission so old save responses cannot restore older metadata or submit unvalidated text.

Treat version selection, code-view apply, imports, and external parameter replacements as explicit reloads. Unchanged parent parameters preserve internal editor state. Imports use one replacement path for their callback and notification. Definition loads share an in-flight request for the same ID, reject obsolete results and failures, and allow retries after a missing definition or current failure.

Save and retract operations retain their original workflow generation. Replacements and disposal invalidate pending work; stale callbacks cannot replace the current definition or show its predecessor's result. Debounced saves carry their generation from enqueue time, and foreground progress belongs to its specific operation.

Serialize diagram loads at the shared diagram component so initialization, imports, and parameter replacements use the same ordering. Each caller retains its own failure or cancellation result; a failed earlier load does not block a later one. The editor selects an activity only when its diagram load still belongs to the current definition.

## Verification

Controlled bUnit tests exercise actual input, blur, and form-submit events with delayed validation and parent rerenders. Coverage includes both fields, out-of-order completion, invalid and stale submissions, workflow-version replacement, old save responses, unvalidated text typed after submission, explicit same-version refresh, import callback/notification ordering, stale/current validation errors, rejection of obsolete queued saves before renderer, service, or callbacks are reached, and delayed save/retract success and failure after generation invalidation. The lifecycle tests render the real editor and preserve service callback-before-result ordering. Workspace tests also exercise the real metadata component through its reload cascade, unchanged parent rerenders, external same-version replacements, out-of-order A/B/A loads, missing-definition retries, pending-request coalescing, obsolete failures, diagram ordering and failure recovery, overlapping foreground saves, and disposal.

- Focused metadata and editor lifecycle regressions: 38 passed, including an independent root rerun.
- Full Workflows suite: 186 passed.
- Workflows Release builds: .NET 8, 9, and 10, zero warnings/errors.
- Baseline evidence: the added submission/save-response cases failed with four behavioral assertions before their fixes.
- Mutation evidence: removing the post-await save guard caused the delayed failure regression to fail; restoring it returned the suite to green.
- Additional baseline evidence: five workspace/parameter assertions reproduced selection resets, repeated loads, and stale save/retract replacement before the parameter-boundary fix.
- Diagram/progress baseline evidence: three regressions failed for a stale final graph, premature loader clearing, and rendering after disposal before the lifecycle fixes.
- `git diff --check` passed.

Manual verification steps:
1. Edit Name and Description while switching with Tab, Enter, and mouse clicks.
2. Repeat with delayed backend responses and autosave enabled.
3. Select another workflow version and check that its metadata loads.

Expected outcome: entered values remain visible, only validated metadata is submitted, and selecting another version reloads its values.

## Screenshots / Recordings

Behavior-only change; the visual layout is unchanged. Validation uses component DOM events and controlled responses. A live browser/backend autosave session was not exercised.

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated
- [x] No unrelated cleanup included
- [x] Self-review and independent review completed
