### PR TITLE
feat(workflows): export the flowchart as PNG, JPEG, or SVG

### DIFF
--- a/src/modules/Elsa.Studio.Alterations/Components/AlterationDesignerHost.razor
+++ b/src/modules/Elsa.Studio.Alterations/Components/AlterationDesignerHost.razor
@@ -42,6 +42,7 @@
         {
             <DiagramDesignerWrapper
                 WorkflowDefinitionVersionId="@WorkflowDefinition.Id"
+                WorkflowDefinition="@WorkflowDefinition"
                 Activity="@FlowchartActivity"
                 IsReadOnly="true"
                 WorkflowInstanceId="@WorkflowInstance.Id"

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
@@ -16,7 +16,6 @@ namespace Elsa.Studio.Workflows.UI.Contexts;
 /// <param name="GraphUpdatedCallback">A callback that is invoked when the graph is updated.</param>
 /// <param name="IsReadOnly">Whether the activity is read-only.</param>
 /// <param name="ActivityStats">A map of activity stats.</param>
-/// <param name="WorkflowDefinition">The workflow definition that the activity belongs to, if known. Diagram designers can use this to derive a proposed file name for exports instead of relying on the root activity's JSON, which does not reliably carry the workflow's name or version.</param>
 public record DisplayContext(
     JsonObject Activity,
     EventCallback<JsonObject> ActivitySelectedCallback = default,
@@ -25,5 +24,12 @@ public record DisplayContext(
     EventCallback<JsonObject> ActivityDoubleClickCallback = default,
     EventCallback GraphUpdatedCallback = default,
     bool IsReadOnly = false,
-    IDictionary<string, ActivityStats>? ActivityStats = null,
-    WorkflowDefinition? WorkflowDefinition = null);
+    IDictionary<string, ActivityStats>? ActivityStats = null)
+{
+    /// <summary>
+    /// The workflow definition that the activity belongs to, if known. Diagram designers can use this to derive a
+    /// proposed file name for exports instead of relying on the root activity's JSON, which does not reliably
+    /// carry the workflow's name or version.
+    /// </summary>
+    public WorkflowDefinition? WorkflowDefinition { get; init; }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Contexts/DisplayContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.UI.Args;
 using Elsa.Studio.Workflows.UI.Models;
@@ -15,12 +16,14 @@ namespace Elsa.Studio.Workflows.UI.Contexts;
 /// <param name="GraphUpdatedCallback">A callback that is invoked when the graph is updated.</param>
 /// <param name="IsReadOnly">Whether the activity is read-only.</param>
 /// <param name="ActivityStats">A map of activity stats.</param>
+/// <param name="WorkflowDefinition">The workflow definition that the activity belongs to, if known. Diagram designers can use this to derive a proposed file name for exports instead of relying on the root activity's JSON, which does not reliably carry the workflow's name or version.</param>
 public record DisplayContext(
-    JsonObject Activity, 
+    JsonObject Activity,
     EventCallback<JsonObject> ActivitySelectedCallback = default,
     EventCallback<JsonObject> ActivityUpdated = default,
     EventCallback<ActivityEmbeddedPortSelectedArgs> ActivityEmbeddedPortSelectedCallback = default,
     EventCallback<JsonObject> ActivityDoubleClickCallback = default,
-    EventCallback GraphUpdatedCallback = default, 
+    EventCallback GraphUpdatedCallback = default,
     bool IsReadOnly = false,
-    IDictionary<string, ActivityStats>? ActivityStats = null);
+    IDictionary<string, ActivityStats>? ActivityStats = null,
+    WorkflowDefinition? WorkflowDefinition = null);

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6ExportPayloadTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6ExportPayloadTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Elsa.Studio.Workflows.Designer.Interop;
+using Elsa.Studio.Workflows.Designer.Models;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+/// <summary>
+/// Pins the payload handed to the <c>exportGraph</c> JavaScript function. That function switches on lowercase format
+/// names, so an enum written as its member name ("Png") or as its numeric value would either be rejected outright or,
+/// worse, fall through to a format the user did not ask for.
+/// </summary>
+public class X6ExportPayloadTests
+{
+    [Theory]
+    [InlineData(ExportGraphFormat.Png, "png")]
+    [InlineData(ExportGraphFormat.Jpeg, "jpeg")]
+    [InlineData(ExportGraphFormat.Svg, "svg")]
+    public void TheFormatIsWrittenAsTheLowercaseNameTheJavaScriptSwitchesOn(ExportGraphFormat format, string expected)
+    {
+        var payload = X6GraphApi.CreateExportPayload(new() { Format = format, FileName = "diagram" });
+
+        Assert.Equal(JsonValueKind.String, payload.GetProperty("format").ValueKind);
+        Assert.Equal(expected, payload.GetProperty("format").GetString());
+    }
+
+    [Fact]
+    public void TheFileNameAndPaddingAreWrittenUnderTheNamesTheJavaScriptReads()
+    {
+        var payload = X6GraphApi.CreateExportPayload(new() { FileName = "diagram", Padding = 30 });
+
+        Assert.Equal("diagram", payload.GetProperty("fileName").GetString());
+        Assert.Equal(30, payload.GetProperty("padding").GetInt32());
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
@@ -8,6 +8,7 @@
     "@antv/layout": "^0.3.25",
     "@antv/x6": "^2.18.1",
     "@antv/x6-plugin-clipboard": "^2.1.6",
+    "@antv/x6-plugin-export": "^2.1.6",
     "@antv/x6-plugin-history": "^2.2.4",
     "@antv/x6-plugin-keyboard": "^2.2.3",
     "@antv/x6-plugin-scroller": "^2.0.10",

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
@@ -8,7 +8,7 @@
     "@antv/layout": "^0.3.25",
     "@antv/x6": "^2.18.1",
     "@antv/x6-plugin-clipboard": "^2.1.6",
-    "@antv/x6-plugin-export": "^2.1.6",
+    "@antv/x6-plugin-export": "2.1.6",
     "@antv/x6-plugin-history": "^2.2.4",
     "@antv/x6-plugin-keyboard": "^2.2.3",
     "@antv/x6-plugin-scroller": "^2.0.10",

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/create-graph.ts
@@ -4,6 +4,7 @@ import {Snapline} from "@antv/x6-plugin-snapline";
 import {Transform} from "@antv/x6-plugin-transform";
 import {Keyboard} from "@antv/x6-plugin-keyboard";
 import {Clipboard} from '@antv/x6-plugin-clipboard';
+import {Export} from '@antv/x6-plugin-export';
 import {History} from '@antv/x6-plugin-history';
 import {DotNetComponentRef, graphBindings} from "./graph-bindings";
 import {DotNetFlowchartDesigner} from "./dotnet-flowchart-designer";
@@ -124,6 +125,9 @@ export async function createGraph(containerId: string, componentRef: DotNetCompo
             },
         }
     });
