### PR TITLE
fix(workflows): stop instance designer refresh timers when the circuit disconnects

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -1,0 +1,207 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Resources.Resilience.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Enums;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Pins that <see cref="WorkflowInstanceDesigner"/>'s periodic activity-state refresh timer stops
+/// quietly instead of crashing the process when the Blazor circuit it belongs to disconnects
+/// (see https://github.com/elsa-workflows/elsa-studio/issues/743).
+/// </summary>
+public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContext, IAsyncLifetime
+{
+    public WorkflowInstanceDesignerDisconnectRefreshTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<ILocalizer>(new TestLocalizer());
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub());
+        Services.AddSingleton<IRemoteFeatureProvider>(new RemoteFeatureProviderStub());
+        Services.AddSingleton(DispatchProxy.Create<IDiagramDesignerService, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IDomAccessor, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IActivityVisitor, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowInstanceObserverFactory, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowInstanceService, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowDefinitionService, ThrowingProxy>());
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task RefreshTickAfterDisposalDoesNotThrowOrCallActivityExecutionService()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+
+        var exception = await Record.ExceptionAsync(() => InvokeRefreshTimerTickAsync(cut.Instance, "exec-1"));
+
+        Assert.Null(exception);
+        Assert.Equal(0, activityExecutionService.ListSummariesCallCount);
+    }
+
+    public static IEnumerable<object[]> CircuitGoneExceptions()
+    {
+        yield return new object[] { new JSDisconnectedException("The circuit has disconnected.") };
+        yield return new object[] { new ObjectDisposedException("ActivityExecutionService") };
+    }
+
+    [Theory]
+    [MemberData(nameof(CircuitGoneExceptions))]
+    public async Task RefreshTickStopsPeriodicRefreshWhenCircuitIsGone(Exception circuitGoneException)
+    {
+        var activityExecutionService = new RecordingActivityExecutionService(circuitGoneException);
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+        SetRefreshTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+
+        var exception = await Record.ExceptionAsync(() => InvokeRefreshTimerTickAsync(cut.Instance, "exec-1"));
+
+        Assert.Null(exception);
+        Assert.Equal(1, activityExecutionService.ListSummariesCallCount);
+
+        // The periodic refresh timer has been stopped and disposed in response to the circuit-gone
+        // exception, so the real Timer can no longer produce a subsequent tick.
+        Assert.Null(GetRefreshTimer(cut.Instance));
+    }
+
+    private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner(IActivityExecutionService activityExecutionService)
+    {
+        Services.AddSingleton(activityExecutionService);
+
+        var workflowInstance = new WorkflowInstance
+        {
+            Id = "instance-1",
+            DefinitionId = "definition-1",
+            Status = WorkflowStatus.Finished
+        };
+
+        return Render<TestWorkflowInstanceDesigner>(parameters => parameters
+            .Add(x => x.WorkflowInstance, workflowInstance));
+    }
+
+    private static void SetLastActivityExecution(WorkflowInstanceDesigner instance, string activityNodeId)
+    {
+        var property = typeof(WorkflowInstanceDesigner).GetProperty("LastActivityExecution", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        property.SetValue(instance, new ActivityExecutionRecord
+        {
+            Id = "exec-1",
+            WorkflowInstanceId = "instance-1",
+            ActivityId = "activity-1",
+            ActivityNodeId = activityNodeId,
+            ActivityType = "Test",
+            Status = ActivityStatus.Running
+        });
+    }
+
+    private static void SetRefreshTimer(WorkflowInstanceDesigner instance, Timer timer) =>
+        GetRefreshTimerField().SetValue(instance, timer);
+
+    private static Timer? GetRefreshTimer(WorkflowInstanceDesigner instance) =>
+        (Timer?)GetRefreshTimerField().GetValue(instance);
+
+    private static FieldInfo GetRefreshTimerField() =>
+        typeof(WorkflowInstanceDesigner).GetField("_refreshTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static Task InvokeRefreshTimerTickAsync(WorkflowInstanceDesigner instance, string activityExecutionRecordId)
+    {
+        var method = typeof(WorkflowInstanceDesigner).GetMethod("RefreshTimerTickAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(instance, [activityExecutionRecordId])!;
+    }
+
+    private sealed class TestWorkflowInstanceDesigner : WorkflowInstanceDesigner
+    {
+        protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IActivityExecutionService"/> that counts calls to <see cref="ListSummariesAsync"/>
+    /// and, when constructed with an exception, throws it from that call to simulate a circuit
+    /// disconnecting mid-refresh.
+    /// </summary>
+    private sealed class RecordingActivityExecutionService(Exception? exceptionToThrow = null) : IActivityExecutionService
+    {
+        public int ListSummariesCallCount { get; private set; }
+
+        public Task<ActivityExecutionReport> GetReportAsync(string workflowInstanceId, JsonObject containerActivity, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IEnumerable<ActivityExecutionRecord>> ListAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default)
+        {
+            ListSummariesCallCount++;
+
+            if (exceptionToThrow != null)
+                throw exceptionToThrow;
+
+            return Task.FromResult<IEnumerable<ActivityExecutionRecordSummary>>([]);
+        }
+
+        public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<PagedListResponse<RetryAttemptRecord>> GetRetriesAsync(string activityInstanceId, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class ActivityRegistryStub : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor> List() => throw new NotSupportedException();
+        public Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor? Find(string activityType, int? version = null) => throw new NotSupportedException();
+        public IEnumerable<Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor> FindAll(string activityType) => throw new NotSupportedException();
+        public void MarkStale() => throw new NotSupportedException();
+    }
+
+    private sealed class RemoteFeatureProviderStub : IRemoteFeatureProvider
+    {
+        public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<IEnumerable<Elsa.Api.Client.Resources.Features.Models.FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    /// <summary>
+    /// A <see cref="DispatchProxy"/> that throws for every call, used for services this component
+    /// depends on but that these tests never exercise.
+    /// </summary>
+    private class ThrowingProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Unexpected call to {targetMethod!.DeclaringType!.Name}.{targetMethod.Name}.");
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -64,6 +64,7 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     {
         yield return new object[] { new JSDisconnectedException("The circuit has disconnected.") };
         yield return new object[] { new ObjectDisposedException("ActivityExecutionService") };
+        yield return new object[] { new OperationCanceledException("The operation was canceled.") };
     }
 
     [Theory]
@@ -83,6 +84,37 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         // The periodic refresh timer has been stopped and disposed in response to the circuit-gone
         // exception, so the real Timer can no longer produce a subsequent tick.
         Assert.Null(GetRefreshTimer(cut.Instance));
+    }
+
+    [Fact]
+    public async Task ElapsedTickAfterDisposalDoesNothing()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+
+        var exception = await Record.ExceptionAsync(() => cut.Instance.ElapsedTimerTickAsync());
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [MemberData(nameof(CircuitGoneExceptions))]
+    public async Task ElapsedTickStopsElapsedTimerWhenCircuitIsGone(Exception circuitGoneException)
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        cut.Instance.ThrowOnRender = circuitGoneException;
+        SetElapsedTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+
+        var exception = await Record.ExceptionAsync(() => cut.Instance.ElapsedTimerTickAsync());
+
+        Assert.Null(exception);
+
+        // The elapsed timer has been stopped and disposed in response to the circuit-gone exception,
+        // so the real Timer can no longer produce a subsequent tick.
+        Assert.Null(GetElapsedTimer(cut.Instance));
     }
 
     private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner(IActivityExecutionService activityExecutionService)
@@ -123,19 +155,38 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     private static FieldInfo GetRefreshTimerField() =>
         typeof(WorkflowInstanceDesigner).GetField("_refreshTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-    private static Task InvokeRefreshTimerTickAsync(WorkflowInstanceDesigner instance, string activityExecutionRecordId)
-    {
-        var method = typeof(WorkflowInstanceDesigner).GetMethod("RefreshTimerTickAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        return (Task)method.Invoke(instance, [activityExecutionRecordId])!;
-    }
+    private static Task InvokeRefreshTimerTickAsync(WorkflowInstanceDesigner instance, string activityExecutionRecordId) =>
+        instance.RefreshTimerTickAsync(activityExecutionRecordId);
 
+    private static void SetElapsedTimer(WorkflowInstanceDesigner instance, Timer timer) =>
+        GetElapsedTimerField().SetValue(instance, timer);
+
+    private static Timer? GetElapsedTimer(WorkflowInstanceDesigner instance) =>
+        (Timer?)GetElapsedTimerField().GetValue(instance);
+
+    private static FieldInfo GetElapsedTimerField() =>
+        typeof(WorkflowInstanceDesigner).GetField("_elapsedTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// A <see cref="WorkflowInstanceDesigner"/> whose state-changed notification can be made to throw
+    /// on demand. bUnit's test renderer does not propagate exceptions from the JS-interop-driven
+    /// render pipeline back through <c>InvokeAsync(StateHasChanged)</c> the way a real Blazor circuit
+    /// does, so the internal <see cref="WorkflowInstanceDesigner.NotifyStateChangedAsync"/> seam is
+    /// overridden here to simulate the circuit-gone exception that a real disconnect would surface
+    /// from that call.
+    /// </summary>
     private sealed class TestWorkflowInstanceDesigner : WorkflowInstanceDesigner
     {
+        public Exception? ThrowOnRender { get; set; }
+
         protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
 
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
         }
+
+        internal override Task NotifyStateChangedAsync() =>
+            ThrowOnRender != null ? Task.FromException(ThrowOnRender) : base.NotifyStateChangedAsync();
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -404,9 +404,23 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     /// </summary>
     private sealed class ThrowingWorkflowInstanceObserver(Exception exceptionToThrow) : IWorkflowInstanceObserver
     {
-        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowExecutionLogUpdatedMessage, Task>? WorkflowJournalUpdated;
-        public event Func<Elsa.Api.Client.RealTime.Messages.ActivityExecutionLogUpdatedMessage, Task>? ActivityExecutionLogUpdated;
-        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowInstanceUpdatedMessage, Task>? WorkflowInstanceUpdated;
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowExecutionLogUpdatedMessage, Task>? WorkflowJournalUpdated
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<Elsa.Api.Client.RealTime.Messages.ActivityExecutionLogUpdatedMessage, Task>? ActivityExecutionLogUpdated
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowInstanceUpdatedMessage, Task>? WorkflowInstanceUpdated
+        {
+            add { }
+            remove { }
+        }
 
         public ValueTask DisposeAsync() => throw exceptionToThrow;
     }

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -74,16 +74,24 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         var activityExecutionService = new RecordingActivityExecutionService(circuitGoneException);
         var cut = RenderDesigner(activityExecutionService);
         SetLastActivityExecution(cut.Instance, "node-1");
-        SetRefreshTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+        using var timer = new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite);
+        SetRefreshTimer(cut.Instance, timer);
 
-        var exception = await Record.ExceptionAsync(() => InvokeRefreshTimerTickAsync(cut.Instance, "exec-1"));
+        try
+        {
+            var exception = await Record.ExceptionAsync(() => InvokeRefreshTimerTickAsync(cut.Instance, "exec-1"));
 
-        Assert.Null(exception);
-        Assert.Equal(1, activityExecutionService.ListSummariesCallCount);
+            Assert.Null(exception);
+            Assert.Equal(1, activityExecutionService.ListSummariesCallCount);
 
-        // The periodic refresh timer has been stopped and disposed in response to the circuit-gone
-        // exception, so the real Timer can no longer produce a subsequent tick.
-        Assert.Null(GetRefreshTimer(cut.Instance));
+            // The periodic refresh timer has been stopped and disposed in response to the circuit-gone
+            // exception, so the real Timer can no longer produce a subsequent tick.
+            Assert.Null(GetRefreshTimer(cut.Instance));
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
     }
 
     [Fact]
@@ -118,14 +126,76 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         var activityExecutionService = new RecordingActivityExecutionService();
         var cut = RenderDesigner(activityExecutionService);
         cut.Instance.ThrowOnRender = circuitGoneException;
-        SetElapsedTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+        using var timer = new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite);
+        SetElapsedTimer(cut.Instance, timer);
 
-        var exception = await Record.ExceptionAsync(() => cut.Instance.ElapsedTimerTickAsync());
+        try
+        {
+            var exception = await Record.ExceptionAsync(() => cut.Instance.ElapsedTimerTickAsync());
+
+            Assert.Null(exception);
+
+            // The elapsed timer has been stopped and disposed in response to the circuit-gone exception,
+            // so the real Timer can no longer produce a subsequent tick.
+            Assert.Null(GetElapsedTimer(cut.Instance));
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task RefreshTimerTickRearmToleratesConcurrentlyDisposedTimer()
+    {
+        var runningRecord = new ActivityExecutionRecord
+        {
+            Id = "exec-1",
+            WorkflowInstanceId = "instance-1",
+            ActivityId = "activity-1",
+            ActivityNodeId = "node-1",
+            ActivityType = "Test",
+            Status = ActivityStatus.Running
+        };
+        var summary = new ActivityExecutionRecordSummary
+        {
+            Id = "exec-1",
+            WorkflowInstanceId = "instance-1",
+            ActivityId = "activity-1",
+            ActivityNodeId = "node-1",
+            ActivityType = "Test",
+            Status = ActivityStatus.Running
+        };
+        var activityExecutionService = new RecordingActivityExecutionService(summariesToReturn: [summary], recordToReturn: runningRecord);
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        // Simulate the timer being disposed concurrently (e.g. by DisposeAsync racing this tick) right
+        // before the tick tries to rearm it.
+        var timer = new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite);
+        SetRefreshTimer(cut.Instance, timer);
+        timer.Dispose();
+
+        var exception = await Record.ExceptionAsync(() => InvokeRefreshTimerTickAsync(cut.Instance, "exec-1"));
 
         Assert.Null(exception);
+    }
 
-        // The elapsed timer has been stopped and disposed in response to the circuit-gone exception,
-        // so the real Timer can no longer produce a subsequent tick.
+    [Fact]
+    public async Task ConcurrentDisposeCallsDetachTimersAtomicallyWithoutThrowing()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+        SetRefreshTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+        SetElapsedTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+
+        var disposable = (IAsyncDisposable)cut.Instance;
+
+        var exception = await Record.ExceptionAsync(() => Task.WhenAll(disposable.DisposeAsync().AsTask(), disposable.DisposeAsync().AsTask()));
+
+        Assert.Null(exception);
+        Assert.Null(GetRefreshTimer(cut.Instance));
         Assert.Null(GetElapsedTimer(cut.Instance));
     }
 
@@ -216,7 +286,10 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     /// and, when constructed with an exception, throws it from that call to simulate a circuit
     /// disconnecting mid-refresh.
     /// </summary>
-    private sealed class RecordingActivityExecutionService(Exception? exceptionToThrow = null) : IActivityExecutionService
+    private sealed class RecordingActivityExecutionService(
+        Exception? exceptionToThrow = null,
+        IEnumerable<ActivityExecutionRecordSummary>? summariesToReturn = null,
+        ActivityExecutionRecord? recordToReturn = null) : IActivityExecutionService
     {
         public int ListSummariesCallCount { get; private set; }
 
@@ -233,11 +306,11 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
             if (exceptionToThrow != null)
                 throw exceptionToThrow;
 
-            return Task.FromResult<IEnumerable<ActivityExecutionRecordSummary>>([]);
+            return Task.FromResult(summariesToReturn ?? []);
         }
 
         public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
+            recordToReturn != null ? Task.FromResult<ActivityExecutionRecord?>(recordToReturn) : throw new NotSupportedException();
 
         public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -158,26 +158,32 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         });
     }
 
+    private const string RefreshTimerFieldName = "_refreshTimer";
+    private const string ElapsedTimerFieldName = "_elapsedTimer";
+
     private static void SetRefreshTimer(WorkflowInstanceDesigner instance, Timer timer) =>
-        GetRefreshTimerField().SetValue(instance, timer);
+        SetTimer(instance, RefreshTimerFieldName, timer);
 
     private static Timer? GetRefreshTimer(WorkflowInstanceDesigner instance) =>
-        (Timer?)GetRefreshTimerField().GetValue(instance);
-
-    private static FieldInfo GetRefreshTimerField() =>
-        typeof(WorkflowInstanceDesigner).GetField("_refreshTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        GetTimer(instance, RefreshTimerFieldName);
 
     private static Task InvokeRefreshTimerTickAsync(WorkflowInstanceDesigner instance, string activityExecutionRecordId) =>
         instance.RefreshTimerTickAsync(activityExecutionRecordId);
 
     private static void SetElapsedTimer(WorkflowInstanceDesigner instance, Timer timer) =>
-        GetElapsedTimerField().SetValue(instance, timer);
+        SetTimer(instance, ElapsedTimerFieldName, timer);
 
     private static Timer? GetElapsedTimer(WorkflowInstanceDesigner instance) =>
-        (Timer?)GetElapsedTimerField().GetValue(instance);
+        GetTimer(instance, ElapsedTimerFieldName);
 
-    private static FieldInfo GetElapsedTimerField() =>
-        typeof(WorkflowInstanceDesigner).GetField("_elapsedTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static Timer? GetTimer(WorkflowInstanceDesigner instance, string fieldName) =>
+        (Timer?)GetTimerField(fieldName).GetValue(instance);
+
+    private static void SetTimer(WorkflowInstanceDesigner instance, string fieldName, Timer? value) =>
+        GetTimerField(fieldName).SetValue(instance, value);
+
+    private static FieldInfo GetTimerField(string fieldName) =>
+        typeof(WorkflowInstanceDesigner).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     /// <summary>
     /// A <see cref="WorkflowInstanceDesigner"/> whose state-changed notification can be made to throw

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -280,6 +280,72 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         }
     }
 
+    /// <summary>
+    /// Pins that <see cref="WorkflowInstanceDesigner.StartElapsedTimer"/> arms the timer it publishes
+    /// (not just creates it disabled), by waiting for a real tick to reach
+    /// <see cref="TestWorkflowInstanceDesigner.NotifyStateChangedAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task StartElapsedTimerOnLiveComponentArmsTimerAndTicks()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        try
+        {
+            cut.Instance.StartElapsedTimer();
+
+            var ticked = await WaitUntilAsync(() => cut.Instance.NotifyStateChangedCallCount > 0, TimeSpan.FromSeconds(5));
+
+            Assert.True(ticked, "The elapsed timer did not tick within the bounded wait.");
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Pins that <see cref="WorkflowInstanceDesigner.RefreshActivityStatePeriodically"/> arms the timer
+    /// it publishes (not just creates it disabled), by waiting for a real tick to reach
+    /// <see cref="RecordingActivityExecutionService.ListSummariesAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task RefreshActivityStatePeriodicallyOnLiveComponentArmsTimerAndTicks()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        try
+        {
+            cut.Instance.RefreshActivityStatePeriodically("exec-1");
+
+            var ticked = await WaitUntilAsync(() => activityExecutionService.ListSummariesCallCount > 0, TimeSpan.FromSeconds(5));
+
+            Assert.True(ticked, "The refresh timer did not tick within the bounded wait.");
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return true;
+
+            await Task.Delay(20);
+        }
+
+        return condition();
+    }
+
     [Fact]
     public async Task DisposeAsyncStopsRefreshTimerEvenWhenObserverDisposalThrows()
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -97,6 +97,18 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         var exception = await Record.ExceptionAsync(() => cut.Instance.ElapsedTimerTickAsync());
 
         Assert.Null(exception);
+        Assert.Equal(0, cut.Instance.NotifyStateChangedCallCount);
+    }
+
+    [Fact]
+    public async Task ElapsedTickBeforeDisposalNotifiesStateChanged()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        await cut.Instance.ElapsedTimerTickAsync();
+
+        Assert.Equal(1, cut.Instance.NotifyStateChangedCallCount);
     }
 
     [Theory]
