### PR TITLE
feat(designer): generate BPMN payload types from Bpmn.Model's schema

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -74,11 +74,24 @@ jobs:
             8.x
             9.x
             10.x
+      - name: Restore Bpmn.Model
+        # Only Bpmn.Model's own schema/bpmn-payload.schema.json is needed here (see
+        # ClientLib/scripts/generate-bpmn-types.js), but restoring the one project that downloads it
+        # is cheap and keeps this from depending on solution-wide restore order.
+        run: dotnet restore src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
       - name: Build workflow designer client assets
         working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib
         run: |
           npm install --force
           npm run build
+      - name: Verify generated BPMN types are up to date
+        # There is no PR-time build in this repository (PR checks are CodeQL, GitGuardian and CLA
+        # only); this is the only place regenerating src/bpmn/types.generated.ts against the
+        # Bpmn.Model schema and diffing it against what is committed actually runs.
+        working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib
+        run: |
+          npm run check:generated
+          npm test
       - name: Build DOM interop client assets
         working-directory: ./src/framework/Elsa.Studio.DomInterop/ClientLib
         run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -79,19 +79,24 @@ jobs:
         # ClientLib/scripts/generate-bpmn-types.js), but restoring the one project that downloads it
         # is cheap and keeps this from depending on solution-wide restore order.
         run: dotnet restore src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
-      - name: Build workflow designer client assets
+      - name: Install workflow designer client dependencies
         working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib
-        run: |
-          npm install --force
-          npm run build
+        run: npm install --force
       - name: Verify generated BPMN types are up to date
-        # There is no PR-time build in this repository (PR checks are CodeQL, GitGuardian and CLA
-        # only); this is the only place regenerating src/bpmn/types.generated.ts against the
-        # Bpmn.Model schema and diffing it against what is committed actually runs.
+        # This must run before "Build workflow designer client assets": that step's `npm run build`
+        # regenerates src/bpmn/types.generated.ts as a side effect (via `npm run generate:bpmn-types`)
+        # and overwrites it on disk, so running the check afterwards would diff the regenerated file
+        # against itself and could never fail. There is no PR-time build in this repository (PR
+        # checks are CodeQL, GitGuardian and CLA only); this is the only place regenerating
+        # types.generated.ts against the Bpmn.Model schema and diffing it against what is committed
+        # actually runs.
         working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib
         run: |
           npm run check:generated
           npm test
+      - name: Build workflow designer client assets
+        working-directory: ./src/modules/Elsa.Studio.Workflows.Designer/ClientLib
+        run: npm run build
       - name: Build DOM interop client assets
         working-directory: ./src/framework/Elsa.Studio.DomInterop/ClientLib
         run: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,13 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <!--
+      Bpmn.Model is also referenced via <PackageDownload> (not <PackageReference>) in
+      Elsa.Studio.Workflows.Designer.csproj, which CPM does not manage. Naming the version here,
+      once, keeps that PackageDownload's version pin from drifting from this file's PackageVersion
+      entry. ClientLib/scripts/generate-bpmn-types.js also reads this property.
+    -->
+    <BpmnModelVersion>0.2.0</BpmnModelVersion>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
     <PackageVersion Include="Elsa.Api.Client" Version="3.8.0-preview.5565" />
@@ -11,7 +18,7 @@
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="BlazorMonaco" Version="3.4.0" />
-    <PackageVersion Include="Bpmn.Model" Version="0.2.0" />
+    <PackageVersion Include="Bpmn.Model" Version="$(BpmnModelVersion)" />
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="9.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="BlazorMonaco" Version="3.4.0" />
+    <PackageVersion Include="Bpmn.Model" Version="0.2.0" />
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="9.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
@@ -27,13 +27,18 @@
     "@types/react-dom": "^18.3.1",
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.2",
+    "json-schema-to-typescript": "16.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.4",
     "typescript": "^5.8.3",
+    "vitest": "3.2.7",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"
   },
   "scripts": {
-    "build": "webpack"
+    "generate:bpmn-types": "node scripts/generate-bpmn-types.js",
+    "check:generated": "node scripts/generate-bpmn-types.js --check",
+    "build": "npm run generate:bpmn-types && webpack",
+    "test": "vitest run --typecheck"
   }
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
@@ -27,6 +27,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
 const PACKAGES_PROPS_PATH = path.join(REPO_ROOT, 'Directory.Packages.props');
 const OUTPUT_PATH = path.join(__dirname, '..', 'src', 'bpmn', 'types.generated.ts');
 const PACKAGE_ID = 'Bpmn.Model';
+const VERSION_PROPERTY_NAME = 'BpmnModelVersion';
 
 // A raw `[k: string]: unknown` (or `any`) index signature is the old hand-written mirror's failure
 // mode: it means some object in the schema lost its shape (usually a missing `additionalProperties:
@@ -38,11 +39,11 @@ const LOOSE_INDEX_SIGNATURE = /\[k: string\]:\s*(unknown|any)\b/;
 
 function readPinnedVersion() {
     const xml = fs.readFileSync(PACKAGES_PROPS_PATH, 'utf8');
-    const pattern = new RegExp(`<PackageVersion\\s+Include="${PACKAGE_ID.replace('.', '\\.')}"\\s+Version="([^"]+)"`);
+    const pattern = new RegExp(`<${VERSION_PROPERTY_NAME}>([^<]+)</${VERSION_PROPERTY_NAME}>`);
     const match = xml.match(pattern);
 
     if (!match) {
-        throw new Error(`Could not find a <PackageVersion Include="${PACKAGE_ID}" .../> entry in ${PACKAGES_PROPS_PATH}.`);
+        throw new Error(`Could not find a <${VERSION_PROPERTY_NAME}>...</${VERSION_PROPERTY_NAME}> property in ${PACKAGES_PROPS_PATH}.`);
     }
 
     return match[1];

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
@@ -101,6 +101,7 @@ async function generate(schemaPath) {
         bannerComment: '',
         style: { semi: true, singleQuote: true },
         enableConstEnums: false,
+        format: false,
     });
 
     if (LOOSE_INDEX_SIGNATURE.test(body)) {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/scripts/generate-bpmn-types.js
@@ -1,0 +1,178 @@
+// Generates src/bpmn/types.generated.ts from the schema Bpmn.Model publishes in its own nupkg
+// (schema/bpmn-payload.schema.json). See elsa-workflows/elsa-core#7909 (W12) and studio issue #997:
+// the point of generating rather than hand-mirroring is that this file, and only this file, ever
+// has to change when the library's payload format version changes.
+//
+// Usage:
+//   node scripts/generate-bpmn-types.js          Regenerates src/bpmn/types.generated.ts in place.
+//                                                 Missing schema (NuGet cache not populated) is a
+//                                                 warning, not a failure: a clean clone still builds
+//                                                 off the checked-in file.
+//   node scripts/generate-bpmn-types.js --check  Regenerates into memory and fails if that differs
+//                                                 from the checked-in file, or if the schema cannot be
+//                                                 found at all (this mode exists to prove it can be).
+//
+// The schema's version is not copied here: it is read straight out of the same
+// Directory.Packages.props entry that pins the NuGet restore, so there is exactly one place that
+// names the version this repository builds against.
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { compile } = require('json-schema-to-typescript');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const PACKAGES_PROPS_PATH = path.join(REPO_ROOT, 'Directory.Packages.props');
+const OUTPUT_PATH = path.join(__dirname, '..', 'src', 'bpmn', 'types.generated.ts');
+const PACKAGE_ID = 'Bpmn.Model';
+
+// A raw `[k: string]: unknown` (or `any`) index signature is the old hand-written mirror's failure
+// mode: it means some object in the schema lost its shape (usually a missing `additionalProperties:
+// false`) and the generator papered over it. A *typed* dictionary the schema declares on purpose --
+// e.g. `bpmnDiagnosticEvent.details`, which is `additionalProperties: { type: "string" }` -- still
+// compiles to an index signature, just not one typed `unknown`/`any`, so it is not what this guards
+// against.
+const LOOSE_INDEX_SIGNATURE = /\[k: string\]:\s*(unknown|any)\b/;
+
+function readPinnedVersion() {
+    const xml = fs.readFileSync(PACKAGES_PROPS_PATH, 'utf8');
+    const pattern = new RegExp(`<PackageVersion\\s+Include="${PACKAGE_ID.replace('.', '\\.')}"\\s+Version="([^"]+)"`);
+    const match = xml.match(pattern);
+
+    if (!match) {
+        throw new Error(`Could not find a <PackageVersion Include="${PACKAGE_ID}" .../> entry in ${PACKAGES_PROPS_PATH}.`);
+    }
+
+    return match[1];
+}
+
+function resolveNuGetGlobalPackagesFolder() {
+    if (process.env.NUGET_PACKAGES) {
+        return process.env.NUGET_PACKAGES;
+    }
+
+    try {
+        const output = execFileSync('dotnet', ['nuget', 'locals', 'global-packages', '--list'], { encoding: 'utf8' });
+        const match = output.match(/global-packages:\s*(.+)/i);
+
+        if (match) {
+            return match[1].trim();
+        }
+    } catch {
+        // dotnet is not on PATH, or the command failed; fall through to the conventional default.
+    }
+
+    return path.join(os.homedir(), '.nuget', 'packages');
+}
+
+function resolveSchemaPath(version) {
+    const nugetFolder = resolveNuGetGlobalPackagesFolder();
+    // NuGet's global-packages folder always keys on the lower-cased package id.
+    return path.join(nugetFolder, PACKAGE_ID.toLowerCase(), version, 'schema', 'bpmn-payload.schema.json');
+}
+
+// json-schema-to-typescript names an enum from its own `tsEnumNames` field. The schema instead
+// publishes names under `x-enumNames` (the convention its own tooling already uses elsewhere), so
+// this copies one to the other wherever both are present -- a mechanical bridge between the two
+// conventions, not a hand-authored fact about any particular enum.
+function bridgeEnumNames(node) {
+    if (!node || typeof node !== 'object') {
+        return;
+    }
+
+    if (Array.isArray(node.enum) && Array.isArray(node['x-enumNames']) && node.enum.length === node['x-enumNames'].length) {
+        node.tsEnumNames = node['x-enumNames'];
+    }
+
+    for (const value of Object.values(node)) {
+        bridgeEnumNames(value);
+    }
+}
+
+async function generate(schemaPath) {
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+    const formatVersion = schema['x-payloadFormatVersion'];
+    bridgeEnumNames(schema);
+
+    const body = await compile(schema, 'BpmnPayload', {
+        bannerComment: '',
+        style: { semi: true, singleQuote: true },
+        enableConstEnums: false,
+    });
+
+    if (LOOSE_INDEX_SIGNATURE.test(body)) {
+        throw new Error(
+            'json-schema-to-typescript emitted a `[k: string]: unknown`/`any` index signature. '
+            + 'That is the failure mode this generator exists to close (see the schema for the object '
+            + 'that lost its shape -- almost certainly one missing `additionalProperties: false`). '
+            + 'Refusing to write it out.'
+        );
+    }
+
+    const header = [
+        '// GENERATED FILE -- do not edit by hand.',
+        `// Source: Bpmn.Model ${schemaPath.match(/[/\\]([^/\\]+)[/\\]schema[/\\]/)?.[1] ?? 'unknown version'}, `
+            + `payload format ${formatVersion}, schema/bpmn-payload.schema.json.`,
+        '// Regenerate with: npm run generate:bpmn-types (from src/modules/Elsa.Studio.Workflows.Designer/ClientLib).',
+        '// See scripts/generate-bpmn-types.js.',
+        '',
+    ].join('\n');
+
+    return header + body;
+}
+
+async function main() {
+    const checkMode = process.argv.includes('--check');
+    const version = readPinnedVersion();
+    const schemaPath = resolveSchemaPath(version);
+
+    if (!fs.existsSync(schemaPath)) {
+        const message = `Bpmn.Model ${version}'s schema was not found at ${schemaPath}. `
+            + 'Restore it first, e.g.: dotnet restore src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj';
+
+        if (checkMode) {
+            console.error(`error: ${message}`);
+            process.exitCode = 1;
+            return;
+        }
+
+        console.warn(`warning: ${message}\nwarning: leaving the already-generated ${path.relative(process.cwd(), OUTPUT_PATH)} untouched.`);
+        return;
+    }
+
+    const generated = await generate(schemaPath);
+
+    if (checkMode) {
+        const existing = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, 'utf8') : null;
+
+        if (existing !== generated) {
+            console.error(
+                `error: ${path.relative(process.cwd(), OUTPUT_PATH)} is out of date with Bpmn.Model ${version}'s schema. `
+                + 'Run `npm run generate:bpmn-types` and commit the result.'
+            );
+            process.exitCode = 1;
+            return;
+        }
+
+        console.log(`${path.relative(process.cwd(), OUTPUT_PATH)} matches Bpmn.Model ${version}'s schema.`);
+        return;
+    }
+
+    const existing = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, 'utf8') : null;
+
+    if (existing === generated) {
+        console.log(`${path.relative(process.cwd(), OUTPUT_PATH)} is already up to date.`);
+        return;
+    }
+
+    fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+    fs.writeFileSync(OUTPUT_PATH, generated);
+    console.log(`Wrote ${path.relative(process.cwd(), OUTPUT_PATH)} from Bpmn.Model ${version}'s schema.`);
+}
+
+main().catch(error => {
+    console.error(error.stack ?? String(error));
+    process.exitCode = 1;
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.process.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.process.json
@@ -1,0 +1,203 @@
+{
+  "processId": "order-process",
+  "name": "Order Process",
+  "isExecutable": true,
+  "isTransaction": false,
+  "elements": [
+    {
+      "elementId": "StartEvent_1",
+      "elementType": "startEvent",
+      "name": "Order Received",
+      "eventDefinitions": [],
+      "properties": {},
+      "cancelActivity": true,
+      "isForCompensation": false,
+      "isTransaction": false,
+      "triggeredByEvent": false,
+      "extensions": {
+        "documentation": [],
+        "extensionElements": [],
+        "foreignAttributes": [],
+        "foreignChildren": []
+      }
+    },
+    {
+      "elementId": "NotifyWarehouse",
+      "elementType": "serviceTask",
+      "name": "Notify Warehouse",
+      "bindingRef": "node-NotifyWarehouse",
+      "eventDefinitions": [],
+      "properties": {},
+      "cancelActivity": true,
+      "isForCompensation": false,
+      "isTransaction": false,
+      "triggeredByEvent": false,
+      "extensions": {
+        "documentation": [
+          {
+            "text": "Tells the warehouse an order needs picking."
+          }
+        ],
+        "extensionElements": [
+          {
+            "name": {
+              "ns": "http://camunda.org/schema/1.0/bpmn",
+              "localName": "inputOutput"
+            },
+            "attributes": [],
+            "children": [
+              {
+                "name": {
+                  "ns": "http://camunda.org/schema/1.0/bpmn",
+                  "localName": "inputParameter"
+                },
+                "value": "${orderId}",
+                "attributes": [
+                  {
+                    "name": {
+                      "localName": "name"
+                    },
+                    "value": "orderId"
+                  }
+                ],
+                "children": []
+              }
+            ]
+          },
+          {
+            "name": {
+              "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+              "localName": "activityBinding"
+            },
+            "attributes": [
+              {
+                "name": {
+                  "localName": "activityType"
+                },
+                "value": "Elsa.WriteLine"
+              }
+            ],
+            "children": [
+              {
+                "name": {
+                  "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                  "localName": "input"
+                },
+                "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Notifying the warehouse\u0022}}",
+                "attributes": [
+                  {
+                    "name": {
+                      "localName": "name"
+                    },
+                    "value": "text"
+                  }
+                ],
+                "children": []
+              }
+            ]
+          }
+        ],
+        "foreignAttributes": [
+          {
+            "name": {
+              "ns": "http://camunda.org/schema/1.0/bpmn",
+              "localName": "asyncBefore"
+            },
+            "value": "true"
+          }
+        ],
+        "foreignChildren": []
+      }
+    },
+    {
+      "elementId": "EndEvent_1",
+      "elementType": "endEvent",
+      "name": "Order Handled",
+      "eventDefinitions": [],
+      "properties": {},
+      "cancelActivity": true,
+      "isForCompensation": false,
+      "isTransaction": false,
+      "triggeredByEvent": false,
+      "extensions": {
+        "documentation": [],
+        "extensionElements": [],
+        "foreignAttributes": [],
+        "foreignChildren": []
+      }
+    }
+  ],
+  "sequenceFlows": [
+    {
+      "flowId": "Flow_1",
+      "sourceRef": "StartEvent_1",
+      "targetRef": "NotifyWarehouse",
+      "isDefault": false,
+      "extensions": {
+        "documentation": [],
+        "extensionElements": [],
+        "foreignAttributes": [],
+        "foreignChildren": []
+      }
+    },
+    {
+      "flowId": "Flow_2",
+      "sourceRef": "NotifyWarehouse",
+      "targetRef": "EndEvent_1",
+      "isDefault": false,
+      "extensions": {
+        "documentation": [],
+        "extensionElements": [],
+        "foreignAttributes": [],
+        "foreignChildren": []
+      }
+    }
+  ],
+  "lanes": [],
+  "variables": [],
+  "extensions": {
+    "documentation": [],
+    "extensionElements": [
+      {
+        "name": {
+          "ns": "http://camunda.org/schema/1.0/bpmn",
+          "localName": "properties"
+        },
+        "attributes": [],
+        "children": [
+          {
+            "name": {
+              "ns": "http://camunda.org/schema/1.0/bpmn",
+              "localName": "property"
+            },
+            "attributes": [
+              {
+                "name": {
+                  "localName": "name"
+                },
+                "value": "owner"
+              },
+              {
+                "name": {
+                  "localName": "value"
+                },
+                "value": "fulfillment-team"
+              }
+            ],
+            "children": []
+          }
+        ]
+      }
+    ],
+    "foreignAttributes": [
+      {
+        "name": {
+          "ns": "http://camunda.org/schema/1.0/bpmn",
+          "localName": "versionTag"
+        },
+        "value": "1.0"
+      }
+    ],
+    "foreignChildren": []
+  }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/process-payload.test-d.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/process-payload.test-d.ts
@@ -1,0 +1,31 @@
+/**
+ * Type-checks a real serialized `BpmnProcess.Process` payload against the generated types, with no
+ * cast anywhere in the assignment below. If `BpmnProcessDefinition` in ../types.generated stops
+ * describing the JSON Elsa's activity serializer actually produces, `npm test` fails to compile this
+ * file -- that is the whole test.
+ *
+ * ../__fixtures__/camunda-order-process.process.json is not a hand-written example: it is the exact
+ * value of the `"process"` property from the `Elsa.BpmnProcess` activity that
+ * `Bpmn.Interchange.BpmnInterchangeDocumentService.ImportAsync` produces for
+ * `test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/camunda-order-process.bpmn` in
+ * elsa-core, captured by asking `Elsa.Workflows.Serialization.Serializers.JsonActivitySerializer` --
+ * the same serializer a GET of a workflow definition goes through -- to serialize the resulting
+ * workflow's root activity, then lifting out the `"process"` property. It was NOT captured through
+ * the HTTP import endpoint mentioned in studio issue #997, because doing that needs a running
+ * elsa-core host, which is outside this repository's test suite; this is the same wire format the
+ * endpoint produces, reached through the library code the endpoint itself calls.
+ *
+ * To reproduce: with elsa-core checked out alongside this repo, run a small program that
+ *   1. builds an `IServiceCollection` with `.AddElsa(elsa => elsa.UseWorkflowManagement().UseBpmnInterchange())`,
+ *   2. calls `provider.PopulateRegistriesAsync()` (Elsa.Testing.Shared.Integration),
+ *   3. resolves `BpmnInterchangeDocumentService` and calls
+ *      `ImportAsync(xml, definitionId: null, name: null, processId: null, cancellationToken)` with the
+ *      asset's XML,
+ *   4. parses `result.ImportResult.WorkflowDefinition.StringData` as JSON and writes out its
+ *      `"process"` property.
+ */
+import type { BpmnProcessDefinition } from '../types.generated';
+import processFixture from '../__fixtures__/camunda-order-process.process.json';
+
+const typedProcess: BpmnProcessDefinition = processFixture;
+void typedProcess;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/process-payload.test-d.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/process-payload.test-d.ts
@@ -29,3 +29,53 @@ import processFixture from '../__fixtures__/camunda-order-process.process.json';
 
 const typedProcess: BpmnProcessDefinition = processFixture;
 void typedProcess;
+
+/**
+ * `BpmnProcessDefinition` (like every structural TypeScript type) happily accepts a value with
+ * *extra* properties, so the plain assignment above cannot catch a field disappearing from the
+ * generated type as long as the fixture still has a property of that name elsewhere -- structural
+ * typing only checks that required properties are present and compatible, not that no others exist.
+ *
+ * `ExcessKeys<Fixture, Shape>` walks both in lockstep -- recursing into nested objects and arrays, so
+ * the same check applies to elements, sequence flows, extensions, etc. -- and collects the name of
+ * every key it finds in `Fixture` that `Shape` does not also declare at that position. If nothing is
+ * excess anywhere, the result is `never`; asserting that below fails to compile the moment the fixture
+ * has a property, at any depth, that the generated type does not.
+ *
+ * This does not attempt a full bidirectional type-equality check (e.g. `expectTypeOf().toEqualTypeOf`)
+ * because the generated types are deliberately looser than any single fixture in places the schema
+ * allows to vary (e.g. `bindingRef?: string | null` is only present on some element kinds): a
+ * `toEqualTypeOf` assertion would fail on that legitimate looseness, not on a real regression.
+ * Excess-key detection is the narrower, correct check for what this test guards against: a field
+ * silently disappearing from the generated type while still being produced by the serializer.
+ *
+ * Two TypeScript quirks the implementation works around, both specific to comparing a type inferred
+ * from imported JSON against a hand-authored one:
+ *  - `IsAny<T>` short-circuits `unknown`-ish leftovers (e.g. an empty array literal infers as `any[]`)
+ *    before they reach `keyof`, which would otherwise widen to `string | number | symbol` and make
+ *    every object look like it has excess keys.
+ *  - `[F] extends [undefined]` short-circuits an absent optional property (e.g. `bindingRef` on a
+ *    fixture element that has none) before the array/object checks: with this project's non-strict
+ *    `tsconfig.json` (see ADR 0005), `undefined` satisfies `extends` against every type, including
+ *    `extends readonly unknown[]`, which would otherwise be misread as an array/shape mismatch.
+ */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type ExcessKeys<Fixture, Shape> = IsAny<Fixture> extends true
+    ? never
+    : [Fixture] extends [undefined]
+        ? never
+        : Fixture extends readonly (infer FixtureElement)[]
+            ? Shape extends readonly (infer ShapeElement)[]
+                ? ExcessKeys<FixtureElement, ShapeElement>
+                : 'ARRAY_SHAPE_MISMATCH'
+            : Fixture extends object
+                ? Shape extends object
+                    ? { [K in keyof Fixture]: K extends keyof Shape ? ExcessKeys<Fixture[K], Exclude<Shape[K], null | undefined>> : K }[keyof Fixture]
+                    : 'OBJECT_SHAPE_MISMATCH'
+                : never;
+
+type IsNever<T> = [T] extends [never] ? true : false;
+
+const noExcessKeys: IsNever<ExcessKeys<typeof processFixture, BpmnProcessDefinition>> = true;
+void noExcessKeys;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/types.generated.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/types.generated.ts
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit by hand.
+// Source: Bpmn.Model 0.2.0, payload format 1.0.0, schema/bpmn-payload.schema.json.
+// Regenerate with: npm run generate:bpmn-types (from src/modules/Elsa.Studio.Workflows.Designer/ClientLib).
+// See scripts/generate-bpmn-types.js.
+/**
+ * Version 1.0.0 of the payload format owned by Bpmn.Model. Generated from the model; do not edit by hand. See ADR 0005.
+ */
+export type BPMNPayloadFormat = BpmnDefinitions | BpmnExecutionState;
+
+export interface BpmnDefinitions {
+  id?: string | null;
+  targetNamespace?: string | null;
+  exporter?: string | null;
+  exporterVersion?: string | null;
+  collaboration?: BpmnCollaboration | null;
+  processes: BpmnProcessDefinition[];
+  diagrams: BpmnDiagram[];
+  messages: BpmnMessageDeclaration[];
+  signals: BpmnSignalDeclaration[];
+  errors: BpmnErrorDeclaration[];
+  escalations: BpmnEscalationDeclaration[];
+  extensions: BpmnExtensions;
+}
+export interface BpmnCollaboration {
+  id?: string | null;
+  pools: BpmnPool[];
+  messageFlows: BpmnMessageFlow[];
+  extensions: BpmnExtensions;
+}
+export interface BpmnPool {
+  poolId: string;
+  name?: string | null;
+  processRef?: string | null;
+  isExecutable: boolean;
+  extensions: BpmnExtensions;
+}
+export interface BpmnExtensions {
+  documentation: BpmnDocumentation[];
+  extensionElements: BpmnExtensionElement[];
+  foreignAttributes: BpmnForeignAttribute[];
+  foreignChildren: BpmnForeignChild[];
+}
+export interface BpmnDocumentation {
+  text: string;
+  textFormat?: string | null;
+}
+export interface BpmnExtensionElement {
+  name: BpmnQName;
+  value?: string | null;
+  attributes: BpmnForeignAttribute[];
+  children: BpmnExtensionElement[];
+}
+export interface BpmnQName {
+  ns?: string | null;
+  localName: string;
+}
+export interface BpmnForeignAttribute {
+  name: BpmnQName;
+  value: string;
+}
+export interface BpmnForeignChild {
+  element: BpmnExtensionElement;
+  index: number;
+}
+export interface BpmnMessageFlow {
+  flowId: string;
+  name?: string | null;
+  sourceElementId?: string | null;
+  sourcePoolId?: string | null;
+  targetElementId?: string | null;
+  targetPoolId?: string | null;
+  messageName?: string | null;
+  extensions: BpmnExtensions;
+}
+export interface BpmnProcessDefinition {
+  processId: string;
+  name?: string | null;
+  isExecutable: boolean;
+  isTransaction: boolean;
+  elements: BpmnElement[];
+  sequenceFlows: BpmnSequenceFlow[];
+  lanes: BpmnLane[];
+  variables: BpmnVariableDeclaration[];
+  extensions: BpmnExtensions;
+}
+export interface BpmnElement {
+  elementId: string;
+  elementType: string;
+  name?: string | null;
+  bindingRef?: string | null;
+  laneId?: string | null;
+  defaultFlowId?: string | null;
+  eventDefinitions: BpmnEventDefinition[];
+  properties: {
+    [k: string]: string;
+  };
+  attachedToRef?: string | null;
+  cancelActivity: boolean;
+  loopCharacteristics?: BpmnLoopCharacteristics | null;
+  isForCompensation: boolean;
+  compensationHandlerElementId?: string | null;
+  isTransaction: boolean;
+  triggeredByEvent: boolean;
+  listenerBindingRef?: string | null;
+  extensions: BpmnExtensions;
+}
+export interface BpmnEventDefinition {
+  type: string;
+  properties: {
+    [k: string]: string;
+  };
+}
+export interface BpmnLoopCharacteristics {
+  isSequential: boolean;
+  cardinality?: number | null;
+  collectionVariable?: string | null;
+  itemVariable: string;
+}
+export interface BpmnSequenceFlow {
+  flowId: string;
+  sourceRef: string;
+  targetRef: string;
+  name?: string | null;
+  conditionOutcome?: string | null;
+  isDefault: boolean;
+  extensions: BpmnExtensions;
+}
+export interface BpmnLane {
+  laneId: string;
+  poolId?: string | null;
+  name?: string | null;
+  extensions: BpmnExtensions;
+}
+export interface BpmnVariableDeclaration {
+  name: string;
+  typeHint?: string | null;
+  defaultValue?: unknown;
+}
+export interface BpmnDiagram {
+  id?: string | null;
+  name?: string | null;
+  plane: BpmnPlane;
+}
+export interface BpmnPlane {
+  id?: string | null;
+  bpmnElementRef?: string | null;
+  shapes: BpmnShape[];
+  edges: BpmnEdge[];
+}
+export interface BpmnShape {
+  id?: string | null;
+  bpmnElementRef: string;
+  bounds: BpmnBounds;
+  isHorizontal?: boolean | null;
+  isExpanded?: boolean | null;
+  isMarkerVisible?: boolean | null;
+  label?: BpmnLabel | null;
+}
+export interface BpmnBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+export interface BpmnLabel {
+  bounds?: BpmnBounds | null;
+}
+export interface BpmnEdge {
+  id?: string | null;
+  bpmnElementRef: string;
+  label?: BpmnLabel | null;
+  waypoints: BpmnPoint[];
+}
+export interface BpmnPoint {
+  x: number;
+  y: number;
+}
+export interface BpmnMessageDeclaration {
+  id: string;
+  name?: string | null;
+}
+export interface BpmnSignalDeclaration {
+  id: string;
+  name?: string | null;
+}
+export interface BpmnErrorDeclaration {
+  id: string;
+  name?: string | null;
+  errorCode?: string | null;
+}
+export interface BpmnEscalationDeclaration {
+  id: string;
+  name?: string | null;
+  escalationCode?: string | null;
+}
+export interface BpmnExecutionState {
+  tokens: BpmnToken[];
+  activeWork: BpmnActiveWork[];
+  diagnostics: BpmnDiagnosticEvent[];
+  sequence: number;
+  races: BpmnEventRace[];
+  loops: BpmnLoopState[];
+  compensables: BpmnCompensable[];
+  compensationRuns: BpmnCompensationRun[];
+  terminated: boolean;
+  cancelling: boolean;
+  pendingFault?: BpmnPendingFault | null;
+}
+export interface BpmnToken {
+  tokenId: string;
+  atElementId: string;
+  flowId?: string | null;
+  parentTokenId?: string | null;
+  status: BpmnTokenStatus;
+  producingWorkHandle?: string | null;
+  iterationKey?: string | null;
+  kind?: BpmnTokenKind | null;
+}
+export interface BpmnActiveWork {
+  nodeId: string;
+  elementId: string;
+  tokenId: string;
+  schedulingCause: string;
+  iterationId?: string | null;
+}
+export interface BpmnDiagnosticEvent {
+  diagnosticId: string;
+  kind: BpmnDiagnosticKind;
+  message: string;
+  elementId?: string | null;
+  flowId?: string | null;
+  tokenId?: string | null;
+  details: {
+    [k: string]: string;
+  };
+}
+export interface BpmnEventRace {
+  raceId: string;
+  gatewayElementId: string;
+  memberTokenIds: string[];
+  resolved: boolean;
+}
+export interface BpmnLoopState {
+  loopId: string;
+  tokenId: string;
+  elementId: string;
+  isSequential: boolean;
+  totalCount: number;
+  nextIndex: number;
+  completedCount: number;
+  items?: unknown[] | null;
+}
+export interface BpmnCompensable {
+  compensableId: string;
+  hostElementId: string;
+  handlerElementId: string;
+  status: BpmnCompensableStatus;
+}
+export interface BpmnCompensationRun {
+  runId: string;
+  throwTokenId: string;
+  pendingCompensableIds: string[];
+}
+export interface BpmnPendingFault {
+  faultCode: string;
+  message: string;
+}
+
+/**
+ * Serialized as an integer: the model declares no JsonStringEnumConverter.
+ */
+export enum BpmnTokenStatus {
+  Active = 0,
+  AwaitingChild = 1,
+  WaitingAtJoin = 2,
+  Consumed = 3,
+  Canceled = 4
+}
+/**
+ * Serialized as an integer: the model declares no JsonStringEnumConverter.
+ */
+export enum BpmnTokenKind {
+  Listener = 0,
+  Activation = 1
+}
+/**
+ * Serialized as an integer: the model declares no JsonStringEnumConverter.
+ */
+export enum BpmnDiagnosticKind {
+  TokenEmitted = 0,
+  Scheduled = 1,
+  Waiting = 2,
+  Joined = 3,
+  Consumed = 4,
+  Canceled = 5,
+  Terminated = 6,
+  BehaviorFailure = 7,
+  Completed = 8,
+  Faulted = 9,
+  CompensationRegistered = 10,
+  CompensationTriggered = 11,
+  Compensated = 12,
+  TransactionCancelled = 13,
+  EscalationRaised = 14,
+  EscalationCaught = 15,
+  EscalationUnhandled = 16,
+  EscalationLate = 17,
+  EventSubprocessActivated = 18,
+  EventSubprocessCompleted = 19,
+  CallActivityFailureRouted = 20,
+  ScopeListenerArmed = 21,
+  ScopeListenerFired = 22,
+  ScopeListenerRetired = 23
+}
+/**
+ * Serialized as an integer: the model declares no JsonStringEnumConverter.
+ */
+export enum BpmnCompensableStatus {
+  Registered = 0,
+  Claimed = 1,
+  Compensated = 2
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/types.generated.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/types.generated.ts
@@ -5,318 +5,319 @@
 /**
  * Version 1.0.0 of the payload format owned by Bpmn.Model. Generated from the model; do not edit by hand. See ADR 0005.
  */
-export type BPMNPayloadFormat = BpmnDefinitions | BpmnExecutionState;
+export type BPMNPayloadFormat = (BpmnDefinitions | BpmnExecutionState)
 
 export interface BpmnDefinitions {
-  id?: string | null;
-  targetNamespace?: string | null;
-  exporter?: string | null;
-  exporterVersion?: string | null;
-  collaboration?: BpmnCollaboration | null;
-  processes: BpmnProcessDefinition[];
-  diagrams: BpmnDiagram[];
-  messages: BpmnMessageDeclaration[];
-  signals: BpmnSignalDeclaration[];
-  errors: BpmnErrorDeclaration[];
-  escalations: BpmnEscalationDeclaration[];
-  extensions: BpmnExtensions;
+id?: (string | null)
+targetNamespace?: (string | null)
+exporter?: (string | null)
+exporterVersion?: (string | null)
+collaboration?: (BpmnCollaboration | null)
+processes: BpmnProcessDefinition[]
+diagrams: BpmnDiagram[]
+messages: BpmnMessageDeclaration[]
+signals: BpmnSignalDeclaration[]
+errors: BpmnErrorDeclaration[]
+escalations: BpmnEscalationDeclaration[]
+extensions: BpmnExtensions
 }
 export interface BpmnCollaboration {
-  id?: string | null;
-  pools: BpmnPool[];
-  messageFlows: BpmnMessageFlow[];
-  extensions: BpmnExtensions;
+id?: (string | null)
+pools: BpmnPool[]
+messageFlows: BpmnMessageFlow[]
+extensions: BpmnExtensions
 }
 export interface BpmnPool {
-  poolId: string;
-  name?: string | null;
-  processRef?: string | null;
-  isExecutable: boolean;
-  extensions: BpmnExtensions;
+poolId: string
+name?: (string | null)
+processRef?: (string | null)
+isExecutable: boolean
+extensions: BpmnExtensions
 }
 export interface BpmnExtensions {
-  documentation: BpmnDocumentation[];
-  extensionElements: BpmnExtensionElement[];
-  foreignAttributes: BpmnForeignAttribute[];
-  foreignChildren: BpmnForeignChild[];
+documentation: BpmnDocumentation[]
+extensionElements: BpmnExtensionElement[]
+foreignAttributes: BpmnForeignAttribute[]
+foreignChildren: BpmnForeignChild[]
 }
 export interface BpmnDocumentation {
-  text: string;
-  textFormat?: string | null;
+text: string
+textFormat?: (string | null)
 }
 export interface BpmnExtensionElement {
-  name: BpmnQName;
-  value?: string | null;
-  attributes: BpmnForeignAttribute[];
-  children: BpmnExtensionElement[];
+name: BpmnQName
+value?: (string | null)
+attributes: BpmnForeignAttribute[]
+children: BpmnExtensionElement[]
 }
 export interface BpmnQName {
-  ns?: string | null;
-  localName: string;
+ns?: (string | null)
+localName: string
 }
 export interface BpmnForeignAttribute {
-  name: BpmnQName;
-  value: string;
+name: BpmnQName
+value: string
 }
 export interface BpmnForeignChild {
-  element: BpmnExtensionElement;
-  index: number;
+element: BpmnExtensionElement
+index: number
 }
 export interface BpmnMessageFlow {
-  flowId: string;
-  name?: string | null;
-  sourceElementId?: string | null;
-  sourcePoolId?: string | null;
-  targetElementId?: string | null;
-  targetPoolId?: string | null;
-  messageName?: string | null;
-  extensions: BpmnExtensions;
+flowId: string
+name?: (string | null)
+sourceElementId?: (string | null)
+sourcePoolId?: (string | null)
+targetElementId?: (string | null)
+targetPoolId?: (string | null)
+messageName?: (string | null)
+extensions: BpmnExtensions
 }
 export interface BpmnProcessDefinition {
-  processId: string;
-  name?: string | null;
-  isExecutable: boolean;
-  isTransaction: boolean;
-  elements: BpmnElement[];
-  sequenceFlows: BpmnSequenceFlow[];
-  lanes: BpmnLane[];
-  variables: BpmnVariableDeclaration[];
-  extensions: BpmnExtensions;
+processId: string
+name?: (string | null)
+isExecutable: boolean
+isTransaction: boolean
+elements: BpmnElement[]
+sequenceFlows: BpmnSequenceFlow[]
+lanes: BpmnLane[]
+variables: BpmnVariableDeclaration[]
+extensions: BpmnExtensions
 }
 export interface BpmnElement {
-  elementId: string;
-  elementType: string;
-  name?: string | null;
-  bindingRef?: string | null;
-  laneId?: string | null;
-  defaultFlowId?: string | null;
-  eventDefinitions: BpmnEventDefinition[];
-  properties: {
-    [k: string]: string;
-  };
-  attachedToRef?: string | null;
-  cancelActivity: boolean;
-  loopCharacteristics?: BpmnLoopCharacteristics | null;
-  isForCompensation: boolean;
-  compensationHandlerElementId?: string | null;
-  isTransaction: boolean;
-  triggeredByEvent: boolean;
-  listenerBindingRef?: string | null;
-  extensions: BpmnExtensions;
+elementId: string
+elementType: string
+name?: (string | null)
+bindingRef?: (string | null)
+laneId?: (string | null)
+defaultFlowId?: (string | null)
+eventDefinitions: BpmnEventDefinition[]
+properties: {
+[k: string]: string
+}
+attachedToRef?: (string | null)
+cancelActivity: boolean
+loopCharacteristics?: (BpmnLoopCharacteristics | null)
+isForCompensation: boolean
+compensationHandlerElementId?: (string | null)
+isTransaction: boolean
+triggeredByEvent: boolean
+listenerBindingRef?: (string | null)
+extensions: BpmnExtensions
 }
 export interface BpmnEventDefinition {
-  type: string;
-  properties: {
-    [k: string]: string;
-  };
+type: string
+properties: {
+[k: string]: string
+}
 }
 export interface BpmnLoopCharacteristics {
-  isSequential: boolean;
-  cardinality?: number | null;
-  collectionVariable?: string | null;
-  itemVariable: string;
+isSequential: boolean
+cardinality?: (number | null)
+collectionVariable?: (string | null)
+itemVariable: string
 }
 export interface BpmnSequenceFlow {
-  flowId: string;
-  sourceRef: string;
-  targetRef: string;
-  name?: string | null;
-  conditionOutcome?: string | null;
-  isDefault: boolean;
-  extensions: BpmnExtensions;
+flowId: string
+sourceRef: string
+targetRef: string
+name?: (string | null)
+conditionOutcome?: (string | null)
+isDefault: boolean
+extensions: BpmnExtensions
 }
 export interface BpmnLane {
-  laneId: string;
-  poolId?: string | null;
-  name?: string | null;
-  extensions: BpmnExtensions;
+laneId: string
+poolId?: (string | null)
+name?: (string | null)
+extensions: BpmnExtensions
 }
 export interface BpmnVariableDeclaration {
-  name: string;
-  typeHint?: string | null;
-  defaultValue?: unknown;
+name: string
+typeHint?: (string | null)
+defaultValue?: unknown
 }
 export interface BpmnDiagram {
-  id?: string | null;
-  name?: string | null;
-  plane: BpmnPlane;
+id?: (string | null)
+name?: (string | null)
+plane: BpmnPlane
 }
 export interface BpmnPlane {
-  id?: string | null;
-  bpmnElementRef?: string | null;
-  shapes: BpmnShape[];
-  edges: BpmnEdge[];
+id?: (string | null)
+bpmnElementRef?: (string | null)
+shapes: BpmnShape[]
+edges: BpmnEdge[]
 }
 export interface BpmnShape {
-  id?: string | null;
-  bpmnElementRef: string;
-  bounds: BpmnBounds;
-  isHorizontal?: boolean | null;
-  isExpanded?: boolean | null;
-  isMarkerVisible?: boolean | null;
-  label?: BpmnLabel | null;
+id?: (string | null)
+bpmnElementRef: string
+bounds: BpmnBounds
+isHorizontal?: (boolean | null)
+isExpanded?: (boolean | null)
+isMarkerVisible?: (boolean | null)
+label?: (BpmnLabel | null)
 }
 export interface BpmnBounds {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+x: number
+y: number
+width: number
+height: number
 }
 export interface BpmnLabel {
-  bounds?: BpmnBounds | null;
+bounds?: (BpmnBounds | null)
 }
 export interface BpmnEdge {
-  id?: string | null;
-  bpmnElementRef: string;
-  label?: BpmnLabel | null;
-  waypoints: BpmnPoint[];
+id?: (string | null)
+bpmnElementRef: string
+label?: (BpmnLabel | null)
+waypoints: BpmnPoint[]
 }
 export interface BpmnPoint {
-  x: number;
-  y: number;
+x: number
+y: number
 }
 export interface BpmnMessageDeclaration {
-  id: string;
-  name?: string | null;
+id: string
+name?: (string | null)
 }
 export interface BpmnSignalDeclaration {
-  id: string;
-  name?: string | null;
+id: string
+name?: (string | null)
 }
 export interface BpmnErrorDeclaration {
-  id: string;
-  name?: string | null;
-  errorCode?: string | null;
+id: string
+name?: (string | null)
+errorCode?: (string | null)
 }
 export interface BpmnEscalationDeclaration {
-  id: string;
-  name?: string | null;
-  escalationCode?: string | null;
+id: string
+name?: (string | null)
+escalationCode?: (string | null)
 }
 export interface BpmnExecutionState {
-  tokens: BpmnToken[];
-  activeWork: BpmnActiveWork[];
-  diagnostics: BpmnDiagnosticEvent[];
-  sequence: number;
-  races: BpmnEventRace[];
-  loops: BpmnLoopState[];
-  compensables: BpmnCompensable[];
-  compensationRuns: BpmnCompensationRun[];
-  terminated: boolean;
-  cancelling: boolean;
-  pendingFault?: BpmnPendingFault | null;
+tokens: BpmnToken[]
+activeWork: BpmnActiveWork[]
+diagnostics: BpmnDiagnosticEvent[]
+sequence: number
+races: BpmnEventRace[]
+loops: BpmnLoopState[]
+compensables: BpmnCompensable[]
+compensationRuns: BpmnCompensationRun[]
+terminated: boolean
+cancelling: boolean
+pendingFault?: (BpmnPendingFault | null)
 }
 export interface BpmnToken {
-  tokenId: string;
-  atElementId: string;
-  flowId?: string | null;
-  parentTokenId?: string | null;
-  status: BpmnTokenStatus;
-  producingWorkHandle?: string | null;
-  iterationKey?: string | null;
-  kind?: BpmnTokenKind | null;
+tokenId: string
+atElementId: string
+flowId?: (string | null)
+parentTokenId?: (string | null)
+status: BpmnTokenStatus
+producingWorkHandle?: (string | null)
+iterationKey?: (string | null)
+kind?: (BpmnTokenKind | null)
 }
 export interface BpmnActiveWork {
-  nodeId: string;
-  elementId: string;
-  tokenId: string;
-  schedulingCause: string;
-  iterationId?: string | null;
+nodeId: string
+elementId: string
+tokenId: string
+schedulingCause: string
+iterationId?: (string | null)
 }
 export interface BpmnDiagnosticEvent {
-  diagnosticId: string;
-  kind: BpmnDiagnosticKind;
-  message: string;
-  elementId?: string | null;
-  flowId?: string | null;
-  tokenId?: string | null;
-  details: {
-    [k: string]: string;
-  };
+diagnosticId: string
+kind: BpmnDiagnosticKind
+message: string
+elementId?: (string | null)
+flowId?: (string | null)
+tokenId?: (string | null)
+details: {
+[k: string]: string
+}
 }
 export interface BpmnEventRace {
-  raceId: string;
-  gatewayElementId: string;
-  memberTokenIds: string[];
-  resolved: boolean;
+raceId: string
+gatewayElementId: string
+memberTokenIds: string[]
+resolved: boolean
 }
 export interface BpmnLoopState {
-  loopId: string;
-  tokenId: string;
-  elementId: string;
-  isSequential: boolean;
-  totalCount: number;
-  nextIndex: number;
-  completedCount: number;
-  items?: unknown[] | null;
+loopId: string
+tokenId: string
+elementId: string
+isSequential: boolean
+totalCount: number
+nextIndex: number
+completedCount: number
+items?: (unknown[] | null)
 }
 export interface BpmnCompensable {
-  compensableId: string;
-  hostElementId: string;
-  handlerElementId: string;
-  status: BpmnCompensableStatus;
+compensableId: string
+hostElementId: string
+handlerElementId: string
+status: BpmnCompensableStatus
 }
 export interface BpmnCompensationRun {
-  runId: string;
-  throwTokenId: string;
-  pendingCompensableIds: string[];
+runId: string
+throwTokenId: string
+pendingCompensableIds: string[]
 }
 export interface BpmnPendingFault {
-  faultCode: string;
-  message: string;
+faultCode: string
+message: string
 }
 
 /**
  * Serialized as an integer: the model declares no JsonStringEnumConverter.
  */
 export enum BpmnTokenStatus {
-  Active = 0,
-  AwaitingChild = 1,
-  WaitingAtJoin = 2,
-  Consumed = 3,
-  Canceled = 4
+Active = 0,
+AwaitingChild = 1,
+WaitingAtJoin = 2,
+Consumed = 3,
+Canceled = 4
 }
 /**
  * Serialized as an integer: the model declares no JsonStringEnumConverter.
  */
 export enum BpmnTokenKind {
-  Listener = 0,
-  Activation = 1
+Listener = 0,
+Activation = 1
 }
 /**
  * Serialized as an integer: the model declares no JsonStringEnumConverter.
  */
 export enum BpmnDiagnosticKind {
-  TokenEmitted = 0,
-  Scheduled = 1,
-  Waiting = 2,
-  Joined = 3,
-  Consumed = 4,
-  Canceled = 5,
-  Terminated = 6,
-  BehaviorFailure = 7,
-  Completed = 8,
-  Faulted = 9,
-  CompensationRegistered = 10,
-  CompensationTriggered = 11,
-  Compensated = 12,
-  TransactionCancelled = 13,
-  EscalationRaised = 14,
-  EscalationCaught = 15,
-  EscalationUnhandled = 16,
-  EscalationLate = 17,
-  EventSubprocessActivated = 18,
-  EventSubprocessCompleted = 19,
-  CallActivityFailureRouted = 20,
-  ScopeListenerArmed = 21,
-  ScopeListenerFired = 22,
-  ScopeListenerRetired = 23
+TokenEmitted = 0,
+Scheduled = 1,
+Waiting = 2,
+Joined = 3,
+Consumed = 4,
+Canceled = 5,
+Terminated = 6,
+BehaviorFailure = 7,
+Completed = 8,
+Faulted = 9,
+CompensationRegistered = 10,
+CompensationTriggered = 11,
+Compensated = 12,
+TransactionCancelled = 13,
+EscalationRaised = 14,
+EscalationCaught = 15,
+EscalationUnhandled = 16,
+EscalationLate = 17,
+EventSubprocessActivated = 18,
+EventSubprocessCompleted = 19,
+CallActivityFailureRouted = 20,
+ScopeListenerArmed = 21,
+ScopeListenerFired = 22,
+ScopeListenerRetired = 23
 }
 /**
  * Serialized as an integer: the model declares no JsonStringEnumConverter.
  */
 export enum BpmnCompensableStatus {
-  Registered = 0,
-  Claimed = 1,
-  Compensated = 2
+Registered = 0,
+Claimed = 1,
+Compensated = 2
 }
+

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/tsconfig.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/tsconfig.json
@@ -9,7 +9,8 @@
     "allowJs": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": [
     "./src/**/*"

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// There is no runtime test suite here (yet): the one thing this package needs verified is that
+// src/bpmn/types.generated.ts actually describes the JSON Elsa's activity serializer produces for a
+// real BpmnProcess.Process value. That is a compile-time question, so it is asked with a `.test-d.ts`
+// file and Vitest's typecheck mode rather than a runtime assertion -- see
+// src/bpmn/__tests__/process-payload.test-d.ts.
+export default defineConfig({
+  test: {
+    include: [],
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.test-d.ts'],
+    },
+  },
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
@@ -25,7 +25,7 @@
             at a version pinned centrally like every other dependency, for ClientLib/scripts/generate-bpmn-types.js
             to read when it regenerates src/bpmn/types.generated.ts. See that script for how the path is resolved.
         -->
-        <PackageDownload Include="Bpmn.Model" Version="[0.2.0]"/>
+        <PackageDownload Include="Bpmn.Model" Version="[$(BpmnModelVersion)]"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj
@@ -19,6 +19,16 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!--
+            Bpmn.Model is not referenced by any C# code here: this project never deserializes a BPMN document.
+            It is downloaded (not referenced) purely so its schema/bpmn-payload.schema.json is available on disk,
+            at a version pinned centrally like every other dependency, for ClientLib/scripts/generate-bpmn-types.js
+            to read when it regenerates src/bpmn/types.generated.ts. See that script for how the path is resolved.
+        -->
+        <PackageDownload Include="Bpmn.Model" Version="[0.2.0]"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <!-- Prevents build error on GH Actions -->
         <Content Remove="ClientLib\package-lock.json;ClientLib\package.json;ClientLib\tsconfig.json"/>
         <!--                <None Include="ClientLib\package-lock.json;ClientLib\package.json;ClientLib\tsconfig.json">-->


### PR DESCRIPTION
Closes #997. Part of elsa-workflows/elsa-core#7909 (W12): the first Studio item of the BPMN program.

## What changed

Studio's designer ClientLib now **generates** its BPMN TypeScript types from the JSON Schema that `Bpmn.Model` packs into its nupkg, instead of hand-mirroring them.

- `scripts/generate-bpmn-types.js` reads `schema/bpmn-payload.schema.json` out of the restored `Bpmn.Model` package (resolved from the NuGet global-packages folder, never copied into the repo) and emits `src/bpmn/types.generated.ts` via `json-schema-to-typescript` 16.0.0 (pinned). Both schema roots (`BpmnDefinitions`, `BpmnExecutionState`) and all 41 `$defs` are emitted; integer enums come out as named `enum`s by bridging the schema's `x-enumNames`; the script fails if the output contains an `unknown`/`any` index signature (the old mirror's escape hatch).
- The generated file is checked in so a clean clone builds without the NuGet cache. `npm run build` regenerates it; `npm run check:generated` fails when the committed file is stale.
- `Bpmn.Model` 0.2.0 is restored through a `PackageDownload` on the Designer project. The version is one MSBuild property (`BpmnModelVersion` in `Directory.Packages.props`) used by the `PackageVersion`, the `PackageDownload` and the generator script.
- `.github/workflows/packages.yml` installs the ClientLib, runs the check (before the build, so it compares against what is committed), then builds. This repo has no PR-time build workflow, so enforcement is on push to main.
- A Vitest type-check test (`src/bpmn/__tests__/process-payload.test-d.ts`) assigns a real captured `process` payload to the generated `BpmnProcessDefinition` type with no casts.

## The serializer trap

The issue asked first whether the `process` property reaches Studio in the library's JSON format or in whatever Elsa's activity serializer emits. Verified: every property on the process-definition tree carries an explicit `[JsonPropertyName]`, and no enum lives in that subtree, so Elsa's global `JsonStringEnumConverter` never fires there. The wire shape is byte-identical to the library's format 1.0.0. `BpmnExecutionState` is persisted by `BpmnScopeMemory` with default options, so its enums are integers as the schema states.

The fixture was captured by running elsa-core's own `BpmnInterchangeDocumentService.ImportAsync` on `camunda-order-process.bpmn` and lifting `process` out of the resulting definition JSON, produced by the same `JsonActivitySerializer` a definition GET uses. Provenance is documented in the test's header.

## Verification

```
dotnet restore src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj --force   # Bpmn.Model 0.2.0 downloaded
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm install --force
npm run check:generated   # pass; exits 1 when types.generated.ts is deliberately staled (verified, then reverted)
npm run build             # pass, no git diff on types.generated.ts
npm test                  # pass: type-check suite; fails when a field is removed from the fixture (verified, then reverted)
dotnet build src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj --configuration Release   # 0 errors
```

Review: two iterations on the standards and spec axes; three must-fix findings resolved (the CI check ordering, the duplicated version pin, a fragile regex). No won't-fix findings carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