+
+    // Registered regardless of the read-only flag: exporting the graph as an image is available in both modes.
+    graph.use(new Export());
 
     graph.use(
         new History({

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/export-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/export-graph.ts
@@ -1,0 +1,39 @@
+import {DataUri} from '@antv/x6';
+import {graphBindings} from "./graph-bindings";
+
+export type ExportGraphFormat = 'png' | 'jpeg' | 'svg';
+
+export interface ExportGraphOptions {
+    fileName: string;
+    format: ExportGraphFormat;
+    padding?: number;
+}
+
+// Downloads the graph's content as an image. The file name is expected without an extension; the one matching the
+// format is appended here so that the downloaded file always advertises the format the user actually asked for.
+export function exportGraph(graphId: string, options: ExportGraphOptions) {
+    const graph = graphBindings[graphId]?.graph;
+
+    if (!graph)
+        return;
+
+    const {format, padding} = options;
+    const download = (dataUri: string) => DataUri.downloadDataUri(dataUri, `${options.fileName}.${format}`);
+
+    switch (format) {
+        case 'png':
+            graph.toPNG(download, {padding});
+            break;
+        case 'jpeg':
+            // Not graph.exportJPEG(): that helper delegates to toPNG() in @antv/x6-plugin-export, which would write
+            // PNG bytes into a .jpeg file. toJPEG() encodes as image/jpeg.
+            graph.toJPEG(download, {padding});
+            break;
+        case 'svg':
+            // Vector output has no raster canvas to pad, so the padding is not applicable here.
+            graph.toSVG(svg => download(DataUri.svgToDataUrl(svg)));
+            break;
+        default:
+            throw new Error(`Unsupported export format: ${format}.`);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
@@ -5,6 +5,7 @@ export * from './center-content';
 export * from './create-graph';
 export * from './dispose-graph';
 export * from './designer-mode';
+export * from './export-graph';
 export * from './graph-bindings';
 export * from './load-graph';
 export * from './paste-cells';

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/FlowchartDesigner.razor.cs
@@ -327,6 +327,12 @@ public partial class FlowchartDesigner : IDisposable, IAsyncDisposable
     /// </summary>
     public async Task CenterContentAsync() => await ScheduleGraphActionAsync(() => _graphApi.CenterContentAsync());
 
+    /// <summary>
+    /// Exports the graph as an image and lets the browser download it.
+    /// </summary>
+    /// <param name="options">The export options.</param>
+    public async Task ExportGraphAsync(ExportGraphOptions options) => await ScheduleGraphActionAsync(() => _graphApi.ExportGraphAsync(options));
+
     /// Update the Graph Layout.
     public async Task AutoLayoutAsync(
         JsonObject activity,

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/X6GraphApi.cs
@@ -11,6 +11,12 @@ namespace Elsa.Studio.Workflows.Designer.Interop;
 /// Provides a wrapper around the X6 graph API.
 public class X6GraphApi
 {
+    private static readonly JsonSerializerOptions ExportSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
     private readonly IJSObjectReference _module;
     private readonly IServiceProvider _serviceProvider;
     private readonly string _containerId;
@@ -107,6 +113,23 @@ public class X6GraphApi
 
     /// Center the canvas content.
     public async Task CenterContentAsync() => await InvokeAsync(module => module.InvokeVoidAsync("centerContent", _containerId));
+
+    /// <summary>
+    /// Exports the canvas content as an image and lets the browser download it.
+    /// </summary>
+    /// <param name="options">The export options.</param>
+    public async Task ExportGraphAsync(ExportGraphOptions options)
+    {
+        var payload = CreateExportPayload(options);
+        await InvokeAsync(module => module.InvokeVoidAsync("exportGraph", _containerId, payload));
+    }
+
+    /// <summary>
+    /// Serializes the export options into the payload the <c>exportGraph</c> JavaScript function expects. That
+    /// function switches on lowercase format names ("png", "jpeg", "svg") and throws on anything else, so the
+    /// enum must be written as a camel-cased string rather than as its member name or its numeric value.
+    /// </summary>
+    internal static JsonElement CreateExportPayload(ExportGraphOptions options) => JsonSerializer.SerializeToElement(options, ExportSerializerOptions);
 
     /// Adjusts the graph layout.
     public async Task AutoLayoutAsync(X6Graph graph)

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/ExportGraphFormat.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/ExportGraphFormat.cs
@@ -1,0 +1,22 @@
+namespace Elsa.Studio.Workflows.Designer.Models;
+
+/// <summary>
+/// The image formats the designer can export its graph to.
+/// </summary>
+public enum ExportGraphFormat
+{
+    /// <summary>
+    /// A raster PNG image.
+    /// </summary>
+    Png,
+
+    /// <summary>
+    /// A raster JPEG image.
+    /// </summary>
+    Jpeg,
+
+    /// <summary>
+    /// A vector SVG image.
+    /// </summary>
+    Svg
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/ExportGraphOptions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/ExportGraphOptions.cs
@@ -1,0 +1,24 @@
+namespace Elsa.Studio.Workflows.Designer.Models;
+
+/// <summary>
+/// Describes how to export the designer's graph as an image.
+/// </summary>
+public class ExportGraphOptions
+{
+    /// <summary>
+    /// Gets or sets the image format to export. Defaults to <see cref="ExportGraphFormat.Png"/>.
+    /// </summary>
+    public ExportGraphFormat Format { get; set; } = ExportGraphFormat.Png;
+
+    /// <summary>
+    /// Gets or sets the name of the downloaded file, without an extension. The extension matching
+    /// <see cref="Format"/> is appended by the designer.
+    /// </summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the padding in pixels to leave around the exported content. Ignored when exporting to
+    /// <see cref="ExportGraphFormat.Svg"/>, which has no raster canvas to pad.
+    /// </summary>
+    public int Padding { get; set; } = 20;
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Bunit;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
@@ -61,22 +62,44 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
     [InlineData("Orders/Fulfillment", 2, "Orders_Fulfillment_v2")]
     [InlineData("", 4, "flowchart_v4")]
     [InlineData(null, 0, "flowchart")]
-    public void TheProposedFileNameDerivesFromTheFlowchartNameAndVersion(string? name, int version, string expected)
+    public void TheProposedFileNameDerivesFromTheWorkflowDefinitionNameAndVersion(string? name, int version, string expected)
     {
-        var flowchart = new JsonObject();
+        var workflowDefinition = new WorkflowDefinition
+        {
+            Name = name!,
+            Version = version
+        };
 
-        if (name is not null)
-            flowchart["name"] = name;
-
-        if (version != 0)
-            flowchart["version"] = version;
-
-        Assert.Equal(expected, FlowchartDiagramDesigner.GetDefaultFileName(flowchart));
+        Assert.Equal(expected, FlowchartDiagramDesigner.GetDefaultFileName(workflowDefinition));
     }
 
     [Fact]
-    public void TheProposedFileNameFallsBackWhenThereIsNoFlowchart() =>
+    public void TheProposedFileNameFallsBackWhenThereIsNoWorkflowDefinition() =>
         Assert.Equal("flowchart", FlowchartDiagramDesigner.GetDefaultFileName(null));
+
+    [Fact]
+    public void TheProposedFileNameIgnoresTheRootActivityJsonEvenWhenItCarriesAName()
+    {
+        // Production shape: a real workflow's root `Elsa.Flowchart` activity carries no `name`, and its `version`
+        // is the activity type's version rather than the workflow's - as reproduced here. `GetDefaultFileName` no
+        // longer even accepts the root activity JSON; it is derived solely from the workflow definition, which is
+        // how production supplies it (via `DisplayContext.WorkflowDefinition`).
+        var rootActivity = new JsonObject
+        {
+            ["type"] = "Elsa.Flowchart",
+            ["version"] = 1
+        };
+        var workflowDefinition = new WorkflowDefinition
+        {
+            Name = "Order processing",
+            Version = 3
+        };
+
+        var fileName = FlowchartDiagramDesigner.GetDefaultFileName(workflowDefinition);
+
+        Assert.Equal("Order processing_v3", fileName);
+        Assert.Null(rootActivity["name"]);
+    }
 
     [Theory]
     [InlineData(SubmitPath.Form)]
@@ -199,8 +222,21 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
 
     private Task SetPaddingAsync(string padding) => PaddingFields().Single().Find("input").ChangeAsync(new ChangeEventArgs { Value = padding });
 
-    private Task SelectFormatAsync(ExportGraphFormat format) =>
-        _dialogProvider.InvokeAsync(() => _dialogProvider.FindAll("input.mud-radio-input")[(int)format].ClickAsync(new MouseEventArgs()));
+    // Radios are matched by their visible label text rather than by position, so a reordering or a missing option
+    // fails the test loudly instead of silently selecting the wrong format.
+    private static string FormatLabel(ExportGraphFormat format) => format switch
+    {
+        ExportGraphFormat.Png => "PNG",
+        ExportGraphFormat.Jpeg => "JPEG",
+        ExportGraphFormat.Svg => "SVG",
+        _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
+    };
+
+    private Task SelectFormatAsync(ExportGraphFormat format) => _dialogProvider.InvokeAsync(() =>
+        _dialogProvider.FindAll("label.mud-radio")
+            .Single(label => label.TextContent.Trim() == FormatLabel(format))
+            .QuerySelector("input.mud-radio-input")!
+            .ClickAsync(new MouseEventArgs()));
 
     private IRenderedComponent<MudTextField<string>> FileNameField() => _dialogProvider.FindComponents<MudTextField<string>>()[0];
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the flowchart export dialog and the file name it proposes.
+/// <para>
+/// The dialog is the only gate between the user and the download: whatever it closes with is handed straight to the
+/// designer's JavaScript export function. So the tests pin both directions of every rule — that invalid options keep
+/// the dialog open, and that valid options actually reach the caller unchanged.
+/// </para>
+/// </summary>
+public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+    private const string ProposedFileName = "Order processing";
+    private const string EmptyFileNameMessage = "Please enter a file name for the export.";
+    private const string NegativePaddingMessage = "The padding cannot be negative.";
+
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public ExportFlowchartDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    /// <summary>Identifies how the dialog is submitted, since both routes must obey the same validation.</summary>
+    public enum SubmitPath
+    {
+        /// <summary>A native form submission, which is what pressing Enter in the file name field produces.</summary>
+        Form,
+
+        /// <summary>The dialog's Ok button, which lives outside the form and validates the model itself.</summary>
+        OkButton
+    }
+
+    [Theory]
+    [InlineData("Order processing", 0, "Order processing")]
+    [InlineData("Order processing", 3, "Order processing_v3")]
+    [InlineData("  Order processing  ", 3, "Order processing_v3")]
+    // '/' is invalid in a file name on every platform the studio runs on, unlike ':' or '\', so it is the only
+    // character this assertion can pin without becoming platform-specific.
+    [InlineData("Orders/Fulfillment", 2, "Orders_Fulfillment_v2")]
+    [InlineData("", 4, "flowchart_v4")]
+    [InlineData(null, 0, "flowchart")]
+    public void TheProposedFileNameDerivesFromTheFlowchartNameAndVersion(string? name, int version, string expected)
+    {
+        var flowchart = new JsonObject();
+
+        if (name is not null)
+            flowchart["name"] = name;
+
+        if (version != 0)
+            flowchart["version"] = version;
+
+        Assert.Equal(expected, FlowchartDiagramDesigner.GetDefaultFileName(flowchart));
+    }
+
+    [Fact]
+    public void TheProposedFileNameFallsBackWhenThereIsNoFlowchart() =>
+        Assert.Equal("flowchart", FlowchartDiagramDesigner.GetDefaultFileName(null));
+
+    [Theory]
+    [InlineData(SubmitPath.Form)]
+    [InlineData(SubmitPath.OkButton)]
+    public async Task TheDialogDoesNotCloseWhenTheFileNameIsEmpty(SubmitPath submitPath)
+    {
+        var dialog = await ShowDialogAsync();
+        await SetFileNameAsync(string.Empty);
+
+        await Submit(submitPath);
+
+        Assert.False(dialog.Result.IsCompleted);
+        _dialogProvider.WaitForAssertion(() => Assert.Contains(EmptyFileNameMessage, _dialogProvider.Markup));
+    }
+
+    [Theory]
+    [InlineData(SubmitPath.Form)]
+    [InlineData(SubmitPath.OkButton)]
+    public async Task TheDialogDoesNotCloseWhenThePaddingIsNegative(SubmitPath submitPath)
+    {
+        var dialog = await ShowDialogAsync();
+        await SetPaddingAsync("-5");
+
+        await Submit(submitPath);
+
+        Assert.False(dialog.Result.IsCompleted);
+        _dialogProvider.WaitForAssertion(() => Assert.Contains(NegativePaddingMessage, _dialogProvider.Markup));
+    }
+
+    [Theory]
+    [InlineData(SubmitPath.Form)]
+    [InlineData(SubmitPath.OkButton)]
+    public async Task TheDialogClosesWithTheSelectedOptions(SubmitPath submitPath)
+    {
+        var dialog = await ShowDialogAsync();
+        await SelectFormatAsync(ExportGraphFormat.Jpeg);
+        await SetFileNameAsync("Fulfillment diagram");
+        await SetPaddingAsync("40");
+
+        await Submit(submitPath);
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        var options = Assert.IsType<ExportGraphOptions>(result?.Data);
+
+        Assert.False(result?.Canceled);
+        Assert.Equal(ExportGraphFormat.Jpeg, options.Format);
+        Assert.Equal("Fulfillment diagram", options.FileName);
+        Assert.Equal(40, options.Padding);
+        Assert.DoesNotContain(EmptyFileNameMessage, _dialogProvider.Markup);
+        Assert.DoesNotContain(NegativePaddingMessage, _dialogProvider.Markup);
+    }
+
+    [Fact]
+    public async Task TheDialogClosesWithTheProposedFileNameAndTheDefaultFormat()
+    {
+        var dialog = await ShowDialogAsync();
+
+        await Submit(SubmitPath.OkButton);
+
+        var options = Assert.IsType<ExportGraphOptions>((await dialog.Result.WaitAsync(Timeout))?.Data);
+
+        Assert.Equal(ExportGraphFormat.Png, options.Format);
+        Assert.Equal(ProposedFileName, options.FileName);
+    }
+
+    [Fact]
+    public async Task ThePaddingFieldIsShownOnlyForTheRasterFormats()
+    {
+        await ShowDialogAsync();
+
+        Assert.NotEmpty(PaddingFields());
+
+        await SelectFormatAsync(ExportGraphFormat.Svg);
+        Assert.Empty(PaddingFields());
+
+        // The other half of the rule: the field comes back rather than disappearing for good.
+        await SelectFormatAsync(ExportGraphFormat.Jpeg);
+        Assert.NotEmpty(PaddingFields());
+    }
+
+    [Fact]
+    public async Task SvgIsNotBlockedByAPaddingTheDialogNoLongerShows()
+    {
+        var dialog = await ShowDialogAsync();
+        await SetPaddingAsync("-5");
+        await Submit(SubmitPath.OkButton);
+
+        Assert.False(dialog.Result.IsCompleted);
+
+        // Switching to SVG hides the padding field, so a padding rule that still applied would keep the dialog open
+        // with its complaint rendered nowhere the user could see or fix it.
+        await SelectFormatAsync(ExportGraphFormat.Svg);
+        await Submit(SubmitPath.OkButton);
+
+        var options = Assert.IsType<ExportGraphOptions>((await dialog.Result.WaitAsync(Timeout))?.Data);
+
+        Assert.Equal(ExportGraphFormat.Svg, options.Format);
+    }
+
+    private async Task<IDialogReference> ShowDialogAsync()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<ExportFlowchartDialog> { { x => x.FileName, ProposedFileName } };
+        var dialog = await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<ExportFlowchartDialog>("Export flowchart", parameters));
+        _dialogProvider.WaitForElement("form");
+        _dialogProvider.WaitForAssertion(() => Assert.Equal(ProposedFileName, FileNameField().Find("input").GetAttribute("value")));
+        return dialog;
+    }
+
+    // The find and the trigger run on the renderer's dispatcher so that a render cannot invalidate the element's
+    // event handler in between. The returned task still completes only when the handler does.
+    private Task Submit(SubmitPath submitPath) => _dialogProvider.InvokeAsync(() => submitPath switch
+    {
+        SubmitPath.Form => _dialogProvider.Find("form").SubmitAsync(),
+        SubmitPath.OkButton => OkButton().ClickAsync(new MouseEventArgs()),
+        _ => throw new ArgumentOutOfRangeException(nameof(submitPath), submitPath, null)
+    });
+
+    private Task SetFileNameAsync(string fileName) => FileNameField().Find("input").ChangeAsync(new ChangeEventArgs { Value = fileName });
+
+    private Task SetPaddingAsync(string padding) => PaddingFields().Single().Find("input").ChangeAsync(new ChangeEventArgs { Value = padding });
+
+    private Task SelectFormatAsync(ExportGraphFormat format) =>
+        _dialogProvider.InvokeAsync(() => _dialogProvider.FindAll("input.mud-radio-input")[(int)format].ClickAsync(new MouseEventArgs()));
+
+    private IRenderedComponent<MudTextField<string>> FileNameField() => _dialogProvider.FindComponents<MudTextField<string>>()[0];
+
+    private IReadOnlyList<IRenderedComponent<MudNumericField<int>>> PaddingFields() => _dialogProvider.FindComponents<MudNumericField<int>>();
+
+    private AngleSharp.Dom.IElement OkButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Ok");
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExportFlowchartDialogTests.cs
@@ -27,7 +27,7 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
     private const string ProposedFileName = "Order processing";
     private const string EmptyFileNameMessage = "Please enter a file name for the export.";
-    private const string NegativePaddingMessage = "The padding cannot be negative.";
+    private const string OutOfRangePaddingMessage = "The padding must be between 0 and 1000 pixels.";
 
     private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
 
@@ -116,17 +116,19 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Theory]
-    [InlineData(SubmitPath.Form)]
-    [InlineData(SubmitPath.OkButton)]
-    public async Task TheDialogDoesNotCloseWhenThePaddingIsNegative(SubmitPath submitPath)
+    [InlineData(SubmitPath.Form, "-5")]
+    [InlineData(SubmitPath.OkButton, "-5")]
+    [InlineData(SubmitPath.Form, "1001")]
+    [InlineData(SubmitPath.OkButton, "1001")]
+    public async Task TheDialogDoesNotCloseWhenThePaddingIsOutOfRange(SubmitPath submitPath, string padding)
     {
         var dialog = await ShowDialogAsync();
-        await SetPaddingAsync("-5");
+        await SetPaddingAsync(padding);
 
         await Submit(submitPath);
 
         Assert.False(dialog.Result.IsCompleted);
-        _dialogProvider.WaitForAssertion(() => Assert.Contains(NegativePaddingMessage, _dialogProvider.Markup));
+        _dialogProvider.WaitForAssertion(() => Assert.Contains(OutOfRangePaddingMessage, _dialogProvider.Markup));
     }
 
     [Theory]
@@ -149,7 +151,7 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
         Assert.Equal("Fulfillment diagram", options.FileName);
         Assert.Equal(40, options.Padding);
         Assert.DoesNotContain(EmptyFileNameMessage, _dialogProvider.Markup);
-        Assert.DoesNotContain(NegativePaddingMessage, _dialogProvider.Markup);
+        Assert.DoesNotContain(OutOfRangePaddingMessage, _dialogProvider.Markup);
     }
 
     [Fact]
@@ -163,6 +165,15 @@ public sealed class ExportFlowchartDialogTests : BunitContext, IAsyncLifetime
 
         Assert.Equal(ExportGraphFormat.Png, options.Format);
         Assert.Equal(ProposedFileName, options.FileName);
+    }
+
+    [Fact]
+    public async Task TheFormatRadioGroupHasAnAccessibleName()
+    {
+        await ShowDialogAsync();
+
+        var radioGroup = _dialogProvider.Find("[role='radiogroup']");
+        Assert.Equal("Format", radioGroup.GetAttribute("aria-label"));
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowDefinitionVersionViewer.razor
@@ -7,7 +7,7 @@
 
 <RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height));" Resize="@OnResize">
     <RadzenSplitterPane Size="70%">
-        <DiagramDesignerWrapper @ref="_diagramDesigner" WorkflowDefinitionVersionId="@_workflowDefinition!.Id" Activity="Activity" IsProgressing="IsProgressing" ActivitySelected="@OnActivitySelected" IsReadOnly="true">
+        <DiagramDesignerWrapper @ref="_diagramDesigner" WorkflowDefinitionVersionId="@_workflowDefinition!.Id" WorkflowDefinition="@_workflowDefinition" Activity="Activity" IsProgressing="IsProgressing" ActivitySelected="@OnActivitySelected" IsReadOnly="true">
             <CustomToolbarItems>
                 <MudTooltip Text="@Localizer["Export this version as a JSON file."]" Inline="false">
                     <MudIconButton Icon="@Icons.Material.Filled.FileDownload" OnClick="OnDownloadClicked">@Localizer["Export"]</MudIconButton>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -8,6 +8,7 @@
     <RadzenSplitterPane Size="70%">
         <DiagramDesignerWrapper @ref="_diagramDesigner"
                                 WorkflowDefinitionVersionId="@_workflowDefinition?.Id"
+                                WorkflowDefinition="@_workflowDefinition"
                                 Activity="@Activity"
                                 IsProgressing="@IsProgressing"
                                 ActivitySelected="@OnActivitySelected"

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor
@@ -10,6 +10,7 @@
             <DiagramDesignerWrapper
                 @ref="_designer"
                 WorkflowDefinitionVersionId="@WorkflowDefinition.Id"
+                WorkflowDefinition="@WorkflowDefinition"
                 Activity="RootActivity"
                 ActivitySelected="OnActivitySelected"
                 IsReadOnly="true"

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
@@ -1,0 +1,29 @@
+@using Variant = MudBlazor.Variant
+@using Elsa.Studio.Workflows.Designer.Models
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+<MudDialog>
+    <DialogContent>
+        <EditForm @key="_editContext" EditContext="_editContext" OnValidSubmit="OnValidSubmit">
+            <FluentValidator Validator="_validator"/>
+            <MudStack>
+                <MudRadioGroup T="ExportGraphFormat" @bind-Value="_model.Format">
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Png" Dense="true">PNG</MudRadio>
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Jpeg" Dense="true">JPEG</MudRadio>
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Svg" Dense="true">SVG</MudRadio>
+                </MudRadioGroup>
+                <MudTextField Label="@Localizer["File name"]" @bind-Value="_model.FileName" For="@(() => _model.FileName)" HelperText="@Localizer["The name of the exported file. The extension is added automatically."]" Variant="Variant.Outlined" Margin="Margin.Dense"/>
+                @* SVG is vector output with no raster canvas to pad, so the field is offered only for the image formats. *@
+                @if (_model.Format != ExportGraphFormat.Svg)
+                {
+                    <MudNumericField T="int" Label="@Localizer["Padding"]" @bind-Value="_model.Padding" For="@(() => _model.Padding)" HelperText="@Localizer["The padding in pixels to leave around the exported flowchart."]" Variant="Variant.Outlined" Margin="Margin.Dense"/>
+                }
+            </MudStack>
+        </EditForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="OnCancelClicked">@Localizer["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" OnClick="OnSubmitClicked">@Localizer["Ok"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
@@ -8,7 +8,7 @@
         <EditForm @key="_editContext" EditContext="_editContext" OnValidSubmit="OnValidSubmit">
             <FluentValidator Validator="_validator"/>
             <MudStack>
-                <MudRadioGroup T="ExportGraphFormat" @bind-Value="_model.Format">
+                <MudRadioGroup T="ExportGraphFormat" @bind-Value="_model.Format" aria-label="@Localizer["Format"]">
                     <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Png" Dense="true">@Localizer["PNG"]</MudRadio>
                     <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Jpeg" Dense="true">@Localizer["JPEG"]</MudRadio>
                     <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Svg" Dense="true">@Localizer["SVG"]</MudRadio>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor
@@ -9,9 +9,9 @@
             <FluentValidator Validator="_validator"/>
             <MudStack>
                 <MudRadioGroup T="ExportGraphFormat" @bind-Value="_model.Format">
-                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Png" Dense="true">PNG</MudRadio>
-                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Jpeg" Dense="true">JPEG</MudRadio>
-                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Svg" Dense="true">SVG</MudRadio>
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Png" Dense="true">@Localizer["PNG"]</MudRadio>
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Jpeg" Dense="true">@Localizer["JPEG"]</MudRadio>
+                    <MudRadio T="ExportGraphFormat" Value="ExportGraphFormat.Svg" Dense="true">@Localizer["SVG"]</MudRadio>
                 </MudRadioGroup>
                 <MudTextField Label="@Localizer["File name"]" @bind-Value="_model.FileName" For="@(() => _model.FileName)" HelperText="@Localizer["The name of the exported file. The extension is added automatically."]" Variant="Variant.Outlined" Margin="Margin.Dense"/>
                 @* SVG is vector output with no raster canvas to pad, so the field is offered only for the image formats. *@

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/ExportFlowchartDialog.razor.cs
@@ -1,0 +1,56 @@
+using Blazilla;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Validators;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
+
+/// <summary>
+/// A dialog that collects the options to export the flowchart as an image with.
+/// </summary>
+public partial class ExportFlowchartDialog
+{
+    private readonly ExportGraphOptions _model = new();
+    private EditContext _editContext = null!;
+    private ExportGraphOptionsValidator _validator = null!;
+
+    /// <summary>
+    /// The file name to propose, without an extension.
+    /// </summary>
+    [Parameter] public string FileName { get; set; } = string.Empty;
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        // Deliberately not OnParametersSet: the dialog's parameters never change once it is shown, and rebuilding the
+        // edit context on a re-render would discard both the user's edits and any validation messages already shown.
+        _model.FileName = FileName;
+        _editContext = new(_model);
+        _validator = new(Localizer);
+    }
+
+    private Task OnCancelClicked()
+    {
+        MudDialog.Cancel();
+        return Task.CompletedTask;
+    }
+
+    private async Task OnSubmitClicked()
+    {
+        // The Ok button lives outside the form, so it has to run the validation itself.
+        if (!await _editContext.ValidateAsync())
+            return;
+
+        await OnValidSubmit();
+    }
+
+    private Task OnValidSubmit()
+    {
+        MudDialog.Close(_model);
+        return Task.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDesignerWrapper.razor.cs
@@ -5,6 +5,7 @@ using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
@@ -169,6 +170,22 @@ public partial class FlowchartDesignerWrapper
     {
         if (ReactDesigner is not null) await ReactDesigner.CenterContentAsync();
         else if (Designer is not null) await Designer.CenterContentAsync();
+    }
+
+    /// <summary>
+    /// Exports the flowchart as an image and lets the browser download it.
+    /// </summary>
+    /// <param name="options">The export options.</param>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the X6 designer is not the rendered designer, which is the case while the React Flow renderer is
+    /// enabled. Failing here is deliberate: silently doing nothing would look like a download that never arrived.
+    /// </exception>
+    public async Task ExportGraphAsync(ExportGraphOptions options)
+    {
+        if (Designer is null)
+            throw new NotSupportedException("Exporting the flowchart as an image is only supported by the X6 designer.");
+
+        await Designer.ExportGraphAsync(options);
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -106,6 +106,7 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
                 childBuilder.OpenComponent<MudIconButton>(0);
                 childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
                 childBuilder.AddAttribute(2, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, onClick));
+                childBuilder.AddAttribute(3, "aria-label", title);
                 childBuilder.CloseComponent();
             }));
 
@@ -144,7 +145,7 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
         var dialog = await dialogService.ShowAsync<ExportFlowchartDialog>(localizer["Export flowchart"], parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false || result.Data is not ExportGraphOptions exportOptions)
+        if ((result?.Canceled ?? true) || result.Data is not ExportGraphOptions exportOptions)
             return;
 
         await _designerWrapper.ExportGraphAsync(exportOptions);

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Nodes;
-using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Options;
@@ -24,6 +24,7 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
 
     private FlowchartDesignerWrapper? _designerWrapper;
     private readonly Guid _id = Guid.NewGuid();
+    private WorkflowDefinition? _workflowDefinition;
 
     /// <inheritdoc />
     public async Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap)
@@ -60,6 +61,8 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
     {
         var flowchart = context.Activity;
         var sequence = 0;
+
+        _workflowDefinition = context.WorkflowDefinition;
 
         return builder =>
         {
@@ -127,7 +130,7 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
 
         var parameters = new DialogParameters<ExportFlowchartDialog>
         {
-            { x => x.FileName, GetDefaultFileName(_designerWrapper.Flowchart) }
+            { x => x.FileName, GetDefaultFileName(_workflowDefinition) }
         };
 
         var options = new DialogOptions
@@ -148,18 +151,20 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
     }
 
     /// <summary>
-    /// Derives the file name to propose for an export from the flowchart's name, suffixed with its version when the
-    /// flowchart carries one. Characters that the host platform does not allow in a file name are replaced with an
-    /// underscore; the browser applies its own sanitization to the download name on top of this.
+    /// Derives the file name to propose for an export from the workflow definition's name, suffixed with its
+    /// version when the definition carries one. The root activity's JSON is not used, because for a real workflow
+    /// its root activity carries no name and its version is the activity type's version, not the workflow's.
+    /// Characters that the host platform does not allow in a file name are replaced with an underscore; the
+    /// browser applies its own sanitization to the download name on top of this.
     /// </summary>
-    internal static string GetDefaultFileName(JsonObject? flowchart)
+    internal static string GetDefaultFileName(WorkflowDefinition? workflowDefinition)
     {
-        var name = flowchart?.GetName()?.Trim();
+        var name = workflowDefinition?.Name?.Trim();
         var invalidChars = Path.GetInvalidFileNameChars();
         var fileName = string.IsNullOrEmpty(name)
             ? DefaultFileName
             : new string(name.Select(c => invalidChars.Contains(c) ? '_' : c).ToArray());
-        var version = flowchart?.GetVersion() ?? 0;
+        var version = workflowDefinition?.Version ?? 0;
 
         return version > 0 ? $"{fileName}_v{version}" : fileName;
     }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -1,5 +1,8 @@
 using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.UI.Contexts;
@@ -7,6 +10,7 @@ using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Options;
 using MudBlazor;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
@@ -14,8 +18,10 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 /// <summary>
 /// A diagram designer that displays a flowchart.
 /// </summary>
-public class FlowchartDiagramDesigner(ILocalizer localizer) : IDiagramDesignerToolboxProvider
+public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialogService, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerToolboxProvider
 {
+    private const string DefaultFileName = "flowchart";
+
     private FlowchartDesignerWrapper? _designerWrapper;
     private readonly Guid _id = Guid.NewGuid();
 
@@ -79,6 +85,10 @@ public class FlowchartDiagramDesigner(ILocalizer localizer) : IDiagramDesignerTo
         yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
         yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
         yield return DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
+
+        // Exporting is available in both read-only and editable mode, but only the X6 designer can produce an image.
+        if (!designerOptions.Value.UseReactFlow)
+            yield return DisplayToolboxItem(localizer["Export"], Icons.Material.Outlined.Download, localizer["Export as image"], OnExportClicked);
     }
 
     private RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)
@@ -109,4 +119,48 @@ public class FlowchartDiagramDesigner(ILocalizer localizer) : IDiagramDesignerTo
     private Task OnZoomToFitClicked() => _designerWrapper != null ? _designerWrapper.ZoomToFitAsync() : Task.CompletedTask;
     private Task OnCenterClicked() => _designerWrapper != null ? _designerWrapper!.CenterContentAsync() : Task.CompletedTask;
     private Task OnAutoLayoutClicked() => _designerWrapper != null ? _designerWrapper!.AutoLayoutAsync() : Task.CompletedTask;
+
+    private async Task OnExportClicked()
+    {
+        if (_designerWrapper == null)
+            return;
+
+        var parameters = new DialogParameters<ExportFlowchartDialog>
+        {
+            { x => x.FileName, GetDefaultFileName(_designerWrapper.Flowchart) }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true,
+            CloseButton = true,
+            CloseOnEscapeKey = true
+        };
+
+        var dialog = await dialogService.ShowAsync<ExportFlowchartDialog>(localizer["Export flowchart"], parameters, options);
+        var result = await dialog.Result;
+
+        if (result?.Canceled != false || result.Data is not ExportGraphOptions exportOptions)
+            return;
+
+        await _designerWrapper.ExportGraphAsync(exportOptions);
+    }
+
+    /// <summary>
+    /// Derives the file name to propose for an export from the flowchart's name, suffixed with its version when the
+    /// flowchart carries one. Characters that the host platform does not allow in a file name are replaced with an
+    /// underscore; the browser applies its own sanitization to the download name on top of this.
+    /// </summary>
+    internal static string GetDefaultFileName(JsonObject? flowchart)
+    {
+        var name = flowchart?.GetName()?.Trim();
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var fileName = string.IsNullOrEmpty(name)
+            ? DefaultFileName
+            : new string(name.Select(c => invalidChars.Contains(c) ? '_' : c).ToArray());
+        var version = flowchart?.GetVersion() ?? 0;
+
+        return version > 0 ? $"{fileName}_v{version}" : fileName;
+    }
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesignerProvider.cs
@@ -2,8 +2,11 @@ using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.UI.Contracts;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+using MudBlazor;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 
@@ -14,7 +17,7 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 /// <summary>
 /// Provides flowchart diagram designer services.
 /// </summary>
-public class FlowchartDiagramDesignerProvider(ILocalizer localizer) : IDiagramDesignerProvider
+public class FlowchartDiagramDesignerProvider(ILocalizer localizer, IDialogService dialogService, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerProvider
 {
     /// <inheritdoc />
     public double Priority => 0;
@@ -23,5 +26,5 @@ public class FlowchartDiagramDesignerProvider(ILocalizer localizer) : IDiagramDe
     public bool GetSupportsActivity(JsonObject activity) => activity.GetTypeName() == "Elsa.Flowchart";
 
     /// <inheritdoc />
-    public IDiagramDesigner GetEditor() => new FlowchartDiagramDesigner(localizer);
+    public IDiagramDesigner GetEditor() => new FlowchartDiagramDesigner(localizer, dialogService, designerOptions);
 }

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Domain.Contexts;
 using Elsa.Studio.Workflows.Domain.Contracts;
@@ -46,6 +47,11 @@ public partial class DiagramDesignerWrapper
     /// The root activity to display.
     [Parameter]
     public JsonObject Activity { get; set; } = null!;
+
+    /// The workflow definition that the displayed activity belongs to, if known. Used, for example, to propose a
+    /// file name for diagram exports.
+    [Parameter]
+    public WorkflowDefinition? WorkflowDefinition { get; set; }
 
     /// Whether the designer is read-only.
     [Parameter]
@@ -515,7 +521,8 @@ public partial class DiagramDesignerWrapper
             EventCallback.Factory.Create<JsonObject>(this, OnActivityDoubleClick),
             EventCallback.Factory.Create(this, OnGraphUpdated),
             IsReadOnly,
-            _activityStats));
+            _activityStats,
+            WorkflowDefinition));
     }
 
     private async Task OnActivitySelected(JsonObject activity)

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -521,8 +521,10 @@ public partial class DiagramDesignerWrapper
             EventCallback.Factory.Create<JsonObject>(this, OnActivityDoubleClick),
             EventCallback.Factory.Create(this, OnGraphUpdated),
             IsReadOnly,