@@ -178,6 +190,7 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     private sealed class TestWorkflowInstanceDesigner : WorkflowInstanceDesigner
     {
         public Exception? ThrowOnRender { get; set; }
+        public int NotifyStateChangedCallCount { get; private set; }
 
         protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
 
@@ -185,8 +198,11 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         {
         }
 
-        internal override Task NotifyStateChangedAsync() =>
-            ThrowOnRender != null ? Task.FromException(ThrowOnRender) : base.NotifyStateChangedAsync();
+        internal override Task NotifyStateChangedAsync()
+        {
+            NotifyStateChangedCallCount++;
+            return ThrowOnRender != null ? Task.FromException(ThrowOnRender) : base.NotifyStateChangedAsync();
+        }
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -181,20 +181,63 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         Assert.Null(exception);
     }
 
+    /// <summary>
+    /// Pins that the refresh timer is detached from <c>_refreshTimer</c> atomically, before the
+    /// (potentially slow) <see cref="Timer.DisposeAsync"/> call completes. To exercise that, the
+    /// refresh timer's callback is kept running (blocked on <paramref name="release"/> below) while
+    /// the first disposal is in flight, so a second, concurrent disposal genuinely overlaps with it
+    /// instead of running after the first has already finished.
+    /// </summary>
     [Fact]
     public async Task ConcurrentDisposeCallsDetachTimersAtomicallyWithoutThrowing()
     {
+        var timeout = TimeSpan.FromSeconds(5);
         var activityExecutionService = new RecordingActivityExecutionService();
         var cut = RenderDesigner(activityExecutionService);
         SetLastActivityExecution(cut.Instance, "node-1");
-        SetRefreshTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
-        SetElapsedTimer(cut.Instance, new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite));
+
+        using var started = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        using var refreshTimer = new Timer(_ =>
+        {
+            started.Set();
+            release.Wait(timeout);
+        }, null, Timeout.Infinite, Timeout.Infinite);
+        using var elapsedTimer = new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite);
+
+        SetRefreshTimer(cut.Instance, refreshTimer);
+        SetElapsedTimer(cut.Instance, elapsedTimer);
+
+        // Fire the refresh timer's callback immediately and wait for it to actually start running.
+        refreshTimer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+        Assert.True(started.Wait(timeout), "The refresh timer callback did not start in time.");
 
         var disposable = (IAsyncDisposable)cut.Instance;
 
