### PR TITLE
fix(workflows): keep the version history tab alive without a cascading workspace

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Tests/VersionHistoryTabMissingWorkspaceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/VersionHistoryTabMissingWorkspaceTests.cs
@@ -1,0 +1,140 @@
+using Bunit;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.WorkflowProperties.Tabs.VersionHistory;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Pins that <see cref="VersionHistoryTab"/> survives being rendered without a cascading
+/// <c>WorkflowDefinitionWorkspace</c>.
+/// <para>
+/// The tab takes its workspace as a cascading parameter of a concrete type, so any host that cascades a
+/// workspace of a different type - a downstream copy of <c>WorkflowDefinitionWorkspace</c> under its own
+/// namespace, for instance - leaves the parameter null. Dereferencing it unconditionally in
+/// <c>OnInitialized</c> throws once into an error boundary, and then again from
+/// <see cref="IDisposable.Dispose"/> during the disposal batch of the renderer, where nothing can catch
+/// it: that second throw takes down the whole Blazor circuit rather than just this tab.
+/// </para>
+/// </summary>
+public sealed class VersionHistoryTabMissingWorkspaceTests : BunitContext, IAsyncLifetime
+{
+    private readonly VersionListingWorkflowDefinitionService _definitionService = new();
+
+    public VersionHistoryTabMissingWorkspaceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IWorkflowDefinitionService>(_definitionService);
+        Services.AddSingleton<IWorkflowDefinitionHistoryService>(new UnusedWorkflowDefinitionHistoryService());
+        Services.AddSingleton<IMediator>(new UnusedMediator());
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void RendersTheVersionListWithoutACascadingWorkspace()
+    {
+        var cut = RenderTab();
+
+        cut.WaitForAssertion(() => Assert.Contains("demo-inzorg-client", _definitionService.RequestedDefinitionIds));
+        Assert.Contains("Version history", cut.Markup);
+    }
+
+    [Fact]
+    public void DisposalWithoutACascadingWorkspaceDoesNotThrow()
+    {
+        var cut = RenderTab();
+
+        var exception = Record.Exception(() => ((IDisposable)cut.Instance).Dispose());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void EditActionsAreDisabledWithoutACascadingWorkspace()
+    {
+        var cut = RenderTab();
+
+        cut.WaitForAssertion(() => Assert.Contains(cut.FindComponents<MudMenu>(), menu => menu.Instance.Label == "Bulk actions"));
+        var bulkActions = cut.FindComponents<MudMenu>().Single(menu => menu.Instance.Label == "Bulk actions");
+        Assert.True(bulkActions.Instance.Disabled);
+    }
+
+    private IRenderedComponent<VersionHistoryTab> RenderTab() => Render<VersionHistoryTab>(parameters => parameters
+        .Add(x => x.DefinitionId, "demo-inzorg-client"));
+
+    private sealed class VersionListingWorkflowDefinitionService : IWorkflowDefinitionService
+    {
+        public ICollection<string> RequestedDefinitionIds { get; } = [];
+
+        public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default)
+        {
+            foreach (var definitionId in request.DefinitionIds ?? [])
+                RequestedDefinitionIds.Add(definitionId);
+
+            return Task.FromResult(new PagedListResponse<WorkflowDefinitionSummary>
+            {
+                Items = [new WorkflowDefinitionSummary { Id = "v1", DefinitionId = "demo-inzorg-client", Version = 1, IsLatest = true }],
+                TotalCount = 1
+            });
+        }
+
+        public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedWorkflowDefinitionHistoryService : IWorkflowDefinitionHistoryService
+    {
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowRetractedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinitionSummary> RevertAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class UnusedMediator : IMediator
+    {
+        public void Subscribe<TNotification, THandler>(THandler handler) where THandler : INotificationHandler<TNotification> where TNotification : INotification => throw new NotSupportedException();
+        public void Unsubscribe<TNotification, THandler>(THandler handler) where THandler : INotificationHandler<TNotification> where TNotification : INotification => throw new NotSupportedException();
+        public void Unsubscribe(INotificationHandler handler) => throw new NotSupportedException();
+        public Task NotifyAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification => throw new NotSupportedException();
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowProperties/Tabs/VersionHistory/VersionHistoryTab.razor.cs
@@ -18,7 +18,13 @@ public partial class VersionHistoryTab : IDisposable
     /// Gets or sets the definition ID.
     [Parameter] public string DefinitionId { get; set; } = default!;
 
-    [CascadingParameter] private WorkflowDefinitionWorkspace Workspace { get; set; } = default!;
+    /// <remarks>
+    /// Null whenever no workspace of this exact type is cascaded - a host that renders this tab under its own
+    /// copy of <see cref="WorkflowDefinitionWorkspace"/> leaves it unset. Every use below tolerates that: the
+    /// version list stays readable and the actions that need a workspace turn themselves off, because throwing
+    /// from <see cref="IDisposable.Dispose"/> here would tear down the entire Blazor circuit.
+    /// </remarks>
+    [CascadingParameter] private WorkflowDefinitionWorkspace? Workspace { get; set; }
     [Inject] private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = default!;
     [Inject] private IWorkflowDefinitionHistoryService WorkflowDefinitionHistoryService { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
@@ -26,19 +32,21 @@ public partial class VersionHistoryTab : IDisposable
     
     private HashSet<WorkflowDefinitionSummary> SelectedDefinitions { get; set; } = new();
     private MudTable<WorkflowDefinitionSummary> Table { get; set; } = default!;
-    private bool IsReadOnly => Workspace.IsReadOnly;
-    private bool HasWorkflowEditPermission => Workspace.HasWorkflowEditPermission;
+    private bool IsReadOnly => Workspace?.IsReadOnly ?? true;
+    private bool HasWorkflowEditPermission => Workspace?.HasWorkflowEditPermission ?? false;
     private long _recordCount = 0;
 
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        Workspace.WorkflowDefinitionUpdated += OnWorkflowDefinitionUpdated;
+        if (Workspace is not null)
+            Workspace.WorkflowDefinitionUpdated += OnWorkflowDefinitionUpdated;
     }
 
     void IDisposable.Dispose()
     {
-        Workspace.WorkflowDefinitionUpdated -= OnWorkflowDefinitionUpdated;
+        if (Workspace is not null)
+            Workspace.WorkflowDefinitionUpdated -= OnWorkflowDefinitionUpdated;
     }
 
     private async Task<TableData<WorkflowDefinitionSummary>> LoadVersionsAsync(TableState tableState, CancellationToken cancellationToken)
@@ -67,6 +75,9 @@ public partial class VersionHistoryTab : IDisposable
 
     private async Task ViewVersionAsync(WorkflowDefinitionSummary workflowDefinitionSummary)
     {
+        if (Workspace is null)
+            return;
+
         var workflowDefinition = (await WorkflowDefinitionService.FindByIdAsync(workflowDefinitionSummary.Id))!;
         await Workspace.DisplayWorkflowDefinitionVersionAsync(workflowDefinition);
     }
@@ -104,7 +115,7 @@ public partial class VersionHistoryTab : IDisposable
         await WorkflowDefinitionService.DeleteVersionAsync(workflowDefinitionVersion);
         await ReloadTableAsync();
 
-        if (Workspace.IsSelectedDefinition(workflowDefinitionVersion.WorkflowDefinitionVersionId))
+        if (Workspace?.IsSelectedDefinition(workflowDefinitionVersion.WorkflowDefinitionVersionId) == true)
             await Workspace.DisplayLatestWorkflowDefinitionVersionAsync();
     }
 
@@ -125,6 +136,9 @@ public partial class VersionHistoryTab : IDisposable
         await WorkflowDefinitionService.BulkDeleteVersionsAsync(definitionVersions);
         await ReloadTableAsync();
 
+        if (Workspace is null)
+            return;
+
         var selectedDefinition = Workspace.GetSelectedDefinition();
         if (selectedDefinition != null && definitionVersions.Any(x => x.WorkflowDefinitionVersionId == selectedDefinition.Id))
             await Workspace.DisplayLatestWorkflowDefinitionVersionAsync();
@@ -132,6 +146,9 @@ public partial class VersionHistoryTab : IDisposable
 
     private async Task OnRollbackClicked(WorkflowDefinitionSummary workflowDefinitionSummary)
     {
+        if (Workspace is null)
+            return;
+
         var definitionVersionId = workflowDefinitionSummary.Id;
         var definitionId = workflowDefinitionSummary.DefinitionId;
         var version = workflowDefinitionSummary.Version;


### PR DESCRIPTION
## The problem

`VersionHistoryTab` takes its workspace as a `[CascadingParameter]` of the **concrete** `WorkflowDefinitionWorkspace` type:

```csharp
[CascadingParameter] private WorkflowDefinitionWorkspace Workspace { get; set; } = default!;

protected override void OnInitialized() => Workspace.WorkflowDefinitionUpdated += OnWorkflowDefinitionUpdated;
void IDisposable.Dispose()              => Workspace.WorkflowDefinitionUpdated -= OnWorkflowDefinitionUpdated;
```

Any host that cascades a workspace of a different type leaves that parameter `null`. Downstream hosts reach this state by copying `WorkflowDefinitionWorkspace` into their own namespace to change which `WorkflowEditor` it instantiates: the copy still does `<CascadingValue Value="this">` and still renders this package's un-forked `WorkflowProperties`, but the cascaded value no longer matches the type this tab asks for.

Because both dereferences were unconditional, opening the tab produced two exceptions:

```
[Warning] ErrorBoundary   Unhandled exception rendering component: Object reference not set to an instance of an object.
   at ...Tabs.VersionHistory.VersionHistoryTab.OnInitialized()

[Warning] RemoteRenderer  Unhandled exception rendering component: Object reference not set to an instance of an object.
   at ...Tabs.VersionHistory.VersionHistoryTab.System.IDisposable.Dispose()
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.DisposeInBatchAsync(RenderBatchBuilder)

[Error]   CircuitHost     Unhandled exception in circuit '...'
```

The first is caught by an error boundary. The second is thrown from `Dispose()` inside the renderer's disposal batch, where no boundary can catch it — so it terminates the **entire Blazor circuit**. The user sees `An error has occurred. This application may no longer respond until reloaded.` and every other page in the Studio is dead until they reload, not just this tab.

Version history is the only one of the four workflow property tabs that reaches for the workspace this way — `Properties`, `Variables` and `Input/Output` take the definition as an ordinary parameter — which is why nothing else broke.

## The change

`Workspace` becomes nullable and every use tolerates its absence:

- `OnInitialized` / `Dispose` — subscribe and unsubscribe only when a workspace is present, so nothing can throw during the disposal batch.
- `IsReadOnly` → `true` and `HasWorkflowEditPermission` → `false` when there is no workspace, which disables bulk actions, rollback and delete through the existing `CanRollback` / `CanDelete` checks.
- `ViewVersionAsync`, `OnRollbackClicked`, `OnDeleteClicked`, `OnBulkDeleteClicked` — return early rather than dereference.

The version list itself still loads and is browsable, since it only needs `DefinitionId` and `IWorkflowDefinitionService`. The one behaviour given up is the auto-refresh subscription, and only in hosts where the parameter was already `null`.

This is deliberately the conservative fix. The underlying design question — that this tab depends on a concrete component type while its siblings depend on `IWorkspace`, which today carries only `IsReadOnly` and `HasWorkflowEditPermission` — would need `IWorkspace` widened with `WorkflowDefinitionUpdated`, `DisplayWorkflowDefinitionVersionAsync`, `DisplayLatestWorkflowDefinitionVersionAsync`, `IsSelectedDefinition` and `GetSelectedDefinition`. Happy to follow up with that if you would prefer it over the guards.

## Tests

`VersionHistoryTabMissingWorkspaceTests` renders the tab with no cascading workspace and pins three things: the version list loads, disposal does not throw, and the edit actions are disabled. All three fail on `main` with `NullReferenceException` at `VersionHistoryTab.OnInitialized()` and pass with this change.

`Elsa.Studio.Workflows.Tests`: 210/210 pass. `Elsa.Studio.Workflows` builds with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