-            _activityStats,
-            WorkflowDefinition));
+            _activityStats)
+        {
+            WorkflowDefinition = WorkflowDefinition
+        });
     }
 
     private async Task OnActivitySelected(JsonObject activity)

--- a/src/modules/Elsa.Studio.Workflows/Validators/ExportGraphOptionsValidator.cs
+++ b/src/modules/Elsa.Studio.Workflows/Validators/ExportGraphOptionsValidator.cs
@@ -1,0 +1,27 @@
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Models;
+using FluentValidation;
+
+namespace Elsa.Studio.Workflows.Validators;
+
+/// <summary>
+/// A validator for <see cref="ExportGraphOptions"/> instances.
+/// </summary>
+public class ExportGraphOptionsValidator : AbstractValidator<ExportGraphOptions>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportGraphOptionsValidator"/> class.
+    /// </summary>
+    /// <param name="localizer">The localizer.</param>
+    public ExportGraphOptionsValidator(ILocalizer localizer)
+    {
+        RuleFor(x => x.FileName).NotEmpty().WithMessage(localizer["Please enter a file name for the export."]);
+
+        // Scoped to the formats whose export actually uses the padding, which are exactly the formats for which the
+        // dialog shows the field. Validating it for SVG too would block the dialog on a field the user cannot see.
+        RuleFor(x => x.Padding)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.Format != ExportGraphFormat.Svg)
+            .WithMessage(localizer["The padding cannot be negative."]);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Validators/ExportGraphOptionsValidator.cs
+++ b/src/modules/Elsa.Studio.Workflows/Validators/ExportGraphOptionsValidator.cs
@@ -10,6 +10,12 @@ namespace Elsa.Studio.Workflows.Validators;
 public class ExportGraphOptionsValidator : AbstractValidator<ExportGraphOptions>
 {
     /// <summary>
+    /// The largest padding, in pixels, that the raster exporter is allowed to apply. The exporter grows the canvas
+    /// by twice this value in each dimension, so an unbounded padding can exhaust the browser's memory.
+    /// </summary>
+    private const int MaxPadding = 1000;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ExportGraphOptionsValidator"/> class.
     /// </summary>
     /// <param name="localizer">The localizer.</param>
@@ -19,9 +25,12 @@ public class ExportGraphOptionsValidator : AbstractValidator<ExportGraphOptions>
 
         // Scoped to the formats whose export actually uses the padding, which are exactly the formats for which the
         // dialog shows the field. Validating it for SVG too would block the dialog on a field the user cannot see.
+        // The bound is enforced here, not via Min/Max on the MudNumericField, because MudBlazor's numeric field
+        // clamps out-of-range values inside SetValueAsync instead of reporting them, which would silently coerce
+        // the input instead of surfacing a validation message. This validator is the single source of truth.
         RuleFor(x => x.Padding)
-            .GreaterThanOrEqualTo(0)
+            .InclusiveBetween(0, MaxPadding)
             .When(x => x.Format != ExportGraphFormat.Svg)
-            .WithMessage(localizer["The padding cannot be negative."]);
+            .WithMessage(localizer["The padding must be between 0 and {0} pixels.", MaxPadding]);
     }
 }