-        var exception = await Record.ExceptionAsync(() => Task.WhenAll(disposable.DisposeAsync().AsTask(), disposable.DisposeAsync().AsTask()));
+        // System.Threading.Timer.DisposeAsync only completes once any in-flight callback finishes, so
+        // this first disposal stays pending while the callback above is blocked on `release`.
+        var firstDisposeTask = disposable.DisposeAsync().AsTask();
 
-        Assert.Null(exception);
+        // The atomic Interlocked.Exchange detach in StopRefreshActivityStatePeriodically happens
+        // before the timer is awaited, so the field is already cleared while the first disposal is
+        // still pending. Against the previous check/await/clear implementation, this assertion would
+        // still hold, but the second call below would then observe a non-null field and race to
+        // dispose/clear it itself instead of being a no-op.
+        Assert.Null(GetRefreshTimer(cut.Instance));
+
+        var secondDisposeException = await Record.ExceptionAsync(() => disposable.DisposeAsync().AsTask());
+
+        Assert.Null(secondDisposeException);
+        Assert.False(firstDisposeTask.IsCompleted, "The first disposal should still be pending on the blocked callback.");
+
+        release.Set();
+
+        var completedTask = await Task.WhenAny(firstDisposeTask, Task.Delay(timeout));
+        Assert.Same(firstDisposeTask, completedTask);
+
+        var firstDisposeException = await Record.ExceptionAsync(() => firstDisposeTask);
+
+        Assert.Null(firstDisposeException);
         Assert.Null(GetRefreshTimer(cut.Instance));
         Assert.Null(GetElapsedTimer(cut.Instance));
     }

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -242,6 +242,81 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         Assert.Null(GetElapsedTimer(cut.Instance));
     }
 
