### PR TITLE
feat(designer): add the canvas-neutral BPMN view model

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18.3.1",
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.2",
+    "jsdom": "30.0.1",
     "json-schema-to-typescript": "16.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.4",

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/README.md
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/README.md
@@ -1,0 +1,88 @@
+# `src/bpmn` — the canvas-neutral BPMN view model
+
+Everything that is true about a BPMN diagram regardless of who draws it.
+
+The design (elsa-workflows/elsa-core#7909 §4, D2) puts most of Studio's BPMN logic here on purpose,
+so that the X6 adapter and a later React Flow adapter stay thin. The review test for anything added
+here or to an adapter: **if it would be identical in both adapters, it belongs in this module.**
+
+Pure TypeScript. Nothing here may import `@antv/x6`, `@xyflow/react`, `react`, or anything from
+`../designer` or `../react-designer`; `__tests__/module-boundaries.test.ts` enforces it.
+
+## The two inputs
+
+BPMN DI is **not** on the activity payload. In `Bpmn.Model`'s schema,
+`bpmnDiagram` / `bpmnPlane` / `bpmnShape` / `bpmnEdge` / `bpmnBounds` / `bpmnLabel` hang off
+`bpmnDefinitions.diagrams`, while the `Elsa.BpmnProcess` activity's `process` property is a
+`bpmnProcessDefinition` — `processId, name, isExecutable, isTransaction, elements, sequenceFlows,
+lanes, variables, extensions` — with no diagram section at all. Pools (`participant`) live on
+`bpmnDefinitions.collaboration`, likewise absent. So structure and geometry come from two different
+places, and `buildBpmnViewModel` takes both:
+
+1. **The `Elsa.BpmnProcess` activity JSON** (`process`, `workBindings`, `activities`, and the nested
+   `BpmnProcess` activities that are the subprocess bodies), typed by `types.generated.ts`. This is
+   the source of truth for **structure and bindings**.
+2. **The source BPMN document**, optional, as a string. elsa-core stores it on the workflow
+   definition's `CustomProperties["Bpmn:SourceXml"]` (with `Bpmn:SourceVersion`); Studio's
+   `WorkflowDefinition` client model exposes `CustomProperties`, and the designer receives the
+   definition through `DisplayContext.WorkflowDefinition`. W10 passes both across JS interop.
+
+`di-reader.ts` reads **only** the BPMNDI section of that document — `BPMNShape[@bpmnElement,
+dc:Bounds, isExpanded, isHorizontal, isMarkerVisible, BPMNLabel/dc:Bounds]`, `BPMNEdge[@bpmnElement,
+di:waypoint*, BPMNLabel]` — plus the participant names on `collaboration` that a pool needs to
+render. It never reads elements, flows, lanes or bindings. That boundary is the point: it keeps this
+module from becoming a second BPMN reader that can disagree with the first one.
+
+DI shapes and edges are matched to payload elements and flows **by id**.
+
+## When the document carries no geometry
+
+A `.bpmn` file is allowed to have no BPMNDI section, and elsa-core's own test assets include two that
+do not. That is the one case that needs a layout of Studio's own, and it is **reported, not silently
+invented**:
+
+* `layout.source` reads `'fallback'` and `layout.reason` says why (no source XML / no diagram
+  section / unparseable / a diagram with no shape for anything here);
+* a `missing-source-xml`, `missing-diagram` or `source-xml-parse-error` diagnostic is raised;
+* every element placed by the fallback reports `geometry.source: 'fallback'`.
+
+`fallback-layout.ts` is a deterministic left-to-right layering by sequence flow order, recursing into
+subprocess bodies. Where a document has *partial* DI — a diagram, but no shape for some element —
+`layout.source` stays `'document'`, the unplaced elements get a fallback rectangle each, and each one
+raises its own `missing-shape` diagnostic. Check `geometry.source` per element to tell them apart.
+
+## What is out of scope, by design
+
+* **No BPMN semantics.** Which flow a gateway takes, whether a join may fire, what a boundary event
+  interrupts: none of that is here. This module renders what the document says and what the instance
+  overlay reports. `BpmnBoundaryAttachment.interrupting` is the document's `cancelActivity` flag and
+  nothing more.
+* **No save path.** D4: the client holds the *entire* document and never writes a reduced projection
+  back. This module reads. Whatever mutates the document (W11, W14) mutates it in place and sends
+  the whole thing.
+* **No auto-layout of a document that has DI.**
+
+## Instance state
+
+Two maps, both optional, both resolved onto elements:
+
+* `elementStats`, keyed by **BPMN element id** — the projection W13 fills in. This is the one that
+  lets a gateway or an event light up: they are not bound work, so they have no activity id.
+* `activityStats`, keyed by **Elsa activity id** — the existing
+  `Elsa.Studio.Workflows.Domain.Models.ActivityStats`, resolved onto elements through `workBindings`.
+  Only bound work has one.
+
+An element carries both, as `stats` and `activityStats`.
+
+## Files
+
+| File | What it does |
+| --- | --- |
+| `index.ts` | The public surface. Adapters and interop import from here. |
+| `model.ts` | Every hand-authored input and output type. Plain immutable data, no methods. |
+| `view-model.ts` | `buildBpmnViewModel`. Walks the scope tree, resolves bindings, geometry and stats, collects diagnostics. |
+| `di-reader.ts` | BPMN DI + collaboration participants, out of the source XML, via the platform `DOMParser`. |
+| `fallback-layout.ts` | The deterministic layered layout for documents with no DI. |
+| `element-kinds.ts` | Classification of the payload's `elementType` strings, mirroring `Bpmn.Model.BpmnElementTypes`. |
+| `types.generated.ts` | Generated from `Bpmn.Model`'s published schema. Never edit by hand; see `../../scripts/generate-bpmn-types.js`. |
+| `__fixtures__/` | `.bpmn` + captured `.activity.json` pairs. See its own README. |

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/README.md
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/README.md
@@ -1,0 +1,88 @@
+# BPMN view model fixtures
+
+Each fixture is a **pair**:
+
+| File | What it is |
+| --- | --- |
+| `<name>.bpmn` | the source BPMN 2.0 document, verbatim |
+| `<name>.activity.json` | the root `Elsa.BpmnProcess` activity JSON elsa-core produces when it imports that document |
+
+The pair is the view model's two inputs (see `../README.md`): the JSON is the typed source of truth
+for structure and bindings, the `.bpmn` is read for BPMN DI geometry and pool names only.
+
+`camunda-order-process.process.json` is the older, single-property fixture the generated-types test
+(`../__tests__/process-payload.test-d.ts`) asserts against. It is the `"process"` property of
+`camunda-order-process.activity.json` and is kept because that test's narrative is about the
+`process` payload specifically.
+
+## How the `.activity.json` files were produced
+
+Not by hand. Each one is the exact `WorkflowDefinition.StringData` that
+`Bpmn.Interchange.BpmnInterchangeDocumentService.ImportAsync` produces for the paired `.bpmn`,
+serialized by `Elsa.Workflows.Serialization.Serializers.JsonActivitySerializer` — the same serializer
+a GET of a workflow definition goes through. Reproduce it with a throwaway console app that
+references elsa-core's `Elsa.Bpmn.Interchange`, `Elsa` and `Elsa.Testing.Shared.Integration`
+projects:
+
+1. build an `IServiceCollection` with `.AddElsa(elsa => elsa.UseWorkflowManagement().UseBpmnInterchange())`;
+2. `await provider.PopulateRegistriesAsync()`;
+3. resolve `BpmnInterchangeDocumentService` and call
+   `ImportAsync(xml, definitionId: null, name: null, processId: null, cancellationToken)`;
+4. write `result.ImportResult.WorkflowDefinition.StringData`, pretty-printed, to `<name>.activity.json`.
+
+Regenerate all of them the same way after a `Bpmn.Model` / `Bpmn.Interchange` version bump: the
+payload is the library's format, not this repository's, so a fixture that no longer matches what the
+library emits is the thing the fixture tests exist to catch.
+
+## Where each document came from, and what it covers
+
+`camunda-order-process`, `non-interrupting-error-event-subprocess` and `publish-gate-process` are
+copies of elsa-core's `test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/*.bpmn`. The
+rest were written here to cover element kinds those miss.
+
+| Fixture | Covers |
+| --- | --- |
+| `camunda-order-process` | A Camunda-authored document: `camunda:*` extension elements and foreign attributes, `bpmn:documentation`, an `elsa:activityBinding`, and a full BPMNDI section. |
+| `publish-gate-process` | A recurring timer start event. **No BPMNDI section** → fallback layout. |
+| `non-interrupting-error-event-subprocess` | A document the reader partly refuses (see *Dropped constructs*). **No BPMNDI section** → fallback layout. |
+| `gateway-routing` | All four gateways, a conditional flow (`vw:conditionOutcome`) and a default flow, an event-based gateway racing a timer and a message catch event, edge and shape labels, `isMarkerVisible`. |
+| `task-kinds-and-lanes` | All eight task kinds, `callActivity`, a collaboration with one pool and two lanes, DI on the plane of the *collaboration* rather than of the process. |
+| `subprocess-boundary-events` | An embedded subprocess with a collection multi-instance marker, an event subprocess (`triggeredByEvent`, with its `listenerBindingRef`), three boundary events on one host — interrupting timer, non-interrupting message, interrupting error — an escalation throw event and a terminate end event. |
+| `transaction-compensation` | A transaction subprocess, a cancel end event and a cancel boundary event, a compensation boundary event associated to a `isForCompensation` handler, and DI for an association edge the payload has no id for. |
+
+## Dropped and degraded constructs
+
+elsa-core's reader reports on an Info / Degraded / Dropped ladder, and the fixtures assert against
+what the payload **actually contains**, not against what the `.bpmn` says. The differences worth
+knowing about:
+
+* **`non-interrupting-error-event-subprocess`**: the `OnError` event subprocess is *Dropped* —
+  "error events are always interrupting per BPMN" — along with the bindings in its body. The
+  captured payload therefore has three elements (`Start_1`, `Settle`, `End_1`) and two flows, and
+  no subprocess at all. That is deliberate on elsa-core's side, and the fixture test asserts the
+  drop rather than fighting it.
+* **`subprocess-boundary-events`**: a collection multi-instance only reads if its collection is a
+  *declared* variable of the enclosing container, so the process declares
+  `<vw:variable name="orderLines"/>`; without it the reader degrades the element to "no loop
+  characteristics". The reader also tallies `<multiInstanceLoopCharacteristics>` as a dropped child
+  element while simultaneously consuming it into `loopCharacteristics` — an artefact of the
+  element-count tally, not a real loss.
+* **Associations have no id in the payload.** `<bpmn:association>` is recorded as
+  `compensationHandlerElementId` on the compensation boundary event, so there is nothing to look its
+  BPMNEdge up by. `transaction-compensation.bpmn` carries such an edge, and the view model reports it
+  as an `unresolved-di-edge` diagnostic: expected, and the reason `BpmnViewAssociation` carries no
+  waypoints.
+
+## `unbound-task-process.bpmn` is deliberately absent
+
+elsa-core's fourth test asset cannot be captured: `BpmnWorkBinder` **refuses** to bind a task with no
+`elsa:activityBinding`, so `ImportAsync` throws
+
+> BPMN element 'Unbound_1' of process 'unbound-process' is a 'serviceTask': the document says what it
+> is for, not how to perform it, and nothing binds it to an Elsa activity.
+
+and no payload exists to capture. An unbound task therefore never reaches Studio through import; it
+arises only from editing the document in Studio (W11/W14) before binding the new element, which is
+what W8 refuses to publish. `../__tests__/view-model.test.ts` covers that state by removing a
+`workBindings` entry, and a `bindingRef`, from a captured payload — the two shapes such an edit
+produces — rather than by shipping a `.bpmn` no test can load.

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.activity.json
@@ -1,0 +1,238 @@
+{
+  "process": {
+    "processId": "order-process",
+    "name": "Order Process",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "StartEvent_1",
+        "elementType": "startEvent",
+        "name": "Order Received",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "NotifyWarehouse",
+        "elementType": "serviceTask",
+        "name": "Notify Warehouse",
+        "bindingRef": "node-NotifyWarehouse",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [
+            {
+              "text": "Tells the warehouse an order needs picking."
+            }
+          ],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "http://camunda.org/schema/1.0/bpmn",
+                "localName": "inputOutput"
+              },
+              "attributes": [],
+              "children": [
+                {
+                  "name": {
+                    "ns": "http://camunda.org/schema/1.0/bpmn",
+                    "localName": "inputParameter"
+                  },
+                  "value": "${orderId}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "orderId"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Notifying the warehouse\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [
+            {
+              "name": {
+                "ns": "http://camunda.org/schema/1.0/bpmn",
+                "localName": "asyncBefore"
+              },
+              "value": "true"
+            }
+          ],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "EndEvent_1",
+        "elementType": "endEvent",
+        "name": "Order Handled",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "StartEvent_1",
+        "targetRef": "NotifyWarehouse",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "NotifyWarehouse",
+        "targetRef": "EndEvent_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [
+        {
+          "name": {
+            "ns": "http://camunda.org/schema/1.0/bpmn",
+            "localName": "properties"
+          },
+          "attributes": [],
+          "children": [
+            {
+              "name": {
+                "ns": "http://camunda.org/schema/1.0/bpmn",
+                "localName": "property"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "name"
+                  },
+                  "value": "owner"
+                },
+                {
+                  "name": {
+                    "localName": "value"
+                  },
+                  "value": "fulfillment-team"
+                }
+              ],
+              "children": []
+            }
+          ]
+        }
+      ],
+      "foreignAttributes": [
+        {
+          "name": {
+            "ns": "http://camunda.org/schema/1.0/bpmn",
+            "localName": "versionTag"
+          },
+          "value": "1.0"
+        }
+      ],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-NotifyWarehouse": "order-process:node-NotifyWarehouse"
+  },
+  "activities": [
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "Notifying the warehouse"
+        }
+      },
+      "id": "order-process:node-NotifyWarehouse",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "order-process",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/camunda-order-process.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                   xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+                   xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+                   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                   xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                   id="Definitions_order-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn"
+                   exporter="Camunda Modeler"
+                   exporterVersion="5.16.0">
+  <bpmn:process id="order-process" name="Order Process" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="owner" value="fulfillment-team" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1" name="Order Received">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="NotifyWarehouse" name="Notify Warehouse" camunda:asyncBefore="true">
+      <bpmn:documentation>Tells the warehouse an order needs picking.</bpmn:documentation>
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="orderId">${orderId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Order Handled">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="NotifyWarehouse" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="NotifyWarehouse" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="order-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NotifyWarehouse_di" bpmnElement="NotifyWarehouse">
+        <omgdc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <omgdc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <omgdi:waypoint x="188" y="120" />
+        <omgdi:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <omgdi:waypoint x="340" y="120" />
+        <omgdi:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/gateway-routing.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/gateway-routing.activity.json
@@ -1,0 +1,544 @@
+{
+  "process": {
+    "processId": "gateway-routing",
+    "name": "Gateway Routing",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "name": "Started",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Fork",
+        "elementType": "parallelGateway",
+        "name": "Fork",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Decide",
+        "elementType": "exclusiveGateway",
+        "name": "Approved?",
+        "defaultFlowId": "Flow_Decide_Reject",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Approve",
+        "elementType": "serviceTask",
+        "name": "Approve",
+        "bindingRef": "node-Approve",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Approved\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Reject",
+        "elementType": "serviceTask",
+        "name": "Reject",
+        "bindingRef": "node-Reject",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Rejected\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "InclusiveSplit",
+        "elementType": "inclusiveGateway",
+        "name": "Notify who?",
+        "defaultFlowId": "Flow_Inclusive_Race",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Race",
+        "elementType": "eventBasedGateway",
+        "name": "Race",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Timeout",
+        "elementType": "intermediateCatchEvent",
+        "name": "After 10 minutes",
+        "bindingRef": "node-Timeout",
+        "eventDefinitions": [
+          {
+            "type": "timer",
+            "properties": {
+              "interval": "PT10M"
+            }
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "ApprovalMessage",
+        "elementType": "intermediateCatchEvent",
+        "name": "Approval received",
+        "bindingRef": "node-ApprovalMessage",
+        "eventDefinitions": [
+          {
+            "type": "message",
+            "properties": {
+              "name": "ApprovalReceived"
+            }
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Join",
+        "elementType": "parallelGateway",
+        "name": "Join",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_1",
+        "elementType": "endEvent",
+        "name": "Done",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_Start_Fork",
+        "sourceRef": "Start_1",
+        "targetRef": "Fork",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Fork_Exclusive",
+        "sourceRef": "Fork",
+        "targetRef": "Decide",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Fork_Inclusive",
+        "sourceRef": "Fork",
+        "targetRef": "InclusiveSplit",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Decide_Approve",
+        "sourceRef": "Decide",
+        "targetRef": "Approve",
+        "name": "yes",
+        "conditionOutcome": "Approved",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Decide_Reject",
+        "sourceRef": "Decide",
+        "targetRef": "Reject",
+        "name": "otherwise",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Inclusive_Race",
+        "sourceRef": "InclusiveSplit",
+        "targetRef": "Race",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Race_Timeout",
+        "sourceRef": "Race",
+        "targetRef": "Timeout",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Race_Approval",
+        "sourceRef": "Race",
+        "targetRef": "ApprovalMessage",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Approve_Join",
+        "sourceRef": "Approve",
+        "targetRef": "Join",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Reject_Join",
+        "sourceRef": "Reject",
+        "targetRef": "Join",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Timeout_Join",
+        "sourceRef": "Timeout",
+        "targetRef": "Join",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Approval_Join",
+        "sourceRef": "ApprovalMessage",
+        "targetRef": "Join",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Join_End",
+        "sourceRef": "Join",
+        "targetRef": "End_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-Approve": "gateway-routing:node-Approve",
+    "node-Reject": "gateway-routing:node-Reject",
+    "node-Timeout": "gateway-routing:node-Timeout",
+    "node-ApprovalMessage": "gateway-routing:node-ApprovalMessage"
+  },
+  "activities": [
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "Approved"
+        }
+      },
+      "id": "gateway-routing:node-Approve",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "Rejected"
+        }
+      },
+      "id": "gateway-routing:node-Reject",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "timeSpan": {
+        "typeName": "TimeSpan",
+        "expression": {
+          "type": "Literal",
+          "value": "00:10:00"
+        }
+      },
+      "id": "gateway-routing:node-Timeout",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Delay",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:119"
+      },
+      "metadata": {}
+    },
+    {
+      "eventName": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "ApprovalReceived"
+        }
+      },
+      "result": null,
+      "id": "gateway-routing:node-ApprovalMessage",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Event",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:120"
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "gateway-routing",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/gateway-routing.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/gateway-routing.bpmn
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                  xmlns:vw="https://bpmn.valenceworks.io/schema/bpmn"
+                  id="Definitions_gateway-routing"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_Approval" name="ApprovalReceived" />
+  <bpmn:process id="gateway-routing" name="Gateway Routing" isExecutable="true">
+    <bpmn:startEvent id="Start_1" name="Started">
+      <bpmn:outgoing>Flow_Start_Fork</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:parallelGateway id="Fork" name="Fork">
+      <bpmn:incoming>Flow_Start_Fork</bpmn:incoming>
+      <bpmn:outgoing>Flow_Fork_Exclusive</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Fork_Inclusive</bpmn:outgoing>
+    </bpmn:parallelGateway>
+
+    <bpmn:exclusiveGateway id="Decide" name="Approved?" default="Flow_Decide_Reject">
+      <bpmn:incoming>Flow_Fork_Exclusive</bpmn:incoming>
+      <bpmn:outgoing>Flow_Decide_Approve</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Decide_Reject</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:serviceTask id="Approve" name="Approve">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Approved"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Decide_Approve</bpmn:incoming>
+      <bpmn:outgoing>Flow_Approve_Join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Reject" name="Reject">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Rejected"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Decide_Reject</bpmn:incoming>
+      <bpmn:outgoing>Flow_Reject_Join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:inclusiveGateway id="InclusiveSplit" name="Notify who?" default="Flow_Inclusive_Race">
+      <bpmn:incoming>Flow_Fork_Inclusive</bpmn:incoming>
+      <bpmn:outgoing>Flow_Inclusive_Race</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+
+    <bpmn:eventBasedGateway id="Race" name="Race">
+      <bpmn:incoming>Flow_Inclusive_Race</bpmn:incoming>
+      <bpmn:outgoing>Flow_Race_Timeout</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Race_Approval</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+
+    <bpmn:intermediateCatchEvent id="Timeout" name="After 10 minutes">
+      <bpmn:incoming>Flow_Race_Timeout</bpmn:incoming>
+      <bpmn:outgoing>Flow_Timeout_Join</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="Timer_1">
+        <bpmn:timeDuration>PT10M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+
+    <bpmn:intermediateCatchEvent id="ApprovalMessage" name="Approval received">
+      <bpmn:incoming>Flow_Race_Approval</bpmn:incoming>
+      <bpmn:outgoing>Flow_Approval_Join</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageDef_1" messageRef="Message_Approval" />
+    </bpmn:intermediateCatchEvent>
+
+    <bpmn:parallelGateway id="Join" name="Join">
+      <bpmn:incoming>Flow_Approve_Join</bpmn:incoming>
+      <bpmn:incoming>Flow_Reject_Join</bpmn:incoming>
+      <bpmn:incoming>Flow_Timeout_Join</bpmn:incoming>
+      <bpmn:incoming>Flow_Approval_Join</bpmn:incoming>
+      <bpmn:outgoing>Flow_Join_End</bpmn:outgoing>
+    </bpmn:parallelGateway>
+
+    <bpmn:endEvent id="End_1" name="Done">
+      <bpmn:incoming>Flow_Join_End</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_Start_Fork" sourceRef="Start_1" targetRef="Fork" />
+    <bpmn:sequenceFlow id="Flow_Fork_Exclusive" sourceRef="Fork" targetRef="Decide" />
+    <bpmn:sequenceFlow id="Flow_Fork_Inclusive" sourceRef="Fork" targetRef="InclusiveSplit" />
+    <bpmn:sequenceFlow id="Flow_Decide_Approve" name="yes" sourceRef="Decide" targetRef="Approve" vw:conditionOutcome="Approved" />
+    <bpmn:sequenceFlow id="Flow_Decide_Reject" name="otherwise" sourceRef="Decide" targetRef="Reject" />
+    <bpmn:sequenceFlow id="Flow_Inclusive_Race" sourceRef="InclusiveSplit" targetRef="Race" />
+    <bpmn:sequenceFlow id="Flow_Race_Timeout" sourceRef="Race" targetRef="Timeout" />
+    <bpmn:sequenceFlow id="Flow_Race_Approval" sourceRef="Race" targetRef="ApprovalMessage" />
+    <bpmn:sequenceFlow id="Flow_Approve_Join" sourceRef="Approve" targetRef="Join" />
+    <bpmn:sequenceFlow id="Flow_Reject_Join" sourceRef="Reject" targetRef="Join" />
+    <bpmn:sequenceFlow id="Flow_Timeout_Join" sourceRef="Timeout" targetRef="Join" />
+    <bpmn:sequenceFlow id="Flow_Approval_Join" sourceRef="ApprovalMessage" targetRef="Join" />
+    <bpmn:sequenceFlow id="Flow_Join_End" sourceRef="Join" targetRef="End_1" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="gateway-routing">
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">
+        <dc:Bounds x="140" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="136" y="265" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Fork_di" bpmnElement="Fork" isMarkerVisible="true">
+        <dc:Bounds x="235" y="215" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Decide_di" bpmnElement="Decide" isMarkerVisible="true">
+        <dc:Bounds x="345" y="105" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="338" y="75" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Approve_di" bpmnElement="Approve">
+        <dc:Bounds x="460" y="40" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Reject_di" bpmnElement="Reject">
+        <dc:Bounds x="460" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="InclusiveSplit_di" bpmnElement="InclusiveSplit">
+        <dc:Bounds x="345" y="325" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Race_di" bpmnElement="Race">
+        <dc:Bounds x="460" y="325" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Timeout_di" bpmnElement="Timeout">
+        <dc:Bounds x="580" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ApprovalMessage_di" bpmnElement="ApprovalMessage">
+        <dc:Bounds x="580" y="382" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Join_di" bpmnElement="Join" isMarkerVisible="true">
+        <dc:Bounds x="700" y="215" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_1_di" bpmnElement="End_1">
+        <dc:Bounds x="810" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_Start_Fork_di" bpmnElement="Flow_Start_Fork">
+        <di:waypoint x="176" y="240" />
+        <di:waypoint x="235" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Fork_Exclusive_di" bpmnElement="Flow_Fork_Exclusive">
+        <di:waypoint x="260" y="215" />
+        <di:waypoint x="260" y="130" />
+        <di:waypoint x="345" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Fork_Inclusive_di" bpmnElement="Flow_Fork_Inclusive">
+        <di:waypoint x="260" y="265" />
+        <di:waypoint x="260" y="350" />
+        <di:waypoint x="345" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Decide_Approve_di" bpmnElement="Flow_Decide_Approve">
+        <di:waypoint x="370" y="105" />
+        <di:waypoint x="370" y="80" />
+        <di:waypoint x="460" y="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="392" y="62" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Decide_Reject_di" bpmnElement="Flow_Decide_Reject">
+        <di:waypoint x="370" y="155" />
+        <di:waypoint x="370" y="190" />
+        <di:waypoint x="460" y="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="172" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Inclusive_Race_di" bpmnElement="Flow_Inclusive_Race">
+        <di:waypoint x="395" y="350" />
+        <di:waypoint x="460" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Race_Timeout_di" bpmnElement="Flow_Race_Timeout">
+        <di:waypoint x="485" y="325" />
+        <di:waypoint x="485" y="300" />
+        <di:waypoint x="580" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Race_Approval_di" bpmnElement="Flow_Race_Approval">
+        <di:waypoint x="485" y="375" />
+        <di:waypoint x="485" y="400" />
+        <di:waypoint x="580" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Approve_Join_di" bpmnElement="Flow_Approve_Join">
+        <di:waypoint x="560" y="80" />
+        <di:waypoint x="725" y="80" />
+        <di:waypoint x="725" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Reject_Join_di" bpmnElement="Flow_Reject_Join">
+        <di:waypoint x="560" y="190" />
+        <di:waypoint x="700" y="190" />
+        <di:waypoint x="725" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Timeout_Join_di" bpmnElement="Flow_Timeout_Join">
+        <di:waypoint x="616" y="300" />
+        <di:waypoint x="725" y="300" />
+        <di:waypoint x="725" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Approval_Join_di" bpmnElement="Flow_Approval_Join">
+        <di:waypoint x="616" y="400" />
+        <di:waypoint x="760" y="400" />
+        <di:waypoint x="760" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Join_End_di" bpmnElement="Flow_Join_End">
+        <di:waypoint x="750" y="240" />
+        <di:waypoint x="810" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/non-interrupting-error-event-subprocess.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/non-interrupting-error-event-subprocess.activity.json
@@ -1,0 +1,132 @@
+{
+  "process": {
+    "processId": "non-interrupting-error-event-subprocess",
+    "name": "Non-Interrupting Error Event Subprocess",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Settle",
+        "elementType": "intermediateCatchEvent",
+        "bindingRef": "node-Settle",
+        "eventDefinitions": [
+          {
+            "type": "timer",
+            "properties": {
+              "interval": "PT5M"
+            }
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_1",
+        "elementType": "endEvent",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "Start_1",
+        "targetRef": "Settle",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "Settle",
+        "targetRef": "End_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-Settle": "non-interrupting-error-event-subprocess:node-Settle"
+  },
+  "activities": [
+    {
+      "timeSpan": {
+        "typeName": "TimeSpan",
+        "expression": {
+          "type": "Literal",
+          "value": "00:05:00"
+        }
+      },
+      "id": "non-interrupting-error-event-subprocess:node-Settle",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Delay",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:119"
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "non-interrupting-error-event-subprocess",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/non-interrupting-error-event-subprocess.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/non-interrupting-error-event-subprocess.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   id="Definitions_non-interrupting-error-event-subprocess"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <!--
+    A non-interrupting error event subprocess, which is not legal BPMN: error events are always interrupting. The
+    reader drops the whole <subProcess>, bindings included, and reports it. The undeclared <serviceTask> in its body
+    is deliberate: an unbound task the binder can see is refused outright, so an import that still succeeds is what
+    proves the drop took the body's bindings with it rather than leaving half the element behind.
+  -->
+  <bpmn:process id="non-interrupting-error-event-subprocess" name="Non-Interrupting Error Event Subprocess" isExecutable="true">
+    <bpmn:startEvent id="Start_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Settle">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration>PT5M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="End_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Settle" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Settle" targetRef="End_1" />
+    <bpmn:subProcess id="OnError" name="On Error" triggeredByEvent="true">
+      <bpmn:startEvent id="ErrorStart" isInterrupting="false">
+        <bpmn:errorEventDefinition id="ErrorDefinition_1" />
+        <bpmn:outgoing>Flow_E1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="HandleError" name="Handle Error">
+        <bpmn:incoming>Flow_E1</bpmn:incoming>
+        <bpmn:outgoing>Flow_E2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="ErrorEnd">
+        <bpmn:incoming>Flow_E2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_E1" sourceRef="ErrorStart" targetRef="HandleError" />
+      <bpmn:sequenceFlow id="Flow_E2" sourceRef="HandleError" targetRef="ErrorEnd" />
+    </bpmn:subProcess>
+  </bpmn:process>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/publish-gate-process.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/publish-gate-process.activity.json
@@ -1,0 +1,167 @@
+{
+  "process": {
+    "processId": "publish-gate-process",
+    "name": "Publish Gate Process",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "eventDefinitions": [
+          {
+            "type": "timer",
+            "properties": {
+              "interval": "PT1H"
+            }
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "NotifyWarehouse",
+        "elementType": "serviceTask",
+        "name": "Notify Warehouse",
+        "bindingRef": "node-NotifyWarehouse",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Notifying the warehouse\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_1",
+        "elementType": "endEvent",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "Start_1",
+        "targetRef": "NotifyWarehouse",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "NotifyWarehouse",
+        "targetRef": "End_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-NotifyWarehouse": "publish-gate-process:node-NotifyWarehouse"
+  },
+  "activities": [
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "Notifying the warehouse"
+        }
+      },
+      "id": "publish-gate-process:node-NotifyWarehouse",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "publish-gate-process",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/publish-gate-process.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/publish-gate-process.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                   id="Definitions_publish-gate-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="publish-gate-process" name="Publish Gate Process" isExecutable="true">
+    <bpmn:startEvent id="Start_1">
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle>R/PT1H</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="NotifyWarehouse" name="Notify Warehouse">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="End_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="NotifyWarehouse" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="NotifyWarehouse" targetRef="End_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/subprocess-boundary-events.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/subprocess-boundary-events.activity.json
@@ -1,0 +1,822 @@
+{
+  "process": {
+    "processId": "subprocess-boundary-events",
+    "name": "Subprocess And Boundary Events",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "name": "Start",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Fulfil",
+        "elementType": "subProcess",
+        "name": "Fulfil Order",
+        "bindingRef": "node-Fulfil",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "loopCharacteristics": {
+          "isSequential": false,
+          "collectionVariable": "orderLines",
+          "itemVariable": "line"
+        },
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "Escalate",
+        "elementType": "serviceTask",
+        "name": "Escalate",
+        "bindingRef": "node-Escalate",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022escalate\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "RaiseLate",
+        "elementType": "intermediateThrowEvent",
+        "name": "Raise late",
+        "eventDefinitions": [
+          {
+            "type": "escalation",
+            "properties": {
+              "code": "LATE",
+              "name": "LateShipment"
+            }
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_Escalated",
+        "elementType": "endEvent",
+        "name": "Escalated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_Terminated",
+        "elementType": "endEvent",
+        "name": "Terminated",
+        "eventDefinitions": [
+          {
+            "type": "terminate",
+            "properties": {}
+          }
+        ],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "OnRecall",
+        "elementType": "subProcess",
+        "name": "On Recall",
+        "bindingRef": "node-OnRecall",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": true,
+        "listenerBindingRef": "node-OnRecall-listener",
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "FulfilTimeout",
+        "elementType": "boundaryEvent",
+        "name": "After 1 hour",
+        "bindingRef": "node-FulfilTimeout",
+        "eventDefinitions": [
+          {
+            "type": "timer",
+            "properties": {
+              "interval": "PT1H"
+            }
+          }
+        ],
+        "properties": {},
+        "attachedToRef": "Fulfil",
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "FulfilNudge",
+        "elementType": "boundaryEvent",
+        "name": "Nudge",
+        "bindingRef": "node-FulfilNudge",
+        "eventDefinitions": [
+          {
+            "type": "message",
+            "properties": {
+              "name": "EscalationRequested"
+            }
+          }
+        ],
+        "properties": {},
+        "attachedToRef": "Fulfil",
+        "cancelActivity": false,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "FulfilFailed",
+        "elementType": "boundaryEvent",
+        "name": "Payment failed",
+        "eventDefinitions": [
+          {
+            "type": "error",
+            "properties": {}
+          }
+        ],
+        "properties": {
+          "bpmn.errorRef": "Error_Payment"
+        },
+        "attachedToRef": "Fulfil",
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "Start_1",
+        "targetRef": "Fulfil",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "Fulfil",
+        "targetRef": "End_Terminated",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Timeout",
+        "sourceRef": "FulfilTimeout",
+        "targetRef": "Escalate",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Nudge",
+        "sourceRef": "FulfilNudge",
+        "targetRef": "Escalate",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Failed",
+        "sourceRef": "FulfilFailed",
+        "targetRef": "Escalate",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_3",
+        "sourceRef": "Escalate",
+        "targetRef": "RaiseLate",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_4",
+        "sourceRef": "RaiseLate",
+        "targetRef": "End_Escalated",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [
+      {
+        "name": "orderLines",
+        "typeHint": "Object"
+      }
+    ],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-Fulfil": "subprocess-boundary-events:node-Fulfil",
+    "node-Escalate": "subprocess-boundary-events:node-Escalate",
+    "node-OnRecall-listener": "subprocess-boundary-events:node-OnRecall-listener",
+    "node-OnRecall": "subprocess-boundary-events:node-OnRecall",
+    "node-FulfilTimeout": "subprocess-boundary-events:node-FulfilTimeout",
+    "node-FulfilNudge": "subprocess-boundary-events:node-FulfilNudge"
+  },
+  "activities": [
+    {
+      "process": {
+        "processId": "Fulfil",
+        "name": "Fulfil Order",
+        "isExecutable": true,
+        "isTransaction": false,
+        "elements": [
+          {
+            "elementId": "Sub_Start",
+            "elementType": "startEvent",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "PickLine",
+            "elementType": "serviceTask",
+            "name": "Pick Line",
+            "bindingRef": "node-PickLine",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "activityBinding"
+                  },
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "activityType"
+                      },
+                      "value": "Elsa.WriteLine"
+                    }
+                  ],
+                  "children": [
+                    {
+                      "name": {
+                        "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                        "localName": "input"
+                      },
+                      "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022pick\u0022}}",
+                      "attributes": [
+                        {
+                          "name": {
+                            "localName": "name"
+                          },
+                          "value": "text"
+                        }
+                      ],
+                      "children": []
+                    }
+                  ]
+                }
+              ],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "Sub_End",
+            "elementType": "endEvent",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "sequenceFlows": [
+          {
+            "flowId": "Sub_Flow_1",
+            "sourceRef": "Sub_Start",
+            "targetRef": "PickLine",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "flowId": "Sub_Flow_2",
+            "sourceRef": "PickLine",
+            "targetRef": "Sub_End",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "lanes": [],
+        "variables": [],
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": [
+            {
+              "element": {
+                "name": {
+                  "ns": "http://www.omg.org/spec/BPMN/20100524/MODEL",
+                  "localName": "multiInstanceLoopCharacteristics"
+                },
+                "attributes": [
+                  {
+                    "name": {
+                      "localName": "isSequential"
+                    },
+                    "value": "false"
+                  },
+                  {
+                    "name": {
+                      "ns": "https://bpmn.valenceworks.io/schema/bpmn",
+                      "localName": "collection"
+                    },
+                    "value": "orderLines"
+                  },
+                  {
+                    "name": {
+                      "ns": "https://bpmn.valenceworks.io/schema/bpmn",
+                      "localName": "itemVariable"
+                    },
+                    "value": "line"
+                  }
+                ],
+                "children": []
+              },
+              "index": 2
+            }
+          ]
+        }
+      },
+      "workBindings": {
+        "node-PickLine": "Fulfil:node-PickLine"
+      },
+      "activities": [
+        {
+          "text": {
+            "typeName": "String",
+            "expression": {
+              "type": "Literal",
+              "value": "pick"
+            }
+          },
+          "id": "Fulfil:node-PickLine",
+          "nodeId": null,
+          "name": null,
+          "type": "Elsa.WriteLine",
+          "version": 1,
+          "customProperties": {
+            "canStartWorkflow": false,
+            "runAsynchronously": false
+          },
+          "metadata": {}
+        }
+      ],
+      "variables": [],
+      "id": "subprocess-boundary-events:node-Fulfil",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.BpmnProcess",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:80"
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "escalate"
+        }
+      },
+      "id": "subprocess-boundary-events:node-Escalate",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "eventName": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "RecallIssued"
+        }
+      },
+      "result": null,
+      "id": "subprocess-boundary-events:node-OnRecall-listener",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Event",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:121"
+      },
+      "metadata": {}
+    },
+    {
+      "process": {
+        "processId": "OnRecall",
+        "name": "On Recall",
+        "isExecutable": true,
+        "isTransaction": false,
+        "elements": [
+          {
+            "elementId": "RecallStart",
+            "elementType": "startEvent",
+            "eventDefinitions": [
+              {
+                "type": "signal",
+                "properties": {
+                  "name": "RecallIssued"
+                }
+              }
+            ],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "HandleRecall",
+            "elementType": "serviceTask",
+            "name": "Handle Recall",
+            "bindingRef": "node-HandleRecall",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "activityBinding"
+                  },
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "activityType"
+                      },
+                      "value": "Elsa.WriteLine"
+                    }
+                  ],
+                  "children": [
+                    {
+                      "name": {
+                        "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                        "localName": "input"
+                      },
+                      "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022recall\u0022}}",
+                      "attributes": [
+                        {
+                          "name": {
+                            "localName": "name"
+                          },
+                          "value": "text"
+                        }
+                      ],
+                      "children": []
+                    }
+                  ]
+                }
+              ],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "RecallEnd",
+            "elementType": "endEvent",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "sequenceFlows": [
+          {
+            "flowId": "Recall_Flow_1",
+            "sourceRef": "RecallStart",
+            "targetRef": "HandleRecall",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "flowId": "Recall_Flow_2",
+            "sourceRef": "HandleRecall",
+            "targetRef": "RecallEnd",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "lanes": [],
+        "variables": [],
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      "workBindings": {
+        "node-HandleRecall": "OnRecall:node-HandleRecall"
+      },
+      "activities": [
+        {
+          "text": {
+            "typeName": "String",
+            "expression": {
+              "type": "Literal",
+              "value": "recall"
+            }
+          },
+          "id": "OnRecall:node-HandleRecall",
+          "nodeId": null,
+          "name": null,
+          "type": "Elsa.WriteLine",
+          "version": 1,
+          "customProperties": {
+            "canStartWorkflow": false,
+            "runAsynchronously": false
+          },
+          "metadata": {}
+        }
+      ],
+      "variables": [],
+      "id": "subprocess-boundary-events:node-OnRecall",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.BpmnProcess",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:80"
+      },
+      "metadata": {}
+    },
+    {
+      "timeSpan": {
+        "typeName": "TimeSpan",
+        "expression": {
+          "type": "Literal",
+          "value": "01:00:00"
+        }
+      },
+      "id": "subprocess-boundary-events:node-FulfilTimeout",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Delay",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:119"
+      },
+      "metadata": {}
+    },
+    {
+      "eventName": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "EscalationRequested"
+        }
+      },
+      "result": null,
+      "id": "subprocess-boundary-events:node-FulfilNudge",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Event",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:120"
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [
+    {
+      "id": "orderLinesVariable",
+      "name": "orderLines",
+      "typeName": "Object"
+    }
+  ],
+  "id": "subprocess-boundary-events",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/subprocess-boundary-events.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/subprocess-boundary-events.bpmn
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                  xmlns:vw="https://bpmn.valenceworks.io/schema/bpmn"
+                  id="Definitions_subprocess-boundary-events"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_Escalate" name="EscalationRequested" />
+  <bpmn:signal id="Signal_Recall" name="RecallIssued" />
+  <bpmn:error id="Error_Payment" name="PaymentFailed" errorCode="PAY-01" />
+  <bpmn:escalation id="Escalation_Late" name="LateShipment" escalationCode="LATE" />
+
+  <bpmn:process id="subprocess-boundary-events" name="Subprocess And Boundary Events" isExecutable="true">
+    <bpmn:extensionElements>
+      <vw:variable name="orderLines" typeHint="Object" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:subProcess id="Fulfil" name="Fulfil Order">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false" vw:collection="orderLines" vw:itemVariable="line" />
+      <bpmn:startEvent id="Sub_Start">
+        <bpmn:outgoing>Sub_Flow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="PickLine" name="Pick Line">
+        <bpmn:extensionElements>
+          <elsa:activityBinding activityType="Elsa.WriteLine">
+            <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"pick"}}</elsa:input>
+          </elsa:activityBinding>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Sub_Flow_1</bpmn:incoming>
+        <bpmn:outgoing>Sub_Flow_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="Sub_End">
+        <bpmn:incoming>Sub_Flow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Sub_Flow_1" sourceRef="Sub_Start" targetRef="PickLine" />
+      <bpmn:sequenceFlow id="Sub_Flow_2" sourceRef="PickLine" targetRef="Sub_End" />
+    </bpmn:subProcess>
+
+    <bpmn:boundaryEvent id="FulfilTimeout" name="After 1 hour" attachedToRef="Fulfil" cancelActivity="true">
+      <bpmn:outgoing>Flow_Timeout</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="Timer_Boundary">
+        <bpmn:timeDuration>PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+
+    <bpmn:boundaryEvent id="FulfilNudge" name="Nudge" attachedToRef="Fulfil" cancelActivity="false">
+      <bpmn:outgoing>Flow_Nudge</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="Message_Boundary" messageRef="Message_Escalate" />
+    </bpmn:boundaryEvent>
+
+    <bpmn:boundaryEvent id="FulfilFailed" name="Payment failed" attachedToRef="Fulfil">
+      <bpmn:outgoing>Flow_Failed</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="Error_Boundary" errorRef="Error_Payment" />
+    </bpmn:boundaryEvent>
+
+    <bpmn:serviceTask id="Escalate" name="Escalate">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"escalate"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Timeout</bpmn:incoming>
+      <bpmn:incoming>Flow_Nudge</bpmn:incoming>
+      <bpmn:incoming>Flow_Failed</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:intermediateThrowEvent id="RaiseLate" name="Raise late">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="Escalation_Throw" escalationRef="Escalation_Late" />
+    </bpmn:intermediateThrowEvent>
+
+    <bpmn:endEvent id="End_Escalated" name="Escalated">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:endEvent id="End_Terminated" name="Terminated">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:terminateEventDefinition id="Terminate_1" />
+    </bpmn:endEvent>
+
+    <bpmn:subProcess id="OnRecall" name="On Recall" triggeredByEvent="true">
+      <bpmn:startEvent id="RecallStart" isInterrupting="true">
+        <bpmn:signalEventDefinition id="Signal_Start" signalRef="Signal_Recall" />
+        <bpmn:outgoing>Recall_Flow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="HandleRecall" name="Handle Recall">
+        <bpmn:extensionElements>
+          <elsa:activityBinding activityType="Elsa.WriteLine">
+            <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"recall"}}</elsa:input>
+          </elsa:activityBinding>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Recall_Flow_1</bpmn:incoming>
+        <bpmn:outgoing>Recall_Flow_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="RecallEnd">
+        <bpmn:incoming>Recall_Flow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Recall_Flow_1" sourceRef="RecallStart" targetRef="HandleRecall" />
+      <bpmn:sequenceFlow id="Recall_Flow_2" sourceRef="HandleRecall" targetRef="RecallEnd" />
+    </bpmn:subProcess>
+
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Fulfil" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Fulfil" targetRef="End_Terminated" />
+    <bpmn:sequenceFlow id="Flow_Timeout" sourceRef="FulfilTimeout" targetRef="Escalate" />
+    <bpmn:sequenceFlow id="Flow_Nudge" sourceRef="FulfilNudge" targetRef="Escalate" />
+    <bpmn:sequenceFlow id="Flow_Failed" sourceRef="FulfilFailed" targetRef="Escalate" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Escalate" targetRef="RaiseLate" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="RaiseLate" targetRef="End_Escalated" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="subprocess-boundary-events">
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">
+        <dc:Bounds x="150" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Fulfil_di" bpmnElement="Fulfil" isExpanded="true">
+        <dc:Bounds x="250" y="120" width="380" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Sub_Start_di" bpmnElement="Sub_Start">
+        <dc:Bounds x="280" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="PickLine_di" bpmnElement="PickLine">
+        <dc:Bounds x="370" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Sub_End_di" bpmnElement="Sub_End">
+        <dc:Bounds x="530" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="FulfilTimeout_di" bpmnElement="FulfilTimeout">
+        <dc:Bounds x="312" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="290" y="345" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="FulfilNudge_di" bpmnElement="FulfilNudge">
+        <dc:Bounds x="412" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="FulfilFailed_di" bpmnElement="FulfilFailed">
+        <dc:Bounds x="512" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Escalate_di" bpmnElement="Escalate">
+        <dc:Bounds x="700" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RaiseLate_di" bpmnElement="RaiseLate">
+        <dc:Bounds x="852" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_Escalated_di" bpmnElement="End_Escalated">
+        <dc:Bounds x="952" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_Terminated_di" bpmnElement="End_Terminated">
+        <dc:Bounds x="700" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="OnRecall_di" bpmnElement="OnRecall" isExpanded="true">
+        <dc:Bounds x="250" y="500" width="380" height="180" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RecallStart_di" bpmnElement="RecallStart">
+        <dc:Bounds x="280" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="HandleRecall_di" bpmnElement="HandleRecall">
+        <dc:Bounds x="370" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RecallEnd_di" bpmnElement="RecallEnd">
+        <dc:Bounds x="530" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="200" />
+        <di:waypoint x="250" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="630" y="200" />
+        <di:waypoint x="700" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Timeout_di" bpmnElement="Flow_Timeout">
+        <di:waypoint x="330" y="338" />
+        <di:waypoint x="330" y="420" />
+        <di:waypoint x="700" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Nudge_di" bpmnElement="Flow_Nudge">
+        <di:waypoint x="430" y="338" />
+        <di:waypoint x="430" y="440" />
+        <di:waypoint x="700" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Failed_di" bpmnElement="Flow_Failed">
+        <di:waypoint x="530" y="338" />
+        <di:waypoint x="530" y="460" />
+        <di:waypoint x="700" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="800" y="420" />
+        <di:waypoint x="852" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="888" y="420" />
+        <di:waypoint x="952" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Sub_Flow_1_di" bpmnElement="Sub_Flow_1">
+        <di:waypoint x="316" y="220" />
+        <di:waypoint x="370" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Sub_Flow_2_di" bpmnElement="Sub_Flow_2">
+        <di:waypoint x="470" y="220" />
+        <di:waypoint x="530" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Recall_Flow_1_di" bpmnElement="Recall_Flow_1">
+        <di:waypoint x="316" y="590" />
+        <di:waypoint x="370" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Recall_Flow_2_di" bpmnElement="Recall_Flow_2">
+        <di:waypoint x="470" y="590" />
+        <di:waypoint x="530" y="590" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/task-kinds-and-lanes.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/task-kinds-and-lanes.activity.json
@@ -1,0 +1,780 @@
+{
+  "process": {
+    "processId": "task-kinds-and-lanes",
+    "name": "Task Kinds And Lanes",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "name": "Order Placed",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "AbstractTask",
+        "elementType": "task",
+        "name": "Abstract Task",
+        "bindingRef": "node-AbstractTask",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022abstract\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "ReviewOrder",
+        "elementType": "userTask",
+        "name": "Review Order",
+        "bindingRef": "node-ReviewOrder",
+        "laneId": "Lane_People",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022review\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "ServiceWork",
+        "elementType": "serviceTask",
+        "name": "Reserve Stock",
+        "bindingRef": "node-ServiceWork",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022reserve\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "ScriptWork",
+        "elementType": "scriptTask",
+        "name": "Compute Total",
+        "bindingRef": "node-ScriptWork",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022total\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "PackBox",
+        "elementType": "manualTask",
+        "name": "Pack Box",
+        "bindingRef": "node-PackBox",
+        "laneId": "Lane_People",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022pack\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "DecideRules",
+        "elementType": "businessRuleTask",
+        "name": "Apply Discount Rules",
+        "bindingRef": "node-DecideRules",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022rules\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "SendShipped",
+        "elementType": "sendTask",
+        "name": "Announce Shipment",
+        "bindingRef": "node-SendShipped",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {
+          "bpmn.messageName": "OrderShipped"
+        },
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "AwaitConfirm",
+        "elementType": "receiveTask",
+        "name": "Await Confirmation",
+        "bindingRef": "node-AwaitConfirm",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {
+          "bpmn.messageName": "ShipmentConfirmed"
+        },
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "ArchiveOrder",
+        "elementType": "callActivity",
+        "name": "Archive Order",
+        "bindingRef": "node-ArchiveOrder",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {
+          "bpmn.calledElement": "archive-order-process"
+        },
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_1",
+        "elementType": "endEvent",
+        "name": "Order Complete",
+        "laneId": "Lane_Automated",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "Start_1",
+        "targetRef": "AbstractTask",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "AbstractTask",
+        "targetRef": "ReviewOrder",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_3",
+        "sourceRef": "ReviewOrder",
+        "targetRef": "ServiceWork",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_4",
+        "sourceRef": "ServiceWork",
+        "targetRef": "ScriptWork",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_5",
+        "sourceRef": "ScriptWork",
+        "targetRef": "PackBox",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_6",
+        "sourceRef": "PackBox",
+        "targetRef": "DecideRules",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_7",
+        "sourceRef": "DecideRules",
+        "targetRef": "SendShipped",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_8",
+        "sourceRef": "SendShipped",
+        "targetRef": "AwaitConfirm",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_9",
+        "sourceRef": "AwaitConfirm",
+        "targetRef": "ArchiveOrder",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_10",
+        "sourceRef": "ArchiveOrder",
+        "targetRef": "End_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [
+      {
+        "laneId": "Lane_Automated",
+        "poolId": "Participant_Fulfilment",
+        "name": "Automated",
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "laneId": "Lane_People",
+        "poolId": "Participant_Fulfilment",
+        "name": "People",
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-AbstractTask": "task-kinds-and-lanes:node-AbstractTask",
+    "node-ReviewOrder": "task-kinds-and-lanes:node-ReviewOrder",
+    "node-ServiceWork": "task-kinds-and-lanes:node-ServiceWork",
+    "node-ScriptWork": "task-kinds-and-lanes:node-ScriptWork",
+    "node-PackBox": "task-kinds-and-lanes:node-PackBox",
+    "node-DecideRules": "task-kinds-and-lanes:node-DecideRules",
+    "node-SendShipped": "task-kinds-and-lanes:node-SendShipped",
+    "node-AwaitConfirm": "task-kinds-and-lanes:node-AwaitConfirm",
+    "node-ArchiveOrder": "task-kinds-and-lanes:node-ArchiveOrder"
+  },
+  "activities": [
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "abstract"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-AbstractTask",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "review"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-ReviewOrder",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "reserve"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-ServiceWork",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "total"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-ScriptWork",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "pack"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-PackBox",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "rules"
+        }
+      },
+      "id": "task-kinds-and-lanes:node-DecideRules",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    },
+    {
+      "eventName": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "OrderShipped"
+        }
+      },
+      "correlationId": null,
+      "isLocalEvent": null,
+      "payload": null,
+      "id": "task-kinds-and-lanes:node-SendShipped",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.PublishEvent",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:122"
+      },
+      "metadata": {}
+    },
+    {
+      "eventName": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "ShipmentConfirmed"
+        }
+      },
+      "result": null,
+      "id": "task-kinds-and-lanes:node-AwaitConfirm",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.Event",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:120"
+      },
+      "metadata": {}
+    },
+    {
+      "workflowDefinitionId": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "archive-order-process"
+        }
+      },
+      "correlationId": null,
+      "input": null,
+      "waitForCompletion": {
+        "typeName": "Boolean",
+        "expression": {
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "startNewTrace": null,
+      "channelName": null,
+      "result": null,
+      "id": "task-kinds-and-lanes:node-ArchiveOrder",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.DispatchWorkflow",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:126"
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "task-kinds-and-lanes",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/task-kinds-and-lanes.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/task-kinds-and-lanes.bpmn
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                  id="Definitions_task-kinds-and-lanes"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_Shipped" name="OrderShipped" />
+  <bpmn:message id="Message_Confirm" name="ShipmentConfirmed" />
+
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_Fulfilment" name="Fulfilment" processRef="task-kinds-and-lanes" />
+  </bpmn:collaboration>
+
+  <bpmn:process id="task-kinds-and-lanes" name="Task Kinds And Lanes" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_1">
+      <bpmn:lane id="Lane_Automated" name="Automated">
+        <bpmn:flowNodeRef>Start_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>AbstractTask</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ServiceWork</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ScriptWork</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>DecideRules</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>SendShipped</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>AwaitConfirm</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ArchiveOrder</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>End_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_People" name="People">
+        <bpmn:flowNodeRef>ReviewOrder</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>PackBox</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="Start_1" name="Order Placed">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:task id="AbstractTask" name="Abstract Task">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"abstract"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:task>
+
+    <bpmn:userTask id="ReviewOrder" name="Review Order">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"review"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:serviceTask id="ServiceWork" name="Reserve Stock">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"reserve"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:scriptTask id="ScriptWork" name="Compute Total" scriptFormat="javascript">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"total"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+    </bpmn:scriptTask>
+
+    <bpmn:manualTask id="PackBox" name="Pack Box">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"pack"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_6</bpmn:outgoing>
+    </bpmn:manualTask>
+
+    <bpmn:businessRuleTask id="DecideRules" name="Apply Discount Rules">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"rules"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_6</bpmn:incoming>
+      <bpmn:outgoing>Flow_7</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+
+    <bpmn:sendTask id="SendShipped" name="Announce Shipment" messageRef="Message_Shipped">
+      <bpmn:incoming>Flow_7</bpmn:incoming>
+      <bpmn:outgoing>Flow_8</bpmn:outgoing>
+    </bpmn:sendTask>
+
+    <bpmn:receiveTask id="AwaitConfirm" name="Await Confirmation" messageRef="Message_Confirm">
+      <bpmn:incoming>Flow_8</bpmn:incoming>
+      <bpmn:outgoing>Flow_9</bpmn:outgoing>
+    </bpmn:receiveTask>
+
+    <bpmn:callActivity id="ArchiveOrder" name="Archive Order" calledElement="archive-order-process">
+      <bpmn:incoming>Flow_9</bpmn:incoming>
+      <bpmn:outgoing>Flow_10</bpmn:outgoing>
+    </bpmn:callActivity>
+
+    <bpmn:endEvent id="End_1" name="Order Complete">
+      <bpmn:incoming>Flow_10</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="AbstractTask" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="AbstractTask" targetRef="ReviewOrder" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ReviewOrder" targetRef="ServiceWork" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceWork" targetRef="ScriptWork" />
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="ScriptWork" targetRef="PackBox" />
+    <bpmn:sequenceFlow id="Flow_6" sourceRef="PackBox" targetRef="DecideRules" />
+    <bpmn:sequenceFlow id="Flow_7" sourceRef="DecideRules" targetRef="SendShipped" />
+    <bpmn:sequenceFlow id="Flow_8" sourceRef="SendShipped" targetRef="AwaitConfirm" />
+    <bpmn:sequenceFlow id="Flow_9" sourceRef="AwaitConfirm" targetRef="ArchiveOrder" />
+    <bpmn:sequenceFlow id="Flow_10" sourceRef="ArchiveOrder" targetRef="End_1" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_Fulfilment_di" bpmnElement="Participant_Fulfilment" isHorizontal="true">
+        <dc:Bounds x="120" y="60" width="1400" height="400" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Automated_di" bpmnElement="Lane_Automated" isHorizontal="true">
+        <dc:Bounds x="150" y="60" width="1370" height="230" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_People_di" bpmnElement="Lane_People" isHorizontal="true">
+        <dc:Bounds x="150" y="290" width="1370" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">
+        <dc:Bounds x="192" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="176" y="185" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AbstractTask_di" bpmnElement="AbstractTask">
+        <dc:Bounds x="280" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReviewOrder_di" bpmnElement="ReviewOrder">
+        <dc:Bounds x="280" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceWork_di" bpmnElement="ServiceWork">
+        <dc:Bounds x="430" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ScriptWork_di" bpmnElement="ScriptWork">
+        <dc:Bounds x="580" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="PackBox_di" bpmnElement="PackBox">
+        <dc:Bounds x="580" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DecideRules_di" bpmnElement="DecideRules">
+        <dc:Bounds x="730" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SendShipped_di" bpmnElement="SendShipped">
+        <dc:Bounds x="880" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AwaitConfirm_di" bpmnElement="AwaitConfirm">
+        <dc:Bounds x="1030" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ArchiveOrder_di" bpmnElement="ArchiveOrder">
+        <dc:Bounds x="1180" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_1_di" bpmnElement="End_1">
+        <dc:Bounds x="1342" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="228" y="160" />
+        <di:waypoint x="280" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="330" y="200" />
+        <di:waypoint x="330" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="380" y="370" />
+        <di:waypoint x="480" y="370" />
+        <di:waypoint x="480" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="530" y="160" />
+        <di:waypoint x="580" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_5_di" bpmnElement="Flow_5">
+        <di:waypoint x="630" y="200" />
+        <di:waypoint x="630" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_6_di" bpmnElement="Flow_6">
+        <di:waypoint x="680" y="370" />
+        <di:waypoint x="780" y="370" />
+        <di:waypoint x="780" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_7_di" bpmnElement="Flow_7">
+        <di:waypoint x="830" y="160" />
+        <di:waypoint x="880" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_8_di" bpmnElement="Flow_8">
+        <di:waypoint x="980" y="160" />
+        <di:waypoint x="1030" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_9_di" bpmnElement="Flow_9">
+        <di:waypoint x="1130" y="160" />
+        <di:waypoint x="1180" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10_di" bpmnElement="Flow_10">
+        <di:waypoint x="1280" y="160" />
+        <di:waypoint x="1342" y="160" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/transaction-compensation.activity.json
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/transaction-compensation.activity.json
@@ -1,0 +1,565 @@
+{
+  "process": {
+    "processId": "transaction-compensation",
+    "name": "Transaction And Compensation",
+    "isExecutable": true,
+    "isTransaction": false,
+    "elements": [
+      {
+        "elementId": "Start_1",
+        "elementType": "startEvent",
+        "name": "Start",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "BookTrip",
+        "elementType": "subProcess",
+        "name": "Book Trip",
+        "bindingRef": "node-BookTrip",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": true,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "NotifyTraveller",
+        "elementType": "serviceTask",
+        "name": "Notify Traveller",
+        "bindingRef": "node-NotifyTraveller",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [
+            {
+              "name": {
+                "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                "localName": "activityBinding"
+              },
+              "attributes": [
+                {
+                  "name": {
+                    "localName": "activityType"
+                  },
+                  "value": "Elsa.WriteLine"
+                }
+              ],
+              "children": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "input"
+                  },
+                  "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022notify\u0022}}",
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "name"
+                      },
+                      "value": "text"
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_Cancelled",
+        "elementType": "endEvent",
+        "name": "Trip Cancelled",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "End_1",
+        "elementType": "endEvent",
+        "name": "Trip Booked",
+        "eventDefinitions": [],
+        "properties": {},
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "elementId": "BookTripCancelled",
+        "elementType": "boundaryEvent",
+        "name": "Cancelled",
+        "eventDefinitions": [
+          {
+            "type": "cancel",
+            "properties": {}
+          }
+        ],
+        "properties": {},
+        "attachedToRef": "BookTrip",
+        "cancelActivity": true,
+        "isForCompensation": false,
+        "isTransaction": false,
+        "triggeredByEvent": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "sequenceFlows": [
+      {
+        "flowId": "Flow_1",
+        "sourceRef": "Start_1",
+        "targetRef": "BookTrip",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_2",
+        "sourceRef": "BookTrip",
+        "targetRef": "End_1",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_Cancelled",
+        "sourceRef": "BookTripCancelled",
+        "targetRef": "NotifyTraveller",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      {
+        "flowId": "Flow_3",
+        "sourceRef": "NotifyTraveller",
+        "targetRef": "End_Cancelled",
+        "isDefault": false,
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      }
+    ],
+    "lanes": [],
+    "variables": [],
+    "extensions": {
+      "documentation": [],
+      "extensionElements": [],
+      "foreignAttributes": [],
+      "foreignChildren": []
+    }
+  },
+  "workBindings": {
+    "node-BookTrip": "transaction-compensation:node-BookTrip",
+    "node-NotifyTraveller": "transaction-compensation:node-NotifyTraveller"
+  },
+  "activities": [
+    {
+      "process": {
+        "processId": "BookTrip",
+        "name": "Book Trip",
+        "isExecutable": true,
+        "isTransaction": true,
+        "elements": [
+          {
+            "elementId": "Tx_Start",
+            "elementType": "startEvent",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "ChargeCard",
+            "elementType": "serviceTask",
+            "name": "Charge Card",
+            "bindingRef": "node-ChargeCard",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "activityBinding"
+                  },
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "activityType"
+                      },
+                      "value": "Elsa.WriteLine"
+                    }
+                  ],
+                  "children": [
+                    {
+                      "name": {
+                        "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                        "localName": "input"
+                      },
+                      "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022charge\u0022}}",
+                      "attributes": [
+                        {
+                          "name": {
+                            "localName": "name"
+                          },
+                          "value": "text"
+                        }
+                      ],
+                      "children": []
+                    }
+                  ]
+                }
+              ],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "RefundCard",
+            "elementType": "serviceTask",
+            "name": "Refund Card",
+            "bindingRef": "node-RefundCard",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": true,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [
+                {
+                  "name": {
+                    "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                    "localName": "activityBinding"
+                  },
+                  "attributes": [
+                    {
+                      "name": {
+                        "localName": "activityType"
+                      },
+                      "value": "Elsa.WriteLine"
+                    }
+                  ],
+                  "children": [
+                    {
+                      "name": {
+                        "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                        "localName": "input"
+                      },
+                      "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022refund\u0022}}",
+                      "attributes": [
+                        {
+                          "name": {
+                            "localName": "name"
+                          },
+                          "value": "text"
+                        }
+                      ],
+                      "children": []
+                    }
+                  ]
+                }
+              ],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "Tx_Cancel_End",
+            "elementType": "endEvent",
+            "name": "Cancelled",
+            "eventDefinitions": [
+              {
+                "type": "cancel",
+                "properties": {}
+              }
+            ],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "Tx_Decide",
+            "elementType": "exclusiveGateway",
+            "name": "Confirmed?",
+            "defaultFlowId": "Tx_Flow_2",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "Tx_End",
+            "elementType": "endEvent",
+            "name": "Booked",
+            "eventDefinitions": [],
+            "properties": {},
+            "cancelActivity": true,
+            "isForCompensation": false,
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "elementId": "ChargeCardCompensation",
+            "elementType": "boundaryEvent",
+            "eventDefinitions": [
+              {
+                "type": "compensation",
+                "properties": {}
+              }
+            ],
+            "properties": {},
+            "attachedToRef": "ChargeCard",
+            "cancelActivity": false,
+            "isForCompensation": false,
+            "compensationHandlerElementId": "RefundCard",
+            "isTransaction": false,
+            "triggeredByEvent": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "sequenceFlows": [
+          {
+            "flowId": "Tx_Flow_1",
+            "sourceRef": "Tx_Start",
+            "targetRef": "ChargeCard",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "flowId": "Tx_Flow_2",
+            "sourceRef": "ChargeCard",
+            "targetRef": "Tx_Decide",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "flowId": "Tx_Flow_3",
+            "sourceRef": "Tx_Decide",
+            "targetRef": "Tx_Cancel_End",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          },
+          {
+            "flowId": "Tx_Flow_4",
+            "sourceRef": "Tx_Decide",
+            "targetRef": "Tx_End",
+            "isDefault": false,
+            "extensions": {
+              "documentation": [],
+              "extensionElements": [],
+              "foreignAttributes": [],
+              "foreignChildren": []
+            }
+          }
+        ],
+        "lanes": [],
+        "variables": [],
+        "extensions": {
+          "documentation": [],
+          "extensionElements": [],
+          "foreignAttributes": [],
+          "foreignChildren": []
+        }
+      },
+      "workBindings": {
+        "node-ChargeCard": "BookTrip:node-ChargeCard",
+        "node-RefundCard": "BookTrip:node-RefundCard"
+      },
+      "activities": [
+        {
+          "text": {
+            "typeName": "String",
+            "expression": {
+              "type": "Literal",
+              "value": "charge"
+            }
+          },
+          "id": "BookTrip:node-ChargeCard",
+          "nodeId": null,
+          "name": null,
+          "type": "Elsa.WriteLine",
+          "version": 1,
+          "customProperties": {
+            "canStartWorkflow": false,
+            "runAsynchronously": false
+          },
+          "metadata": {}
+        },
+        {
+          "text": {
+            "typeName": "String",
+            "expression": {
+              "type": "Literal",
+              "value": "refund"
+            }
+          },
+          "id": "BookTrip:node-RefundCard",
+          "nodeId": null,
+          "name": null,
+          "type": "Elsa.WriteLine",
+          "version": 1,
+          "customProperties": {
+            "canStartWorkflow": false,
+            "runAsynchronously": false
+          },
+          "metadata": {}
+        }
+      ],
+      "variables": [],
+      "id": "transaction-compensation:node-BookTrip",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.BpmnProcess",
+      "version": 1,
+      "customProperties": {
+        "source": "BpmnWorkBinder.cs:80"
+      },
+      "metadata": {}
+    },
+    {
+      "text": {
+        "typeName": "String",
+        "expression": {
+          "type": "Literal",
+          "value": "notify"
+        }
+      },
+      "id": "transaction-compensation:node-NotifyTraveller",
+      "nodeId": null,
+      "name": null,
+      "type": "Elsa.WriteLine",
+      "version": 1,
+      "customProperties": {
+        "canStartWorkflow": false,
+        "runAsynchronously": false
+      },
+      "metadata": {}
+    }
+  ],
+  "variables": [],
+  "id": "transaction-compensation",
+  "type": "Elsa.BpmnProcess",
+  "version": 1,
+  "customProperties": {
+    "source": "BpmnWorkBinder.cs:80",
+    "canStartWorkflow": true
+  },
+  "metadata": {}
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/transaction-compensation.bpmn
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__fixtures__/transaction-compensation.bpmn
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                  id="Definitions_transaction-compensation"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="transaction-compensation" name="Transaction And Compensation" isExecutable="true">
+    <bpmn:startEvent id="Start_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:transaction id="BookTrip" name="Book Trip">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:startEvent id="Tx_Start">
+        <bpmn:outgoing>Tx_Flow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="ChargeCard" name="Charge Card">
+        <bpmn:extensionElements>
+          <elsa:activityBinding activityType="Elsa.WriteLine">
+            <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"charge"}}</elsa:input>
+          </elsa:activityBinding>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Tx_Flow_1</bpmn:incoming>
+        <bpmn:outgoing>Tx_Flow_2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="ChargeCardCompensation" attachedToRef="ChargeCard" cancelActivity="false">
+        <bpmn:compensateEventDefinition id="Compensate_Boundary" />
+      </bpmn:boundaryEvent>
+      <bpmn:serviceTask id="RefundCard" name="Refund Card" isForCompensation="true">
+        <bpmn:extensionElements>
+          <elsa:activityBinding activityType="Elsa.WriteLine">
+            <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"refund"}}</elsa:input>
+          </elsa:activityBinding>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:association id="Compensation_Association" associationDirection="One" sourceRef="ChargeCardCompensation" targetRef="RefundCard" />
+      <bpmn:endEvent id="Tx_Cancel_End" name="Cancelled">
+        <bpmn:incoming>Tx_Flow_3</bpmn:incoming>
+        <bpmn:cancelEventDefinition id="Cancel_End" />
+      </bpmn:endEvent>
+      <bpmn:exclusiveGateway id="Tx_Decide" name="Confirmed?" default="Tx_Flow_2">
+        <bpmn:incoming>Tx_Flow_2</bpmn:incoming>
+        <bpmn:outgoing>Tx_Flow_3</bpmn:outgoing>
+        <bpmn:outgoing>Tx_Flow_4</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="Tx_End" name="Booked">
+        <bpmn:incoming>Tx_Flow_4</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Tx_Flow_1" sourceRef="Tx_Start" targetRef="ChargeCard" />
+      <bpmn:sequenceFlow id="Tx_Flow_2" sourceRef="ChargeCard" targetRef="Tx_Decide" />
+      <bpmn:sequenceFlow id="Tx_Flow_3" sourceRef="Tx_Decide" targetRef="Tx_Cancel_End" />
+      <bpmn:sequenceFlow id="Tx_Flow_4" sourceRef="Tx_Decide" targetRef="Tx_End" />
+    </bpmn:transaction>
+
+    <bpmn:boundaryEvent id="BookTripCancelled" name="Cancelled" attachedToRef="BookTrip" cancelActivity="true">
+      <bpmn:outgoing>Flow_Cancelled</bpmn:outgoing>
+      <bpmn:cancelEventDefinition id="Cancel_Boundary" />
+    </bpmn:boundaryEvent>
+
+    <bpmn:serviceTask id="NotifyTraveller" name="Notify Traveller">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"notify"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Cancelled</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:endEvent id="End_Cancelled" name="Trip Cancelled">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:endEvent id="End_1" name="Trip Booked">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="BookTrip" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="BookTrip" targetRef="End_1" />
+    <bpmn:sequenceFlow id="Flow_Cancelled" sourceRef="BookTripCancelled" targetRef="NotifyTraveller" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="NotifyTraveller" targetRef="End_Cancelled" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="transaction-compensation">
+      <bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">
+        <dc:Bounds x="150" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BookTrip_di" bpmnElement="BookTrip" isExpanded="true">
+        <dc:Bounds x="250" y="100" width="560" height="240" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Tx_Start_di" bpmnElement="Tx_Start">
+        <dc:Bounds x="280" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ChargeCard_di" bpmnElement="ChargeCard">
+        <dc:Bounds x="360" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ChargeCardCompensation_di" bpmnElement="ChargeCardCompensation">
+        <dc:Bounds x="392" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RefundCard_di" bpmnElement="RefundCard">
+        <dc:Bounds x="360" y="280" width="100" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Tx_Decide_di" bpmnElement="Tx_Decide" isMarkerVisible="true">
+        <dc:Bounds x="520" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Tx_Cancel_End_di" bpmnElement="Tx_Cancel_End">
+        <dc:Bounds x="640" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Tx_End_di" bpmnElement="Tx_End">
+        <dc:Bounds x="640" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BookTripCancelled_di" bpmnElement="BookTripCancelled">
+        <dc:Bounds x="512" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NotifyTraveller_di" bpmnElement="NotifyTraveller">
+        <dc:Bounds x="640" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_Cancelled_di" bpmnElement="End_Cancelled">
+        <dc:Bounds x="800" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_1_di" bpmnElement="End_1">
+        <dc:Bounds x="890" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="220" />
+        <di:waypoint x="250" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="810" y="220" />
+        <di:waypoint x="890" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Cancelled_di" bpmnElement="Flow_Cancelled">
+        <di:waypoint x="530" y="358" />
+        <di:waypoint x="530" y="440" />
+        <di:waypoint x="640" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="740" y="440" />
+        <di:waypoint x="800" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Tx_Flow_1_di" bpmnElement="Tx_Flow_1">
+        <di:waypoint x="316" y="200" />
+        <di:waypoint x="360" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Tx_Flow_2_di" bpmnElement="Tx_Flow_2">
+        <di:waypoint x="460" y="200" />
+        <di:waypoint x="520" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Tx_Flow_3_di" bpmnElement="Tx_Flow_3">
+        <di:waypoint x="545" y="175" />
+        <di:waypoint x="545" y="138" />
+        <di:waypoint x="640" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Tx_Flow_4_di" bpmnElement="Tx_Flow_4">
+        <di:waypoint x="545" y="225" />
+        <di:waypoint x="545" y="258" />
+        <di:waypoint x="640" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Compensation_Association_di" bpmnElement="Compensation_Association">
+        <di:waypoint x="410" y="258" />
+        <di:waypoint x="410" y="280" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/diagram-fixtures.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/diagram-fixtures.test.ts
@@ -1,0 +1,196 @@
+/**
+ * R3b: run every `.bpmn` fixture through the view model and check what came out.
+ *
+ * These are the assertions each adapter will later be held to as well -- element and flow sets,
+ * endpoints, and the fact that every shape the document draws resolves to something the view model
+ * exposes -- which is why the expected values here are written out by hand from the documents rather
+ * than snapshotted from whatever the builder happened to produce.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildBpmnViewModel } from '../view-model';
+import { FIXTURE_NAMES, loadFixture, readDiagramReferences, type FixtureName } from './fixtures';
+
+interface FixtureExpectation {
+    /** Scope process ids, root first then depth-first. */
+    readonly scopeIds: readonly string[];
+    readonly elementCount: number;
+    readonly flowCount: number;
+    readonly layoutSource: 'document' | 'fallback';
+    /**
+     * DI edges the document draws that are legitimately not sequence flows. Only associations
+     * qualify today: the payload records one as `compensationHandlerElementId` on the boundary
+     * event, so it has no id for an edge to be matched by. See ../__fixtures__/README.md.
+     */
+    readonly unresolvedEdgeIds?: readonly string[];
+}
+
+const EXPECTATIONS: Record<FixtureName, FixtureExpectation> = {
+    'camunda-order-process': {
+        scopeIds: ['order-process'],
+        elementCount: 3,
+        flowCount: 2,
+        layoutSource: 'document',
+    },
+    'gateway-routing': {
+        scopeIds: ['gateway-routing'],
+        elementCount: 11,
+        flowCount: 13,
+        layoutSource: 'document',
+    },
+    // The reader drops this document's non-interrupting error event subprocess outright, and the
+    // document carries no BPMNDI at all -- both asserted, because both are what Studio will see.
+    'non-interrupting-error-event-subprocess': {
+        scopeIds: ['non-interrupting-error-event-subprocess'],
+        elementCount: 3,
+        flowCount: 2,
+        layoutSource: 'fallback',
+    },
+    'publish-gate-process': {
+        scopeIds: ['publish-gate-process'],
+        elementCount: 3,
+        flowCount: 2,
+        layoutSource: 'fallback',
+    },
+    'subprocess-boundary-events': {
+        scopeIds: ['subprocess-boundary-events', 'Fulfil', 'OnRecall'],
+        elementCount: 16,
+        flowCount: 11,
+        layoutSource: 'document',
+    },
+    'task-kinds-and-lanes': {
+        scopeIds: ['task-kinds-and-lanes'],
+        elementCount: 11,
+        flowCount: 10,
+        layoutSource: 'document',
+    },
+    'transaction-compensation': {
+        scopeIds: ['transaction-compensation', 'BookTrip'],
+        elementCount: 13,
+        flowCount: 8,
+        layoutSource: 'document',
+        unresolvedEdgeIds: ['Compensation_Association'],
+    },
+};
+
+describe.each(FIXTURE_NAMES)('%s', name => {
+    const fixture = loadFixture(name);
+    const expectation = EXPECTATIONS[name];
+    const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+
+    it('reads the scope tree the payload declares', () => {
+        expect(model.scopes.map(scope => scope.id)).toEqual(expectation.scopeIds);
+        expect(model.processId).toBe(expectation.scopeIds[0]);
+    });
+
+    it('reads every element and flow', () => {
+        expect(model.elements).toHaveLength(expectation.elementCount);
+        expect(model.flows).toHaveLength(expectation.flowCount);
+    });
+
+    it('reports no errors', () => {
+        expect(model.diagnostics.filter(diagnostic => diagnostic.severity === 'error')).toEqual([]);
+    });
+
+    it('gives every flow endpoints that exist in the flow\'s own scope', () => {
+        const elementIdsByScope = new Map<string, Set<string>>();
+
+        for (const element of model.elements) {
+            const ids = elementIdsByScope.get(element.scopeId) ?? new Set<string>();
+
+            ids.add(element.id);
+            elementIdsByScope.set(element.scopeId, ids);
+        }
+
+        for (const flow of model.flows) {
+            const ids = elementIdsByScope.get(flow.scopeId) ?? new Set<string>();
+
+            expect(ids.has(flow.sourceElementId), `${flow.id} source ${flow.sourceElementId}`).toBe(true);
+            expect(ids.has(flow.targetElementId), `${flow.id} target ${flow.targetElementId}`).toBe(true);
+        }
+    });
+
+    it('resolves every DI shape to an element, lane or pool', () => {
+        const references = readDiagramReferences(fixture.sourceXml);
+        const drawable = new Set<string>([
+            ...model.elements.map(element => element.id),
+            ...model.lanes.map(lane => lane.id),
+            ...model.pools.map(pool => pool.id),
+        ]);
+
+        expect(references.shapes.filter(id => !drawable.has(id))).toEqual([]);
+        expect(model.diagnostics.filter(diagnostic => diagnostic.code === 'unresolved-di-shape')).toEqual([]);
+    });
+
+    it('resolves every DI edge to a sequence flow, apart from the documented exceptions', () => {
+        const references = readDiagramReferences(fixture.sourceXml);
+        const flowIds = new Set(model.flows.map(flow => flow.id));
+
+        expect(references.edges.filter(id => !flowIds.has(id))).toEqual(expectation.unresolvedEdgeIds ?? []);
+    });
+
+    it(`lays the diagram out from the ${expectation.layoutSource}`, () => {
+        expect(model.layout.source).toBe(expectation.layoutSource);
+
+        // The direction that could be mistaken for success: a fallback layout that quietly claims to
+        // be the author's own coordinates, or DI that quietly stops being read. Both are visible only
+        // by checking every element agrees with what the diagram as a whole claims.
+        for (const element of model.elements) {
+            expect(element.geometry.source, element.id).toBe(expectation.layoutSource);
+        }
+
+        if (expectation.layoutSource === 'fallback') {
+            expect(model.layout.reason).toBeTruthy();
+        } else {
+            expect(model.layout.reason).toBeNull();
+        }
+    });
+
+    it('places every element somewhere with a real size', () => {
+        for (const element of model.elements) {
+            expect(Number.isFinite(element.geometry.x), element.id).toBe(true);
+            expect(Number.isFinite(element.geometry.y), element.id).toBe(true);
+            expect(element.geometry.width, element.id).toBeGreaterThan(0);
+            expect(element.geometry.height, element.id).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('geometry read straight from BPMN DI', () => {
+    it('uses the exact bounds, label bounds and waypoints the document states', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+        const task = model.elements.find(element => element.id === 'NotifyWarehouse')!;
+
+        expect(task.geometry).toEqual({ x: 240, y: 80, width: 100, height: 80, source: 'document' });
+        expect(model.elements.find(element => element.id === 'StartEvent_1')!.geometry)
+            .toEqual({ x: 152, y: 102, width: 36, height: 36, source: 'document' });
+        expect(model.flows.find(flow => flow.id === 'Flow_1')!.waypoints)
+            .toEqual([{ x: 188, y: 120 }, { x: 240, y: 120 }]);
+    });
+
+    it('reads a label\'s own bounds off the shape and the edge that carry one', () => {
+        const fixture = loadFixture('gateway-routing');
+        const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+
+        expect(model.elements.find(element => element.id === 'Decide')!.labelGeometry)
+            .toEqual({ x: 338, y: 75, width: 64, height: 14 });
+        expect(model.flows.find(flow => flow.id === 'Flow_Decide_Approve')!.labelGeometry)
+            .toEqual({ x: 392, y: 62, width: 20, height: 14 });
+        // A shape with no BPMNLabel says nothing about where the label goes; it does not report zeroes.
+        expect(model.elements.find(element => element.id === 'Fork')!.labelGeometry).toBeNull();
+    });
+
+    it('reads the DI flags a renderer needs from the shape', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(model.elements.find(element => element.id === 'Fulfil')!.isExpanded).toBe(true);
+        expect(model.elements.find(element => element.id === 'Escalate')!.isExpanded).toBeNull();
+        expect(build('gateway-routing').elements.find(element => element.id === 'Decide')!.isMarkerVisible).toBe(true);
+    });
+});
+
+function build(name: FixtureName) {
+    const fixture = loadFixture(name);
+
+    return buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fallback-layout.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fallback-layout.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The fallback layout's own edge cases, driven directly rather than through a `.bpmn` fixture.
+ *
+ * A loop, a scope nothing reaches, and a boundary event whose host is missing are all documents a
+ * modeller can produce but which no captured fixture contains -- and each is a shape where a naive
+ * layered layout either loops forever or quietly drops a node. ../__fixtures__ covers the layout's
+ * behaviour on real documents; this covers the ways it could fail to terminate or to place.
+ */
+import { describe, expect, it } from 'vitest';
+import { computeFallbackLayout, layoutKey, type LayoutScope } from '../fallback-layout';
+
+function scope(id: string, elements: LayoutScope['elements'], flows: LayoutScope['flows'] = []): LayoutScope {
+    return { id, elements, flows };
+}
+
+function node(id: string, elementType = 'serviceTask', extra: Partial<LayoutScope['elements'][number]> = {}) {
+    return { id, elementType, attachedToElementId: null, childScopeId: null, ...extra };
+}
+
+describe('computeFallbackLayout', () => {
+    it('places a chain left to right, one column per layer', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [node('a', 'startEvent'), node('b'), node('c', 'endEvent')], [
+                { sourceRef: 'a', targetRef: 'b' },
+                { sourceRef: 'b', targetRef: 'c' },
+            ]),
+        ], 'p');
+
+        const a = placements.get(layoutKey('p', 'a'))!;
+        const b = placements.get(layoutKey('p', 'b'))!;
+        const c = placements.get(layoutKey('p', 'c'))!;
+
+        expect(a.x).toBeLessThan(b.x);
+        expect(b.x).toBeLessThan(c.x);
+        expect(a).toMatchObject({ width: 36, height: 36 });
+        expect(b).toMatchObject({ width: 100, height: 80 });
+    });
+
+    it('stacks a split\'s branches in the same column', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [node('gate', 'exclusiveGateway'), node('left'), node('right')], [
+                { sourceRef: 'gate', targetRef: 'left' },
+                { sourceRef: 'gate', targetRef: 'right' },
+            ]),
+        ], 'p');
+
+        const left = placements.get(layoutKey('p', 'left'))!;
+        const right = placements.get(layoutKey('p', 'right'))!;
+
+        expect(left.x).toBe(right.x);
+        expect(left.y).toBeLessThan(right.y);
+    });
+
+    // Kahn's algorithm leaves every node on a cycle unranked; without the second pass this would
+    // either loop or drop the whole loop body off the canvas.
+    it('terminates and places every element of a process that loops back on itself', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [node('a', 'startEvent'), node('b'), node('c'), node('d', 'endEvent')], [
+                { sourceRef: 'a', targetRef: 'b' },
+                { sourceRef: 'b', targetRef: 'c' },
+                { sourceRef: 'c', targetRef: 'b' },
+                { sourceRef: 'c', targetRef: 'd' },
+            ]),
+        ], 'p');
+
+        expect(['a', 'b', 'c', 'd'].every(id => placements.has(layoutKey('p', id)))).toBe(true);
+    });
+
+    it('places a process made entirely of a cycle', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [node('a'), node('b')], [
+                { sourceRef: 'a', targetRef: 'b' },
+                { sourceRef: 'b', targetRef: 'a' },
+            ]),
+        ], 'p');
+
+        expect(placements.size).toBe(2);
+    });
+
+    it('grows a host to fit the scope it contains, however deep the nesting goes', () => {
+        const placements = computeFallbackLayout([
+            scope('outer', [node('host', 'subProcess', { childScopeId: 'middle' })]),
+            scope('middle', [node('inner', 'subProcess', { childScopeId: 'innermost' })]),
+            scope('innermost', [node('x'), node('y'), node('z')], [
+                { sourceRef: 'x', targetRef: 'y' },
+                { sourceRef: 'y', targetRef: 'z' },
+            ]),
+        ], 'outer');
+
+        const host = placements.get(layoutKey('outer', 'host'))!;
+        const inner = placements.get(layoutKey('middle', 'inner'))!;
+        const z = placements.get(layoutKey('innermost', 'z'))!;
+
+        expect(inner.x).toBeGreaterThan(host.x);
+        expect(inner.x + inner.width).toBeLessThanOrEqual(host.x + host.width);
+        expect(z.x + z.width).toBeLessThanOrEqual(inner.x + inner.width);
+        expect(z.y + z.height).toBeLessThanOrEqual(inner.y + inner.height);
+    });
+
+    it('lays a boundary event out as an ordinary node when its host is not in the scope', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [
+                node('host'),
+                node('orphan', 'boundaryEvent', { attachedToElementId: 'somewhere-else' }),
+            ]),
+        ], 'p');
+
+        const host = placements.get(layoutKey('p', 'host'))!;
+        const orphan = placements.get(layoutKey('p', 'orphan'))!;
+
+        expect(orphan).toBeDefined();
+        expect(orphan.y).toBeGreaterThan(host.y + host.height);
+    });
+
+    it('places nothing, rather than guessing a root, when the named root scope is not there', () => {
+        expect(computeFallbackLayout([scope('p', [node('a')])], 'missing').size).toBe(0);
+    });
+
+    it('terminates on a scope tree that refers back to itself', () => {
+        const placements = computeFallbackLayout([
+            scope('p', [node('host', 'subProcess', { childScopeId: 'p' })]),
+        ], 'p');
+
+        expect(placements.has(layoutKey('p', 'host'))).toBe(true);
+    });
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fixture-payloads.test-d.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fixture-payloads.test-d.ts
@@ -1,0 +1,34 @@
+/**
+ * Type-checks every captured `.activity.json` fixture against the shape `buildBpmnViewModel`
+ * actually consumes, with no cast anywhere in the assignments below.
+ *
+ * `../__tests__/process-payload.test-d.ts` asks the narrower question -- does
+ * `BpmnProcessDefinition` still describe the `process` payload -- for one fixture, and asks it
+ * exhaustively (no excess keys at any depth). This file asks the wider one for all of them: the
+ * *whole* root activity, including the nested `Elsa.BpmnProcess` activities that are the subprocess
+ * bodies, has to satisfy `BpmnActivity`, whose `process` and `activities` properties are what make
+ * that recursion type-checked. If a `Bpmn.Model` version bump changes the payload in a way the
+ * generated types no longer cover, `npm test` stops compiling here.
+ *
+ * Runtime assertions about these same fixtures live in ./diagram-fixtures.test.ts.
+ */
+import type { BpmnActivity } from '../model';
+import camundaOrderProcess from '../__fixtures__/camunda-order-process.activity.json';
+import gatewayRouting from '../__fixtures__/gateway-routing.activity.json';
+import nonInterruptingErrorEventSubprocess from '../__fixtures__/non-interrupting-error-event-subprocess.activity.json';
+import publishGateProcess from '../__fixtures__/publish-gate-process.activity.json';
+import subprocessBoundaryEvents from '../__fixtures__/subprocess-boundary-events.activity.json';
+import taskKindsAndLanes from '../__fixtures__/task-kinds-and-lanes.activity.json';
+import transactionCompensation from '../__fixtures__/transaction-compensation.activity.json';
+
+const fixtures: BpmnActivity[] = [
+    camundaOrderProcess,
+    gatewayRouting,
+    nonInterruptingErrorEventSubprocess,
+    publishGateProcess,
+    subprocessBoundaryEvents,
+    taskKindsAndLanes,
+    transactionCompensation,
+];
+
+void fixtures;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fixtures.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/fixtures.ts
@@ -1,0 +1,60 @@
+/**
+ * Loads the `.bpmn` + `.activity.json` fixture pairs. See ../__fixtures__/README.md for what each
+ * one covers and how the `.activity.json` half was captured.
+ *
+ * The pairs are read off disk rather than imported as modules so that the `.bpmn` half is available
+ * as the exact text Studio receives on `CustomProperties["Bpmn:SourceXml"]`, and so that a test can
+ * independently re-read the document's DI without going through the reader it is checking.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BpmnActivity } from '../model';
+
+const FIXTURES_DIRECTORY = join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__');
+
+export const FIXTURE_NAMES = [
+    'camunda-order-process',
+    'gateway-routing',
+    'non-interrupting-error-event-subprocess',
+    'publish-gate-process',
+    'subprocess-boundary-events',
+    'task-kinds-and-lanes',
+    'transaction-compensation',
+] as const;
+
+export type FixtureName = (typeof FIXTURE_NAMES)[number];
+
+export interface Fixture {
+    readonly name: FixtureName;
+    /** The root `Elsa.BpmnProcess` activity JSON, as elsa-core's import produced it. */
+    readonly activity: BpmnActivity;
+    /** The source document, as `CustomProperties["Bpmn:SourceXml"]` carries it. */
+    readonly sourceXml: string;
+}
+
+export function loadFixture(name: FixtureName): Fixture {
+    return {
+        name,
+        activity: JSON.parse(readFileSync(join(FIXTURES_DIRECTORY, `${name}.activity.json`), 'utf8')) as BpmnActivity,
+        sourceXml: readFileSync(join(FIXTURES_DIRECTORY, `${name}.bpmn`), 'utf8'),
+    };
+}
+
+/**
+ * Pulls the ids a document's `BPMNShape` / `BPMNEdge` elements draw straight out of the XML text.
+ *
+ * Deliberately a regex over the raw source, not a call into `di-reader.ts`: a fixture test that
+ * asked the reader what the document contains and then checked the answer against itself would pass
+ * for a reader that silently found nothing.
+ */
+export function readDiagramReferences(sourceXml: string): { shapes: string[]; edges: string[] } {
+    return {
+        shapes: matchAll(sourceXml, /<bpmndi:BPMNShape\b[^>]*\bbpmnElement="([^"]+)"/g),
+        edges: matchAll(sourceXml, /<bpmndi:BPMNEdge\b[^>]*\bbpmnElement="([^"]+)"/g),
+    };
+}
+
+function matchAll(text: string, pattern: RegExp): string[] {
+    return Array.from(text.matchAll(pattern), match => match[1]);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/module-boundaries.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/module-boundaries.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The scope guard for src/bpmn.
+ *
+ * The whole point of this module is that it is canvas-neutral: an X6 adapter and a later React Flow
+ * adapter both consume it, so it may not know about either. A single stray `import` from `@antv/x6`
+ * or `../react-designer` would compile, pass every other test, and quietly make the module
+ * un-reusable -- which is exactly the kind of regression that only a check like this catches.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const MODULE_DIRECTORY = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Packages this module may never reach for, whatever the import syntax. */
+const FORBIDDEN_PACKAGES = [
+    '@antv/x6',
+    '@antv/layout',
+    '@xyflow/react',
+    'react',
+    'react-dom',
+];
+
+/** Sibling source trees this module may never reach into. */
+const FORBIDDEN_SIBLING_DIRECTORIES = ['designer', 'react-designer'];
+
+describe('src/bpmn module boundaries', () => {
+    const files = collectTypeScriptFiles(MODULE_DIRECTORY).map(file => relative(MODULE_DIRECTORY, file));
+
+    it('has source files to check', () => {
+        // Guards the guard: a path bug that found nothing would otherwise report success.
+        expect(files.length).toBeGreaterThan(5);
+    });
+
+    it.each(files)('%s imports neither canvas package nor designer source', file => {
+        const offending = readImportSpecifiers(readFileSync(join(MODULE_DIRECTORY, file), 'utf8')).filter(isForbidden);
+
+        expect(offending, `${file} must stay canvas-neutral`).toEqual([]);
+    });
+});
+
+function isForbidden(specifier: string): boolean {
+    if (FORBIDDEN_PACKAGES.some(name => specifier === name || specifier.startsWith(`${name}/`))) return true;
+
+    // Anything that climbs out of src/bpmn and back down into a sibling designer tree, at any depth.
+    const segments = specifier.split('/');
+
+    return segments[0] === '..'
+        && segments.some(segment => FORBIDDEN_SIBLING_DIRECTORIES.includes(segment));
+}
+
+/** Static imports and re-exports, `import type`, dynamic `import()` and CommonJS `require()`. */
+function readImportSpecifiers(source: string): string[] {
+    const patterns = [
+        /\b(?:import|export)\s[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/g,
+        /\bimport\s*['"]([^'"]+)['"]/g,
+        /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+        /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    ];
+
+    return patterns.flatMap(pattern => Array.from(source.matchAll(pattern), match => match[1]));
+}
+
+function collectTypeScriptFiles(directory: string): string[] {
+    return readdirSync(directory).flatMap(entry => {
+        const path = join(directory, entry);
+
+        if (statSync(path).isDirectory()) return collectTypeScriptFiles(path);
+
+        return path.endsWith('.ts') || path.endsWith('.tsx') ? [path] : [];
+    });
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
@@ -160,12 +160,54 @@ describe('scopes', () => {
         expect(element(model, 'Fulfil').listenerBinding).toBeNull();
     });
 
+    it('reports a listener binding ref that workBindings does not map as unresolved, not silently', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        delete (activity.workBindings as Record<string, string>)['node-OnRecall-listener'];
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'OnRecall').listenerBinding).toMatchObject({
+            state: 'unresolved',
+            bindingRef: 'node-OnRecall-listener',
+            activityId: null,
+        });
+
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'unresolved-listener-binding')!;
+
+        expect(diagnostic).toMatchObject({ severity: 'error', elementId: 'OnRecall', scopeId: 'subprocess-boundary-events' });
+        expect(diagnostic.message).toContain('OnRecall');
+        expect(diagnostic.message).toContain('node-OnRecall-listener');
+    });
+
     it('marks a transaction on both the element and the scope it hosts', () => {
         const model = build('transaction-compensation');
 
         expect(element(model, 'BookTrip').isTransaction).toBe(true);
         expect(model.scopes.find(scope => scope.id === 'BookTrip')!.isTransaction).toBe(true);
         expect(model.scopes.find(scope => scope.id === 'transaction-compensation')!.isTransaction).toBe(false);
+    });
+
+    it('reports two distinct nested processes reusing a processId, and still renders the first one', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const onRecall = activity.activities!.find(candidate => candidate.id === 'subprocess-boundary-events:node-OnRecall')!;
+
+        // Two distinct payload objects -- `Fulfil`'s and `OnRecall`'s -- now claim the same processId.
+        (onRecall.process as { processId: string }).processId = 'Fulfil';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'duplicate-process-id')!;
+
+        expect(diagnostic).toMatchObject({ severity: 'error', elementId: 'OnRecall', scopeId: 'subprocess-boundary-events' });
+        expect(diagnostic.message).toContain('Fulfil');
+        expect(diagnostic.message).toContain('subprocess-boundary-events:node-Fulfil');
+        expect(diagnostic.message).toContain('subprocess-boundary-events:node-OnRecall');
+
+        // The first scope to claim the processId is kept, elements and all.
+        expect(model.scopes.map(scope => scope.id)).toEqual(['subprocess-boundary-events', 'Fulfil']);
+        expect(element(model, 'PickLine').scopeId).toBe('Fulfil');
     });
 
     it('reads multi-instance markers', () => {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
@@ -1,0 +1,631 @@
+/**
+ * What the view model says about a document, kind by kind.
+ *
+ * The invariant every test here is really about: **the view model reports the document, and reports
+ * when it cannot.** Nothing it emits may be indistinguishable from the document having said so --
+ * an invented coordinate must be marked as invented, an unbound task must be a state rather than an
+ * absence, and a fault in the input must leave a diagnostic behind rather than an empty diagram that
+ * looks like an empty process.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { BpmnActivity, BpmnActivityDescriptor, BpmnViewElement, BpmnViewModel } from '../model';
+import { buildBpmnViewModel } from '../view-model';
+import { loadFixture, type FixtureName } from './fixtures';
+
+const WRITE_LINE_DESCRIPTOR: BpmnActivityDescriptor = {
+    typeName: 'Elsa.WriteLine',
+    version: 1,
+    name: 'WriteLine',
+    displayName: 'Write Line',
+    category: 'Console',
+    color: '#fff',
+};
+
+function build(name: FixtureName, overrides: { sourceXml?: string | null } = {}): BpmnViewModel {
+    const fixture = loadFixture(name);
+
+    return buildBpmnViewModel({
+        activity: fixture.activity,
+        sourceXml: 'sourceXml' in overrides ? overrides.sourceXml : fixture.sourceXml,
+        activityDescriptors: [WRITE_LINE_DESCRIPTOR],
+    });
+}
+
+function element(model: BpmnViewModel, id: string): BpmnViewElement {
+    const found = model.elements.find(candidate => candidate.id === id);
+
+    expect(found, `no element '${id}' in the view model`).toBeDefined();
+
+    return found!;
+}
+
+describe('elements', () => {
+    it('reads all eight task kinds, the call activity and the subprocess as their own element types', () => {
+        const model = build('task-kinds-and-lanes');
+        const kinds = new Map(model.elements.map(candidate => [candidate.id, candidate]));
+
+        expect([...kinds.values()].filter(candidate => candidate.kind === 'task').map(candidate => candidate.elementType).sort())
+            .toEqual([
+                'businessRuleTask',
+                'manualTask',
+                'receiveTask',
+                'scriptTask',
+                'sendTask',
+                'serviceTask',
+                'task',
+                'userTask',
+            ]);
+        expect(element(model, 'ArchiveOrder').kind).toBe('callActivity');
+        expect(element(model, 'ArchiveOrder').properties['bpmn.calledElement']).toBe('archive-order-process');
+        expect(element(model, 'AwaitConfirm').properties['bpmn.messageName']).toBe('ShipmentConfirmed');
+    });
+
+    it('reads all four gateways', () => {
+        const model = build('gateway-routing');
+
+        expect(model.elements.filter(candidate => candidate.kind === 'gateway').map(candidate => candidate.elementType).sort())
+            .toEqual(['eventBasedGateway', 'exclusiveGateway', 'inclusiveGateway', 'parallelGateway', 'parallelGateway']);
+    });
+
+    it('reads start, intermediate and end events with their event definitions', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(element(model, 'Start_1').eventDefinitions).toEqual([]);
+        expect(element(model, 'RaiseLate').elementType).toBe('intermediateThrowEvent');
+        expect(element(model, 'RaiseLate').eventDefinitions.map(definition => definition.type)).toEqual(['escalation']);
+        expect(element(model, 'End_Terminated').eventDefinitions.map(definition => definition.type)).toEqual(['terminate']);
+        expect(element(build('gateway-routing'), 'Timeout').eventDefinitions)
+            .toEqual([{ type: 'timer', properties: { interval: 'PT10M' } }]);
+    });
+
+    it('classifies an element type it has never heard of as unknown rather than dropping it', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        (activity.process!.elements[0] as { elementType: string }).elementType = 'adHocSubProcess';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(model.elements).toHaveLength(3);
+        expect(element(model, 'StartEvent_1').kind).toBe('unknown');
+        expect(element(model, 'StartEvent_1').elementType).toBe('adHocSubProcess');
+    });
+});
+
+describe('boundary events', () => {
+    // The dangerous direction here is a non-interrupting boundary event reported as interrupting, or
+    // the other way round: both render, both look plausible, and only one is what the document says.
+    it('reports interrupting and non-interrupting attachment as the document states each', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(element(model, 'FulfilTimeout').boundary)
+            .toEqual({ hostElementId: 'Fulfil', hostResolved: true, interrupting: true });
+        expect(element(model, 'FulfilNudge').boundary)
+            .toEqual({ hostElementId: 'Fulfil', hostResolved: true, interrupting: false });
+        expect(element(model, 'FulfilFailed').boundary)
+            .toEqual({ hostElementId: 'Fulfil', hostResolved: true, interrupting: true });
+    });
+
+    it('leaves boundary attachment null on everything that is not a boundary event', () => {
+        // `cancelActivity` reads `true` on every element in the payload, boundary or not, so exposing
+        // the raw flag would make every task look interrupting. Only a boundary event gets one.
+        const model = build('subprocess-boundary-events');
+
+        expect(element(model, 'Fulfil').boundary).toBeNull();
+        expect(element(model, 'Escalate').boundary).toBeNull();
+        expect(element(model, 'Start_1').boundary).toBeNull();
+    });
+
+    it('reports a boundary event whose host is not in its scope, and still renders it', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const boundary = activity.process!.elements.find(candidate => candidate.elementId === 'FulfilTimeout')!;
+
+        (boundary as { attachedToRef: string }).attachedToRef = 'NoSuchElement';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'FulfilTimeout').boundary)
+            .toEqual({ hostElementId: 'NoSuchElement', hostResolved: false, interrupting: true });
+        expect(model.diagnostics.map(diagnostic => diagnostic.code)).toContain('unresolved-boundary-host');
+    });
+});
+
+describe('scopes', () => {
+    it('flattens subprocess and event subprocess bodies into scopes with a parent and a host', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(model.scopes.map(scope => [scope.id, scope.parentScopeId, scope.hostElementId, scope.depth])).toEqual([
+            ['subprocess-boundary-events', null, null, 0],
+            ['Fulfil', 'subprocess-boundary-events', 'Fulfil', 1],
+            ['OnRecall', 'subprocess-boundary-events', 'OnRecall', 1],
+        ]);
+        expect(element(model, 'Fulfil').childScopeId).toBe('Fulfil');
+        expect(element(model, 'PickLine').scopeId).toBe('Fulfil');
+        expect(element(model, 'PickLine').parentElementId).toBe('Fulfil');
+        expect(element(model, 'Start_1').parentElementId).toBeNull();
+    });
+
+    it('marks an event subprocess and carries the listener it arms', () => {
+        const model = build('subprocess-boundary-events');
+        const eventSubProcess = element(model, 'OnRecall');
+
+        expect(eventSubProcess.isEventSubProcess).toBe(true);
+        expect(element(model, 'Fulfil').isEventSubProcess).toBe(false);
+        expect(eventSubProcess.listenerBinding).toMatchObject({
+            state: 'bound',
+            bindingRef: 'node-OnRecall-listener',
+            activityType: 'Elsa.Event',
+        });
+        expect(element(model, 'Fulfil').listenerBinding).toBeNull();
+    });
+
+    it('marks a transaction on both the element and the scope it hosts', () => {
+        const model = build('transaction-compensation');
+
+        expect(element(model, 'BookTrip').isTransaction).toBe(true);
+        expect(model.scopes.find(scope => scope.id === 'BookTrip')!.isTransaction).toBe(true);
+        expect(model.scopes.find(scope => scope.id === 'transaction-compensation')!.isTransaction).toBe(false);
+    });
+
+    it('reads multi-instance markers', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(element(model, 'Fulfil').loopCharacteristics)
+            .toEqual({ isSequential: false, collectionVariable: 'orderLines', itemVariable: 'line' });
+        expect(element(model, 'Escalate').loopCharacteristics).toBeNull();
+    });
+});
+
+describe('compensation', () => {
+    it('reads the handler, its association, and the cancel events around a transaction', () => {
+        const model = build('transaction-compensation');
+
+        expect(element(model, 'RefundCard').isForCompensation).toBe(true);
+        expect(element(model, 'ChargeCard').isForCompensation).toBe(false);
+        expect(model.associations).toEqual([{
+            sourceElementId: 'ChargeCardCompensation',
+            targetElementId: 'RefundCard',
+            scopeId: 'BookTrip',
+            targetResolved: true,
+        }]);
+        expect(element(model, 'ChargeCardCompensation').eventDefinitions.map(definition => definition.type))
+            .toEqual(['compensation']);
+        expect(element(model, 'BookTripCancelled').eventDefinitions.map(definition => definition.type))
+            .toEqual(['cancel']);
+        expect(element(model, 'Tx_Cancel_End').eventDefinitions.map(definition => definition.type))
+            .toEqual(['cancel']);
+    });
+
+    it('reports a compensation handler that is not in the boundary event\'s own scope', () => {
+        const fixture = loadFixture('transaction-compensation');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const nested = activity.activities!.find(candidate => candidate.process?.processId === 'BookTrip')!;
+        const boundary = nested.process!.elements.find(candidate => candidate.elementId === 'ChargeCardCompensation')!;
+
+        (boundary as { compensationHandlerElementId: string }).compensationHandlerElementId = 'NoSuchHandler';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(model.associations[0]).toMatchObject({ targetElementId: 'NoSuchHandler', targetResolved: false });
+        expect(model.diagnostics.map(diagnostic => diagnostic.code)).toContain('unresolved-compensation-handler');
+    });
+});
+
+describe('flows', () => {
+    it('reads condition outcomes and the gateway\'s default flow', () => {
+        const model = build('gateway-routing');
+        const conditional = model.flows.find(flow => flow.id === 'Flow_Decide_Approve')!;
+        const fallbackFlow = model.flows.find(flow => flow.id === 'Flow_Decide_Reject')!;
+
+        expect(conditional).toMatchObject({ conditionOutcome: 'Approved', isDefault: false, name: 'yes' });
+        // The payload records the default on the *gateway* (`defaultFlowId`), not on the flow, so a
+        // view model that only looked at `BpmnSequenceFlow.isDefault` would silently mark none.
+        expect(fallbackFlow).toMatchObject({ conditionOutcome: null, isDefault: true, name: 'otherwise' });
+        expect(element(model, 'Decide').defaultFlowId).toBe('Flow_Decide_Reject');
+    });
+
+    it('drops a flow with a dangling endpoint and says so, rather than emitting an undrawable edge', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        (activity.process!.sequenceFlows[0] as { targetRef: string }).targetRef = 'NoSuchElement';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(model.flows.map(flow => flow.id)).toEqual(['Flow_2']);
+
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'dangling-flow')!;
+
+        expect(diagnostic.severity).toBe('error');
+        expect(diagnostic.message).toContain('NoSuchElement');
+    });
+});
+
+describe('lanes and pools', () => {
+    it('retains lanes and pools with their geometry, and attaches no meaning to membership', () => {
+        const model = build('task-kinds-and-lanes');
+
+        expect(model.pools).toEqual([{
+            id: 'Participant_Fulfilment',
+            name: 'Fulfilment',
+            processId: 'task-kinds-and-lanes',
+            geometry: { x: 120, y: 60, width: 1400, height: 400, source: 'document' },
+            isHorizontal: true,
+        }]);
+        expect(model.lanes.map(lane => [lane.id, lane.name, lane.poolId, lane.isHorizontal])).toEqual([
+            ['Lane_Automated', 'Automated', 'Participant_Fulfilment', true],
+            ['Lane_People', 'People', 'Participant_Fulfilment', true],
+        ]);
+        expect(model.lanes[1].geometry).toEqual({ x: 150, y: 290, width: 1370, height: 170, source: 'document' });
+        expect(element(model, 'ReviewOrder').laneId).toBe('Lane_People');
+        expect(element(model, 'ServiceWork').laneId).toBe('Lane_Automated');
+    });
+
+    it('still gives a lane a pool when the source document is gone, and says the name is unknown', () => {
+        // Pools live on the document's collaboration, which the activity payload does not carry at
+        // all. Dropping the pool would make the lane look like it belongs to the process itself.
+        const model = build('task-kinds-and-lanes', { sourceXml: null });
+
+        expect(model.pools).toEqual([
+            { id: 'Participant_Fulfilment', name: null, processId: null, geometry: null, isHorizontal: null },
+        ]);
+        expect(model.diagnostics.map(diagnostic => diagnostic.code)).toContain('unresolved-pool');
+    });
+});
+
+describe('binding display', () => {
+    it('names a bound activity through workBindings and the descriptor catalogue', () => {
+        const model = build('camunda-order-process');
+
+        expect(element(model, 'NotifyWarehouse').binding).toEqual({
+            state: 'bound',
+            bindingRef: 'node-NotifyWarehouse',
+            activityId: 'order-process:node-NotifyWarehouse',
+            activityType: 'Elsa.WriteLine',
+            activityName: null,
+            displayName: 'Write Line',
+            descriptor: WRITE_LINE_DESCRIPTOR,
+        });
+    });
+
+    it('falls back to the activity type when no descriptor was supplied', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'NotifyWarehouse').binding).toMatchObject({
+            state: 'bound',
+            displayName: 'Elsa.WriteLine',
+            descriptor: null,
+        });
+    });
+
+    it('prefers the activity\'s own name over the descriptor\'s display name', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        (activity.activities![0] as { name: string }).name = 'Tell the warehouse';
+
+        const model = buildBpmnViewModel({
+            activity,
+            sourceXml: fixture.sourceXml,
+            activityDescriptors: [WRITE_LINE_DESCRIPTOR],
+        });
+
+        expect(element(model, 'NotifyWarehouse').binding).toMatchObject({ displayName: 'Tell the warehouse' });
+    });
+
+    it('leaves binding null for an element that performs no work of its own', () => {
+        const model = build('gateway-routing');
+
+        expect(element(model, 'Decide').binding).toBeNull();
+        expect(element(model, 'Start_1').binding).toBeNull();
+        expect(element(model, 'End_1').binding).toBeNull();
+    });
+
+    // An unbound task is a *state*, not an absence: W8 makes it a publish error, so the canvas has to
+    // be able to show it. elsa-core's own binder refuses to import such a document, so this is the
+    // shape a Studio-side edit (W11/W14) produces -- see ../__fixtures__/README.md.
+    it('reports a task that declares no binding ref as unbound, loudly', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const task = activity.process!.elements.find(candidate => candidate.elementId === 'NotifyWarehouse')!;
+
+        delete (task as { bindingRef?: string | null }).bindingRef;
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'NotifyWarehouse').binding).toEqual({
+            state: 'unbound',
+            bindingRef: null,
+            activityId: null,
+            activityType: null,
+            activityName: null,
+            displayName: null,
+            descriptor: null,
+        });
+
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'unbound-work')!;
+
+        expect(diagnostic).toMatchObject({ severity: 'warning', elementId: 'NotifyWarehouse', scopeId: 'order-process' });
+    });
+
+    it('reports a binding ref that workBindings does not map as unresolved, not as bound to nothing', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        delete (activity.workBindings as Record<string, string>)['node-NotifyWarehouse'];
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'NotifyWarehouse').binding).toMatchObject({
+            state: 'unresolved',
+            bindingRef: 'node-NotifyWarehouse',
+            activityId: null,
+            displayName: null,
+        });
+        expect(model.diagnostics.find(candidate => candidate.code === 'unresolved-binding')!.severity).toBe('error');
+    });
+
+    it('reports a binding ref mapped to an activity the scope does not carry as unresolved', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        (activity.workBindings as Record<string, string>)['node-NotifyWarehouse'] = 'order-process:gone';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'NotifyWarehouse').binding).toMatchObject({
+            state: 'unresolved',
+            activityId: 'order-process:gone',
+        });
+    });
+});
+
+describe('instance state', () => {
+    it('keys element stats by BPMN element id, so a gateway can light up too', () => {
+        const fixture = loadFixture('gateway-routing');
+        const model = buildBpmnViewModel({
+            activity: fixture.activity,
+            sourceXml: fixture.sourceXml,
+            elementStats: { Decide: { started: 3, completed: 3 }, Race: { active: 1, blocked: true } },
+        });
+
+        expect(element(model, 'Decide').stats).toEqual({ started: 3, completed: 3 });
+        expect(element(model, 'Race').stats).toEqual({ active: 1, blocked: true });
+        expect(element(model, 'Fork').stats).toBeNull();
+    });
+
+    it('resolves activity stats onto the element whose binding names that activity', () => {
+        const fixture = loadFixture('gateway-routing');
+        const model = buildBpmnViewModel({
+            activity: fixture.activity,
+            sourceXml: fixture.sourceXml,
+            activityStats: { 'gateway-routing:node-Approve': { started: 2, completed: 1, faulted: true } },
+        });
+
+        expect(element(model, 'Approve').activityStats).toEqual({ started: 2, completed: 1, faulted: true });
+        expect(element(model, 'Reject').activityStats).toBeNull();
+        // A gateway has no bound activity, so activity-keyed state can never reach it -- which is the
+        // whole reason the element-keyed map exists alongside it.
+        expect(element(model, 'Decide').activityStats).toBeNull();
+    });
+
+    it('keeps the two maps apart even when an activity id and an element id collide', () => {
+        const fixture = loadFixture('gateway-routing');
+        const model = buildBpmnViewModel({
+            activity: fixture.activity,
+            sourceXml: fixture.sourceXml,
+            elementStats: { Approve: { started: 9 } },
+            activityStats: { 'gateway-routing:node-Approve': { started: 2 } },
+        });
+
+        expect(element(model, 'Approve').stats).toEqual({ started: 9 });
+        expect(element(model, 'Approve').activityStats).toEqual({ started: 2 });
+    });
+});
+
+describe('camunda extensions', () => {
+    it('still carries camunda extension elements, foreign attributes and documentation', () => {
+        const model = build('camunda-order-process');
+        const task = element(model, 'NotifyWarehouse');
+
+        expect(task.extensions.extensionElements.map(node => `${node.name.ns}#${node.name.localName}`)).toEqual([
+            'http://camunda.org/schema/1.0/bpmn#inputOutput',
+            'https://elsaworkflows.io/schemas/bpmn/v1#activityBinding',
+        ]);
+        expect(task.extensions.foreignAttributes).toEqual([
+            { name: { ns: 'http://camunda.org/schema/1.0/bpmn', localName: 'asyncBefore' }, value: 'true' },
+        ]);
+        expect(task.extensions.documentation).toEqual([{ text: 'Tells the warehouse an order needs picking.' }]);
+        expect(task.extensions.extensionElements[0].children[0])
+            .toMatchObject({ value: '${orderId}', attributes: [{ name: { localName: 'name' }, value: 'orderId' }] });
+    });
+});
+
+describe('geometry fallback', () => {
+    it('uses the document\'s coordinates when it has them and says so', () => {
+        const model = build('camunda-order-process');
+
+        expect(model.layout).toEqual({ source: 'document', reason: null });
+        expect(model.diagnostics.filter(diagnostic => diagnostic.code === 'missing-source-xml')).toEqual([]);
+    });
+
+    // The same document, both ways: the one thing that must never happen is a fallback layout that is
+    // indistinguishable from the author's own coordinates.
+    it('falls back and says so when the same document arrives with no source XML', () => {
+        const withSource = build('camunda-order-process');
+        const withoutSource = build('camunda-order-process', { sourceXml: null });
+
+        expect(withoutSource.layout.source).toBe('fallback');
+        expect(withoutSource.layout.reason).toContain('no BPMN source document');
+        expect(withoutSource.diagnostics.map(diagnostic => diagnostic.code)).toContain('missing-source-xml');
+        expect(withoutSource.elements.every(candidate => candidate.geometry.source === 'fallback')).toBe(true);
+        expect(withoutSource.elements.map(candidate => candidate.geometry))
+            .not.toEqual(withSource.elements.map(candidate => candidate.geometry));
+    });
+
+    it('falls back when the document carries no BPMNDI section at all', () => {
+        const model = build('publish-gate-process');
+
+        expect(model.layout.source).toBe('fallback');
+        expect(model.layout.reason).toContain('no BPMNDI diagram section');
+        expect(model.diagnostics.map(diagnostic => diagnostic.code)).toContain('missing-diagram');
+    });
+
+    it('falls back, loudly, when the document has a diagram but none of it is for this process', () => {
+        // The quietest way this could go wrong: DI that is present but for a different process (a
+        // stale source, the wrong plane) placing nothing while the model still claims to be drawn
+        // from the document.
+        const fixture = loadFixture('camunda-order-process');
+        const otherProcess = fixture.sourceXml.replace(/bpmnElement="(StartEvent_1|NotifyWarehouse|EndEvent_1)"/g, 'bpmnElement="$1_elsewhere"');
+        const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: otherProcess });
+
+        expect(model.layout.source).toBe('fallback');
+        expect(model.layout.reason).toContain('no BPMNShape for any element of this process');
+        expect(model.diagnostics.filter(diagnostic => diagnostic.code === 'missing-diagram'))
+            .toMatchObject([{ severity: 'warning', message: model.layout.reason }]);
+        expect(model.diagnostics.filter(diagnostic => diagnostic.code === 'unresolved-di-shape')).toHaveLength(3);
+    });
+
+    it('says the same thing in layout.reason and in the diagnostic that explains it', () => {
+        for (const model of [
+            build('camunda-order-process', { sourceXml: null }),
+            build('publish-gate-process'),
+            build('camunda-order-process', { sourceXml: '<bpmn:definitions><not-closed>' }),
+        ]) {
+            const explanation = model.diagnostics.find(diagnostic =>
+                diagnostic.code === 'missing-source-xml'
+                || diagnostic.code === 'missing-diagram'
+                || diagnostic.code === 'source-xml-parse-error')!;
+
+            expect(explanation.message).toBe(model.layout.reason);
+        }
+    });
+
+    it('reports unparseable source XML as an error and still returns a usable diagram', () => {
+        const model = build('camunda-order-process', { sourceXml: '<bpmn:definitions><not-closed>' });
+
+        expect(model.elements).toHaveLength(3);
+        expect(model.layout.source).toBe('fallback');
+        expect(model.diagnostics.find(diagnostic => diagnostic.code === 'source-xml-parse-error')!.severity).toBe('error');
+    });
+
+    it('places only the elements a partial diagram misses, and marks each one', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const withoutOneShape = fixture.sourceXml.replace(
+            /<bpmndi:BPMNShape id="NotifyWarehouse_di"[\s\S]*?<\/bpmndi:BPMNShape>/,
+            '');
+        const model = buildBpmnViewModel({ activity: fixture.activity, sourceXml: withoutOneShape });
+
+        // The document still chose the coordinates for everything else, so the diagram as a whole is
+        // still the document's; only the one element it forgot is this module's guess.
+        expect(model.layout.source).toBe('document');
+        expect(element(model, 'StartEvent_1').geometry.source).toBe('document');
+        expect(element(model, 'NotifyWarehouse').geometry.source).toBe('fallback');
+        expect(model.diagnostics.filter(diagnostic => diagnostic.code === 'missing-shape'))
+            .toMatchObject([{ severity: 'warning', elementId: 'NotifyWarehouse' }]);
+    });
+
+    it('lays a document with no DI out left to right, nesting a subprocess body inside its host', () => {
+        const model = build('subprocess-boundary-events', { sourceXml: null });
+        const host = element(model, 'Fulfil').geometry;
+        const nested = element(model, 'PickLine').geometry;
+
+        expect(model.layout.source).toBe('fallback');
+        expect(element(model, 'Start_1').geometry.x).toBeLessThan(host.x);
+        expect(nested.x).toBeGreaterThan(host.x);
+        expect(nested.y).toBeGreaterThan(host.y);
+        expect(nested.x + nested.width).toBeLessThanOrEqual(host.x + host.width);
+        expect(nested.y + nested.height).toBeLessThanOrEqual(host.y + host.height);
+
+        // A boundary event sits on its host's edge rather than in a column of its own.
+        const boundary = element(model, 'FulfilTimeout').geometry;
+
+        expect(boundary.x).toBeGreaterThanOrEqual(host.x);
+        expect(boundary.y).toBeGreaterThan(host.y);
+    });
+
+    it('is deterministic: the same input lays out identically every time', () => {
+        expect(build('subprocess-boundary-events', { sourceXml: null }).elements.map(candidate => candidate.geometry))
+            .toEqual(build('subprocess-boundary-events', { sourceXml: null }).elements.map(candidate => candidate.geometry));
+    });
+
+    it('marks a flow with no DI edge as fallback-routed rather than reporting empty waypoints as real', () => {
+        const model = build('publish-gate-process');
+
+        expect(model.flows.every(flow => flow.geometrySource === 'fallback' && flow.waypoints.length === 0)).toBe(true);
+        expect(build('camunda-order-process').flows.every(flow => flow.geometrySource === 'document')).toBe(true);
+    });
+});
+
+describe('refusals', () => {
+    it('returns an empty diagram with an error when the activity is not a BPMN process', () => {
+        const model = buildBpmnViewModel({ activity: { id: 'root', type: 'Elsa.Flowchart' } });
+
+        expect(model.elements).toEqual([]);
+        expect(model.scopes).toEqual([]);
+        expect(model.diagnostics).toMatchObject([{ code: 'not-a-bpmn-process', severity: 'error' }]);
+    });
+
+    // buildBpmnViewModel sits on a JS interop boundary, so what reaches it is JSON.parse output rather
+    // than a value TypeScript has checked -- and W11/W14 edit that document in place before sending it
+    // back whole. A half-built element has to render as an element with nothing on it.
+    it('renders a payload whose optional collections an in-place edit has not created yet', () => {
+        const fixture = loadFixture('camunda-order-process');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const task = activity.process!.elements.find(candidate => candidate.elementId === 'NotifyWarehouse')!;
+
+        delete (task as Partial<typeof task>).extensions;
+        delete (task as Partial<typeof task>).eventDefinitions;
+        delete (task as Partial<typeof task>).properties;
+        delete (activity.process as Partial<typeof activity.process>).lanes;
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+        const rendered = element(model, 'NotifyWarehouse');
+
+        expect(model.elements).toHaveLength(3);
+        expect(model.lanes).toEqual([]);
+        expect(rendered.eventDefinitions).toEqual([]);
+        expect(rendered.properties).toEqual({});
+        expect(rendered.extensions)
+            .toEqual({ documentation: [], extensionElements: [], foreignAttributes: [], foreignChildren: [] });
+    });
+
+    it('reports an element id used by two scopes, because instance state cannot tell them apart', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const nested = activity.activities!.find(candidate => candidate.process?.processId === 'Fulfil')!;
+
+        (nested.process!.elements[0] as { elementId: string }).elementId = 'Start_1';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'duplicate-element-id')!;
+
+        expect(diagnostic).toMatchObject({ severity: 'error', elementId: 'Start_1', scopeId: 'Fulfil' });
+    });
+});
+
+describe('the module reads and never writes', () => {
+    let fixture: ReturnType<typeof loadFixture>;
+    let before: string;
+
+    beforeEach(() => {
+        fixture = loadFixture('transaction-compensation');
+        before = JSON.stringify(fixture.activity);
+    });
+
+    // D4: the client holds the entire document, and this module owns no save path. A build that
+    // quietly edited its input would corrupt the very document W11/W14 send back whole.
+    it('leaves the activity payload it was given untouched', () => {
+        buildBpmnViewModel({
+            activity: fixture.activity,
+            sourceXml: fixture.sourceXml,
+            activityDescriptors: [WRITE_LINE_DESCRIPTOR],
+            elementStats: { BookTrip: { active: 1 } },
+            activityStats: { 'transaction-compensation:node-BookTrip': { started: 1 } },
+        });
+
+        expect(JSON.stringify(fixture.activity)).toBe(before);
+    });
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/di-reader.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/di-reader.ts
@@ -1,0 +1,257 @@
+/**
+ * Reads BPMN DI geometry -- and nothing else -- out of a BPMN 2.0 document.
+ *
+ * BPMN DI is not on the `Elsa.BpmnProcess` activity payload: in the payload schema, shapes and
+ * edges hang off `bpmnDefinitions.diagrams`, while the activity's `process` property is a
+ * `bpmnProcessDefinition` with no diagram section at all. The one place Studio can get real
+ * coordinates from is the document the definition was imported from, which elsa-core stores on the
+ * workflow definition's `CustomProperties["Bpmn:SourceXml"]`.
+ *
+ * **This reader is geometry-only, on purpose.** It reads `bpmndi:BPMNShape`, `bpmndi:BPMNEdge` and
+ * their bounds, waypoints and labels, plus the participant names on `bpmn:collaboration` that a
+ * pool needs to render -- which are likewise absent from a payload rooted at a single process.
+ * It never reads elements, flows, lanes or bindings: the JSON is the typed source of truth for
+ * structure, and letting this file grow into a second BPMN reader is exactly the failure that
+ * would put two disagreeing views of the same document into Studio.
+ *
+ * Parsing goes through the platform `DOMParser`, which the browser provides at runtime and Vitest's
+ * jsdom environment provides in tests.
+ */
+
+const NS_DI = 'http://www.omg.org/spec/BPMN/20100524/DI';
+const NS_DC = 'http://www.omg.org/spec/DD/20100524/DC';
+const NS_DD_DI = 'http://www.omg.org/spec/DD/20100524/DI';
+const NS_MODEL = 'http://www.omg.org/spec/BPMN/20100524/MODEL';
+
+/** Bounds as BPMN DI states them. */
+export interface DiBounds {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface DiShape {
+    readonly elementId: string;
+    readonly bounds: DiBounds;
+    readonly labelBounds: DiBounds | null;
+    readonly isExpanded: boolean | null;
+    readonly isHorizontal: boolean | null;
+    readonly isMarkerVisible: boolean | null;
+}
+
+export interface DiEdge {
+    readonly elementId: string;
+    readonly waypoints: readonly { x: number; y: number }[];
+    readonly labelBounds: DiBounds | null;
+}
+
+export interface DiParticipant {
+    readonly id: string;
+    readonly name: string | null;
+    readonly processId: string | null;
+}
+
+/** What one source document yielded. */
+export interface BpmnDiagramInterchange {
+    /** Whether the document contained at least one `bpmndi:BPMNDiagram` with a plane. */
+    readonly hasDiagram: boolean;
+    readonly shapes: ReadonlyMap<string, DiShape>;
+    readonly edges: ReadonlyMap<string, DiEdge>;
+    readonly participants: readonly DiParticipant[];
+    /** Element ids claimed by more than one shape; the first shape in document order was kept. */
+    readonly duplicateShapeIds: readonly string[];
+    /** Set when the document could not be parsed as XML at all. Everything else is then empty. */
+    readonly parseError: string | null;
+}
+
+const EMPTY: BpmnDiagramInterchange = {
+    hasDiagram: false,
+    shapes: new Map(),
+    edges: new Map(),
+    participants: [],
+    duplicateShapeIds: [],
+    parseError: null,
+};
+
+/**
+ * Reads every diagram in the document into one geometry index keyed by the id of the element each
+ * shape or edge draws.
+ *
+ * All planes are merged. A modeller writes a collapsed subprocess's body into a plane of its own,
+ * and an expanded one into the same plane as its parent; since the payload already says which scope
+ * an element belongs to, which plane its geometry was written on carries no extra information.
+ */
+export function readDiagramInterchange(sourceXml: string | null | undefined): BpmnDiagramInterchange {
+    if (sourceXml == null || sourceXml.trim().length === 0) return EMPTY;
+
+    let document: Document;
+
+    try {
+        document = new DOMParser().parseFromString(sourceXml, 'application/xml');
+    } catch (error) {
+        return { ...EMPTY, parseError: error instanceof Error ? error.message : String(error) };
+    }
+
+    const parserError = findParserError(document);
+
+    if (parserError != null) return { ...EMPTY, parseError: parserError };
+
+    const shapes = new Map<string, DiShape>();
+    const edges = new Map<string, DiEdge>();
+    const duplicateShapeIds: string[] = [];
+    const planes = Array.from(document.getElementsByTagNameNS(NS_DI, 'BPMNPlane'));
+
+    for (const plane of planes) {
+        for (const shapeElement of childrenNS(plane, NS_DI, 'BPMNShape')) {
+            const elementId = trimmedAttribute(shapeElement, 'bpmnElement');
+            const bounds = readBounds(firstChildNS(shapeElement, NS_DC, 'Bounds'));
+
+            if (elementId == null || bounds == null) continue;
+
+            if (shapes.has(elementId)) {
+                duplicateShapeIds.push(elementId);
+                continue;
+            }
+
+            shapes.set(elementId, {
+                elementId,
+                bounds,
+                labelBounds: readLabelBounds(shapeElement),
+                isExpanded: readBooleanAttribute(shapeElement, 'isExpanded'),
+                isHorizontal: readBooleanAttribute(shapeElement, 'isHorizontal'),
+                isMarkerVisible: readBooleanAttribute(shapeElement, 'isMarkerVisible'),
+            });
+        }
+
+        for (const edgeElement of childrenNS(plane, NS_DI, 'BPMNEdge')) {
+            const elementId = trimmedAttribute(edgeElement, 'bpmnElement');
+
+            if (elementId == null || edges.has(elementId)) continue;
+
+            const waypoints: { x: number; y: number }[] = [];
+
+            for (const waypoint of childrenNS(edgeElement, NS_DD_DI, 'waypoint')) {
+                const x = readNumber(waypoint, 'x');
+                const y = readNumber(waypoint, 'y');
+
+                if (x != null && y != null) waypoints.push({ x, y });
+            }
+
+            edges.set(elementId, { elementId, waypoints, labelBounds: readLabelBounds(edgeElement) });
+        }
+    }
+
+    const participants: DiParticipant[] = [];
+
+    for (const collaboration of Array.from(document.getElementsByTagNameNS(NS_MODEL, 'collaboration'))) {
+        for (const participant of childrenNS(collaboration, NS_MODEL, 'participant')) {
+            const id = trimmedAttribute(participant, 'id');
+
+            if (id == null) continue;
+
+            participants.push({
+                id,
+                name: trimmedAttribute(participant, 'name'),
+                processId: trimmedAttribute(participant, 'processRef'),
+            });
+        }
+    }
+
+    return { hasDiagram: planes.length > 0, shapes, edges, participants, duplicateShapeIds, parseError: null };
+}
+
+/**
+ * The namespaces a `DOMParser` puts its own `parsererror` element in. Chromium and WebKit use XHTML;
+ * Gecko -- and jsdom, which follows it -- use Mozilla's own. A null namespace is accepted too,
+ * because an engine that emits a bare `parsererror` is still reporting a parse failure.
+ */
+const PARSER_ERROR_NAMESPACES: readonly (string | null)[] = [
+    null,
+    'http://www.w3.org/1999/xhtml',
+    'http://www.mozilla.org/newlayout/xml/parsererror.xml',
+];
+
+/**
+ * A `DOMParser` reports a malformed document by *returning* one whose content is a `parsererror`
+ * element rather than by throwing, so every caller has to look for it explicitly. Checking the
+ * namespace as well as the local name keeps a BPMN document that legitimately contains an element
+ * called `parsererror` -- retained foreign content, say -- from being read as a parse failure.
+ */
+function findParserError(document: Document): string | null {
+    for (const error of Array.from(document.getElementsByTagName('parsererror'))) {
+        if (PARSER_ERROR_NAMESPACES.includes(error.namespaceURI)) {
+            return (error.textContent ?? 'The BPMN source could not be parsed as XML.').trim();
+        }
+    }
+
+    return null;
+}
+
+function childrenNS(parent: Element, namespaceUri: string, localName: string): Element[] {
+    const matches: Element[] = [];
+
+    for (const node of Array.from(parent.childNodes)) {
+        if (node.nodeType !== 1) continue;
+
+        const element = node as Element;
+
+        if (element.namespaceURI === namespaceUri && element.localName === localName) matches.push(element);
+    }
+
+    return matches;
+}
+
+function firstChildNS(parent: Element, namespaceUri: string, localName: string): Element | null {
+    return childrenNS(parent, namespaceUri, localName)[0] ?? null;
+}
+
+/** A `BPMNLabel` carries its own `dc:Bounds`; a label with no bounds is a label the modeller left where it fell. */
+function readLabelBounds(owner: Element): DiBounds | null {
+    const label = firstChildNS(owner, NS_DI, 'BPMNLabel');
+
+    return label == null ? null : readBounds(firstChildNS(label, NS_DC, 'Bounds'));
+}
+
+function readBounds(element: Element | null): DiBounds | null {
+    if (element == null) return null;
+
+    const x = readNumber(element, 'x');
+    const y = readNumber(element, 'y');
+    const width = readNumber(element, 'width');
+    const height = readNumber(element, 'height');
+
+    if (x == null || y == null || width == null || height == null) return null;
+
+    return { x, y, width, height };
+}
+
+function readNumber(element: Element, name: string): number | null {
+    const raw = trimmedAttribute(element, name);
+
+    if (raw == null) return null;
+
+    const value = Number(raw);
+
+    return Number.isFinite(value) ? value : null;
+}
+
+function readBooleanAttribute(element: Element, name: string): boolean | null {
+    const raw = trimmedAttribute(element, name);
+
+    if (raw == null) return null;
+
+    const lowered = raw.toLowerCase();
+
+    return lowered === 'true' ? true : lowered === 'false' ? false : null;
+}
+
+function trimmedAttribute(element: Element, name: string): string | null {
+    const raw = element.getAttribute(name);
+
+    if (raw == null) return null;
+
+    const trimmed = raw.trim();
+
+    return trimmed.length === 0 ? null : trimmed;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/element-kinds.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/element-kinds.ts
@@ -1,0 +1,84 @@
+/**
+ * Classification of the `elementType` strings the payload carries.
+ *
+ * The payload schema types `BpmnElement.elementType` as a plain string, so there is no generated
+ * union to switch on; these tables mirror `Bpmn.Model.BpmnElementTypes`, which is where the values
+ * come from. An `elementType` that appears in none of them classifies as `'unknown'` and is still
+ * rendered -- a library that adds an element kind should show up on the canvas as a placeholder,
+ * not disappear from it.
+ */
+import type { BpmnElementKind } from './model';
+
+/** The eight task-family element types. `callActivity` behaves as one but is its own kind here. */
+export const TASK_ELEMENT_TYPES: readonly string[] = [
+    'task',
+    'userTask',
+    'serviceTask',
+    'scriptTask',
+    'manualTask',
+    'businessRuleTask',
+    'sendTask',
+    'receiveTask',
+];
+
+export const GATEWAY_ELEMENT_TYPES: readonly string[] = [
+    'exclusiveGateway',
+    'parallelGateway',
+    'inclusiveGateway',
+    'eventBasedGateway',
+];
+
+export const EVENT_ELEMENT_TYPES: readonly string[] = [
+    'startEvent',
+    'endEvent',
+    'intermediateCatchEvent',
+    'intermediateThrowEvent',
+    'boundaryEvent',
+];
+
+export const BOUNDARY_EVENT_ELEMENT_TYPE = 'boundaryEvent';
+export const SUB_PROCESS_ELEMENT_TYPE = 'subProcess';
+export const CALL_ACTIVITY_ELEMENT_TYPE = 'callActivity';
+
+const KIND_BY_ELEMENT_TYPE: ReadonlyMap<string, BpmnElementKind> = new Map<string, BpmnElementKind>([
+    ...TASK_ELEMENT_TYPES.map(type => [type, 'task'] as const),
+    ...GATEWAY_ELEMENT_TYPES.map(type => [type, 'gateway'] as const),
+    ...EVENT_ELEMENT_TYPES.map(type => [type, 'event'] as const),
+    [CALL_ACTIVITY_ELEMENT_TYPE, 'callActivity'],
+    [SUB_PROCESS_ELEMENT_TYPE, 'subProcess'],
+]);
+
+export function classifyElementType(elementType: string): BpmnElementKind {
+    return KIND_BY_ELEMENT_TYPE.get(elementType) ?? 'unknown';
+}
+
+/**
+ * Whether an element of this type performs work the host has to supply, and is therefore
+ * *unbound* -- a visible state, and a publish error under W8 -- when it declares no binding ref.
+ *
+ * The eight tasks, `callActivity` and `subProcess` are exactly the kinds `BpmnWorkBinder` refuses
+ * to bind without one. An event is deliberately not on this list: a plain start or end event
+ * legitimately binds nothing, so absence of a binding there is not a defect to report.
+ */
+export function requiresWorkBinding(elementType: string): boolean {
+    return TASK_ELEMENT_TYPES.includes(elementType)
+        || elementType === CALL_ACTIVITY_ELEMENT_TYPE
+        || elementType === SUB_PROCESS_ELEMENT_TYPE;
+}
+
+/**
+ * The size a fallback layout gives an element of this kind, in BPMN DI units.
+ *
+ * These are the sizes the BPMN 2.0 DI examples and every mainstream modeller use, so a fallback
+ * diagram reads at the same scale as one that carries real coordinates.
+ */
+export function defaultSizeFor(elementType: string): { width: number; height: number } {
+    switch (classifyElementType(elementType)) {
+        case 'event':
+            return { width: 36, height: 36 };
+        case 'gateway':
+            return { width: 50, height: 50 };
+        default:
+            return { width: 100, height: 80 };
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/fallback-layout.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/fallback-layout.ts
@@ -1,0 +1,336 @@
+/**
+ * A deterministic layered layout, used only where the document carries no BPMN DI to place an
+ * element with.
+ *
+ * This is not auto-layout in the sense the design rules out: a document that carries DI is never
+ * touched by it. It exists so that a `.bpmn` file written without a diagram section -- which the
+ * BPMN spec permits, and which elsa-core's own test assets include -- still renders as something
+ * an author can read and correct, rather than as every element stacked at the origin. Whenever it
+ * runs, the view model says so: `layout.source` reads `'fallback'` and every element it placed
+ * reports `geometry.source: 'fallback'`.
+ *
+ * The layout is left-to-right by sequence flow order, one column per layer, and recurses into
+ * subprocess bodies so a nested scope is drawn inside the element that hosts it.
+ */
+import { BOUNDARY_EVENT_ELEMENT_TYPE, defaultSizeFor } from './element-kinds';
+
+/** Padding between a scope's border and the elements inside it. */
+const PADDING = 40;
+/** Horizontal gap between two layers. */
+const LAYER_GAP = 60;
+/** Vertical gap between two elements in the same layer. */
+const ROW_GAP = 40;
+/** How far a boundary event's box overlaps its host's bottom edge, i.e. half its height. */
+const BOUNDARY_OVERLAP = 18;
+/** Horizontal step between two boundary events on the same host. */
+const BOUNDARY_STEP = 44;
+/** Inset from the host's left edge to the first boundary event. */
+const BOUNDARY_INSET = 20;
+
+const MINIMUM_SCOPE_WIDTH = 200;
+const MINIMUM_SCOPE_HEIGHT = 120;
+
+export interface LayoutElement {
+    readonly id: string;
+    readonly elementType: string;
+    /** The host element id for a boundary event whose host is in this scope; null otherwise. */
+    readonly attachedToElementId: string | null;
+    /** The process id of the scope this element hosts, when it is a subprocess. */
+    readonly childScopeId: string | null;
+}
+
+export interface LayoutScope {
+    readonly id: string;
+    readonly elements: readonly LayoutElement[];
+    readonly flows: readonly { readonly sourceRef: string; readonly targetRef: string }[];
+}
+
+export interface LayoutRect {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+}
+
+/** Keys a placement by the scope it belongs to, because element ids are only unique per document. */
+export function layoutKey(scopeId: string, elementId: string): string {
+    return `${scopeId}/${elementId}`;
+}
+
+/**
+ * Places every element of every scope, in the coordinate space the document's own plane would use.
+ *
+ * Returns absolute rectangles keyed by {@link layoutKey}. A scope that is unreachable from
+ * `rootScopeId` -- which should not happen, and would mean the activity tree disagrees with itself
+ * -- is simply not placed; the caller reports the element as unplaced rather than this function
+ * inventing a second root.
+ */
+export function computeFallbackLayout(scopes: readonly LayoutScope[], rootScopeId: string): Map<string, LayoutRect> {
+    const scopesById = new Map(scopes.map(scope => [scope.id, scope]));
+    const localLayouts = new Map<string, ScopeLayout>();
+    const placements = new Map<string, LayoutRect>();
+    const root = scopesById.get(rootScopeId);
+
+    if (root == null) return placements;
+
+    layoutScope(root, scopesById, localLayouts, new Set());
+    assignAbsolute(rootScopeId, 0, 0, scopesById, localLayouts, placements, new Set());
+
+    return placements;
+}
+
+interface ScopeLayout {
+    readonly width: number;
+    readonly height: number;
+    /** Element rectangles relative to the scope's own top-left corner. */
+    readonly local: Map<string, LayoutRect>;
+}
+
+/**
+ * Lays one scope out, sizing any subprocess element to the scope it hosts first, and returns the
+ * size the scope's own box therefore needs.
+ *
+ * `visiting` guards against a cycle in the scope tree. The activity tree cannot legitimately
+ * contain one, but a cycle here would be an unbounded recursion rather than a wrong picture, so it
+ * is closed rather than assumed away.
+ */
+function layoutScope(
+    scope: LayoutScope,
+    scopesById: ReadonlyMap<string, LayoutScope>,
+    localLayouts: Map<string, ScopeLayout>,
+    visiting: Set<string>): ScopeLayout {
+    const cached = localLayouts.get(scope.id);
+
+    if (cached != null) return cached;
+
+    if (visiting.has(scope.id)) {
+        const degenerate: ScopeLayout = { width: MINIMUM_SCOPE_WIDTH, height: MINIMUM_SCOPE_HEIGHT, local: new Map() };
+
+        localLayouts.set(scope.id, degenerate);
+
+        return degenerate;
+    }
+
+    visiting.add(scope.id);
+
+    const sizes = new Map<string, { width: number; height: number }>();
+
+    for (const element of scope.elements) {
+        const child = element.childScopeId == null ? null : scopesById.get(element.childScopeId);
+        const fallbackSize = defaultSizeFor(element.elementType);
+
+        sizes.set(element.id, child == null
+            ? fallbackSize
+            : sizeOfChildScope(child, scopesById, localLayouts, visiting, fallbackSize));
+    }
+
+    visiting.delete(scope.id);
+
+    const attached = scope.elements.filter(element => isAttached(element, scope));
+    const attachedIds = new Set(attached.map(element => element.id));
+    const layered = scope.elements.filter(element => !attachedIds.has(element.id));
+    const layerByElementId = assignLayers(layered, scope.flows, attachedIds);
+    const local = new Map<string, LayoutRect>();
+
+    // One column per layer, each as wide as its widest element; elements are centred in their column
+    // and stacked top-down in document order, so the same document always produces the same picture.
+    const layerCount = layered.length === 0
+        ? 0
+        : Math.max(...layered.map(element => layerByElementId.get(element.id) ?? 0)) + 1;
+    const columnWidths: number[] = [];
+    const columnOffsets: number[] = [];
+
+    for (let layer = 0; layer < layerCount; layer++) {
+        const widths = layered
+            .filter(element => (layerByElementId.get(element.id) ?? 0) === layer)
+            .map(element => sizes.get(element.id)!.width);
+
+        columnWidths[layer] = widths.length === 0 ? 0 : Math.max(...widths);
+        columnOffsets[layer] = layer === 0
+            ? PADDING
+            : columnOffsets[layer - 1] + columnWidths[layer - 1] + LAYER_GAP;
+    }
+
+    const nextRowTop: number[] = new Array(layerCount).fill(PADDING);
+
+    for (const element of layered) {
+        const layer = layerByElementId.get(element.id) ?? 0;
+        const size = sizes.get(element.id)!;
+        const x = columnOffsets[layer] + (columnWidths[layer] - size.width) / 2;
+        const y = nextRowTop[layer];
+
+        nextRowTop[layer] = y + size.height + ROW_GAP;
+        local.set(element.id, { x, y, width: size.width, height: size.height });
+    }
+
+    for (const [hostId, events] of groupByHost(attached)) {
+        const host = local.get(hostId);
+
+        if (host == null) continue;
+
+        events.forEach((element, index) => {
+            const size = sizes.get(element.id)!;
+
+            local.set(element.id, {
+                x: host.x + BOUNDARY_INSET + index * BOUNDARY_STEP,
+                y: host.y + host.height - BOUNDARY_OVERLAP,
+                width: size.width,
+                height: size.height,
+            });
+        });
+    }
+
+    const rects = Array.from(local.values());
+    const width = Math.max(MINIMUM_SCOPE_WIDTH, ...rects.map(rect => rect.x + rect.width + PADDING));
+    const height = Math.max(MINIMUM_SCOPE_HEIGHT, ...rects.map(rect => rect.y + rect.height + PADDING));
+    const layout: ScopeLayout = { width, height, local };
+
+    localLayouts.set(scope.id, layout);
+
+    return layout;
+}
+
+function sizeOfChildScope(
+    child: LayoutScope,
+    scopesById: ReadonlyMap<string, LayoutScope>,
+    localLayouts: Map<string, ScopeLayout>,
+    visiting: Set<string>,
+    minimum: { width: number; height: number }): { width: number; height: number } {
+    const childLayout = layoutScope(child, scopesById, localLayouts, visiting);
+
+    return {
+        width: Math.max(minimum.width, childLayout.width),
+        height: Math.max(minimum.height, childLayout.height),
+    };
+}
+
+/**
+ * A boundary event is placed on its host rather than in a layer -- but only when that host is
+ * genuinely in the same scope. One whose `attachedToRef` resolves to nothing is laid out as an
+ * ordinary node, so a broken document still shows the element somewhere findable.
+ */
+function isAttached(element: LayoutElement, scope: LayoutScope): boolean {
+    return element.elementType === BOUNDARY_EVENT_ELEMENT_TYPE
+        && element.attachedToElementId != null
+        && scope.elements.some(candidate => candidate.id === element.attachedToElementId);
+}
+
+function groupByHost(attached: readonly LayoutElement[]): Map<string, LayoutElement[]> {
+    const byHost = new Map<string, LayoutElement[]>();
+
+    for (const element of attached) {
+        const hostId = element.attachedToElementId!;
+        const existing = byHost.get(hostId);
+
+        if (existing == null) byHost.set(hostId, [element]);
+        else existing.push(element);
+    }
+
+    return byHost;
+}
+
+/**
+ * Longest-path layering over the sequence flows, by Kahn's algorithm.
+ *
+ * A BPMN process may legitimately contain a loop, and Kahn's algorithm leaves every node on a cycle
+ * unassigned. Those are then taken in document order and given one more than the deepest layer any
+ * already-placed predecessor reached, which terminates and is stable for a given document -- the
+ * point here is a readable, reproducible picture, not an optimal one.
+ */
+function assignLayers(
+    layered: readonly LayoutElement[],
+    flows: readonly { readonly sourceRef: string; readonly targetRef: string }[],
+    excludedIds: ReadonlySet<string>): Map<string, number> {
+    const ids = new Set(layered.map(element => element.id));
+    const successors = new Map<string, string[]>();
+    const predecessors = new Map<string, string[]>();
+
+    for (const flow of flows) {
+        // A flow out of a boundary event starts at the host's edge, so it says nothing about layers.
+        if (!ids.has(flow.sourceRef) || !ids.has(flow.targetRef) || excludedIds.has(flow.sourceRef)) continue;
+
+        append(successors, flow.sourceRef, flow.targetRef);
+        append(predecessors, flow.targetRef, flow.sourceRef);
+    }
+
+    const layers = new Map<string, number>();
+    const settled = new Set<string>();
+    const remainingPredecessors = new Map<string, number>(
+        layered.map(element => [element.id, (predecessors.get(element.id) ?? []).length]));
+    const queue = layered.filter(element => remainingPredecessors.get(element.id) === 0).map(element => element.id);
+
+    for (let index = 0; index < queue.length; index++) {
+        const id = queue[index];
+        const layer = layers.get(id) ?? 0;
+
+        layers.set(id, layer);
+        settled.add(id);
+
+        for (const successor of successors.get(id) ?? []) {
+            layers.set(successor, Math.max(layers.get(successor) ?? 0, layer + 1));
+
+            const remaining = (remainingPredecessors.get(successor) ?? 0) - 1;
+
+            remainingPredecessors.set(successor, remaining);
+
+            if (remaining === 0) queue.push(successor);
+        }
+    }
+
+    for (const element of layered) {
+        if (settled.has(element.id)) continue;
+
+        const resolved = (predecessors.get(element.id) ?? [])
+            .filter(id => settled.has(id))
+            .map(id => layers.get(id)!);
+
+        layers.set(element.id, resolved.length === 0 ? 0 : Math.max(...resolved) + 1);
+        settled.add(element.id);
+    }
+
+    return layers;
+}
+
+function append(map: Map<string, string[]>, key: string, value: string): void {
+    const existing = map.get(key);
+
+    if (existing == null) map.set(key, [value]);
+    else existing.push(value);
+}
+
+function assignAbsolute(
+    scopeId: string,
+    originX: number,
+    originY: number,
+    scopesById: ReadonlyMap<string, LayoutScope>,
+    localLayouts: ReadonlyMap<string, ScopeLayout>,
+    placements: Map<string, LayoutRect>,
+    visited: Set<string>): void {
+    if (visited.has(scopeId)) return;
+
+    visited.add(scopeId);
+
+    const scope = scopesById.get(scopeId);
+    const layout = localLayouts.get(scopeId);
+
+    if (scope == null || layout == null) return;
+
+    for (const element of scope.elements) {
+        const local = layout.local.get(element.id);
+
+        if (local == null) continue;
+
+        const absolute: LayoutRect = {
+            x: originX + local.x,
+            y: originY + local.y,
+            width: local.width,
+            height: local.height,
+        };
+
+        placements.set(layoutKey(scopeId, element.id), absolute);
+
+        if (element.childScopeId != null) {
+            assignAbsolute(element.childScopeId, absolute.x, absolute.y, scopesById, localLayouts, placements, visited);
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/index.ts
@@ -1,0 +1,51 @@
+/**
+ * The canvas-neutral BPMN view model. See ./README.md.
+ *
+ * This is the only entry point either designer adapter -- or .NET JS interop -- should import from.
+ */
+export { buildBpmnViewModel } from './view-model';
+export {
+    BOUNDARY_EVENT_ELEMENT_TYPE,
+    CALL_ACTIVITY_ELEMENT_TYPE,
+    EVENT_ELEMENT_TYPES,
+    GATEWAY_ELEMENT_TYPES,
+    SUB_PROCESS_ELEMENT_TYPE,
+    TASK_ELEMENT_TYPES,
+    classifyElementType,
+    defaultSizeFor,
+    requiresWorkBinding,
+} from './element-kinds';
+export type {
+    BpmnActivity,
+    BpmnActivityDescriptor,
+    BpmnActivityStats,
+    BpmnBinding,
+    BpmnBindingState,
+    BpmnBoundaryAttachment,
+    BpmnDiagnostic,
+    BpmnDiagnosticCode,
+    BpmnDiagnosticSeverity,
+    BpmnElementKind,
+    BpmnElementStats,
+    BpmnGeometrySource,
+    BpmnLayoutInfo,
+    BpmnRect,
+    BpmnViewAssociation,
+    BpmnViewElement,
+    BpmnViewFlow,
+    BpmnViewLane,
+    BpmnViewModel,
+    BpmnViewModelInput,
+    BpmnViewPool,
+    BpmnViewScope,
+} from './model';
+export type {
+    BpmnBounds,
+    BpmnElement,
+    BpmnEventDefinition,
+    BpmnExtensions,
+    BpmnLoopCharacteristics,
+    BpmnPoint,
+    BpmnProcessDefinition,
+    BpmnSequenceFlow,
+} from './types.generated';

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
@@ -334,6 +334,16 @@ export type BpmnDiagnosticCode =
     | 'unbound-work'
     /** An element declares a binding ref that `workBindings` or `activities` does not resolve. */
     | 'unresolved-binding'
+    /**
+     * An event subprocess declares a listener binding ref that `workBindings` or `activities` does
+     * not resolve.
+     */
+    | 'unresolved-listener-binding'
+    /**
+     * Two different nested processes reuse the same processId; the second, and everything it hosts,
+     * is not shown.
+     */
+    | 'duplicate-process-id'
     /** A sequence flow names a source or target its scope does not contain; the flow is dropped. */
     | 'dangling-flow'
     /** A boundary event names a host its scope does not contain. */

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
@@ -1,0 +1,388 @@
+/**
+ * The canvas-neutral BPMN view model: everything that is true about a BPMN diagram regardless of
+ * who draws it. See ./README.md for the two-input contract and the rules this module works under.
+ *
+ * Everything here is plain, immutable data with no methods, so an X6 adapter, a React Flow adapter
+ * and .NET JS interop can all consume the same value without adapting it first.
+ */
+import type {
+    BpmnBounds,
+    BpmnEventDefinition,
+    BpmnExtensions,
+    BpmnLoopCharacteristics,
+    BpmnPoint,
+    BpmnProcessDefinition,
+} from './types.generated';
+
+// ---------------------------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * The part of an Elsa activity's serialized JSON this module reads.
+ *
+ * An `Elsa.BpmnProcess` activity additionally carries {@link process}, {@link workBindings} and
+ * {@link activities}; every other activity is only ever reached as the target of a work binding,
+ * where its id, type and name are all this module needs. A nested BPMN scope -- an embedded
+ * subprocess or an event subprocess body -- is itself an `Elsa.BpmnProcess` in {@link activities},
+ * which is why this one type describes both.
+ */
+export interface BpmnActivity {
+    readonly id: string;
+    readonly type: string;
+    readonly name?: string | null;
+    readonly version?: number;
+    /** Present when this activity is a BPMN scope. */
+    readonly process?: BpmnProcessDefinition | null;
+    /** Maps each binding ref the scope's definition declares to the id of the activity that runs it. */
+    readonly workBindings?: Readonly<Record<string, string>> | null;
+    /** The activities bound as this scope's work. */
+    readonly activities?: readonly BpmnActivity[] | null;
+}
+
+/**
+ * The activity-descriptor fields needed to name a bound activity.
+ *
+ * Deliberately a structural subset of `Elsa.Studio.Workflows.Designer.Models.ActivityDescriptorDto`
+ * (and of the wider `ActivityDescriptor` the API client exposes) rather than an import of either:
+ * nothing in this module may depend on a canvas package or on the designer's own models.
+ */
+export interface BpmnActivityDescriptor {
+    readonly typeName: string;
+    readonly version?: number;
+    readonly name?: string | null;
+    readonly displayName?: string | null;
+    readonly category?: string | null;
+    readonly description?: string | null;
+    readonly color?: string | null;
+    readonly icon?: string | null;
+}
+
+/**
+ * Execution counters for one Elsa activity, keyed by activity id.
+ *
+ * Mirrors `Elsa.Studio.Workflows.Domain.Models.ActivityStats`, which is what the workflow instance
+ * viewer already fetches. Only *bound* work has one of these, which is exactly why
+ * {@link BpmnElementStats} exists alongside it.
+ */
+export interface BpmnActivityStats {
+    readonly started?: number;
+    readonly completed?: number;
+    readonly uncompleted?: number;
+    readonly blocked?: boolean;
+    readonly faulted?: boolean;
+    readonly metadata?: Readonly<Record<string, unknown>> | null;
+}
+
+/**
+ * Instance state for one BPMN element, keyed by BPMN element id.
+ *
+ * This module never reads a field of this type -- it only keys the map onto elements -- so the
+ * projection that fills it (W13) owns the shape and may widen it without changing anything here.
+ * The fields below are the ones a BPMN overlay needs at minimum; all are optional so that a
+ * projection which cannot compute one says nothing rather than reporting a zero.
+ */
+export interface BpmnElementStats {
+    /** How many tokens have entered this element. */
+    readonly started?: number;
+    /** How many tokens have left it having completed. */
+    readonly completed?: number;
+    /** How many tokens are sitting on it right now (a waiting catch event, an armed listener). */
+    readonly active?: number;
+    /** Whether a token is parked here waiting for something external. */
+    readonly blocked?: boolean;
+    /** Whether execution faulted at this element. */
+    readonly faulted?: boolean;
+    /** Whether a token here was cancelled (an interrupted activity, a lost event race). */
+    readonly canceled?: boolean;
+}
+
+/** Everything {@link buildBpmnViewModel} reads. */
+export interface BpmnViewModelInput {
+    /** The root `Elsa.BpmnProcess` activity JSON, exactly as the workflow definition carries it. */
+    readonly activity: BpmnActivity;
+    /**
+     * The imported BPMN document, from the workflow definition's `CustomProperties["Bpmn:SourceXml"]`.
+     * Read for BPMN DI geometry and collaboration participants only -- never for process structure.
+     * Absent or DI-less source produces a deterministic fallback layout and says so.
+     */
+    readonly sourceXml?: string | null;
+    /** Activity descriptors already loaded by the designer, used to name bound activities. */
+    readonly activityDescriptors?: readonly BpmnActivityDescriptor[] | null;
+    /** Instance state keyed by BPMN element id. */
+    readonly elementStats?: Readonly<Record<string, BpmnElementStats>> | null;
+    /** Instance state keyed by Elsa activity id, resolved onto elements through `workBindings`. */
+    readonly activityStats?: Readonly<Record<string, BpmnActivityStats>> | null;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------------------------
+
+/** Where a piece of geometry came from. */
+export type BpmnGeometrySource = 'document' | 'fallback';
+
+/** A placed rectangle, in the coordinate space of the document's BPMN plane. */
+export interface BpmnRect extends Readonly<BpmnBounds> {
+    readonly source: BpmnGeometrySource;
+}
+
+/** How an element's work is (or is not) bound to an Elsa activity. */
+export type BpmnBindingState =
+    /** The element declares a binding ref and `workBindings` resolves it to an activity. */
+    | 'bound'
+    /** The element needs work performed and declares no binding ref at all. A publish error (W8). */
+    | 'unbound'
+    /** The element declares a binding ref that `workBindings` -- or `activities` -- does not resolve. */
+    | 'unresolved';
+
+/** The bound Elsa activity behind one BPMN element, and how it should be named on the canvas. */
+export interface BpmnBinding {
+    readonly state: BpmnBindingState;
+    /** The binding ref the document declares, or null when the element declares none. */
+    readonly bindingRef: string | null;
+    /** The Elsa activity id `workBindings` maps {@link bindingRef} to. */
+    readonly activityId: string | null;
+    /** The bound activity's type name, e.g. `Elsa.WriteLine`. */
+    readonly activityType: string | null;
+    /** The bound activity's own name, when the author gave it one. */
+    readonly activityName: string | null;
+    /** What to show: the activity's name, else its descriptor's display name, else its type name. */
+    readonly displayName: string | null;
+    /** The descriptor {@link activityType} resolved to, when one was supplied. */
+    readonly descriptor: BpmnActivityDescriptor | null;
+}
+
+/** Which family of BPMN element this is. Refine with {@link BpmnViewElement.elementType}. */
+export type BpmnElementKind = 'event' | 'gateway' | 'task' | 'callActivity' | 'subProcess' | 'unknown';
+
+/** A boundary event's attachment to the activity it is drawn on. */
+export interface BpmnBoundaryAttachment {
+    /** The `attachedToRef` the document declares, resolved or not. */
+    readonly hostElementId: string;
+    /** Whether the host element was actually found in the same scope. */
+    readonly hostResolved: boolean;
+    /**
+     * Whether catching interrupts the host, i.e. `cancelActivity`. Purely what the document says;
+     * what interrupting *does* is the engine's business, not this module's.
+     */
+    readonly interrupting: boolean;
+}
+
+/** One BPMN flow element, in the scope it belongs to. */
+export interface BpmnViewElement {
+    /** The BPMN element id. Unique per document; see the `duplicate-element-id` diagnostic. */
+    readonly id: string;
+    /** The raw BPMN element type, e.g. `serviceTask`, `eventBasedGateway`, `boundaryEvent`. */
+    readonly elementType: string;
+    /** The family {@link elementType} belongs to. */
+    readonly kind: BpmnElementKind;
+    readonly name: string | null;
+    /** The process id of the scope this element lives in. */
+    readonly scopeId: string;
+    /** The subprocess element hosting {@link scopeId} in its parent, or null at the root scope. */
+    readonly parentElementId: string | null;
+    /** For a subprocess/transaction/event subprocess: the process id of the scope it contains. */
+    readonly childScopeId: string | null;
+    /** The lane this element was assigned to, or null. */
+    readonly laneId: string | null;
+    readonly geometry: BpmnRect;
+    readonly labelGeometry: Readonly<BpmnBounds> | null;
+    /** How this element's work resolves, or null for an element that performs no work. */
+    readonly binding: BpmnBinding | null;
+    /**
+     * The listener an event subprocess arms while its enclosing scope runs (`listenerBindingRef`).
+     *
+     * Only an event subprocess has one, and the event it waits for is otherwise invisible on the
+     * canvas: the start event inside the body carries the event definition but no binding of its
+     * own, so this is the only place the armed work appears.
+     */
+    readonly listenerBinding: BpmnBinding | null;
+    /** Instance state keyed by this element's own id. */
+    readonly stats: BpmnElementStats | null;
+    /** Instance state for the bound activity, resolved through `workBindings`. */
+    readonly activityStats: BpmnActivityStats | null;
+    /** Set only on a boundary event. */
+    readonly boundary: BpmnBoundaryAttachment | null;
+    /** The event definitions the document declares, verbatim. */
+    readonly eventDefinitions: readonly BpmnEventDefinition[];
+    /** Multi-instance markers, or null when the element is not multi-instance. */
+    readonly loopCharacteristics: BpmnLoopCharacteristics | null;
+    /** Whether this element is a compensation handler (`isForCompensation`). */
+    readonly isForCompensation: boolean;
+    /** Whether this element is a transaction subprocess. */
+    readonly isTransaction: boolean;
+    /** Whether this subprocess is an event subprocess (`triggeredByEvent`). */
+    readonly isEventSubProcess: boolean;
+    /** The sequence flow taken when no conditional flow out of this gateway matches. */
+    readonly defaultFlowId: string | null;
+    /** Whether the document's DI draws this subprocess expanded. Null when DI says nothing. */
+    readonly isExpanded: boolean | null;
+    /** Whether the document's DI draws the gateway's own marker. Null when DI says nothing. */
+    readonly isMarkerVisible: boolean | null;
+    /** Reader-populated element properties, e.g. `bpmn.calledElement`, `bpmn.messageName`. */
+    readonly properties: Readonly<Record<string, string>>;
+    /** Documentation, extension elements, foreign attributes and children, retained verbatim. */
+    readonly extensions: BpmnExtensions;
+}
+
+/** One sequence flow. */
+export interface BpmnViewFlow {
+    readonly id: string;
+    readonly sourceElementId: string;
+    readonly targetElementId: string;
+    readonly name: string | null;
+    readonly scopeId: string;
+    /** The outcome the source element must produce for this flow to be taken, when conditional. */
+    readonly conditionOutcome: string | null;
+    /** Whether this is the source gateway's default flow. */
+    readonly isDefault: boolean;
+    /** Empty when the document carries no DI edge for this flow; see {@link geometrySource}. */
+    readonly waypoints: readonly BpmnPoint[];
+    readonly geometrySource: BpmnGeometrySource;
+    readonly labelGeometry: Readonly<BpmnBounds> | null;
+    readonly extensions: BpmnExtensions;
+}
+
+/**
+ * The association drawn from a compensation boundary event to the handler activity it triggers.
+ *
+ * The payload records this as `compensationHandlerElementId` on the boundary event, not as an
+ * element with an id of its own, so there is nothing to look a DI edge up by: an association never
+ * carries document waypoints and the adapter routes it. See ./README.md.
+ */
+export interface BpmnViewAssociation {
+    /** The compensation boundary event. */
+    readonly sourceElementId: string;
+    /** The compensation handler activity. */
+    readonly targetElementId: string;
+    readonly scopeId: string;
+    /** Whether {@link targetElementId} was found in the same scope. */
+    readonly targetResolved: boolean;
+}
+
+/** One lane, retained and rendered; this module attaches no meaning to lane membership. */
+export interface BpmnViewLane {
+    readonly id: string;
+    readonly name: string | null;
+    readonly scopeId: string;
+    readonly poolId: string | null;
+    readonly geometry: BpmnRect | null;
+    /** Whether the document's DI draws the lane horizontally. Null when DI says nothing. */
+    readonly isHorizontal: boolean | null;
+    readonly extensions: BpmnExtensions;
+}
+
+/**
+ * One pool (a `participant` on the document's collaboration), retained and rendered.
+ *
+ * Pools are not on the activity payload at all -- the payload's root is a single process -- so a
+ * pool's name and geometry come from the source XML. A pool referenced by a lane in the payload
+ * with no participant in the XML is still reported here, unnamed, so the lane has a parent.
+ */
+export interface BpmnViewPool {
+    readonly id: string;
+    readonly name: string | null;
+    /** The process the participant refers to, when the document says. */
+    readonly processId: string | null;
+    readonly geometry: BpmnRect | null;
+    readonly isHorizontal: boolean | null;
+}
+
+/** One BPMN process scope: the root process, or a subprocess/event subprocess body. */
+export interface BpmnViewScope {
+    /** The process id, which is also {@link BpmnViewElement.scopeId} for its elements. */
+    readonly id: string;
+    readonly name: string | null;
+    readonly isExecutable: boolean;
+    readonly isTransaction: boolean;
+    /** The enclosing scope's process id, or null for the root scope. */
+    readonly parentScopeId: string | null;
+    /** The subprocess element in the parent scope that hosts this one, or null for the root. */
+    readonly hostElementId: string | null;
+    /** The id of the `Elsa.BpmnProcess` activity that runs this scope. */
+    readonly activityId: string;
+    /** How deep this scope sits; 0 for the root. */
+    readonly depth: number;
+}
+
+/** What a diagnostic is about. */
+export type BpmnDiagnosticCode =
+    /** The input activity is not a BPMN scope, so there is nothing to render. */
+    | 'not-a-bpmn-process'
+    /** No source XML was supplied, so the whole diagram is laid out by fallback. */
+    | 'missing-source-xml'
+    /** The source XML could not be parsed as XML. */
+    | 'source-xml-parse-error'
+    /**
+     * The source XML carries no BPMN DI this document can be placed from -- either no diagram
+     * section at all, or one with no shape for any element of this process -- so the layout is a
+     * fallback.
+     */
+    | 'missing-diagram'
+    /** One element has no DI shape; that element alone is placed by fallback. */
+    | 'missing-shape'
+    /** A DI shape names an element, lane or pool this document does not have. */
+    | 'unresolved-di-shape'
+    /** A DI edge names a flow this document does not have. */
+    | 'unresolved-di-edge'
+    /** Two DI shapes claim the same element id; the first is used. */
+    | 'duplicate-di-shape'
+    /** Two elements in this document share an id. */
+    | 'duplicate-element-id'
+    /** An element that needs work performed declares no binding ref. A publish error (W8). */
+    | 'unbound-work'
+    /** An element declares a binding ref that `workBindings` or `activities` does not resolve. */
+    | 'unresolved-binding'
+    /** A sequence flow names a source or target its scope does not contain; the flow is dropped. */
+    | 'dangling-flow'
+    /** A boundary event names a host its scope does not contain. */
+    | 'unresolved-boundary-host'
+    /** A compensation boundary event names a handler its scope does not contain. */
+    | 'unresolved-compensation-handler'
+    /** A lane names a pool the document's collaboration does not declare. */
+    | 'unresolved-pool';
+
+export type BpmnDiagnosticSeverity = 'info' | 'warning' | 'error';
+
+/** One thing worth telling the user about the document, in document order. */
+export interface BpmnDiagnostic {
+    readonly code: BpmnDiagnosticCode;
+    readonly severity: BpmnDiagnosticSeverity;
+    readonly message: string;
+    readonly elementId: string | null;
+    readonly scopeId: string | null;
+}
+
+/** Where the diagram's coordinates came from, as a whole. */
+export interface BpmnLayoutInfo {
+    /**
+     * `'document'` when at least one element was placed from BPMN DI, `'fallback'` when none was.
+     * A document that places some but not all elements stays `'document'` and reports a
+     * `missing-shape` diagnostic per element; check {@link BpmnViewElement.geometry}`.source` to
+     * tell the two apart per element.
+     */
+    readonly source: BpmnGeometrySource;
+    /** Why the layout fell back, or null when it did not. */
+    readonly reason: string | null;
+}
+
+/** The whole diagram, canvas-neutral. */
+export interface BpmnViewModel {
+    /** The root scope's process id. */
+    readonly processId: string;
+    readonly name: string | null;
+    readonly isExecutable: boolean;
+    /** The root scope first, then nested scopes in depth-first document order. */
+    readonly scopes: readonly BpmnViewScope[];
+    /** Every element of every scope, in scope order then document order. */
+    readonly elements: readonly BpmnViewElement[];
+    /** Every drawable sequence flow. A flow with a dangling endpoint is reported, not listed. */
+    readonly flows: readonly BpmnViewFlow[];
+    /** Compensation boundary event to compensation handler associations. */
+    readonly associations: readonly BpmnViewAssociation[];
+    readonly lanes: readonly BpmnViewLane[];
+    readonly pools: readonly BpmnViewPool[];
+    readonly layout: BpmnLayoutInfo;
+    readonly diagnostics: readonly BpmnDiagnostic[];
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
@@ -1,0 +1,638 @@
+/**
+ * Builds the canvas-neutral BPMN view model. See ./README.md for the two-input contract.
+ *
+ * The rule this file works under: it renders what the document says and what the instance overlay
+ * reports, and decides nothing. Which flow a gateway takes, whether a join may fire, what a boundary
+ * event interrupts -- none of that is here. The one place it *does* form an opinion is geometry, and
+ * only when the document supplies none: see ./fallback-layout.ts, which always says so.
+ *
+ * Nothing here mutates its input and nothing here writes a document back. D4 keeps the whole
+ * document on the client; whatever edits it (W11, W14) edits it in place and sends the whole thing.
+ */
+import { readDiagramInterchange, type BpmnDiagramInterchange, type DiBounds } from './di-reader';
+import {
+    BOUNDARY_EVENT_ELEMENT_TYPE,
+    classifyElementType,
+    requiresWorkBinding,
+} from './element-kinds';
+import { computeFallbackLayout, layoutKey, type LayoutRect, type LayoutScope } from './fallback-layout';
+import type {
+    BpmnActivity,
+    BpmnActivityDescriptor,
+    BpmnBinding,
+    BpmnBoundaryAttachment,
+    BpmnDiagnostic,
+    BpmnDiagnosticCode,
+    BpmnDiagnosticSeverity,
+    BpmnRect,
+    BpmnViewAssociation,
+    BpmnViewElement,
+    BpmnViewFlow,
+    BpmnViewLane,
+    BpmnViewModel,
+    BpmnViewModelInput,
+    BpmnViewPool,
+    BpmnViewScope,
+} from './model';
+import type { BpmnBounds, BpmnElement, BpmnEventDefinition, BpmnExtensions, BpmnProcessDefinition } from './types.generated';
+
+/**
+ * The collections the payload always carries, defaulted for the one caller that might not.
+ *
+ * `buildBpmnViewModel` sits on a JS interop boundary: what arrives is `JSON.parse` output, not a
+ * value TypeScript has checked, and W11/W14 edit that document in place before sending it back
+ * whole. A newly added element that has not yet grown an `extensions` object should render as an
+ * element with nothing on it, not take the designer down inside whichever consumer dereferences it
+ * first.
+ */
+const EMPTY_EXTENSIONS: BpmnExtensions = {
+    documentation: [],
+    extensionElements: [],
+    foreignAttributes: [],
+    foreignChildren: [],
+};
+
+const EMPTY_EVENT_DEFINITIONS: readonly BpmnEventDefinition[] = [];
+
+/**
+ * Reads an `Elsa.BpmnProcess` activity payload, and optionally the BPMN document it was imported
+ * from, into one immutable description of the diagram.
+ *
+ * Never throws on a malformed input. A document Studio cannot render is reported through
+ * {@link BpmnViewModel.diagnostics} and produces an empty-but-valid view model, because the caller
+ * is a designer component: a diagnostic it can put on screen is worth more than an exception that
+ * takes the circuit down.
+ */
+export function buildBpmnViewModel(input: BpmnViewModelInput): BpmnViewModel {
+    const diagnostics: BpmnDiagnostic[] = [];
+    const report = (
+        code: BpmnDiagnosticCode,
+        severity: BpmnDiagnosticSeverity,
+        message: string,
+        elementId: string | null = null,
+        scopeId: string | null = null) => diagnostics.push({ code, severity, message, elementId, scopeId });
+
+    const rootProcess = input.activity?.process;
+
+    if (rootProcess == null || typeof rootProcess.processId !== 'string') {
+        report(
+            'not-a-bpmn-process',
+            'error',
+            `The activity '${input.activity?.id ?? '(none)'}' of type '${input.activity?.type ?? '(none)'}' carries no BPMN process, so there is no diagram to show.`);
+
+        return emptyViewModel(diagnostics);
+    }
+
+    const scopes = collectScopes(input.activity, rootProcess);
+    const diagram = readDiagramInterchange(input.sourceXml);
+
+    for (const duplicate of diagram.duplicateShapeIds) {
+        report('duplicate-di-shape', 'warning', `More than one BPMNShape draws '${duplicate}'; the first one in the document is used.`, duplicate);
+    }
+
+    const descriptorsByType = indexDescriptors(input.activityDescriptors);
+    const placements = resolvePlacements(scopes, diagram);
+    const elements: BpmnViewElement[] = [];
+    const flows: BpmnViewFlow[] = [];
+    const associations: BpmnViewAssociation[] = [];
+    const lanes: BpmnViewLane[] = [];
+    const seenElementIds = new Map<string, string>();
+
+    for (const scope of scopes) {
+        const scopeElements = scope.definition.elements ?? [];
+        const elementsById = new Map(scopeElements.map(element => [element.elementId, element]));
+
+        for (const element of scopeElements) {
+            const alreadySeenInScope = seenElementIds.get(element.elementId);
+
+            if (alreadySeenInScope != null) {
+                report(
+                    'duplicate-element-id',
+                    'error',
+                    `The element id '${element.elementId}' is used ${alreadySeenInScope === scope.id
+                        ? `twice in scope '${scope.id}'`
+                        : `both in scope '${alreadySeenInScope}' and in scope '${scope.id}'`}. Anything keyed by element id -- instance state above all -- cannot tell the two apart.`,
+                    element.elementId,
+                    scope.id);
+            } else {
+                seenElementIds.set(element.elementId, scope.id);
+            }
+
+            elements.push(buildElement(element, scope, elementsById, placements, diagram, descriptorsByType, input, report));
+
+            if (element.compensationHandlerElementId != null) {
+                const targetResolved = elementsById.has(element.compensationHandlerElementId);
+
+                if (!targetResolved) {
+                    report(
+                        'unresolved-compensation-handler',
+                        'error',
+                        `The compensation boundary event '${element.elementId}' names the handler '${element.compensationHandlerElementId}', which is not in scope '${scope.id}'.`,
+                        element.elementId,
+                        scope.id);
+                }
+
+                associations.push({
+                    sourceElementId: element.elementId,
+                    targetElementId: element.compensationHandlerElementId,
+                    scopeId: scope.id,
+                    targetResolved,
+                });
+            }
+        }
+
+        for (const flow of scope.definition.sequenceFlows ?? []) {
+            const source = elementsById.get(flow.sourceRef);
+            const target = elementsById.get(flow.targetRef);
+
+            if (source == null || target == null) {
+                report(
+                    'dangling-flow',
+                    'error',
+                    `The sequence flow '${flow.flowId}' of scope '${scope.id}' runs from '${flow.sourceRef}' to '${flow.targetRef}', and ${source == null ? `'${flow.sourceRef}'` : `'${flow.targetRef}'`} is not an element of that scope. The flow is not drawn.`,
+                    flow.flowId,
+                    scope.id);
+
+                continue;
+            }
+
+            const edge = diagram.edges.get(flow.flowId);
+
+            flows.push({
+                id: flow.flowId,
+                sourceElementId: flow.sourceRef,
+                targetElementId: flow.targetRef,
+                name: flow.name ?? null,
+                scopeId: scope.id,
+                conditionOutcome: flow.conditionOutcome ?? null,
+                // The reader records a gateway's default flow on the gateway, and the flag on the flow
+                // is only set by documents that say it there instead; honour both so neither
+                // representation of the same fact goes missing.
+                isDefault: flow.isDefault === true || source.defaultFlowId === flow.flowId,
+                waypoints: edge?.waypoints ?? [],
+                geometrySource: edge != null && edge.waypoints.length > 0 ? 'document' : 'fallback',
+                labelGeometry: toBounds(edge?.labelBounds ?? null),
+                extensions: flow.extensions ?? EMPTY_EXTENSIONS,
+            });
+        }
+
+        for (const lane of scope.definition.lanes ?? []) {
+            const shape = diagram.shapes.get(lane.laneId);
+
+            lanes.push({
+                id: lane.laneId,
+                name: lane.name ?? null,
+                scopeId: scope.id,
+                poolId: lane.poolId ?? null,
+                geometry: shape == null ? null : { ...shape.bounds, source: 'document' },
+                isHorizontal: shape?.isHorizontal ?? null,
+                extensions: lane.extensions ?? EMPTY_EXTENSIONS,
+            });
+        }
+    }
+
+    const pools = buildPools(lanes, diagram, report);
+    const usesDocumentGeometry = elements.some(element => element.geometry.source === 'document');
+    const reason = fallbackReason(input, diagram);
+
+    // One decision, made where the answer is finally known, so the diagnostic a user reads and the
+    // `layout.reason` an adapter surfaces can never say different things. A parse failure is
+    // reported even for a process with nothing in it, because it is a fault in the input rather
+    // than a description of the diagram; the other two are not, since "nothing was placed" is not
+    // news about a process with nothing to place.
+    if (diagram.parseError != null) {
+        report('source-xml-parse-error', 'error', reason);
+    } else if (!usesDocumentGeometry && elements.length > 0) {
+        report(
+            input.sourceXml == null || input.sourceXml.trim().length === 0 ? 'missing-source-xml' : 'missing-diagram',
+            'warning',
+            reason);
+    }
+
+    for (const element of elements) {
+        if (element.geometry.source === 'document' || !usesDocumentGeometry) continue;
+
+        report(
+            'missing-shape',
+            'warning',
+            `The BPMN source carries a diagram but no BPMNShape for '${element.id}', so that element alone is placed by fallback and may overlap the rest.`,
+            element.id,
+            element.scopeId);
+    }
+
+    reportUnresolvedDiagramReferences(diagram, elements, lanes, pools, flows, report);
+
+    return {
+        processId: rootProcess.processId,
+        name: rootProcess.name ?? null,
+        isExecutable: rootProcess.isExecutable === true,
+        scopes: scopes.map(scope => scope.view),
+        elements,
+        flows,
+        associations,
+        lanes,
+        pools,
+        layout: usesDocumentGeometry
+            ? { source: 'document', reason: null }
+            : { source: 'fallback', reason },
+        diagnostics,
+    };
+}
+
+type Report = (
+    code: BpmnDiagnosticCode,
+    severity: BpmnDiagnosticSeverity,
+    message: string,
+    elementId?: string | null,
+    scopeId?: string | null) => void;
+
+interface ScopeNode {
+    readonly id: string;
+    readonly definition: BpmnProcessDefinition;
+    readonly workBindings: Readonly<Record<string, string>>;
+    readonly activitiesById: ReadonlyMap<string, BpmnActivity>;
+    /** The process id of the scope a given element hosts, for the elements that host one. */
+    readonly childScopeByElementId: ReadonlyMap<string, string>;
+    readonly view: BpmnViewScope;
+}
+
+/**
+ * Walks the activity tree into a flat, depth-first list of scopes.
+ *
+ * A nested BPMN scope is an `Elsa.BpmnProcess` bound as its host element's work, so the scope
+ * hierarchy is exactly the activity hierarchy. `visited` closes the one way that could not
+ * terminate: an activity graph that -- through a hand-edited payload -- reaches the same scope
+ * twice.
+ */
+function collectScopes(rootActivity: BpmnActivity, rootProcess: BpmnProcessDefinition): ScopeNode[] {
+    const scopes: ScopeNode[] = [];
+    const visited = new Set<string>();
+
+    const walk = (
+        activity: BpmnActivity,
+        definition: BpmnProcessDefinition,
+        parentScopeId: string | null,
+        hostElementId: string | null,
+        depth: number): void => {
+        if (visited.has(definition.processId)) return;
+
+        visited.add(definition.processId);
+
+        const workBindings = activity.workBindings ?? {};
+        const activitiesById = new Map((activity.activities ?? []).map(child => [child.id, child]));
+        const childScopeByElementId = new Map<string, string>();
+        const nested: { element: BpmnElement; activity: BpmnActivity; process: BpmnProcessDefinition }[] = [];
+
+        for (const element of definition.elements ?? []) {
+            const boundActivityId = element.bindingRef == null ? null : workBindings[element.bindingRef] ?? null;
+            const bound = boundActivityId == null ? null : activitiesById.get(boundActivityId) ?? null;
+
+            if (bound?.process == null || typeof bound.process.processId !== 'string') continue;
+
+            childScopeByElementId.set(element.elementId, bound.process.processId);
+            nested.push({ element, activity: bound, process: bound.process });
+        }
+
+        scopes.push({
+            id: definition.processId,
+            definition,
+            workBindings,
+            activitiesById,
+            childScopeByElementId,
+            view: {
+                id: definition.processId,
+                name: definition.name ?? null,
+                isExecutable: definition.isExecutable === true,
+                isTransaction: definition.isTransaction === true,
+                parentScopeId,
+                hostElementId,
+                activityId: activity.id,
+                depth,
+            },
+        });
+
+        for (const child of nested) {
+            walk(child.activity, child.process, definition.processId, child.element.elementId, depth + 1);
+        }
+    };
+
+    walk(rootActivity, rootProcess, null, null, 0);
+
+    return scopes;
+}
+
+/**
+ * Resolves every element to a rectangle, preferring the document's own DI shape and falling back to
+ * a computed placement only for the elements no shape covers.
+ *
+ * The fallback is computed for the whole document as soon as *any* element needs it, so that a
+ * document with partial DI still places its unplaced elements relative to each other rather than
+ * one at a time on top of one another. Those elements are individually reported as `missing-shape`.
+ */
+function resolvePlacements(scopes: readonly ScopeNode[], diagram: BpmnDiagramInterchange): Map<string, BpmnRect> {
+    const placements = new Map<string, BpmnRect>();
+    const missing: { scopeId: string; elementId: string }[] = [];
+
+    for (const scope of scopes) {
+        for (const element of scope.definition.elements ?? []) {
+            const shape = diagram.shapes.get(element.elementId);
+
+            if (shape == null) missing.push({ scopeId: scope.id, elementId: element.elementId });
+            else placements.set(layoutKey(scope.id, element.elementId), { ...shape.bounds, source: 'document' });
+        }
+    }
+
+    if (missing.length === 0) return placements;
+
+    const fallback = computeFallbackLayout(scopes.map(toLayoutScope), scopes[0].id);
+
+    for (const { scopeId, elementId } of missing) {
+        const key = layoutKey(scopeId, elementId);
+        const rect: LayoutRect = fallback.get(key) ?? { x: 0, y: 0, width: 100, height: 80 };
+
+        placements.set(key, { ...rect, source: 'fallback' });
+    }
+
+    return placements;
+}
+
+function toLayoutScope(scope: ScopeNode): LayoutScope {
+    return {
+        id: scope.id,
+        elements: (scope.definition.elements ?? []).map(element => ({
+            id: element.elementId,
+            elementType: element.elementType,
+            attachedToElementId: element.attachedToRef ?? null,
+            childScopeId: scope.childScopeByElementId.get(element.elementId) ?? null,
+        })),
+        flows: (scope.definition.sequenceFlows ?? []).map(flow => ({ sourceRef: flow.sourceRef, targetRef: flow.targetRef })),
+    };
+}
+
+function buildElement(
+    element: BpmnElement,
+    scope: ScopeNode,
+    elementsById: ReadonlyMap<string, BpmnElement>,
+    placements: ReadonlyMap<string, BpmnRect>,
+    diagram: BpmnDiagramInterchange,
+    descriptorsByType: ReadonlyMap<string, BpmnActivityDescriptor>,
+    input: BpmnViewModelInput,
+    report: Report): BpmnViewElement {
+    const shape = diagram.shapes.get(element.elementId);
+    const binding = resolveBinding(element.bindingRef ?? null, element.elementType, scope, descriptorsByType);
+    const listenerBinding = element.listenerBindingRef == null
+        ? null
+        : resolveBinding(element.listenerBindingRef, element.elementType, scope, descriptorsByType);
+
+    if (binding?.state === 'unbound') {
+        report(
+            'unbound-work',
+            'warning',
+            `The ${element.elementType} '${element.name ?? element.elementId}' says what it is for but not how to perform it, and nothing binds it to an Elsa activity. The workflow cannot be published until it does.`,
+            element.elementId,
+            scope.id);
+    } else if (binding?.state === 'unresolved') {
+        report(
+            'unresolved-binding',
+            'error',
+            `The ${element.elementType} '${element.name ?? element.elementId}' declares the binding ref '${element.bindingRef}', which scope '${scope.id}' does not map to an activity it carries.`,
+            element.elementId,
+            scope.id);
+    }
+
+    let boundary: BpmnBoundaryAttachment | null = null;
+
+    if (element.elementType === BOUNDARY_EVENT_ELEMENT_TYPE && element.attachedToRef != null) {
+        const hostResolved = elementsById.has(element.attachedToRef);
+
+        if (!hostResolved) {
+            report(
+                'unresolved-boundary-host',
+                'error',
+                `The boundary event '${element.elementId}' is attached to '${element.attachedToRef}', which is not an element of scope '${scope.id}'.`,
+                element.elementId,
+                scope.id);
+        }
+
+        boundary = { hostElementId: element.attachedToRef, hostResolved, interrupting: element.cancelActivity === true };
+    }
+
+    const activityId = binding?.activityId ?? null;
+
+    return {
+        id: element.elementId,
+        elementType: element.elementType,
+        kind: classifyElementType(element.elementType),
+        name: element.name ?? null,
+        scopeId: scope.id,
+        parentElementId: scope.view.hostElementId,
+        childScopeId: scope.childScopeByElementId.get(element.elementId) ?? null,
+        laneId: element.laneId ?? null,
+        geometry: placements.get(layoutKey(scope.id, element.elementId))
+            ?? { x: 0, y: 0, width: 100, height: 80, source: 'fallback' },
+        labelGeometry: toBounds(shape?.labelBounds ?? null),
+        binding,
+        listenerBinding,
+        stats: input.elementStats?.[element.elementId] ?? null,
+        activityStats: activityId == null ? null : input.activityStats?.[activityId] ?? null,
+        boundary,
+        eventDefinitions: element.eventDefinitions ?? EMPTY_EVENT_DEFINITIONS,
+        loopCharacteristics: element.loopCharacteristics ?? null,
+        isForCompensation: element.isForCompensation === true,
+        isTransaction: element.isTransaction === true,
+        isEventSubProcess: element.triggeredByEvent === true,
+        defaultFlowId: element.defaultFlowId ?? null,
+        isExpanded: shape?.isExpanded ?? null,
+        isMarkerVisible: shape?.isMarkerVisible ?? null,
+        properties: element.properties ?? {},
+        extensions: element.extensions ?? EMPTY_EXTENSIONS,
+    };
+}
+
+/**
+ * Resolves one binding ref through `workBindings` and the scope's own activities.
+ *
+ * Returns null only for an element that declares no binding ref *and* needs none. An element that
+ * needs work performed and declares none is reported as `'unbound'` rather than as nothing: W8
+ * makes that a publish error, so it has to be a state the canvas can show, not an absence.
+ */
+function resolveBinding(
+    bindingRef: string | null,
+    elementType: string,
+    scope: ScopeNode,
+    descriptorsByType: ReadonlyMap<string, BpmnActivityDescriptor>): BpmnBinding | null {
+    if (bindingRef == null) {
+        if (!requiresWorkBinding(elementType)) return null;
+
+        return {
+            state: 'unbound',
+            bindingRef: null,
+            activityId: null,
+            activityType: null,
+            activityName: null,
+            displayName: null,
+            descriptor: null,
+        };
+    }
+
+    const activityId = scope.workBindings[bindingRef] ?? null;
+    const activity = activityId == null ? null : scope.activitiesById.get(activityId) ?? null;
+
+    if (activity == null) {
+        return {
+            state: 'unresolved',
+            bindingRef,
+            activityId,
+            activityType: null,
+            activityName: null,
+            displayName: null,
+            descriptor: null,
+        };
+    }
+
+    const descriptor = descriptorsByType.get(activity.type) ?? null;
+    const activityName = emptyToNull(activity.name);
+
+    return {
+        state: 'bound',
+        bindingRef,
+        activityId,
+        activityType: activity.type,
+        activityName,
+        displayName: activityName ?? emptyToNull(descriptor?.displayName) ?? activity.type,
+        descriptor,
+    };
+}
+
+/**
+ * The pools a lane can belong to, from the source document's collaboration.
+ *
+ * A pool is not on the activity payload -- its root is a single process -- so a document Studio has
+ * no source XML for has no pool names. A lane that names a pool nothing declares still gets one
+ * here, unnamed and ungeometried, so the lane has somewhere to hang: dropping it would make the
+ * lane look like it belongs to the process itself, which is a different picture.
+ */
+function buildPools(
+    lanes: readonly BpmnViewLane[],
+    diagram: BpmnDiagramInterchange,
+    report: Report): BpmnViewPool[] {
+    const pools: BpmnViewPool[] = [];
+    const declared = new Set<string>();
+
+    for (const participant of diagram.participants) {
+        const shape = diagram.shapes.get(participant.id);
+
+        declared.add(participant.id);
+        pools.push({
+            id: participant.id,
+            name: participant.name,
+            processId: participant.processId,
+            geometry: shape == null ? null : { ...shape.bounds, source: 'document' },
+            isHorizontal: shape?.isHorizontal ?? null,
+        });
+    }
+
+    for (const lane of lanes) {
+        if (lane.poolId == null || declared.has(lane.poolId)) continue;
+
+        declared.add(lane.poolId);
+        pools.push({ id: lane.poolId, name: null, processId: null, geometry: null, isHorizontal: null });
+        report(
+            'unresolved-pool',
+            'info',
+            `The lane '${lane.id}' belongs to the pool '${lane.poolId}', which the stored BPMN source does not declare as a participant, so the pool is drawn without a name.`,
+            lane.id,
+            lane.scopeId);
+    }
+
+    return pools;
+}
+
+/**
+ * Reports DI that draws something this document does not have.
+ *
+ * A BPMN document legitimately carries DI for things the payload does not model -- text
+ * annotations, data objects, and the association edge between a compensation boundary event and its
+ * handler, which the payload records as a property rather than as an element with an id. So an
+ * unresolved shape or edge is reported as information, not as a defect: the point is that the
+ * fixture tests can assert every shape resolves for the documents where it should, and that a
+ * reader change which starts silently dropping elements shows up here rather than nowhere.
+ */
+function reportUnresolvedDiagramReferences(
+    diagram: BpmnDiagramInterchange,
+    elements: readonly BpmnViewElement[],
+    lanes: readonly BpmnViewLane[],
+    pools: readonly BpmnViewPool[],
+    flows: readonly BpmnViewFlow[],
+    report: Report): void {
+    const drawable = new Set<string>([
+        ...elements.map(element => element.id),
+        ...lanes.map(lane => lane.id),
+        ...pools.map(pool => pool.id),
+    ]);
+    const drawableFlows = new Set(flows.map(flow => flow.id));
+
+    for (const shape of diagram.shapes.values()) {
+        if (drawable.has(shape.elementId)) continue;
+
+        report('unresolved-di-shape', 'info', `The BPMN source draws a shape for '${shape.elementId}', which is not an element, lane or pool of this process.`, shape.elementId);
+    }
+
+    for (const edge of diagram.edges.values()) {
+        if (drawableFlows.has(edge.elementId)) continue;
+
+        report('unresolved-di-edge', 'info', `The BPMN source draws an edge for '${edge.elementId}', which is not a sequence flow of this process.`, edge.elementId);
+    }
+}
+
+/** Why a diagram would be laid out by fallback -- used both as `layout.reason` and as a diagnostic. */
+function fallbackReason(input: BpmnViewModelInput, diagram: BpmnDiagramInterchange): string {
+    const consequence = 'so the diagram is laid out by fallback rather than by the coordinates its author chose.';
+
+    if (diagram.parseError != null) return `The stored BPMN source could not be parsed as XML (${diagram.parseError}), ${consequence}`;
+    if (input.sourceXml == null || input.sourceXml.trim().length === 0) return `This workflow definition carries no BPMN source document, ${consequence}`;
+    if (!diagram.hasDiagram) return `The stored BPMN source carries no BPMNDI diagram section, ${consequence}`;
+
+    return `The stored BPMN source carries a diagram, but no BPMNShape for any element of this process, ${consequence}`;
+}
+
+function indexDescriptors(
+    descriptors: readonly BpmnActivityDescriptor[] | null | undefined): ReadonlyMap<string, BpmnActivityDescriptor> {
+    const byType = new Map<string, BpmnActivityDescriptor>();
+
+    for (const descriptor of descriptors ?? []) {
+        if (descriptor?.typeName == null) continue;
+
+        const existing = byType.get(descriptor.typeName);
+
+        // The catalogue can carry several versions of one activity type; the highest wins, which is
+        // the one the designer would place.
+        if (existing == null || (descriptor.version ?? 0) >= (existing.version ?? 0)) byType.set(descriptor.typeName, descriptor);
+    }
+
+    return byType;
+}
+
+function toBounds(bounds: DiBounds | null): Readonly<BpmnBounds> | null {
+    return bounds == null ? null : { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height };
+}
+
+function emptyToNull(value: string | null | undefined): string | null {
+    return value == null || value.trim().length === 0 ? null : value;
+}
+
+function emptyViewModel(diagnostics: readonly BpmnDiagnostic[]): BpmnViewModel {
+    return {
+        processId: '',
+        name: null,
+        isExecutable: false,
+        scopes: [],
+        elements: [],
+        flows: [],
+        associations: [],
+        lanes: [],
+        pools: [],
+        layout: { source: 'fallback', reason: 'There is no BPMN process to lay out.' },
+        diagnostics,
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
@@ -83,7 +83,7 @@ export function buildBpmnViewModel(input: BpmnViewModelInput): BpmnViewModel {
         return emptyViewModel(diagnostics);
     }
 
-    const scopes = collectScopes(input.activity, rootProcess);
+    const scopes = collectScopes(input.activity, rootProcess, report);
     const diagram = readDiagramInterchange(input.sourceXml);
 
     for (const duplicate of diagram.duplicateShapeIds) {
@@ -261,12 +261,15 @@ interface ScopeNode {
  *
  * A nested BPMN scope is an `Elsa.BpmnProcess` bound as its host element's work, so the scope
  * hierarchy is exactly the activity hierarchy. `visited` closes the one way that could not
- * terminate: an activity graph that -- through a hand-edited payload -- reaches the same scope
- * twice.
+ * terminate: an activity graph that -- through a hand-edited payload -- reaches the very same
+ * payload object twice. A *different* payload object that happens to carry a processId already
+ * seen is not a cycle but a malformed document -- two distinct nested processes cannot share an
+ * id, since everything keyed by it (this map, instance state) could only ever mean one of them --
+ * so that case is reported and stopped, rather than silently treated the same as a cycle.
  */
-function collectScopes(rootActivity: BpmnActivity, rootProcess: BpmnProcessDefinition): ScopeNode[] {
+function collectScopes(rootActivity: BpmnActivity, rootProcess: BpmnProcessDefinition, report: Report): ScopeNode[] {
     const scopes: ScopeNode[] = [];
-    const visited = new Set<string>();
+    const visited = new Map<string, { readonly definition: BpmnProcessDefinition; readonly activityId: string }>();
 
     const walk = (
         activity: BpmnActivity,
@@ -274,9 +277,22 @@ function collectScopes(rootActivity: BpmnActivity, rootProcess: BpmnProcessDefin
         parentScopeId: string | null,
         hostElementId: string | null,
         depth: number): void => {
-        if (visited.has(definition.processId)) return;
+        const seen = visited.get(definition.processId);
 
-        visited.add(definition.processId);
+        if (seen != null) {
+            if (seen.definition !== definition) {
+                report(
+                    'duplicate-process-id',
+                    'error',
+                    `The processId '${definition.processId}' is used by two different nested BPMN processes, hosted by the activities '${seen.activityId}' and '${activity.id}'. Instance state and the scope hierarchy cannot tell the two apart, so only the first is shown.`,
+                    hostElementId,
+                    parentScopeId);
+            }
+
+            return;
+        }
+
+        visited.set(definition.processId, { definition, activityId: activity.id });
 
         const workBindings = activity.workBindings ?? {};
         const activitiesById = new Map((activity.activities ?? []).map(child => [child.id, child]));
@@ -396,6 +412,15 @@ function buildElement(
             'unresolved-binding',
             'error',
             `The ${element.elementType} '${element.name ?? element.elementId}' declares the binding ref '${element.bindingRef}', which scope '${scope.id}' does not map to an activity it carries.`,
+            element.elementId,
+            scope.id);
+    }
+
+    if (listenerBinding?.state === 'unresolved') {
+        report(
+            'unresolved-listener-binding',
+            'error',
+            `The event subprocess '${element.name ?? element.elementId}' declares the listener binding ref '${element.listenerBindingRef}', which scope '${scope.id}' does not map to an activity it carries.`,
             element.elementId,
             scope.id);
     }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
@@ -1,16 +1,24 @@
 import { defineConfig } from 'vitest/config';
 
-// There is no runtime test suite here (yet): the one thing this package needs verified is that
-// src/bpmn/types.generated.ts actually describes the JSON Elsa's activity serializer produces for a
-// real BpmnProcess.Process value. That is a compile-time question, so it is asked with a `.test-d.ts`
-// file and Vitest's typecheck mode rather than a runtime assertion -- see
-// src/bpmn/__tests__/process-payload.test-d.ts.
+// Two suites, both under src/bpmn:
+//
+//  - `*.test.ts`, run in a jsdom environment. src/bpmn/di-reader.ts parses BPMN DI with the platform
+//    `DOMParser`, which is what the browser gives it at runtime; jsdom is the one test environment
+//    that provides the same API with real XML namespace support, so the reader under test is the
+//    reader that ships rather than an injected stand-in.
+//  - `*.test-d.ts`, run by Vitest's typecheck mode. Whether src/bpmn/types.generated.ts still
+//    describes the JSON Elsa's activity serializer produces is a compile-time question, so it is
+//    asked with a type-level assertion rather than a runtime one -- see
+//    src/bpmn/__tests__/process-payload.test-d.ts.
+//
+// The designer and react-designer bundles have no test suite; they are covered by the .NET side.
 export default defineConfig({
-  test: {
-    include: [],
-    typecheck: {
-      enabled: true,
-      include: ['src/**/*.test-d.ts'],
+    test: {
+        environment: 'jsdom',
+        include: ['src/**/*.test.ts'],
+        typecheck: {
+            enabled: true,
+            include: ['src/**/*.test-d.ts'],
+        },
     },
-  },
 });


### PR DESCRIPTION
Closes #1005. Part of elsa-workflows/elsa-core#7909 (W9a). Depends on #1008 (W12), merged.

## What changed

A new pure-TypeScript module, `src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/`, holding everything that is true about a BPMN diagram regardless of which canvas draws it. The X6 adapter (W9c) and a later React Flow adapter (W9b) consume it and stay thin.

`buildBpmnViewModel({ activity, sourceXml?, activityDescriptors?, elementStats?, activityStats? })` returns one immutable, method-free description of the diagram:

- **Structure and bindings** from the `Elsa.BpmnProcess` activity JSON (`process`, `workBindings`, `activities`, nested scopes), typed by the generated types from W12. Every element kind the library models is classified in `element-kinds.ts`: all eight task kinds, `callActivity`, embedded, event and transaction subprocesses, the four gateways, start/intermediate/end events with their event definitions, boundary events with `cancelActivity`, lanes, compensation handlers and their associations.
- **Geometry** from BPMN DI. DI is not on the activity payload (in the schema it hangs off `bpmnDefinitions.diagrams`), so the second input is the imported document's XML, which elsa-core stores on the definition's `Bpmn:SourceXml` custom property. `di-reader.ts` reads only `BPMNShape`/`BPMNEdge`/`BPMNLabel`/`dc:Bounds`/`di:waypoint` and `collaboration/participant` names, namespace-URI matched, never structure, so it is not a second BPMN reader. Without DI the module produces a deterministic fallback layout and says so (`layout.source: 'fallback'` plus a reason that is also a diagnostic); it never passes invented coordinates off as the author's.
- **Binding display** resolved through `workBindings` and activity descriptors, with explicit `bound` / `unbound` / `unresolved` states, since an unbound task is a publish error (W8).
- **Stats** keyed both by activity id (`ActivityStats`, bound work only) and by BPMN element id (the projection W13 fills in, so gateways and events can light up).
- **Diagnostics** for everything it cannot resolve (flow endpoints, boundary hosts, compensation handlers, binding refs, duplicate ids, DI for a different process). Nothing is dropped silently.

Canvas neutrality is enforced by a test that scans `src/bpmn` for imports of `@antv/x6`, `@xyflow/react`, `react`, `src/designer` or `src/react-designer`.

## Fixtures

Seven `.bpmn` + `.activity.json` pairs under `__fixtures__/`, each captured by running elsa-core's own `BpmnInterchangeDocumentService.ImportAsync` and lifting the root activity JSON, so the tests see exactly what Studio receives. The README records the procedure and the constructs elsa-core's reader dropped or degraded (for example the non-interrupting error event subprocess, which BPMN forbids). `unbound-task-process.bpmn` cannot be captured because the binder refuses it; the unbound state is tested by removing a binding from a captured payload instead.

One deliberate conservatism: compensation associations carry no DI waypoints in the model, because the payload records the association as a property of the boundary event rather than as an element with an id. Rather than guess geometry from a naming convention a Camunda file would not follow, the view model reports it and the adapter routes the edge.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib
npm test                    # 124/124 tests, 6 files, plus 2 type-check files, 0 type errors
npx tsc --noEmit -p tsconfig.json
npm run build               # webpack ok; types.generated.ts unchanged
git status --short          # clean after build
dotnet build src/modules/Elsa.Studio.Workflows.Designer/Elsa.Studio.Workflows.Designer.csproj --configuration Release   # 0 warnings, 0 errors
```

Review: one iteration on the standards and spec axes, both clean; the module-boundary test was proven to fail on a canary import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