### PR DESCRIPTION
Closes #585

Adds an **Export** action to the flowchart designer toolbox (editable and read-only views) that downloads the diagram as PNG, JPEG, or SVG.

## What changed
- **Designer client library**: registers `@antv/x6-plugin-export` (2.1.6, the last 2.x line matching the installed x6 2.18) and adds a single `exportGraph(graphId, options)` function that encodes the requested format, applies padding for the raster formats, appends the matching extension, and throws on an unknown format.
- **Designer interop**: `ExportGraphOptions`/`ExportGraphFormat` carried through `X6GraphApi`, `FlowchartDesigner`, and `FlowchartDesignerWrapper`. A test pins the C#-to-JS payload contract (camel-cased properties, lower-cased format).
- **Workflows module**: an `ExportFlowchartDialog` (format, file name, padding; padding hidden for SVG) validated with FluentValidation via Blazilla, following the dialog pattern adopted in #993. The proposed file name is the workflow definition's name plus a `_v{version}` suffix, sanitized for file-name use; to make that name available, `DisplayContext` gained an optional trailing `WorkflowDefinition` parameter, and `DiagramDesignerWrapper` an optional `WorkflowDefinition` parameter that its four hosts now pass.
- The Export item is only offered when the X6 renderer is active; the React Flow designer has no export path, and the wrapper throws `NotSupportedException` rather than silently doing nothing.

## Notes
- `@antv/x6-plugin-export`'s `exportJPEG()` delegates to `toPNG()` upstream, so it would download PNG bytes under a `.jpeg` name. The implementation calls `toJPEG()` directly and derives the extension from the same value that selects the encoder.
- PDF is out of scope: the X6 export plugin cannot produce it, and the issue lists it as a possible format only.
- Credit to @KnibbsyMan for the approach explored in the draft #720 (X6 export plugin, options dialog, toolbox button). That branch is far behind main and relied on the now-removed Blazored.FluentValidation package, so the feature was re-implemented on top of main instead of merged.

## Verification
- `npm run build` in the designer ClientLib: webpack compiled successfully.
- `dotnet build Elsa.Studio.sln`: 0 errors, no new warnings.
- `Elsa.Studio.Workflows.Tests`: 260 passed (new dialog, validation, file-name, and payload tests); `Elsa.Studio.Workflows.Designer.Tests`: 74 passed on net8.0/net9.0/net10.0.
- Not verified in a browser (no end-to-end harness in this repository): the actual download and the visual effect of padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)