+    [Fact]
+    public async Task StartElapsedTimerAfterDisposalLeavesTimerFieldNull()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+
+        cut.Instance.StartElapsedTimer();
+
+        Assert.Null(GetElapsedTimer(cut.Instance));
+    }
+
+    [Fact]
+    public async Task StartElapsedTimerOnLiveComponentInstallsTimerOnce()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        try
+        {
+            cut.Instance.StartElapsedTimer();
+            var firstTimer = GetElapsedTimer(cut.Instance);
+            Assert.NotNull(firstTimer);
+
+            cut.Instance.StartElapsedTimer();
+            var secondTimer = GetElapsedTimer(cut.Instance);
+
+            Assert.Same(firstTimer, secondTimer);
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task RefreshActivityStatePeriodicallyAfterDisposalLeavesTimerFieldNull()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+
+        cut.Instance.RefreshActivityStatePeriodically("exec-1");
+
+        Assert.Null(GetRefreshTimer(cut.Instance));
+    }
+
+    [Fact]
+    public async Task RefreshActivityStatePeriodicallyOnLiveComponentInstallsTimerOnce()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        try
+        {
+            cut.Instance.RefreshActivityStatePeriodically("exec-1");
+            var firstTimer = GetRefreshTimer(cut.Instance);
+            Assert.NotNull(firstTimer);
+
+            cut.Instance.RefreshActivityStatePeriodically("exec-1");
+            var secondTimer = GetRefreshTimer(cut.Instance);
+
+            Assert.NotNull(secondTimer);
+            Assert.NotSame(firstTimer, secondTimer);
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
     private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner(IActivityExecutionService activityExecutionService)
     {
         Services.AddSingleton(activityExecutionService);

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -279,6 +279,25 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     }
 
     [Fact]
+    public async Task DisposeAsyncStopsRefreshTimerEvenWhenObserverDisposalThrows()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+        SetLastActivityExecution(cut.Instance, "node-1");
+
+        var observerException = new InvalidOperationException("Observer disposal failed.");
+        SetWorkflowInstanceObserver(cut.Instance, new ThrowingWorkflowInstanceObserver(observerException));
+
+        using var refreshTimer = new Timer(_ => { }, null, Timeout.Infinite, Timeout.Infinite);
+        SetRefreshTimer(cut.Instance, refreshTimer);
+
+        var exception = await Record.ExceptionAsync(() => ((IAsyncDisposable)cut.Instance).DisposeAsync().AsTask());
+
+        Assert.Same(observerException, exception);
+        Assert.Null(GetRefreshTimer(cut.Instance));
+    }
+
+    [Fact]
     public async Task RefreshActivityStatePeriodicallyAfterDisposalLeavesTimerFieldNull()
     {
         var activityExecutionService = new RecordingActivityExecutionService();
@@ -372,6 +391,25 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
 
     private static FieldInfo GetTimerField(string fieldName) =>
         typeof(WorkflowInstanceDesigner).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static void SetWorkflowInstanceObserver(WorkflowInstanceDesigner instance, IWorkflowInstanceObserver observer)
+    {
+        var property = typeof(WorkflowInstanceDesigner).GetProperty("WorkflowInstanceObserver", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        property.SetValue(instance, observer);
+    }
+
+    /// <summary>
+    /// An <see cref="IWorkflowInstanceObserver"/> whose <see cref="DisposeAsync"/> throws, used to pin
+    /// that the periodic refresh timer is still stopped when observer disposal faults.
+    /// </summary>
+    private sealed class ThrowingWorkflowInstanceObserver(Exception exceptionToThrow) : IWorkflowInstanceObserver
+    {
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowExecutionLogUpdatedMessage, Task>? WorkflowJournalUpdated;
+        public event Func<Elsa.Api.Client.RealTime.Messages.ActivityExecutionLogUpdatedMessage, Task>? ActivityExecutionLogUpdated;
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowInstanceUpdatedMessage, Task>? WorkflowInstanceUpdated;
+
+        public ValueTask DisposeAsync() => throw exceptionToThrow;
+    }
 
     /// <summary>
     /// A <see cref="WorkflowInstanceDesigner"/> whose state-changed notification can be made to throw

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -12,6 +12,8 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 using Elsa.Studio.Workflows.Contracts;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Models;
+using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
@@ -336,9 +338,74 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         }
     }
 
-    private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner(IActivityExecutionService activityExecutionService)
+    /// <summary>
+    /// Pins that a <see cref="WorkflowInstanceObserver"/> created by a factory call that was still in
+    /// flight when <c>DisposeAsync</c> ran is disposed immediately instead of being published and
+    /// subscribed on the torn-down component (see
+    /// https://github.com/elsa-workflows/elsa-studio/issues/743).
+    /// </summary>
+    [Fact]
+    public async Task CreateObserverAsyncDisposesObserverCreatedAfterDisposal()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var factory = new GatedWorkflowInstanceObserverFactory();
+        var cut = RenderDesigner(activityExecutionService, factory);
+        SetDesigner(cut.Instance, new JsonObject());
+
+        var createTask = cut.Instance.CreateObserverAsync();
+        Assert.True(factory.CreateAsyncEntered.Wait(TimeSpan.FromSeconds(5)), "The factory was not called in time.");
+
+        await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+
+        var observer = new CountingWorkflowInstanceObserver();
+        factory.Release(observer);
+
+        await createTask;
+
+        Assert.Null(GetWorkflowInstanceObserver(cut.Instance));
+        Assert.Equal(1, observer.DisposeCallCount);
+        Assert.Equal(0, observer.SubscribeCount);
+    }
+
+    /// <summary>
+    /// Keeps the live-circuit path exercised: when the component is not disposed, a created observer
+    /// is still published to <see cref="WorkflowInstanceObserver"/> and subscribed to.
+    /// </summary>
+    [Fact]
+    public async Task CreateObserverAsyncOnLiveComponentPublishesAndSubscribesObserver()
+    {
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var factory = new GatedWorkflowInstanceObserverFactory();
+        var cut = RenderDesigner(activityExecutionService, factory);
+        SetDesigner(cut.Instance, new JsonObject());
+
+        var observer = new CountingWorkflowInstanceObserver();
+        var createTask = cut.Instance.CreateObserverAsync();
+        Assert.True(factory.CreateAsyncEntered.Wait(TimeSpan.FromSeconds(5)), "The factory was not called in time.");
+        factory.Release(observer);
+
+        await createTask;
+
+        try
+        {
+            Assert.Same(observer, GetWorkflowInstanceObserver(cut.Instance));
+            Assert.Equal(1, observer.SubscribeCount);
+            Assert.Equal(0, observer.DisposeCallCount);
+        }
+        finally
+        {
+            await ((IAsyncDisposable)cut.Instance).DisposeAsync();
+        }
+    }
+
+    private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner(
+        IActivityExecutionService activityExecutionService,
+        IWorkflowInstanceObserverFactory? observerFactory = null)
     {
         Services.AddSingleton(activityExecutionService);
+
+        if (observerFactory != null)
+            Services.AddSingleton(observerFactory);
 
         var workflowInstance = new WorkflowInstance
         {
@@ -392,10 +459,88 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
     private static FieldInfo GetTimerField(string fieldName) =>
         typeof(WorkflowInstanceDesigner).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-    private static void SetWorkflowInstanceObserver(WorkflowInstanceDesigner instance, IWorkflowInstanceObserver observer)
+    private static void SetWorkflowInstanceObserver(WorkflowInstanceDesigner instance, IWorkflowInstanceObserver observer) =>
+        GetWorkflowInstanceObserverProperty().SetValue(instance, observer);
+
+    private static IWorkflowInstanceObserver? GetWorkflowInstanceObserver(WorkflowInstanceDesigner instance) =>
+        (IWorkflowInstanceObserver?)GetWorkflowInstanceObserverProperty().GetValue(instance);
+
+    private static PropertyInfo GetWorkflowInstanceObserverProperty() =>
+        typeof(WorkflowInstanceDesigner).GetProperty("WorkflowInstanceObserver", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// Attaches a bare <see cref="DiagramDesignerWrapper"/> (not rendered through bUnit, so its own
+    /// injected dependencies are never touched) to <c>_designer</c>, with its <c>Activity</c> parameter
+    /// set via reflection to avoid setting a component parameter outside of its render pipeline.
+    /// </summary>
+    private static void SetDesigner(WorkflowInstanceDesigner instance, JsonObject activity)
     {
-        var property = typeof(WorkflowInstanceDesigner).GetProperty("WorkflowInstanceObserver", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        property.SetValue(instance, observer);
+        var designer = new DiagramDesignerWrapper();
+        var activityProperty = typeof(DiagramDesignerWrapper).GetProperty(nameof(DiagramDesignerWrapper.Activity))!;
+        activityProperty.SetValue(designer, activity);
+
+        var field = typeof(WorkflowInstanceDesigner).GetField("_designer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(instance, designer);
+    }
+
+    /// <summary>
+    /// An <see cref="IWorkflowInstanceObserverFactory"/> whose <see cref="CreateAsync(WorkflowInstanceObserverContext)"/>
+    /// blocks until <see cref="Release"/> is called, used to pin the window during which
+    /// <c>WorkflowInstanceDesigner.CreateObserverAsync</c> is awaiting the factory when disposal runs.
+    /// </summary>
+    private sealed class GatedWorkflowInstanceObserverFactory : IWorkflowInstanceObserverFactory
+    {
+        private readonly TaskCompletionSource<IWorkflowInstanceObserver> _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// Signaled once <see cref="CreateAsync(WorkflowInstanceObserverContext)"/> has been called.
+        public ManualResetEventSlim CreateAsyncEntered { get; } = new(false);
+
+        public Task<IWorkflowInstanceObserver> CreateAsync(string workflowInstanceId) => throw new NotSupportedException();
+
+        public Task<IWorkflowInstanceObserver> CreateAsync(WorkflowInstanceObserverContext context)
+        {
+            CreateAsyncEntered.Set();
+            return _gate.Task;
+        }
+
+        /// Unblocks the pending <see cref="CreateAsync(WorkflowInstanceObserverContext)"/> call with the given observer.
+        public void Release(IWorkflowInstanceObserver observer) => _gate.SetResult(observer);
+    }
+
+    /// <summary>
+    /// An <see cref="IWorkflowInstanceObserver"/> that counts subscriptions and disposals, used to pin
+    /// that an observer created after disposal is disposed without being subscribed, while an observer
+    /// created on a live component is both subscribed and left undisposed.
+    /// </summary>
+    private sealed class CountingWorkflowInstanceObserver : IWorkflowInstanceObserver
+    {
+        public int DisposeCallCount { get; private set; }
+        public int SubscribeCount { get; private set; }
+        public int UnsubscribeCount { get; private set; }
+
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowExecutionLogUpdatedMessage, Task>? WorkflowJournalUpdated
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<Elsa.Api.Client.RealTime.Messages.ActivityExecutionLogUpdatedMessage, Task>? ActivityExecutionLogUpdated
+        {
+            add => SubscribeCount++;
+            remove => UnsubscribeCount++;
+        }
+
+        public event Func<Elsa.Api.Client.RealTime.Messages.WorkflowInstanceUpdatedMessage, Task>? WorkflowInstanceUpdated
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCallCount++;
+            return ValueTask.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerDisconnectRefreshTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json.Nodes;
 using Bunit;
@@ -242,6 +243,63 @@ public sealed class WorkflowInstanceDesignerDisconnectRefreshTests : BunitContex
         Assert.Null(firstDisposeException);
         Assert.Null(GetRefreshTimer(cut.Instance));
         Assert.Null(GetElapsedTimer(cut.Instance));
+    }
+
+    /// <summary>
+    /// Pins that stopping the refresh timer from within its own tick (the path used by
+    /// <see cref="WorkflowInstanceDesigner.RefreshTimerTickAsync"/>'s terminal-state branch and by
+    /// <see cref="RunTimerTickAsync"/>'s stop delegate) does not wait for an in-flight callback to
+    /// return (see https://github.com/elsa-workflows/elsa-studio/issues/743).
+    /// <see cref="Timer.DisposeAsync"/> only completes once any callback currently executing on the
+    /// timer has returned, regardless of which thread calls it, so awaiting it from the callback that
+    /// is itself executing would deadlock. This test keeps the timer's own callback blocked (simulating
+    /// it still being "in flight") and invokes the private, non-waiting stop method directly -
+    /// deliberately bypassing the render pipeline (<c>InvokeAsync</c>/<c>StateHasChanged</c>) so the
+    /// assertion is not confounded by ThreadPool contention between the blocked callback and the
+    /// renderer's dispatcher. Against an implementation that used the draining, <c>DisposeAsync</c>-based
+    /// stop from this path instead, the call below would block until the callback released.
+    /// </summary>
+    [Fact]
+    public void StoppingRefreshTimerFromTickPathDoesNotWaitForInFlightCallback()
+    {
+        var startTimeout = TimeSpan.FromSeconds(5);
+        var assertionBound = TimeSpan.FromMilliseconds(500);
+        var activityExecutionService = new RecordingActivityExecutionService();
+        var cut = RenderDesigner(activityExecutionService);
+
+        using var started = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        using var refreshTimer = new Timer(_ =>
+        {
+            started.Set();
+
+            // Block for longer than the assertion bound below (but still bounded, so this thread is
+            // not tied up indefinitely if the assertion below fails), keeping the callback genuinely
+            // "in flight" for the whole window the assertion is checking.
+            release.Wait(TimeSpan.FromSeconds(10));
+        }, null, Timeout.Infinite, Timeout.Infinite);
+
+        SetRefreshTimer(cut.Instance, refreshTimer);
+
+        // Fire the timer's own callback and wait for it to actually start running, so a genuine
+        // callback is in flight on the timer while the stop call below tries to stop it.
+        refreshTimer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+        Assert.True(started.Wait(startTimeout), "The refresh timer callback did not start in time.");
+
+        try
+        {
+            var stopMethod = typeof(WorkflowInstanceDesigner).GetMethod("StopRefreshTimer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var stopwatch = Stopwatch.StartNew();
+
+            stopMethod.Invoke(cut.Instance, null);
+
+            Assert.True(stopwatch.Elapsed < assertionBound, $"Stopping the timer from the tick path took {stopwatch.Elapsed}, which suggests it waited for the blocked callback.");
+            Assert.Null(GetRefreshTimer(cut.Instance));
+        }
+        finally
+        {
+            release.Set();
+        }
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -260,12 +260,36 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     private void StartElapsedTimer()
     {
         if (_elapsedTimer == null)
-            _elapsedTimer = new(_ =>
-            {
-                if (_disposed) return;
-                _ = InvokeAsync(StateHasChanged);
-            }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            _elapsedTimer = new(_ => _ = ElapsedTimerTickAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
     }
+
+    /// <summary>
+    /// The body of the elapsed timer tick, extracted so tests can invoke it directly instead of
+    /// waiting for the real <see cref="Timer"/> to fire.
+    /// </summary>
+    internal async Task ElapsedTimerTickAsync()
+    {
+        if (_disposed) return;
+
+        try
+        {
+            await NotifyStateChangedAsync();
+        }
+        catch (Exception ex) when (IsCircuitGoneException(ex))
+        {
+            // The circuit has disconnected (e.g. the browser tab hosting this workflow instance was
+            // closed) while the render was in flight. Stop the elapsed timer instead of letting the
+            // exception escape the timer callback and crash the process.
+            StopElapsedTimer();
+        }
+    }
+
+    /// <summary>
+    /// Invokes <see cref="ComponentBase.StateHasChanged"/> on the renderer's dispatcher. Extracted as
+    /// a virtual seam so tests can simulate a circuit-gone exception surfacing from the render
+    /// pipeline without needing a real Blazor circuit.
+    /// </summary>
+    internal virtual Task NotifyStateChangedAsync() => InvokeAsync(StateHasChanged);
 
     private void StopElapsedTimer()
     {
@@ -359,7 +383,7 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     /// The body of the periodic refresh timer tick, extracted so tests can invoke it directly instead
     /// of waiting for the real <see cref="Timer"/> to fire.
     /// </summary>
-    private async Task RefreshTimerTickAsync(string activityExecutionRecordId)
+    internal async Task RefreshTimerTickAsync(string activityExecutionRecordId)
     {
         if (_disposed) return;
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -486,7 +486,13 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         var timer = new Timer(Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
         if (!PublishRefreshTimer(timer))
+        {
+            // PublishRefreshTimer already disposes the timer it detaches on this path; dispose it here
+            // too so static analysis can see the local is disposed on every path (a second Timer.Dispose()
+            // call is a safe no-op).
+            timer.Dispose();
             return;
+        }
 
         try
         {
@@ -526,7 +532,7 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     /// </summary>
     internal async Task RefreshTimerTickAsync(string activityExecutionRecordId)
     {
-        var ticked = await RunTimerTickAsync(() => RefreshSelectedItemAsync(activityExecutionRecordId), StopRefreshActivityStatePeriodically);
+        var ticked = await RunTimerTickAsync(() => RefreshSelectedItemAsync(activityExecutionRecordId), StopRefreshTimerAsync);
 
         if (!ticked) return;
 
@@ -534,7 +540,9 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
         if (LastActivityExecution == null || (LastActivityExecution.IsFused() && LastActivityExecution.Status != ActivityStatus.Running))
         {
-            await StopRefreshActivityStatePeriodically();
+            // Called from the tick itself: use the non-waiting stop so this callback does not await
+            // its own completion (Timer.DisposeAsync waits for in-flight callbacks to return).
+            StopRefreshTimer();
         }
         else
         {
@@ -553,6 +561,30 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Stops the refresh timer without waiting for an in-flight callback to return. Use this from
+    /// within the timer's own callback (<see cref="RefreshTimerTickAsync"/>): <see cref="Timer.DisposeAsync"/>
+    /// only completes once active callbacks return, so awaiting it from the callback that is currently
+    /// executing would deadlock the callback on its own completion.
+    /// </summary>
+    private void StopRefreshTimer()
+    {
+        var timer = Interlocked.Exchange(ref _refreshTimer, null);
+        timer?.Dispose();
+    }
+
+    private Task StopRefreshTimerAsync()
+    {
+        StopRefreshTimer();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Stops the refresh timer and drains any in-flight callback before returning. Use this only from
+    /// callers that are not themselves executing on the timer callback (e.g. <see cref="DisposeAsync"/>
+    /// or a non-timer caller), since <see cref="Timer.DisposeAsync"/> waits for active callbacks to
+    /// finish.
+    /// </summary>
     private async Task StopRefreshActivityStatePeriodically()
     {
         var timer = Interlocked.Exchange(ref _refreshTimer, null);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -45,7 +45,7 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     private readonly Dictionary<string, ICollection<ActivityExecutionRecordSummary>> _activityExecutionRecordsLookup = new();
     private readonly Dictionary<string, ActivityExecutionRecord> _lastActivityExecutionRecordLookup = new();
     private Timer? _elapsedTimer;
-    private bool _disposed;
+    private volatile bool _disposed;
     private bool IsAlterationsEnabled { get; set; }
 
     /// The workflow instance.

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -84,7 +84,13 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     private JsonObject? SelectedActivity { get; set; }
     private ActivityDescriptor? ActivityDescriptor { get; set; }
     private JournalEntry? SelectedWorkflowExecutionLogRecord { get; set; }
-    private IWorkflowInstanceObserver? WorkflowInstanceObserver { get; set; } = null!;
+    private IWorkflowInstanceObserver? _workflowInstanceObserver;
+
+    private IWorkflowInstanceObserver? WorkflowInstanceObserver
+    {
+        get => _workflowInstanceObserver;
+        set => _workflowInstanceObserver = value;
+    }
     private ICollection<ActivityExecutionRecordSummary> SelectedActivityExecutions { get; set; } = new List<ActivityExecutionRecordSummary>();
     private ActivityExecutionRecord? LastActivityExecution { get; set; }
     private Timer? _refreshTimer;
@@ -206,29 +212,68 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         }
     }
 
-    private async Task CreateObserverAsync()
+    /// <summary>
+    /// Creates and publishes a new <see cref="WorkflowInstanceObserver"/>, unless the component is or
+    /// becomes disposed while the factory call is in flight. Internal so tests can invoke it directly
+    /// to pin the disposal race it guards against.
+    /// </summary>
+    internal async Task CreateObserverAsync()
     {
         if (_workflowInstance == null || _designer == null)
             return;
 
         await DisposeObserverAsync();
+
+        if (_disposed) return;
+
         var container = _designer.GetCurrentContainerActivityOrRoot();
         var observerContext = new WorkflowInstanceObserverContext
         {
             WorkflowInstanceId = _workflowInstance.Id,
             ContainerActivity = container,
         };
-        WorkflowInstanceObserver = await WorkflowInstanceObserverFactory.CreateAsync(observerContext);
-        WorkflowInstanceObserver.ActivityExecutionLogUpdated += OnActivityExecutionLogUpdated;
+        var observer = await WorkflowInstanceObserverFactory.CreateAsync(observerContext);
+
+        if (_disposed)
+        {
+            // DisposeAsync ran while the factory call above was in flight; dispose the observer we just
+            // created instead of publishing and subscribing it on a torn-down component.
+            await observer.DisposeAsync();
+            return;
+        }
+
+        observer.ActivityExecutionLogUpdated += OnActivityExecutionLogUpdated;
+
+        var previousObserver = Interlocked.Exchange(ref _workflowInstanceObserver, observer);
+
+        if (previousObserver != null)
+        {
+            previousObserver.ActivityExecutionLogUpdated -= OnActivityExecutionLogUpdated;
+            await previousObserver.DisposeAsync();
+        }
+
+        if (_disposed)
+        {
+            // DisposeAsync ran between the guard above and publishing the observer; detach and dispose
+            // it, guarding against DisposeObserverAsync having already detached it.
+            var disposedObserver = Interlocked.Exchange(ref _workflowInstanceObserver, null);
+
+            if (disposedObserver != null)
+            {
+                disposedObserver.ActivityExecutionLogUpdated -= OnActivityExecutionLogUpdated;
+                await disposedObserver.DisposeAsync();
+            }
+        }
     }
 
     private async Task DisposeObserverAsync()
     {
-        if (WorkflowInstanceObserver != null!)
+        var observer = Interlocked.Exchange(ref _workflowInstanceObserver, null);
+
+        if (observer != null)
         {
-            WorkflowInstanceObserver.ActivityExecutionLogUpdated -= OnActivityExecutionLogUpdated;
-            await WorkflowInstanceObserver.DisposeAsync();
-            WorkflowInstanceObserver = null;
+            observer.ActivityExecutionLogUpdated -= OnActivityExecutionLogUpdated;
+            await observer.DisposeAsync();
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -257,10 +257,30 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         }
     }
 
-    private void StartElapsedTimer()
+    /// <summary>
+    /// Starts the periodic elapsed-time timer, unless the component has already been disposed. Internal
+    /// so tests can invoke it directly to pin the disposal race it guards against.
+    /// </summary>
+    internal void StartElapsedTimer()
     {
-        if (_elapsedTimer == null)
-            _elapsedTimer = new(_ => _ = ElapsedTimerTickAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        if (_disposed) return;
+        if (_elapsedTimer != null) return;
+
+        var timer = new Timer(_ => _ = ElapsedTimerTickAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+        if (Interlocked.CompareExchange(ref _elapsedTimer, timer, null) is not null)
+        {
+            // Another caller already installed a timer; discard the one we just created.
+            timer.Dispose();
+            return;
+        }
+
+        if (_disposed)
+        {
+            // DisposeAsync ran between the guard above and publishing the timer; detach and dispose it.
+            var disposedTimer = Interlocked.Exchange(ref _elapsedTimer, null);
+            disposedTimer?.Dispose();
+        }
     }
 
     /// <summary>
@@ -390,11 +410,26 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         });
     }
 
-    private void RefreshActivityStatePeriodically(string activityExecutionRecordId)
+    /// <summary>
+    /// Starts the periodic activity-state refresh timer, unless the component has already been
+    /// disposed. Internal so tests can invoke it directly to pin the disposal race it guards against.
+    /// </summary>
+    internal void RefreshActivityStatePeriodically(string activityExecutionRecordId)
     {
+        if (_disposed) return;
+
         async void Callback(object? _) => await RefreshTimerTickAsync(activityExecutionRecordId);
 
-        _refreshTimer = new(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        var timer = new Timer(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        var previousTimer = Interlocked.Exchange(ref _refreshTimer, timer);
+        previousTimer?.Dispose();
+
+        if (_disposed)
+        {
+            // DisposeAsync ran between the guard above and publishing the timer; detach and dispose it.
+            var disposedTimer = Interlocked.Exchange(ref _refreshTimer, null);
+            disposedTimer?.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -313,7 +313,9 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
         async void Callback(object? _) => await ElapsedTimerTickAsync();
 
-        var timer = new Timer(Callback, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        // Create the timer disabled so its callback cannot fire before the timer is published to
+        // _elapsedTimer; it is armed only after publication succeeds.
+        var timer = new Timer(Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
         if (Interlocked.CompareExchange(ref _elapsedTimer, timer, null) is not null)
         {
@@ -327,6 +329,16 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             // DisposeAsync ran between the guard above and publishing the timer; detach and dispose it.
             var disposedTimer = Interlocked.Exchange(ref _elapsedTimer, null);
             disposedTimer?.Dispose();
+            return;
+        }
+
+        try
+        {
+            timer.Change(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        }
+        catch (ObjectDisposedException)
+        {
+            // The timer was disposed concurrently (e.g. by DisposeAsync racing this publish); nothing to arm.
         }
     }
 
@@ -467,16 +479,32 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
         async void Callback(object? _) => await RefreshTimerTickAsync(activityExecutionRecordId);
 
-        // Ownership of the timer created here transfers to _refreshTimer via PublishRefreshTimer; it is
-        // disposed by the stop path (StopRefreshActivityStatePeriodically) or by DisposeAsync.
-        PublishRefreshTimer(new Timer(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan));
+        // Create the timer disabled so its callback cannot fire before the timer is published to
+        // _refreshTimer; it is armed only after publication succeeds. Ownership of the timer created
+        // here transfers to _refreshTimer via PublishRefreshTimer; it is disposed by the stop path
+        // (StopRefreshActivityStatePeriodically) or by DisposeAsync.
+        var timer = new Timer(Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+        if (!PublishRefreshTimer(timer))
+            return;
+
+        try
+        {
+            timer.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            // The timer was disposed concurrently (e.g. by DisposeAsync racing this publish); nothing to arm.
+        }
     }
 
     /// <summary>
     /// Publishes a newly created refresh timer to <see cref="_refreshTimer"/>, disposing any timer it
     /// replaces, and detaches the published timer again if the component was disposed concurrently.
+    /// Returns <c>true</c> when <paramref name="timer"/> remains the published instance and should be
+    /// armed; <c>false</c> when it was detached again and must not be armed.
     /// </summary>
-    private void PublishRefreshTimer(Timer timer)
+    private bool PublishRefreshTimer(Timer timer)
     {
         var previousTimer = Interlocked.Exchange(ref _refreshTimer, timer);
         previousTimer?.Dispose();
@@ -486,7 +514,10 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             // DisposeAsync ran between the guard above and publishing the timer; detach and dispose it.
             var disposedTimer = Interlocked.Exchange(ref _refreshTimer, null);
             disposedTimer?.Dispose();
+            return false;
         }
+
+        return true;
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -24,6 +24,7 @@ using Elsa.Studio.Workflows.Shared.Components;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor;
 using Radzen;
 using Radzen.Blazor;
@@ -44,6 +45,7 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     private readonly Dictionary<string, ICollection<ActivityExecutionRecordSummary>> _activityExecutionRecordsLookup = new();
     private readonly Dictionary<string, ActivityExecutionRecord> _lastActivityExecutionRecordLookup = new();
     private Timer? _elapsedTimer;
+    private bool _disposed;
     private bool IsAlterationsEnabled { get; set; }
 
     /// The workflow instance.
@@ -258,7 +260,11 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     private void StartElapsedTimer()
     {
         if (_elapsedTimer == null)
-            _elapsedTimer = new(_ => InvokeAsync(StateHasChanged), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            _elapsedTimer = new(_ =>
+            {
+                if (_disposed) return;
+                _ = InvokeAsync(StateHasChanged);
+            }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
     }
 
     private void StopElapsedTimer()
@@ -344,17 +350,38 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
     private void RefreshActivityStatePeriodically(string activityExecutionRecordId)
     {
-        async void Callback(object? _)
-        {
-            await RefreshSelectedItemAsync(activityExecutionRecordId);
-
-            if (LastActivityExecution == null || (LastActivityExecution.IsFused() && LastActivityExecution.Status != ActivityStatus.Running))
-                await StopRefreshActivityStatePeriodically();
-            else
-                _refreshTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
-        }
+        async void Callback(object? _) => await RefreshTimerTickAsync(activityExecutionRecordId);
 
         _refreshTimer = new(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+    }
+
+    /// <summary>
+    /// The body of the periodic refresh timer tick, extracted so tests can invoke it directly instead
+    /// of waiting for the real <see cref="Timer"/> to fire.
+    /// </summary>
+    private async Task RefreshTimerTickAsync(string activityExecutionRecordId)
+    {
+        if (_disposed) return;
+
+        try
+        {
+            await RefreshSelectedItemAsync(activityExecutionRecordId);
+        }
+        catch (Exception ex) when (IsCircuitGoneException(ex))
+        {
+            // The circuit has disconnected (e.g. the browser tab hosting this workflow instance was
+            // closed) while the refresh was in flight. Stop refreshing instead of letting the
+            // exception escape the timer callback and crash the process.
+            await StopRefreshActivityStatePeriodically();
+            return;
+        }
+
+        if (_disposed) return;
+
+        if (LastActivityExecution == null || (LastActivityExecution.IsFused() && LastActivityExecution.Status != ActivityStatus.Running))
+            await StopRefreshActivityStatePeriodically();
+        else
+            _refreshTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
     }
 
     private async Task StopRefreshActivityStatePeriodically()
@@ -365,6 +392,13 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             _refreshTimer = null;
         }
     }
+
+    /// <summary>
+    /// Determines whether the given exception signals that the Blazor circuit is gone (disconnected
+    /// or already disposed), in which case timer callbacks should stop quietly instead of throwing.
+    /// </summary>
+    private static bool IsCircuitGoneException(Exception ex) =>
+        ex is ObjectDisposedException or JSDisconnectedException or OperationCanceledException;
 
     private static ActivityStats Map(ActivityExecutionStats source)
     {
@@ -429,10 +463,9 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
+        _disposed = true;
         StopElapsedTimer();
         await DisposeObserverAsync();
-
-        if (_refreshTimer != null)
-            await _refreshTimer.DisposeAsync();
+        await StopRefreshActivityStatePeriodically();
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -308,11 +308,8 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
     private void StopElapsedTimer()
     {
-        if (_elapsedTimer != null)
-        {
-            _elapsedTimer?.Dispose();
-            _elapsedTimer = null;
-        }
+        var timer = Interlocked.Exchange(ref _elapsedTimer, null);
+        timer?.Dispose();
     }
 
     private Task StopElapsedTimerAsync()
@@ -413,18 +410,33 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         if (_disposed) return;
 
         if (LastActivityExecution == null || (LastActivityExecution.IsFused() && LastActivityExecution.Status != ActivityStatus.Running))
+        {
             await StopRefreshActivityStatePeriodically();
+        }
         else
-            _refreshTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        {
+            var timer = _refreshTimer;
+
+            if (timer == null) return;
+
+            try
+            {
+                timer.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The timer was disposed concurrently (e.g. by DisposeAsync racing this tick); nothing to rearm.
+            }
+        }
     }
 
     private async Task StopRefreshActivityStatePeriodically()
     {
-        if (_refreshTimer != null)
-        {
-            await _refreshTimer.DisposeAsync();
-            _refreshTimer = null;
-        }
+        var timer = Interlocked.Exchange(ref _refreshTimer, null);
+
+        if (timer is null) return;
+
+        await timer.DisposeAsync();
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -266,7 +266,9 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
         if (_disposed) return;
         if (_elapsedTimer != null) return;
 
-        var timer = new Timer(_ => _ = ElapsedTimerTickAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        async void Callback(object? _) => await ElapsedTimerTickAsync();
+
+        var timer = new Timer(Callback, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 
         if (Interlocked.CompareExchange(ref _elapsedTimer, timer, null) is not null)
         {
@@ -420,7 +422,17 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
 
         async void Callback(object? _) => await RefreshTimerTickAsync(activityExecutionRecordId);
 
-        var timer = new Timer(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        // Ownership of the timer created here transfers to _refreshTimer via PublishRefreshTimer; it is
+        // disposed by the stop path (StopRefreshActivityStatePeriodically) or by DisposeAsync.
+        PublishRefreshTimer(new Timer(Callback, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan));
+    }
+
+    /// <summary>
+    /// Publishes a newly created refresh timer to <see cref="_refreshTimer"/>, disposing any timer it
+    /// replaces, and detaches the published timer again if the component was disposed concurrently.
+    /// </summary>
+    private void PublishRefreshTimer(Timer timer)
+    {
         var previousTimer = Interlocked.Exchange(ref _refreshTimer, timer);
         previousTimer?.Dispose();
 
@@ -546,7 +558,14 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     {
         _disposed = true;
         StopElapsedTimer();
-        await DisposeObserverAsync();
-        await StopRefreshActivityStatePeriodically();
+
+        try
+        {
+            await DisposeObserverAsync();
+        }
+        finally
+        {
+            await StopRefreshActivityStatePeriodically();
+        }
     }
 }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -269,19 +269,34 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     /// </summary>
     internal async Task ElapsedTimerTickAsync()
     {
-        if (_disposed) return;
+        await RunTimerTickAsync(NotifyStateChangedAsync, StopElapsedTimerAsync);
+    }
+
+    /// <summary>
+    /// Runs the body of a periodic timer tick, guarding it against disposal and a disconnected
+    /// circuit. Returns <c>false</c> when the component was already disposed or when <paramref name="work"/>
+    /// threw a circuit-gone exception (in which case <paramref name="stopTimer"/> stopped the timer);
+    /// returns <c>true</c> when <paramref name="work"/> completed normally. Exceptions that do not
+    /// signal a gone circuit propagate to the caller.
+    /// </summary>
+    private async Task<bool> RunTimerTickAsync(Func<Task> work, Func<Task> stopTimer)
+    {
+        if (_disposed) return false;
 
         try
         {
-            await NotifyStateChangedAsync();
+            await work();
         }
         catch (Exception ex) when (IsCircuitGoneException(ex))
         {
             // The circuit has disconnected (e.g. the browser tab hosting this workflow instance was
-            // closed) while the render was in flight. Stop the elapsed timer instead of letting the
-            // exception escape the timer callback and crash the process.
-            StopElapsedTimer();
+            // closed) while the tick was in flight. Stop the timer instead of letting the exception
+            // escape the timer callback and crash the process.
+            await stopTimer();
+            return false;
         }
+
+        return true;
     }
 
     /// <summary>
@@ -298,6 +313,12 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             _elapsedTimer?.Dispose();
             _elapsedTimer = null;
         }
+    }
+
+    private Task StopElapsedTimerAsync()
+    {
+        StopElapsedTimer();
+        return Task.CompletedTask;
     }
 
     private async Task HandleActivitySelectedAsync(JsonObject activity)
@@ -385,20 +406,9 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
     /// </summary>
     internal async Task RefreshTimerTickAsync(string activityExecutionRecordId)
     {
-        if (_disposed) return;
+        var ticked = await RunTimerTickAsync(() => RefreshSelectedItemAsync(activityExecutionRecordId), StopRefreshActivityStatePeriodically);
 
-        try
-        {
-            await RefreshSelectedItemAsync(activityExecutionRecordId);
-        }
-        catch (Exception ex) when (IsCircuitGoneException(ex))
-        {
-            // The circuit has disconnected (e.g. the browser tab hosting this workflow instance was
-            // closed) while the refresh was in flight. Stop refreshing instead of letting the
-            // exception escape the timer callback and crash the process.
-            await StopRefreshActivityStatePeriodically();
-            return;
-        }
+        if (!ticked) return;
 
         if (_disposed) return;
 


### PR DESCRIPTION
## Purpose

Stop Elsa Studio from crashing when a Blazor Server circuit disconnects while a workflow instance is open, for example when the tab showing the instance is closed.

## Scope

- [x] Bug fix (behavior change)

## Description

### Problem

`WorkflowInstanceDesigner` drives a periodic refresh timer and a one-second elapsed-time timer. After `POST /_blazor/disconnect` the circuit's scoped services and JS interop are disposed, but the timers kept firing on thread-pool threads. The refresh path then threw `ObjectDisposedException` or `Microsoft.JSInterop.JSDisconnectedException` from `RefreshActivityStatePeriodically`, and because the timer callback is `async void` the exception escaped and took the host down.

### Solution

- The component tracks disposal. `DisposeAsync` marks it disposed first, then stops and disposes both timers and the observer, so no timer body runs after disposal, including the documented case where a `System.Threading.Timer` callback fires once more after `Dispose`.
- Both timer ticks run through one shared guard: return immediately when disposed; on `ObjectDisposedException`, `JSDisconnectedException`, or `OperationCanceledException` treat the circuit as gone, stop that timer, and return; let every other exception propagate exactly as before, so real failures are not hidden.
- Stopping a timer detaches it atomically from its field before disposing it, and the refresh rearm tolerates a timer that disposal just disposed, so a tick racing `DisposeAsync` cannot throw out of the callback.
- Timer creation and observer creation both re-check disposal after their asynchronous or racy step: a timer published after disposal is detached and disposed at once, and an observer whose factory completed after teardown started is disposed instead of being subscribed, so a lifecycle continuation cannot leave a live timer or observer rooting the disposed component.
- Live-circuit behavior is unchanged: the refresh cadence, `StateHasChanged`, the details-tab refresh, and observer subscription are as they were.
- The tick bodies are exposed as `internal` seams (the assembly already grants the test project internals access), plus an `internal virtual` state-notification seam so a test can make the render notification throw. No public surface changed.

This builds on the approach in the draft PR #770, which caught only `ObjectDisposedException` on one path.

### Tests

`WorkflowInstanceDesignerDisconnectRefreshTests` (bunit, 18 tests) renders a lightweight subclass of the component and drives the ticks directly: after disposal neither tick does anything (the activity execution service is not called and no state notification is issued); when the service or the render notification throws any of the three circuit-gone exceptions, nothing propagates and the corresponding timer is stopped so later ticks make no further calls; a live tick still notifies once; a rearm against a timer disposed concurrently does not throw; two genuinely overlapping disposals (one blocked on an in-flight callback) leave both timer fields null without throwing; timer creators are no-ops after disposal and install exactly one timer on a live component; disposal stops the refresh timer even when observer disposal throws; and an observer created by a factory that completes after disposal is disposed and never published, while a normal creation still publishes and subscribes. The disposed and stop-on-disconnect assertions were checked to fail with the guards removed.

## Verification

- `dotnet build Elsa.Studio.sln`: success.
- `dotnet test src/modules/Elsa.Studio.Workflows.Tests/...`: 204 passed.

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

