### PR TITLE
feat(designer): render BPMN diagrams on the X6 canvas

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/Elsa.Studio.Workflows.Designer.Tests.csproj
@@ -78,6 +78,12 @@
         <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\api\update-activity-size.ts"
               Link="DesignerAssets\update-activity-size.ts"
               CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\internal\canvas-ready.ts"
+              Link="DesignerAssets\canvas-ready.ts"
+              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\bpmn\graph-registry.ts"
+              Link="DesignerAssets\bpmn-graph-registry.ts"
+              CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6DesignerModeContractTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/X6DesignerModeContractTests.cs
@@ -97,14 +97,32 @@ public sealed class X6DesignerModeContractTests
     {
         var disposal = ReadAsset("dispose-graph.ts");
         var loading = ReadAsset("load-graph.ts");
+        var canvasReady = ReadAsset("canvas-ready.ts");
 
         Assert.Contains("binding.graph.dispose()", disposal, StringComparison.Ordinal);
         Assert.True(
             disposal.IndexOf("binding.graph.dispose()", StringComparison.Ordinal) <
             disposal.IndexOf("delete graphBindings[graphId]", StringComparison.Ordinal));
-        Assert.Contains("!container.isConnected", loading, StringComparison.Ordinal);
-        Assert.Contains("graphBindings[graphId]?.graph !== graph", loading, StringComparison.Ordinal);
-        Assert.Contains("graphBindings[graphId] !== binding", loading, StringComparison.Ordinal);
+
+        // The wait for a laid-out container is shared with the BPMN canvas, so the two guards that
+        // stop a stale load from stealing the viewport live in canvas-ready.ts: the container must
+        // still be in the document, and the caller must still recognise the graph as its own.
+        Assert.Contains("!container.isConnected", canvasReady, StringComparison.Ordinal);
+        Assert.Contains("!isCurrent()", canvasReady, StringComparison.Ordinal);
+        Assert.Contains("whenCanvasHasHeight(graph, () => graphBindings[graphId] === binding)", loading, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GraphDisposal_AlsoTearsDownABpmnCanvasRegisteredUnderTheSameId()
+    {
+        var disposal = ReadAsset("dispose-graph.ts");
+        var registry = ReadAsset("bpmn-graph-registry.ts");
+
+        // The BPMN adapter keeps its own registry, so the generic teardown has to reach it as well;
+        // otherwise a component that calls the wrong one leaks an X6 graph without saying so.
+        Assert.Contains("disposeBpmnGraphBinding(graphId)", disposal, StringComparison.Ordinal);
+        Assert.Contains("binding.graph.dispose()", registry, StringComparison.Ordinal);
+        Assert.Contains("delete bpmnGraphBindings[graphId]", registry, StringComparison.Ordinal);
     }
 
     private static string ReadAsset(string name) =>

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.bpmn.css
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/css/designer.bpmn.css
@@ -1,0 +1,66 @@
+/*
+ * The BPMN canvas palette.
+ *
+ * Scoped to the class `createBpmnGraph` puts on its container, so the adapter is themed whatever
+ * wrapper hosts it rather than depending on the host having chosen one of the flowchart designer's
+ * version classes. Every value is a MudBlazor palette variable, so light and dark follow the app.
+ */
+.elsa-bpmn-diagram-designer {
+    --elsa-bpmn-canvas: var(--mud-palette-surface);
+    --elsa-bpmn-grid: var(--mud-palette-lines-default);
+    --elsa-bpmn-stroke: var(--mud-palette-text-primary);
+    --elsa-bpmn-surface: var(--mud-palette-surface);
+    --elsa-bpmn-text: var(--mud-palette-text-primary);
+    --elsa-bpmn-muted: var(--mud-palette-text-secondary);
+    --elsa-bpmn-edge: var(--mud-palette-text-primary);
+    --elsa-bpmn-selection: var(--mud-palette-primary);
+
+    /* Pools and lanes are scenery: a hairline and a tinted header band, nothing that competes with
+       the elements they hold. */
+    --elsa-bpmn-container-surface: transparent;
+    --elsa-bpmn-container-stroke: var(--mud-palette-lines-default);
+    --elsa-bpmn-header-surface: color-mix(in srgb, var(--mud-palette-text-primary) 5%, transparent);
+
+    /* An element whose work is not bound, or whose binding does not resolve. W8 refuses to publish
+       a workflow in that state, so it is called out rather than left to look ordinary. */
+    --elsa-bpmn-unbound: var(--mud-palette-warning);
+
+    /* Instance state. The first four mirror the flowchart's badge colours; `canceled` is the one
+       the flowchart has no equivalent for, and is deliberately not the fault colour. */
+    --elsa-bpmn-badge-faulted: var(--mud-palette-error);
+    --elsa-bpmn-badge-faulted-text: var(--mud-palette-error-text);
+    --elsa-bpmn-badge-canceled: var(--mud-palette-text-disabled);
+    --elsa-bpmn-badge-canceled-text: var(--mud-palette-surface);
+    --elsa-bpmn-badge-blocked: var(--mud-palette-warning);
+    --elsa-bpmn-badge-blocked-text: var(--mud-palette-warning-text);
+    --elsa-bpmn-badge-active: var(--mud-palette-info);
+    --elsa-bpmn-badge-active-text: var(--mud-palette-info-text);
+    --elsa-bpmn-badge-completed: var(--mud-palette-success);
+    --elsa-bpmn-badge-completed-text: var(--mud-palette-success-text);
+    --elsa-bpmn-badge-idle: var(--mud-palette-lines-default);
+    --elsa-bpmn-badge-idle-text: var(--mud-palette-text-secondary);
+}
+
+.elsa-bpmn-diagram-designer .x6-graph-background {
+    background-color: var(--elsa-bpmn-canvas);
+}
+
+.elsa-bpmn-diagram-designer .elsa-bpmn-selection .x6-widget-selection-box {
+    border: solid 2px var(--elsa-bpmn-selection);
+    border-radius: 4px;
+    box-shadow: none;
+}
+
+.elsa-bpmn-diagram-designer .elsa-bpmn-selection .x6-widget-selection-inner {
+    border: none;
+    box-shadow: none;
+}
+
+/* Read-only: the pointer says "this can be inspected", never "this can be dragged". */
+.elsa-bpmn-diagram-designer .x6-node {
+    cursor: pointer;
+}
+
+.elsa-bpmn-diagram-designer .x6-edge {
+    cursor: default;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
@@ -646,6 +646,19 @@ describe('refusals', () => {
 
         expect(diagnostic).toMatchObject({ severity: 'error', elementId: 'Start_1', scopeId: 'Fulfil' });
     });
+
+    it('reports a flow id used by two scopes, mirroring the duplicate-element-id diagnostic', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const nested = activity.activities!.find(candidate => candidate.process?.processId === 'Fulfil')!;
+
+        (nested.process!.sequenceFlows![0] as { flowId: string }).flowId = 'Flow_1';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+        const diagnostic = model.diagnostics.find(candidate => candidate.code === 'duplicate-flow-id')!;
+
+        expect(diagnostic).toMatchObject({ severity: 'error', elementId: 'Flow_1', scopeId: 'Fulfil' });
+    });
 });
 
 describe('the module reads and never writes', () => {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
@@ -330,6 +330,8 @@ export type BpmnDiagnosticCode =
     | 'duplicate-di-shape'
     /** Two elements in this document share an id. */
     | 'duplicate-element-id'
+    /** Two sequence flows in this document share an id. */
+    | 'duplicate-flow-id'
     /** An element that needs work performed declares no binding ref. A publish error (W8). */
     | 'unbound-work'
     /** An element declares a binding ref that `workBindings` or `activities` does not resolve. */

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
@@ -97,6 +97,7 @@ export function buildBpmnViewModel(input: BpmnViewModelInput): BpmnViewModel {
     const associations: BpmnViewAssociation[] = [];
     const lanes: BpmnViewLane[] = [];
     const seenElementIds = new Map<string, string>();
+    const seenFlowIds = new Map<string, string>();
 
     for (const scope of scopes) {
         const scopeElements = scope.definition.elements ?? [];
@@ -142,6 +143,21 @@ export function buildBpmnViewModel(input: BpmnViewModelInput): BpmnViewModel {
         }
 
         for (const flow of scope.definition.sequenceFlows ?? []) {
+            const alreadySeenFlow = seenFlowIds.get(flow.flowId);
+
+            if (alreadySeenFlow != null) {
+                report(
+                    'duplicate-flow-id',
+                    'error',
+                    `The sequence flow id '${flow.flowId}' is used ${alreadySeenFlow === scope.id
+                        ? `twice in scope '${scope.id}'`
+                        : `both in scope '${alreadySeenFlow}' and in scope '${scope.id}'`}. Anything keyed by flow id cannot tell the two apart.`,
+                    flow.flowId,
+                    scope.id);
+            } else {
+                seenFlowIds.set(flow.flowId, scope.id);
+            }
+
             const source = elementsById.get(flow.sourceRef);
             const target = elementsById.get(flow.targetRef);
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer.ts
@@ -1,5 +1,6 @@
 import "../css/designer.v1.css";
 import "../css/designer.v2.css";
+import "../css/designer.bpmn.css";
 import {initialize} from "./designer/internal/init";
 
 export * from "./designer/api";

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/bpmn-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/bpmn-designer.ts
@@ -1,0 +1,123 @@
+/**
+ * The JS interop surface of the BPMN canvas: the functions W10's Blazor component calls.
+ *
+ * Every one of them takes the container id as its first argument, the same convention the flowchart
+ * designer's API uses, so a `X6GraphApi`-shaped wrapper on the .NET side works unchanged. The
+ * viewport commands are deliberately *not* duplicated here: `zoomToFit` and `centerContent` already
+ * resolve a graph from either registry, so a BPMN canvas uses the same two functions everything
+ * else does.
+ */
+import type {BpmnDiagnostic, BpmnViewModel, BpmnViewModelInput, BpmnActivityStats, BpmnElementStats} from '../../bpmn';
+import {buildBpmnViewModel} from '../../bpmn';
+import {bpmnGraphBindings, disposeBpmnGraphBinding} from '../bpmn/graph-registry';
+import {
+    createBpmnGraph as mountBpmnGraph,
+    loadBpmnDiagram as loadIntoBinding,
+    selectBpmnElement as selectInBinding,
+    updateBpmnActivityStats as updateActivityStatsInBinding,
+    updateBpmnElementStats as updateElementStatsInBinding,
+} from '../bpmn/mount';
+import type {BpmnGraphSettings} from '../bpmn/graph-options';
+import type {DotNetComponentRef} from './graph-bindings';
+
+export type {BpmnGraphSettings} from '../bpmn/graph-options';
+export type {BpmnElementSelection} from '../bpmn/dotnet-bpmn-designer';
+
+/**
+ * Creates a read-only BPMN canvas in the element with the given id and registers it under that id.
+ *
+ * Selection and double-click on an element are raised to `componentRef` as `HandleActivitySelected`
+ * and `HandleActivityDoubleClick` -- the flowchart designer's own method names -- carrying a
+ * {@link BpmnElementSelection} rather than an activity. Clicking the canvas, a lane or a pool
+ * raises `HandleCanvasSelected`.
+ *
+ * @returns the graph id, which is the container id.
+ */
+export function createBpmnGraph(containerId: string, componentRef: DotNetComponentRef, settings?: BpmnGraphSettings): string {
+    return mountBpmnGraph(containerId, componentRef, settings);
+}
+
+/**
+ * Builds the canvas-neutral view model from an `Elsa.BpmnProcess` activity payload and, optionally,
+ * the BPMN document it was imported from.
+ *
+ * Exposed separately from {@link loadBpmnDiagram} because the view model is worth having on the
+ * .NET side in its own right: `diagnostics` is what a document with an unbound task, a dangling
+ * flow or no BPMN DI at all has to say for itself, and `layout.source` tells the user whether the
+ * diagram they are looking at is the author's or Studio's.
+ */
+export function buildBpmnDiagram(input: BpmnViewModelInput | string): BpmnViewModel {
+    return buildBpmnViewModel(typeof input === 'string' ? JSON.parse(input) as BpmnViewModelInput : input);
+}
+
+/**
+ * Draws a diagram, replacing whatever the canvas held.
+ *
+ * Accepts either an already-built {@link BpmnViewModel} or the {@link BpmnViewModelInput} to build
+ * one from -- the two are told apart by `elements`, which only the view model has -- so a caller
+ * that has no use for the diagnostics can pass the activity payload straight across interop instead
+ * of sending a whole view model back and forth.
+ *
+ * @returns the view model's diagnostics, in document order.
+ */
+export function loadBpmnDiagram(graphId: string, model: BpmnViewModel | BpmnViewModelInput | string): readonly BpmnDiagnostic[] {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) {
+        console.warn(`No BPMN graph with id '${graphId}' to load a diagram into.`);
+        return [];
+    }
+
+    const parsed = typeof model === 'string' ? JSON.parse(model) : model;
+    const viewModel: BpmnViewModel = Array.isArray((parsed as BpmnViewModel).elements)
+        ? parsed as BpmnViewModel
+        : buildBpmnViewModel(parsed as BpmnViewModelInput);
+
+    loadIntoBinding(binding, viewModel);
+
+    return viewModel.diagnostics;
+}
+
+/**
+ * Replaces the whole element-keyed instance overlay.
+ *
+ * The map is authoritative: an element it no longer mentions loses its badge, so a fault that has
+ * been cleared disappears from the canvas rather than outliving the instance that raised it. Pass
+ * null or an empty map to clear the overlay entirely.
+ */
+export function updateBpmnElementStats(graphId: string, elementStats: Readonly<Record<string, BpmnElementStats>> | null): void {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) return;
+
+    updateElementStatsInBinding(binding, elementStats);
+}
+
+/**
+ * Updates the activity-keyed stats for one Elsa activity, on every element bound to it.
+ *
+ * This is the existing `ActivityStats` the workflow instance viewer already fetches; the
+ * element-keyed map is the one that lets a gateway or an event -- which are not bound work and have
+ * no activity id -- light up at all.
+ */
+export function updateBpmnActivityStats(graphId: string, activityId: string, activityStats: BpmnActivityStats | null): void {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) return;
+
+    updateActivityStatsInBinding(binding, activityId, activityStats);
+}
+
+/** Selects one BPMN element by its element id, optionally centring the viewport on it. */
+export function selectBpmnElement(graphId: string, elementId: string, center = false): void {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) return;
+
+    selectInBinding(binding, elementId, center);
+}
+
+/** Disposes the BPMN canvas registered under this id. Safe to call for an id that names none. */
+export function disposeBpmnGraph(graphId: string): void {
+    disposeBpmnGraphBinding(graphId);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/bpmn-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/bpmn-designer.ts
@@ -10,6 +10,7 @@
 import type {BpmnDiagnostic, BpmnViewModel, BpmnViewModelInput, BpmnActivityStats, BpmnElementStats} from '../../bpmn';
 import {buildBpmnViewModel} from '../../bpmn';
 import {bpmnGraphBindings, disposeBpmnGraphBinding} from '../bpmn/graph-registry';
+import type {BpmnGraphBinding} from '../bpmn/graph-registry';
 import {
     createBpmnGraph as mountBpmnGraph,
     loadBpmnDiagram as loadIntoBinding,
@@ -22,6 +23,25 @@ import type {DotNetComponentRef} from './graph-bindings';
 
 export type {BpmnGraphSettings} from '../bpmn/graph-options';
 export type {BpmnElementSelection} from '../bpmn/dotnet-bpmn-designer';
+
+/**
+ * Looks up the BPMN graph binding registered under `graphId`, warning to the console if `action`
+ * is given and there is none.
+ *
+ * Every interop function below needs this same "find it or bail" guard before it can touch a
+ * binding; centralising it keeps the four call sites down to the one line that differs between
+ * them, without changing which of them logs a warning.
+ */
+function resolveBpmnBinding(graphId: string, action?: string): BpmnGraphBinding | undefined {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) {
+        if (action != null) console.warn(`No BPMN graph with id '${graphId}' to ${action}.`);
+        return undefined;
+    }
+
+    return binding;
+}
 
 /**
  * Creates a read-only BPMN canvas in the element with the given id and registers it under that id.
@@ -61,12 +81,9 @@ export function buildBpmnDiagram(input: BpmnViewModelInput | string): BpmnViewMo
  * @returns the view model's diagnostics, in document order.
  */
 export function loadBpmnDiagram(graphId: string, model: BpmnViewModel | BpmnViewModelInput | string): readonly BpmnDiagnostic[] {
-    const binding = bpmnGraphBindings[graphId];
+    const binding = resolveBpmnBinding(graphId, 'load a diagram into');
 
-    if (binding == null) {
-        console.warn(`No BPMN graph with id '${graphId}' to load a diagram into.`);
-        return [];
-    }
+    if (binding == null) return [];
 
     const parsed = typeof model === 'string' ? JSON.parse(model) : model;
     const viewModel: BpmnViewModel = Array.isArray((parsed as BpmnViewModel).elements)
@@ -86,7 +103,7 @@ export function loadBpmnDiagram(graphId: string, model: BpmnViewModel | BpmnView
  * null or an empty map to clear the overlay entirely.
  */
 export function updateBpmnElementStats(graphId: string, elementStats: Readonly<Record<string, BpmnElementStats>> | null): void {
-    const binding = bpmnGraphBindings[graphId];
+    const binding = resolveBpmnBinding(graphId);
 
     if (binding == null) return;
 
@@ -101,7 +118,7 @@ export function updateBpmnElementStats(graphId: string, elementStats: Readonly<R
  * no activity id -- light up at all.
  */
 export function updateBpmnActivityStats(graphId: string, activityId: string, activityStats: BpmnActivityStats | null): void {
-    const binding = bpmnGraphBindings[graphId];
+    const binding = resolveBpmnBinding(graphId);
 
     if (binding == null) return;
 
@@ -110,7 +127,7 @@ export function updateBpmnActivityStats(graphId: string, activityId: string, act
 
 /** Selects one BPMN element by its element id, optionally centring the viewport on it. */
 export function selectBpmnElement(graphId: string, elementId: string, center = false): void {
-    const binding = bpmnGraphBindings[graphId];
+    const binding = resolveBpmnBinding(graphId);
 
     if (binding == null) return;
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/center-content.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/center-content.ts
@@ -1,9 +1,7 @@
-import {graphBindings} from "./graph-bindings";
+import {findGraph} from "./find-graph";
 
 export function centerContent(graphId: string) {
-    const {graph} = graphBindings[graphId];
-    
-    graph.centerContent({
+    findGraph(graphId)?.centerContent({
         padding: 20,
         useCellGeometry: true
     });

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dispose-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/dispose-graph.ts
@@ -1,9 +1,15 @@
 import {graphBindings} from "./graph-bindings";
+import {disposeBpmnGraphBinding} from "../bpmn/graph-registry";
 
 export function disposeGraph(graphId: string) {
     const binding = graphBindings[graphId];
-    if (!binding)
+
+    // A BPMN canvas is registered elsewhere; disposing it here as well means a component that calls
+    // the generic teardown cannot leak a graph just because it used the other designer.
+    if (!binding) {
+        disposeBpmnGraphBinding(graphId);
         return;
+    }
 
     binding.graph.dispose();
     delete graphBindings[graphId];

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/find-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/find-graph.ts
@@ -1,0 +1,19 @@
+import type {Graph} from '@antv/x6';
+import {graphBindings} from './graph-bindings';
+import {bpmnGraphBindings} from '../bpmn/graph-registry';
+
+/**
+ * Resolves a graph by container id, whichever designer created it.
+ *
+ * The flowchart, sequence and state-machine designers share one binding registry; the BPMN adapter
+ * keeps its own, because a BPMN canvas has neither a `DesignerMode` nor a
+ * `DotNetFlowchartDesigner`. The viewport commands -- zoom to fit, centre -- are the same operation
+ * on either, so they go through here rather than growing a BPMN-specific twin.
+ *
+ * Returns null rather than throwing for an id that names nothing: these are called from .NET after
+ * a component has already begun disposing often enough that a missing graph is a normal race, not a
+ * defect.
+ */
+export function findGraph(graphId: string): Graph | null {
+    return graphBindings[graphId]?.graph ?? bpmnGraphBindings[graphId]?.graph ?? null;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/index.ts
@@ -20,4 +20,5 @@ export * from './update-activity-size';
 export * from './update-activity-stats';
 export * from './zoom-to-fit';
 export * from './auto-layout';
+export * from './bpmn-designer';
 export {DotNetFlowchartDesigner} from "./dotnet-flowchart-designer";

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/load-graph.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/load-graph.ts
@@ -1,7 +1,8 @@
-import {Graph, Model} from '@antv/x6';
+import {Model} from '@antv/x6';
 import {graphBindings} from "./graph-bindings";
 import {arrangeSequenceGraph, normalizeSequenceOrientation, withSuppressedGraphUpdated} from "./sequence-mode";
 import {applyStateMachineGraphAccessibility} from '../internal/state-machine-accessibility';
+import {whenCanvasHasHeight} from '../internal/canvas-ready';
 
 export function loadGraph(graphId: string, data: string | Model.FromJSONData) {
     const binding = graphBindings[graphId];
@@ -14,35 +15,13 @@ export function loadGraph(graphId: string, data: string | Model.FromJSONData) {
         arrangeSequenceGraph(binding);
     }
 
-    waitUntilCanvasHasNonZeroHeight(graphId, graph).then(ready => {
-        if (!ready || graphBindings[graphId] !== binding)
+    whenCanvasHasHeight(graph, () => graphBindings[graphId] === binding).then(ready => {
+        if (!ready)
             return;
 
         if (binding.mode === 'stateMachine')
             applyStateMachineGraphAccessibility(graph);
 
         graph.centerContent({padding: 20});
-    });
-}
-
-function waitUntilCanvasHasNonZeroHeight(graphId: string, graph: Graph): Promise<boolean> {
-    const container = graph.container;
-
-    return new Promise(resolve => {
-        const checkSize = () => {
-            if (!container.isConnected || graphBindings[graphId]?.graph !== graph) {
-                resolve(false);
-                return;
-            }
-
-            const clientRect = container.getBoundingClientRect();
-
-            if (clientRect.height == 0)
-                window.requestAnimationFrame(checkSize);
-            else
-                resolve(true);
-        };
-
-        checkSize();
     });
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/zoom-to-fit.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/api/zoom-to-fit.ts
@@ -1,8 +1,7 @@
-import {graphBindings} from "./graph-bindings";
+import {findGraph} from "./find-graph";
 
 export function zoomToFit(graphId: string) {
-    const {graph} = graphBindings[graphId];
-    graph.zoomToFit({
+    findGraph(graphId)?.zoomToFit({
         padding: 20,
         minScale: 0.5,
         maxScale: 3

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/README.md
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/README.md
@@ -1,0 +1,66 @@
+# `src/designer/bpmn` — the X6 BPMN adapter
+
+Draws the canvas-neutral BPMN view model (`../../bpmn`) with `@antv/x6`. X6 is what users get unless
+they opt into React Flow (`DesignerOptions.UseReactFlow`, default false), so BPMN ships on it first.
+
+**Read-only.** No dragging, no resizing, no connecting, no adding. That is W14. Selection, double
+click, zoom to fit, centre and the instance-state overlay are all that is here.
+
+## What belongs here, and what does not
+
+The review test from the design (elsa-workflows/elsa-core#7909 §4, D2): **if it would be identical
+in a React Flow adapter, it belongs in `../../bpmn`, not here.** Element kinds, geometry, waypoints,
+bindings, boundary attachment, lane membership, diagnostics and the fallback layout all arrive
+already resolved on the view model, and nothing in this folder re-derives any of them.
+
+What *is* here is canvas-specific by that same test: SVG path data for the BPMN markers, X6 shape
+registrations, painting order, and the X6 attribute shapes they are expressed in. A React Flow
+adapter would render an event definition as a React component, not as a `d` string.
+
+## The split, and why
+
+`buildBpmnX6Cells(viewModel)` is a **pure function** returning plain `Node.Metadata` and
+`Edge.Metadata` — no `Graph`, no DOM, `@antv/x6` imported for types only. That is what lets
+`__tests__/cells.test.ts` run the whole mapping against every W9a fixture and assert the
+correspondence a screenshot cannot: one node per element, one edge per flow, every boundary event
+still naming its host, every default flow still carrying its marker, every cell id unique.
+`mount.ts` is the remaining sliver that genuinely needs a live graph.
+
+`graph-options.ts` is separate for the same reason: read-only is the property the whole adapter
+rests on, and as a value it can be asserted rather than reviewed.
+
+## Files
+
+| File | What it does |
+| --- | --- |
+| `cells.ts` | `buildBpmnX6Cells`. The mapping. Pure. |
+| `shapes.ts` | `registerBpmnShapes()`: the X6 node/edge shapes and the `bpmnWaypoint` anchor. |
+| `graph-options.ts` | The read-only `Graph` configuration, as a value. |
+| `glyphs.ts` | SVG path data for event definitions, task types, gateways and activity markers. |
+| `stats.ts` | Which badge one element's instance state resolves to. |
+| `palette.ts` | The CSS custom properties the shapes paint with; see `css/designer.bpmn.css`. |
+| `constants.ts` | Shape names, cell id prefixes, painting order. No imports, so `cells.ts` stays loadable without X6. |
+| `mount.ts` | Creating the graph, loading cells, updating stats, selection. |
+| `graph-registry.ts` | Live BPMN graphs by container id. |
+| `dotnet-bpmn-designer.ts` | The interop calls back into .NET. |
+
+The exported JS interop surface is `../api/bpmn-designer.ts`; `../designer.ts` re-exports it with
+the rest of `../api`.
+
+## Three decisions worth knowing about
+
+**Boundary events are not X6 children of their host.** A boundary event sits astride its host's
+border, so embedding it would give X6 a child overlapping its own parent's body and change which of
+the two a click on that border resolves to. `parent`/`children` is also X6's *model* hierarchy, not
+a drawing hint, and using it would make the canvas assert a containment the document does not have.
+The host is recorded in the node's `data` instead. Lanes and pools hold nothing for the same reason,
+and are `pointerEvents: 'none'` so they never intercept a click meant for what is drawn over them.
+
+**Edges are pinned to the document's own waypoints.** The `bpmnWaypoint` anchor expresses each end
+as an offset from the node's own rectangle, so the line is the author's line to the pixel and still
+belongs to the two nodes it joins. X6's built-in `topLeft` anchor cannot do this: it measures the
+node's *rendered* bounding box, which for a BPMN node includes the name drawn outside the shape.
+
+**The overlay is replaced, never merged.** `updateBpmnElementStats` sets every element's stats from
+the map it is given, so an element the map stops mentioning loses its badge. A fault that outlives
+the instance that raised it is the failure that looks most like success.

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
@@ -1,0 +1,406 @@
+/**
+ * W9c's gate: run every W9a rendering fixture through the X6 mapping and check what came out.
+ *
+ * The mapping is a pure function precisely so this can be done without a browser. What is asserted
+ * is the correspondence between the view model and the cell set -- a node per element, an edge per
+ * flow, a boundary event that still names its host, a default flow that still carries its marker --
+ * because that correspondence is the one thing a screenshot cannot check and the one thing that,
+ * when it breaks, produces a diagram that looks entirely reasonable and is missing something.
+ */
+import type { Edge } from '@antv/x6';
+import { describe, expect, it } from 'vitest';
+import { buildBpmnViewModel } from '../../../bpmn';
+import type { BpmnViewModel } from '../../../bpmn';
+import { FIXTURE_NAMES, loadFixture, type FixtureName } from '../../../bpmn/__tests__/fixtures';
+import { buildBpmnX6Cells, type BpmnElementCellData, type BpmnFlowCellData, type BpmnX6Cells } from '../cells';
+import { ACTIVITY_MARKER_GLYPHS } from '../glyphs';
+import {
+    BPMN_ACTIVITY_SHAPE,
+    BPMN_ASSOCIATION_SHAPE,
+    BPMN_EVENT_SHAPE,
+    BPMN_FLOW_SHAPE,
+    BPMN_GATEWAY_SHAPE,
+    BPMN_LANE_CELL_PREFIX,
+    BPMN_POOL_CELL_PREFIX,
+    BPMN_WAYPOINT_ANCHOR,
+} from '../constants';
+
+interface CellExpectation {
+    /** Element count, from the W9a fixture expectations, restated so a drift in either shows up. */
+    readonly elements: number;
+    readonly flows: number;
+    readonly resolvedAssociations: number;
+    readonly placedLanes: number;
+    readonly placedPools: number;
+    readonly boundaryEvents: number;
+}
+
+const EXPECTATIONS: Record<FixtureName, CellExpectation> = {
+    'camunda-order-process': { elements: 3, flows: 2, resolvedAssociations: 0, placedLanes: 0, placedPools: 0, boundaryEvents: 0 },
+    'gateway-routing': { elements: 11, flows: 13, resolvedAssociations: 0, placedLanes: 0, placedPools: 0, boundaryEvents: 0 },
+    'non-interrupting-error-event-subprocess': { elements: 3, flows: 2, resolvedAssociations: 0, placedLanes: 0, placedPools: 0, boundaryEvents: 0 },
+    'publish-gate-process': { elements: 3, flows: 2, resolvedAssociations: 0, placedLanes: 0, placedPools: 0, boundaryEvents: 0 },
+    'subprocess-boundary-events': { elements: 16, flows: 11, resolvedAssociations: 0, placedLanes: 0, placedPools: 0, boundaryEvents: 3 },
+    'task-kinds-and-lanes': { elements: 11, flows: 10, resolvedAssociations: 0, placedLanes: 2, placedPools: 1, boundaryEvents: 0 },
+    'transaction-compensation': { elements: 13, flows: 8, resolvedAssociations: 1, placedLanes: 0, placedPools: 0, boundaryEvents: 2 },
+};
+
+const SHAPE_BY_KIND: Readonly<Record<string, string>> = {
+    event: BPMN_EVENT_SHAPE,
+    gateway: BPMN_GATEWAY_SHAPE,
+    task: BPMN_ACTIVITY_SHAPE,
+    callActivity: BPMN_ACTIVITY_SHAPE,
+    subProcess: BPMN_ACTIVITY_SHAPE,
+    unknown: BPMN_ACTIVITY_SHAPE,
+};
+
+describe.each(FIXTURE_NAMES)('%s', name => {
+    const model = build(name);
+    const cells = buildBpmnX6Cells(model);
+    const expectation = EXPECTATIONS[name];
+    const nodesById = new Map(cells.nodes.map(node => [node.id!, node]));
+    const edgesById = new Map(cells.edges.map(edge => [edge.id!, edge]));
+
+    it('agrees with the view model about how much there is to draw', () => {
+        // Both directions: the counts the view model reports, and the counts W9a's own fixture
+        // expectations state. A change that quietly loses an element fails whichever way it came in.
+        expect(model.elements).toHaveLength(expectation.elements);
+        expect(model.flows).toHaveLength(expectation.flows);
+
+        expect(cells.nodes).toHaveLength(expectation.elements + expectation.placedLanes + expectation.placedPools);
+        expect(cells.edges).toHaveLength(expectation.flows + expectation.resolvedAssociations);
+        expect(cells.undrawn).toEqual([]);
+    });
+
+    it('gives every cell an id of its own', () => {
+        const ids = [...cells.nodes, ...cells.edges].map(cell => cell.id);
+
+        // X6 keys its model by id and a repeat replaces the cell already there, so a duplicate is a
+        // silently missing shape rather than an error.
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids.every(id => typeof id === 'string' && id.length > 0)).toBe(true);
+    });
+
+    it('draws one node per element, at the geometry the view model resolved', () => {
+        for (const element of model.elements) {
+            const node = nodesById.get(element.id);
+
+            expect(node, element.id).toBeDefined();
+            expect(node!.shape, element.id).toBe(SHAPE_BY_KIND[element.kind]);
+            expect({ x: node!.x, y: node!.y, width: node!.width, height: node!.height }, element.id).toEqual({
+                x: element.geometry.x,
+                y: element.geometry.y,
+                width: element.geometry.width,
+                height: element.geometry.height,
+            });
+        }
+    });
+
+    it('never parents one node inside another', () => {
+        // The embedding trap, both halves of it: a boundary event embedded in its host breaks
+        // hit-testing on the host's border, and a lane embedding its contents would make the canvas
+        // assert a containment the BPMN document does not have.
+        for (const node of cells.nodes) {
+            expect((node as any).parent, `${node.id} parent`).toBeUndefined();
+            expect((node as any).children, `${node.id} children`).toBeUndefined();
+        }
+    });
+
+    it('keeps every boundary event attached to a host that is on the canvas', () => {
+        const boundaries = model.elements.filter(element => element.boundary != null);
+
+        expect(boundaries).toHaveLength(expectation.boundaryEvents);
+
+        for (const boundary of boundaries) {
+            const node = nodesById.get(boundary.id)!;
+            const data = node.data as BpmnElementCellData;
+            const host = nodesById.get(boundary.boundary!.hostElementId);
+
+            expect(data.boundaryHostElementId, boundary.id).toBe(boundary.boundary!.hostElementId);
+            expect(host, `${boundary.id} host`).toBeDefined();
+            // In front of the host, so a click on the shared border reaches the boundary event.
+            expect(node.zIndex!, `${boundary.id} z-index`).toBeGreaterThan(host!.zIndex!);
+        }
+    });
+
+    it('draws one edge per flow, linked to the two elements it joins', () => {
+        for (const flow of model.flows) {
+            const edge = edgesById.get(flow.id);
+
+            expect(edge, flow.id).toBeDefined();
+            expect(terminalCell(edge!.source), `${flow.id} source`).toBe(flow.sourceElementId);
+            expect(terminalCell(edge!.target), `${flow.id} target`).toBe(flow.targetElementId);
+            expect(edge!.shape, flow.id).toBe(BPMN_FLOW_SHAPE);
+        }
+    });
+
+    it('draws a flow through the document\'s own waypoints, end to end', () => {
+        for (const flow of model.flows) {
+            const edge = edgesById.get(flow.id)!;
+
+            if (flow.waypoints.length === 0) {
+                // Nothing to be verbatim about: the edge is linked to its nodes and X6 routes it.
+                expect(anchorArgs(edge.source), flow.id).toBeNull();
+                expect(edge.vertices, flow.id).toEqual([]);
+                continue;
+            }
+
+            const source = model.elements.find(element => element.scopeId === flow.scopeId && element.id === flow.sourceElementId)!;
+            const target = model.elements.find(element => element.scopeId === flow.scopeId && element.id === flow.targetElementId)!;
+            const first = flow.waypoints[0];
+            const last = flow.waypoints[flow.waypoints.length - 1];
+
+            expect(anchorArgs(edge.source), `${flow.id} source anchor`)
+                .toEqual({ dx: first.x - source.geometry.x, dy: first.y - source.geometry.y });
+            expect(anchorArgs(edge.target), `${flow.id} target anchor`)
+                .toEqual({ dx: last.x - target.geometry.x, dy: last.y - target.geometry.y });
+            expect(edge.vertices, `${flow.id} vertices`).toEqual(flow.waypoints.slice(1, -1).map(point => ({ x: point.x, y: point.y })));
+        }
+    });
+
+    it('marks every default flow the document declares', () => {
+        for (const flow of model.flows) {
+            const marker = sourceMarker(edgesById.get(flow.id)!);
+
+            if (flow.isDefault) expect(marker?.name, `${flow.id}`).toBe('path');
+            else expect(marker?.name, `${flow.id}`).not.toBe('path');
+        }
+    });
+
+    it('draws each lane and pool the document places, behind everything in it', () => {
+        const elementZ = Math.min(...model.elements.map(element => nodesById.get(element.id)!.zIndex!));
+
+        for (const lane of model.lanes.filter(candidate => candidate.geometry != null)) {
+            const node = nodesById.get(`${BPMN_LANE_CELL_PREFIX}${lane.id}`);
+
+            expect(node, lane.id).toBeDefined();
+            expect(node!.zIndex!, lane.id).toBeLessThan(elementZ);
+        }
+
+        for (const pool of model.pools.filter(candidate => candidate.geometry != null)) {
+            const node = nodesById.get(`${BPMN_POOL_CELL_PREFIX}${pool.id}`);
+
+            expect(node, pool.id).toBeDefined();
+            expect(node!.zIndex!, pool.id).toBeLessThan(elementZ);
+        }
+    });
+
+    it('draws a nested scope in front of the subprocess that contains it', () => {
+        for (const scope of model.scopes.filter(candidate => candidate.hostElementId != null)) {
+            const host = nodesById.get(scope.hostElementId!);
+            const contained = model.elements.filter(element => element.scopeId === scope.id);
+
+            if (host == null || contained.length === 0) continue;
+
+            for (const element of contained) {
+                expect(nodesById.get(element.id)!.zIndex!, `${element.id} over ${scope.hostElementId}`)
+                    .toBeGreaterThan(host.zIndex!);
+            }
+        }
+    });
+
+    it('draws a scope\'s flows behind that scope\'s elements', () => {
+        for (const flow of model.flows) {
+            const edge = edgesById.get(flow.id)!;
+            const source = nodesById.get(flow.sourceElementId)!;
+
+            expect(edge.zIndex!, flow.id).toBeLessThan(source.zIndex!);
+        }
+    });
+});
+
+describe('fallback layouts', () => {
+    it('produce a complete cell set even though nothing in the document is placed', () => {
+        for (const name of FIXTURE_NAMES) {
+            const model = build(name);
+
+            if (model.layout.source !== 'fallback') continue;
+
+            const cells = buildBpmnX6Cells(model);
+
+            expect(cells.nodes, name).toHaveLength(model.elements.length);
+            expect(cells.edges, name).toHaveLength(model.flows.length);
+            expect(cells.nodes.every(node => Number.isFinite(node.x) && (node.width ?? 0) > 0), name).toBe(true);
+        }
+
+        // Guards the guard: at least one fixture must actually reach the branch above.
+        expect(FIXTURE_NAMES.filter(name => build(name).layout.source === 'fallback').length).toBeGreaterThan(0);
+    });
+});
+
+describe('compensation associations', () => {
+    it('are drawn as their own dashed edge from the boundary event to the handler', () => {
+        const model = build('transaction-compensation');
+        const cells = buildBpmnX6Cells(model);
+        const association = model.associations[0];
+        const edge = cells.edges.find(candidate => candidate.shape === BPMN_ASSOCIATION_SHAPE);
+
+        expect(association).toBeDefined();
+        expect(edge, 'association edge').toBeDefined();
+        expect(terminalCell(edge!.source)).toBe(association.sourceElementId);
+        expect(terminalCell(edge!.target)).toBe(association.targetElementId);
+        expect((edge!.data as BpmnFlowCellData).cellKind).toBe('association');
+    });
+});
+
+describe('conditional flow markers', () => {
+    // No fixture carries a conditional flow out of an activity, so the rule -- diamond on a flow
+    // leaving an activity, nothing on one leaving a gateway, which is what every BPMN modeller
+    // draws -- is checked against a view model edited to produce both cases from one document.
+    const model = build('gateway-routing');
+    const fromGateway = model.flows.find(flow => flow.conditionOutcome != null)!;
+
+    it('leaves a gateway\'s conditional flows undecorated', () => {
+        const edge = buildBpmnX6Cells(model).edges.find(candidate => candidate.id === fromGateway.id)!;
+
+        expect(model.elements.find(element => element.id === fromGateway.sourceElementId)!.kind).toBe('gateway');
+        expect(sourceMarker(edge)).toBeNull();
+    });
+
+    it('puts a diamond on a conditional flow leaving an activity', () => {
+        const fromTask = model.flows.find(flow => model.elements.some(element => element.id === flow.sourceElementId && element.kind === 'task'))!;
+        const edited: BpmnViewModel = {
+            ...model,
+            flows: model.flows.map(flow => flow.id === fromTask.id ? { ...flow, conditionOutcome: 'Approved' } : flow),
+        };
+        const edge = buildBpmnX6Cells(edited).edges.find(candidate => candidate.id === fromTask.id)!;
+
+        expect(sourceMarker(edge)?.name).toBe('diamond');
+    });
+});
+
+describe('activity markers', () => {
+    const model = build('subprocess-boundary-events');
+
+    it('marks a multi-instance activity with the parallel bars the document implies', () => {
+        const node = nodeOf(buildBpmnX6Cells(model), 'Fulfil');
+
+        expect(model.elements.find(element => element.id === 'Fulfil')!.loopCharacteristics!.isSequential).toBe(false);
+        expect(attr(node, 'markerA').display).toBe('block');
+        expect(attr(node, 'markerA').d).toBe(ACTIVITY_MARKER_GLYPHS.multiInstanceParallel.d);
+    });
+
+    it('draws an expanded subprocess as a container, with no collapse marker', () => {
+        const node = nodeOf(buildBpmnX6Cells(model), 'Fulfil');
+
+        expect(model.elements.find(element => element.id === 'Fulfil')!.isExpanded).toBe(true);
+        expect([attr(node, 'markerA').d, attr(node, 'markerB').d])
+            .not.toContain(ACTIVITY_MARKER_GLYPHS.collapsed.d);
+    });
+
+    it('marks a subprocess the document draws collapsed', () => {
+        const collapsed: BpmnViewModel = {
+            ...model,
+            elements: model.elements.map(element => element.id === 'Fulfil' ? { ...element, isExpanded: false } : element),
+        };
+        const node = nodeOf(buildBpmnX6Cells(collapsed), 'Fulfil');
+
+        expect(attr(node, 'markerA').d).toBe(ACTIVITY_MARKER_GLYPHS.collapsed.d);
+        // Collapsed, so the name goes back to the middle of the box rather than the top corner.
+        expect(attr(node, 'label').textAnchor).toBe('middle');
+    });
+
+    it('marks a compensation handler', () => {
+        const compensation = build('transaction-compensation');
+        const handler = compensation.elements.find(element => element.isForCompensation)!;
+        const node = nodeOf(buildBpmnX6Cells(compensation), handler.id);
+
+        expect(attr(node, 'markerA').d).toBe(ACTIVITY_MARKER_GLYPHS.compensation.d);
+    });
+
+    it('draws BPMN\'s double border on a transaction subprocess, and on nothing else', () => {
+        const compensation = build('transaction-compensation');
+        const cells = buildBpmnX6Cells(compensation);
+        const transaction = compensation.elements.find(element => element.isTransaction)!;
+
+        expect(attr(nodeOf(cells, transaction.id), 'innerBorder').display).toBe('block');
+
+        for (const element of compensation.elements.filter(candidate => !candidate.isTransaction && candidate.kind !== 'event' && candidate.kind !== 'gateway')) {
+            expect(attr(nodeOf(cells, element.id), 'innerBorder').display, element.id).toBe('none');
+        }
+    });
+});
+
+describe('activity labels', () => {
+    it('breaks a name between words rather than through one', () => {
+        const model = build('task-kinds-and-lanes');
+        const node = nodeOf(buildBpmnX6Cells(model), 'SendShipped');
+        const lines = (attr(node, 'label').text as string).split('\n');
+
+        // X6's own textWrap splits by character count, which turns "Announce Shipment" into
+        // "Announce Shipm" / "ent"; the mapping breaks it first so it cannot.
+        expect(model.elements.find(element => element.id === 'SendShipped')!.name).toBe('Announce Shipment');
+        expect(lines).toEqual(['Announce', 'Shipment']);
+    });
+
+    it('leaves a name that fits on one line alone', () => {
+        const model = build('task-kinds-and-lanes');
+
+        expect(attr(nodeOf(buildBpmnX6Cells(model), 'PackBox'), 'label').text).toBe('Pack Box');
+        expect(attr(nodeOf(buildBpmnX6Cells(model), 'ServiceWork'), 'label').text).toBe('Reserve Stock');
+    });
+
+    it('shortens a name too long for the box instead of losing the end of it', () => {
+        // X6 drops the lines past its own budget without an ellipsis when the text it is given is
+        // already wrapped, so a long name would come out looking like a shorter, different name.
+        const model = build('task-kinds-and-lanes');
+        const named: BpmnViewModel = {
+            ...model,
+            elements: model.elements.map(element => element.id === 'PackBox'
+                ? { ...element, name: 'Pack the box and print the customs declaration form' }
+                : element),
+        };
+        const text = attr(nodeOf(buildBpmnX6Cells(named), 'PackBox'), 'label').text as string;
+
+        expect(text.split('\n')).toHaveLength(2);
+        expect(text.endsWith('\u2026')).toBe(true);
+    });
+});
+
+describe('lanes and pools the document does not place', () => {
+    it('are reported as undrawn rather than dropped in silence', () => {
+        const model = build('task-kinds-and-lanes');
+        const edited: BpmnViewModel = {
+            ...model,
+            lanes: model.lanes.map((lane, index) => index === 0 ? { ...lane, geometry: null } : lane),
+        };
+        const cells = buildBpmnX6Cells(edited);
+
+        expect(cells.undrawn).toEqual([{
+            kind: 'lane',
+            id: model.lanes[0].id,
+            reason: 'The BPMN source places no shape for this lane.',
+        }]);
+        expect(cells.nodes).toHaveLength(model.elements.length + model.lanes.length - 1 + model.pools.length);
+    });
+});
+
+function build(name: FixtureName): BpmnViewModel {
+    const fixture = loadFixture(name);
+
+    return buildBpmnViewModel({ activity: fixture.activity, sourceXml: fixture.sourceXml });
+}
+
+function nodeOf(cells: BpmnX6Cells, id: string) {
+    return cells.nodes.find(node => node.id === id)!;
+}
+
+function attr(node: { attrs?: unknown }, selector: string): Record<string, any> {
+    return (node.attrs as Record<string, Record<string, any>>)[selector] ?? {};
+}
+
+function terminalCell(terminal: Edge.Metadata['source']): string | null {
+    return (terminal as { cell?: string } | undefined)?.cell ?? null;
+}
+
+function anchorArgs(terminal: Edge.Metadata['source']): { dx: number; dy: number } | null {
+    const anchor = (terminal as { anchor?: { name?: string; args?: { dx: number; dy: number } } } | undefined)?.anchor;
+
+    if (anchor?.name !== BPMN_WAYPOINT_ANCHOR) return null;
+
+    return anchor.args ?? null;
+}
+
+function sourceMarker(edge: Edge.Metadata): { name?: string } | null {
+    return (edge.attrs as any)?.line?.sourceMarker ?? null;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
@@ -10,7 +10,7 @@
 import type { Edge } from '@antv/x6';
 import { describe, expect, it } from 'vitest';
 import { buildBpmnViewModel } from '../../../bpmn';
-import type { BpmnViewModel } from '../../../bpmn';
+import type { BpmnActivity, BpmnViewModel } from '../../../bpmn';
 import { FIXTURE_NAMES, loadFixture, type FixtureName } from '../../../bpmn/__tests__/fixtures';
 import { buildBpmnX6Cells, type BpmnElementCellData, type BpmnFlowCellData, type BpmnX6Cells } from '../cells';
 import { ACTIVITY_MARKER_GLYPHS } from '../glyphs';
@@ -70,6 +70,7 @@ describe.each(FIXTURE_NAMES)('%s', name => {
         expect(cells.nodes).toHaveLength(expectation.elements + expectation.placedLanes + expectation.placedPools);
         expect(cells.edges).toHaveLength(expectation.flows + expectation.resolvedAssociations);
         expect(cells.undrawn).toEqual([]);
+        expect(cells.collisions).toEqual([]);
     });
 
     it('gives every cell an id of its own', () => {
@@ -372,6 +373,48 @@ describe('lanes and pools the document does not place', () => {
             reason: 'The BPMN source places no shape for this lane.',
         }]);
         expect(cells.nodes).toHaveLength(model.elements.length + model.lanes.length - 1 + model.pools.length);
+    });
+});
+
+describe('duplicate cell ids', () => {
+    // BPMN requires element ids to be document-unique, and the view model already reports a
+    // violation as `duplicate-element-id` -- but it still renders both elements, which is what would
+    // otherwise hand X6 two cells sharing an id and let it pick a survivor arbitrarily.
+    it('keeps the first element with a colliding id and drops the duplicate along with the flow attached to it', () => {
+        const fixture = loadFixture('subprocess-boundary-events');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+        const nested = activity.activities!.find(candidate => candidate.process?.processId === 'Fulfil')!;
+        const subStart = nested.process!.elements.find(candidate => candidate.elementId === 'Sub_Start')! as { elementId: string };
+        const subFlow1 = nested.process!.sequenceFlows!.find(candidate => candidate.flowId === 'Sub_Flow_1')! as { sourceRef: string };
+
+        // 'Start_1' already names the root scope's start event; renaming this nested scope's start
+        // event to the same id, and its outgoing flow along with it, reproduces the collision without
+        // touching anything the view model itself would refuse to build.
+        subStart.elementId = 'Start_1';
+        subFlow1.sourceRef = 'Start_1';
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+        const cells = buildBpmnX6Cells(model);
+        const rootStart = model.elements.find(candidate => candidate.scopeId === model.processId && candidate.id === 'Start_1')!;
+        const survivors = cells.nodes.filter(node => node.id === 'Start_1');
+
+        expect(survivors).toHaveLength(1);
+        expect({ x: survivors[0].x, y: survivors[0].y }).toEqual({ x: rootStart.geometry.x, y: rootStart.geometry.y });
+
+        expect(cells.collisions).toContainEqual(expect.objectContaining({ kind: 'element', id: 'Start_1' }));
+        expect(cells.collisions).toContainEqual(expect.objectContaining({ kind: 'flow', id: 'Sub_Flow_1' }));
+
+        // The dropped duplicate's own flow never reaches the canvas, so nothing from the 'Fulfil'
+        // scope ends up attached to the root's surviving 'Start_1' node.
+        expect(cells.edges.some(edge => edge.id === 'Sub_Flow_1')).toBe(false);
+
+        for (const edge of cells.edges) {
+            const data = edge.data as BpmnFlowCellData;
+
+            if (terminalCell(edge.source) === 'Start_1' || terminalCell(edge.target) === 'Start_1') {
+                expect(data.scopeId, edge.id as string).toBe(model.processId);
+            }
+        }
     });
 });
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/graph-options.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/graph-options.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Read-only means read-only.
+ *
+ * W9c renders a BPMN diagram; W14 is what makes one editable. Every interaction X6 offers therefore
+ * has to be refused, and the refusal has to be checkable -- a graph configured inside a
+ * `new Graph(...)` call can only be reviewed by reading it, and a single flag flipped by an X6
+ * upgrade or a copy-paste from the flowchart designer would make the canvas quietly editable.
+ */
+import { describe, expect, it } from 'vitest';
+import { BPMN_READ_ONLY_INTERACTING, createBpmnGraphOptions } from '../graph-options';
+
+describe('createBpmnGraphOptions', () => {
+    const options = createBpmnGraphOptions();
+
+    it('refuses every interaction X6 knows how to offer', () => {
+        const interacting = options.interacting as Record<string, unknown>;
+
+        expect(Object.keys(interacting).length).toBeGreaterThan(0);
+
+        for (const [name, value] of Object.entries(interacting)) {
+            // `false`, not a predicate that happens to return false today.
+            expect(value, name).toBe(false);
+        }
+    });
+
+    it('names every interaction X6 has, so a new one cannot slip in unrefused', () => {
+        expect(Object.keys(BPMN_READ_ONLY_INTERACTING).sort()).toEqual([
+            'arrowheadMovable',
+            'edgeLabelMovable',
+            'edgeMovable',
+            'magnetConnectable',
+            'nodeMovable',
+            'stopDelegateOnDragging',
+            'toolsAddable',
+            'useEdgeTools',
+            'vertexAddable',
+            'vertexDeletable',
+            'vertexMovable',
+        ]);
+    });
+
+    it('refuses to connect anything, whatever else is enabled', () => {
+        const connecting = options.connecting!;
+
+        expect(connecting.allowBlank).toBe(false);
+        expect(connecting.allowLoop).toBe(false);
+        expect(connecting.allowNode).toBe(false);
+        expect(connecting.allowEdge).toBe(false);
+        expect(connecting.allowPort).toBe(false);
+        expect((connecting.validateMagnet as () => boolean)()).toBe(false);
+        expect((connecting.validateConnection as () => boolean)()).toBe(false);
+    });
+
+    it('leaves X6 embedding off, so nothing on the canvas can reparent an element', () => {
+        expect(options.embedding).toEqual({ enabled: false });
+    });
+
+    it('still allows the two things a reader needs', () => {
+        expect(options.panning).toEqual({ enabled: true });
+        expect((options.mousewheel as { enabled: boolean }).enabled).toBe(true);
+    });
+
+    it('lets the host turn panning, zooming and the grid off', () => {
+        const quiet = createBpmnGraphOptions({ panning: false, mousewheel: false, grid: false });
+
+        expect(quiet.panning).toEqual({ enabled: false });
+        expect((quiet.mousewheel as { enabled: boolean }).enabled).toBe(false);
+        expect(quiet.grid).toBe(false);
+    });
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The instance overlay, and the two ways it can quietly lie.
+ *
+ * A stats badge is the only part of the canvas that changes while a user watches it, and both of
+ * its failure modes look like success: a fault that stops being drawn because something else about
+ * the element also became true, and a cancellation drawn as a fault because the two share a colour.
+ * Both are asserted here in both directions.
+ */
+import { describe, expect, it } from 'vitest';
+import { statsBadgeAttrs } from '../cells';
+import { BADGE_SURFACE_BY_TONE } from '../palette';
+import { resolveBpmnStatsBadge } from '../stats';
+
+describe('resolveBpmnStatsBadge', () => {
+    it('says nothing about an element the overlay says nothing about', () => {
+        expect(resolveBpmnStatsBadge(null, null)).toBeNull();
+        expect(resolveBpmnStatsBadge(undefined, undefined)).toBeNull();
+    });
+
+    it('distinguishes an element that has not run from an element nobody is watching', () => {
+        // A definition carries no stats and gets no badges; an instance in which this element has
+        // not been reached yet carries a zeroed entry and gets one. Collapsing the two would make a
+        // running instance look like a definition.
+        expect(resolveBpmnStatsBadge({}, null)).toEqual({ tone: 'idle', count: 0, title: 'Not started (0)' });
+    });
+
+    it('keeps a fault visible even when the element also completed', () => {
+        const badge = resolveBpmnStatsBadge({ started: 3, completed: 2, faulted: true }, null);
+
+        expect(badge?.tone).toBe('faulted');
+        expect(badge?.count).toBe(3);
+    });
+
+    it('keeps a fault visible when it is the bound activity that faulted', () => {
+        expect(resolveBpmnStatsBadge({ started: 1, completed: 1 }, { started: 1, completed: 1, faulted: true })?.tone)
+            .toBe('faulted');
+    });
+
+    it('reports a cancellation as a cancellation, not as a failure', () => {
+        const badge = resolveBpmnStatsBadge({ started: 1, canceled: true }, null);
+
+        expect(badge?.tone).toBe('canceled');
+        expect(badge?.title).toBe('Canceled (1)');
+        expect(BADGE_SURFACE_BY_TONE.canceled).not.toBe(BADGE_SURFACE_BY_TONE.faulted);
+    });
+
+    it('still reports a fault on an element that was also cancelled', () => {
+        // The other direction of the same question: cancelling on the way out of a fault must not
+        // hide the fault that caused it.
+        expect(resolveBpmnStatsBadge({ started: 1, canceled: true, faulted: true }, null)?.tone).toBe('faulted');
+    });
+
+    it('prefers blocked to running, and running to completed', () => {
+        expect(resolveBpmnStatsBadge({ started: 2, completed: 1, active: 1, blocked: true }, null)?.tone).toBe('blocked');
+        expect(resolveBpmnStatsBadge({ started: 2, completed: 1, active: 1 }, null)?.tone).toBe('active');
+        expect(resolveBpmnStatsBadge({ started: 1, completed: 1, active: 0 }, null)?.tone).toBe('completed');
+    });
+
+    it('reads the flowchart\'s own counters when only an activity is being watched', () => {
+        // `uncompleted` is the flowchart's name for what BPMN calls active, so a bound activity with
+        // work outstanding lights up the same on both canvases.
+        expect(resolveBpmnStatsBadge(null, { started: 2, completed: 1, uncompleted: 1 })?.tone).toBe('active');
+        expect(resolveBpmnStatsBadge(null, { started: 1, completed: 1, uncompleted: 0 })?.tone).toBe('completed');
+        expect(resolveBpmnStatsBadge(null, { blocked: true, started: 1 })?.tone).toBe('blocked');
+    });
+});
+
+describe('statsBadgeAttrs', () => {
+    it('clears the badge when the overlay no longer mentions the element', () => {
+        // The dangerous direction: a fault that disappears from the map has to disappear from the
+        // canvas. Attributes that merely stopped being written would leave the old badge on screen.
+        const attrs = statsBadgeAttrs(null);
+
+        expect(attrs.statsBadge.display).toBe('none');
+        expect(attrs.statsLabel.display).toBe('none');
+        expect(attrs.statsLabel.text).toBe('');
+    });
+
+    it('draws the badge in its own tone, with its count', () => {
+        const attrs = statsBadgeAttrs(resolveBpmnStatsBadge({ started: 4, faulted: true }, null));
+
+        expect(attrs.statsBadge.display).toBe('block');
+        expect(attrs.statsBadge.fill).toBe(BADGE_SURFACE_BY_TONE.faulted);
+        expect(attrs.statsLabel.text).toBe('4');
+    });
+
+    it('writes the same attribute keys whether the badge is drawn or cleared', () => {
+        // Both paths must touch the same selectors, or re-applying one after the other would leave
+        // half the previous badge behind.
+        expect(Object.keys(statsBadgeAttrs(null)).sort())
+            .toEqual(Object.keys(statsBadgeAttrs(resolveBpmnStatsBadge({ completed: 1 }, null))).sort());
+    });
+});

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
@@ -90,4 +90,27 @@ describe('statsBadgeAttrs', () => {
         expect(Object.keys(statsBadgeAttrs(null)).sort())
             .toEqual(Object.keys(statsBadgeAttrs(resolveBpmnStatsBadge({ completed: 1 }, null))).sort());
     });
+
+    // The badge is the only part of the canvas that tells faulted, cancelled and blocked apart by
+    // colour alone; the title is what lets a tooltip, or a screen reader, say the same thing in words.
+    it('gives a faulted badge its title as a tooltip and an aria-label', () => {
+        const attrs = statsBadgeAttrs(resolveBpmnStatsBadge({ started: 1, faulted: true }, null));
+
+        expect(attrs.statsBadgeTitle.text).toBe('Faulted (1)');
+        expect(attrs.statsBadgeGroup['aria-label']).toBe('Faulted (1)');
+    });
+
+    it('gives a cancelled badge its title as a tooltip and an aria-label', () => {
+        const attrs = statsBadgeAttrs(resolveBpmnStatsBadge({ started: 1, canceled: true }, null));
+
+        expect(attrs.statsBadgeTitle.text).toBe('Canceled (1)');
+        expect(attrs.statsBadgeGroup['aria-label']).toBe('Canceled (1)');
+    });
+
+    it('gives a blocked badge its title as a tooltip and an aria-label', () => {
+        const attrs = statsBadgeAttrs(resolveBpmnStatsBadge({ started: 1, blocked: true }, null));
+
+        expect(attrs.statsBadgeTitle.text).toBe('Blocked (1)');
+        expect(attrs.statsBadgeGroup['aria-label']).toBe('Blocked (1)');
+    });
 });

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
@@ -1,0 +1,860 @@
+/**
+ * The mapping: one canvas-neutral BPMN view model in, one set of X6 node and edge metadata out.
+ *
+ * This layer is deliberately pure. It takes no `Graph`, touches no DOM and imports nothing from
+ * `@antv/x6` except types, so the whole mapping can be run against every W9a fixture under vitest
+ * and a divergence between the view model and the canvas -- an element that produces no node, a
+ * boundary event that loses its host, a default flow that loses its marker -- fails a test rather
+ * than showing up as a diagram that merely looks plausible.
+ *
+ * What it does *not* do is decide anything about BPMN. Kinds, geometry, waypoints, bindings,
+ * boundary attachment, lane membership and instance state all arrive already resolved on the view
+ * model; this file only chooses shapes, attributes and painting order for them.
+ */
+import type { Edge, Node } from '@antv/x6';
+import type {
+    BpmnActivityStats,
+    BpmnBindingState,
+    BpmnElementKind,
+    BpmnElementStats,
+    BpmnViewElement,
+    BpmnViewFlow,
+    BpmnViewLane,
+    BpmnViewModel,
+    BpmnViewPool,
+} from '../../bpmn';
+import { BOUNDARY_EVENT_ELEMENT_TYPE } from '../../bpmn';
+import {
+    BPMN_ACTIVITY_SHAPE,
+    BPMN_ASSOCIATION_CELL_PREFIX,
+    BPMN_ASSOCIATION_SHAPE,
+    BPMN_EVENT_SHAPE,
+    BPMN_FLOW_SHAPE,
+    BPMN_GATEWAY_SHAPE,
+    BPMN_LANE_CELL_PREFIX,
+    BPMN_LANE_SHAPE,
+    BPMN_POOL_CELL_PREFIX,
+    BPMN_POOL_SHAPE,
+    BPMN_WAYPOINT_ANCHOR,
+    LANE_Z_INDEX,
+    POOL_Z_INDEX,
+    boundaryZIndex,
+    elementZIndex,
+    flowZIndex,
+} from './constants';
+import {
+    ACTIVITY_MARKER_GLYPHS,
+    GATEWAY_GLYPHS,
+    TASK_TYPE_GLYPHS,
+    resolveEventGlyph,
+    type Glyph,
+} from './glyphs';
+import {
+    BADGE_SURFACE_BY_TONE,
+    BADGE_TEXT_BY_TONE,
+    CONTAINER_STROKE,
+    CONTAINER_SURFACE,
+    EDGE,
+    HEADER_SURFACE,
+    MUTED,
+    STROKE,
+    SURFACE,
+    TEXT,
+    UNBOUND,
+} from './palette';
+import { resolveBpmnStatsBadge, type BpmnStatsBadge } from './stats';
+
+const CATCHING_EVENT_TYPES: readonly string[] = ['startEvent', 'intermediateCatchEvent', BOUNDARY_EVENT_ELEMENT_TYPE];
+const RINGED_EVENT_TYPES: readonly string[] = ['intermediateCatchEvent', 'intermediateThrowEvent', BOUNDARY_EVENT_ELEMENT_TYPE];
+
+// ---------------------------------------------------------------------------------------------
+// Cell data
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * What every element node carries as X6 `data`.
+ *
+ * The mount layer reads nothing else off a node: selection, double-click and both stats updates are
+ * all answered from here, which is what keeps the interop payload the same whether the user clicked
+ * a task with a bound activity or a gateway with none.
+ */
+export interface BpmnElementCellData {
+    readonly cellKind: 'element';
+    readonly elementId: string;
+    readonly elementType: string;
+    readonly kind: BpmnElementKind;
+    readonly name: string | null;
+    /** The process id of the scope the element lives in. */
+    readonly scopeId: string;
+    /** The `Elsa.BpmnProcess` activity that runs {@link scopeId}. W10 needs it to open the scope. */
+    readonly scopeActivityId: string;
+    /** The bound Elsa activity, or null for an element that performs no work. */
+    readonly activityId: string | null;
+    readonly bindingState: BpmnBindingState | null;
+    /** Set only on a boundary event: the element it is drawn on. */
+    readonly boundaryHostElementId: string | null;
+    readonly childScopeId: string | null;
+    readonly stats: BpmnElementStats | null;
+    readonly activityStats: BpmnActivityStats | null;
+}
+
+/** What a lane or pool node carries. Containers are visual only; nothing is bound to them. */
+export interface BpmnContainerCellData {
+    readonly cellKind: 'lane' | 'pool';
+    readonly id: string;
+    readonly name: string | null;
+}
+
+export interface BpmnFlowCellData {
+    readonly cellKind: 'flow' | 'association';
+    readonly id: string;
+    readonly scopeId: string;
+    readonly sourceElementId: string;
+    readonly targetElementId: string;
+    readonly isDefault: boolean;
+    readonly conditionOutcome: string | null;
+}
+
+export type BpmnCellData = BpmnElementCellData | BpmnContainerCellData | BpmnFlowCellData;
+
+/** Something the view model describes that the canvas cannot draw, and why. */
+export interface BpmnUndrawn {
+    readonly kind: 'lane' | 'pool';
+    readonly id: string;
+    readonly reason: string;
+}
+
+export interface BpmnX6Cells {
+    readonly nodes: readonly Node.Metadata[];
+    readonly edges: readonly Edge.Metadata[];
+    /**
+     * Lanes and pools left off the canvas because the document places them nowhere.
+     *
+     * Never elements or flows: the view model always resolves a rectangle for an element, and an
+     * edge that is linked to its two nodes needs no geometry of its own.
+     */
+    readonly undrawn: readonly BpmnUndrawn[];
+}
+
+// ---------------------------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Maps a whole view model onto X6 cells.
+ *
+ * Guarantees, all of them checked by `__tests__/cells.test.ts` against every W9a fixture:
+ *
+ *  * one node per element, keyed by the element id verbatim, plus one node per lane and per pool
+ *    the document places;
+ *  * one edge per sequence flow, keyed by the flow id, plus one per resolved compensation
+ *    association;
+ *  * every boundary event's node names its host in `data.boundaryHostElementId`, and no boundary
+ *    event is an X6 child of anything -- see `nodeForElement` for why;
+ *  * every cell id is unique, so `fromJSON` cannot silently drop one.
+ */
+export function buildBpmnX6Cells(viewModel: BpmnViewModel): BpmnX6Cells {
+    const context = createContext(viewModel);
+    const nodes: Node.Metadata[] = [];
+    const edges: Edge.Metadata[] = [];
+    const undrawn: BpmnUndrawn[] = [];
+
+    for (const pool of viewModel.pools) {
+        const node = nodeForPool(pool);
+
+        if (node == null) undrawn.push({ kind: 'pool', id: pool.id, reason: 'The BPMN source places no shape for this pool.' });
+        else nodes.push(node);
+    }
+
+    for (const lane of viewModel.lanes) {
+        const node = nodeForLane(lane);
+
+        if (node == null) undrawn.push({ kind: 'lane', id: lane.id, reason: 'The BPMN source places no shape for this lane.' });
+        else nodes.push(node);
+    }
+
+    for (const element of viewModel.elements) {
+        nodes.push(nodeForElement(element, context));
+    }
+
+    for (const flow of viewModel.flows) {
+        edges.push(edgeForFlow(flow, context));
+    }
+
+    for (const association of viewModel.associations) {
+        if (!association.targetResolved) continue;
+
+        edges.push(edgeForAssociation(association.sourceElementId, association.targetElementId, association.scopeId, context));
+    }
+
+    return { nodes, edges, undrawn };
+}
+
+interface BuildContext {
+    readonly depthByScopeId: ReadonlyMap<string, number>;
+    readonly activityIdByScopeId: ReadonlyMap<string, string>;
+    readonly scopeIdsWithElements: ReadonlySet<string>;
+    readonly elementsByScopedId: ReadonlyMap<string, BpmnViewElement>;
+}
+
+function createContext(viewModel: BpmnViewModel): BuildContext {
+    return {
+        depthByScopeId: new Map(viewModel.scopes.map(scope => [scope.id, scope.depth])),
+        activityIdByScopeId: new Map(viewModel.scopes.map(scope => [scope.id, scope.activityId])),
+        scopeIdsWithElements: new Set(viewModel.elements.map(element => element.scopeId)),
+        elementsByScopedId: new Map(viewModel.elements.map(element => [scopedKey(element.scopeId, element.id), element])),
+    };
+}
+
+/** Scope-qualified, because an element id is only guaranteed unique within the document. */
+function scopedKey(scopeId: string, elementId: string): string {
+    return `${scopeId}\u0000${elementId}`;
+}
+
+function depthOf(context: BuildContext, scopeId: string): number {
+    return context.depthByScopeId.get(scopeId) ?? 0;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Element nodes
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * One element, one node -- and, for a boundary event, a node that is a *sibling* of its host rather
+ * than an X6 child of it.
+ *
+ * X6's embedding was rejected here twice over. A boundary event sits astride its host's border, so
+ * making it a child would hand X6 a child that overlaps its own parent's body and change which of
+ * the two a click on that border resolves to. And `parent`/`children` is X6's model hierarchy, not
+ * a drawing hint: using it here would make the canvas assert a containment the BPMN document does
+ * not have, which is the same reason lanes and pools do not embed the elements they hold. The host
+ * is recorded as data instead, which is everything a read-only canvas needs and everything W14 will
+ * need to move the two together.
+ */
+function nodeForElement(element: BpmnViewElement, context: BuildContext): Node.Metadata {
+    const depth = depthOf(context, element.scopeId);
+    const isBoundary = element.elementType === BOUNDARY_EVENT_ELEMENT_TYPE;
+    const data: BpmnElementCellData = {
+        cellKind: 'element',
+        elementId: element.id,
+        elementType: element.elementType,
+        kind: element.kind,
+        name: element.name,
+        scopeId: element.scopeId,
+        scopeActivityId: context.activityIdByScopeId.get(element.scopeId) ?? '',
+        activityId: element.binding?.activityId ?? null,
+        bindingState: element.binding?.state ?? null,
+        boundaryHostElementId: element.boundary?.hostElementId ?? null,
+        childScopeId: element.childScopeId,
+        stats: element.stats,
+        activityStats: element.activityStats,
+    };
+
+    return {
+        id: element.id,
+        shape: shapeForElement(element),
+        x: element.geometry.x,
+        y: element.geometry.y,
+        width: element.geometry.width,
+        height: element.geometry.height,
+        zIndex: isBoundary ? boundaryZIndex(depth) : elementZIndex(depth),
+        data,
+        attrs: attrsForElement(element, context),
+    };
+}
+
+function shapeForElement(element: BpmnViewElement): string {
+    switch (element.kind) {
+        case 'event':
+            return BPMN_EVENT_SHAPE;
+        case 'gateway':
+            return BPMN_GATEWAY_SHAPE;
+        default:
+            return BPMN_ACTIVITY_SHAPE;
+    }
+}
+
+function attrsForElement(element: BpmnViewElement, context: BuildContext): Record<string, any> {
+    const base = element.kind === 'event'
+        ? eventAttrs(element)
+        : element.kind === 'gateway'
+            ? gatewayAttrs(element)
+            : activityAttrs(element, context);
+
+    return { ...base, ...statsBadgeAttrs(resolveBpmnStatsBadge(element.stats, element.activityStats)) };
+}
+
+// -- events ------------------------------------------------------------------------------------
+
+function eventAttrs(element: BpmnViewElement): Record<string, any> {
+    const radius = Math.min(element.geometry.width, element.geometry.height) / 2;
+    const isEnd = element.elementType === 'endEvent';
+    const isRinged = RINGED_EVENT_TYPES.includes(element.elementType);
+    // A non-interrupting boundary event is drawn dashed. That is the document's `cancelActivity`
+    // flag as the view model reports it, not something inferred from what the event does.
+    const isNonInterrupting = element.boundary != null && !element.boundary.interrupting;
+    const strokeDasharray = isNonInterrupting ? '4 3' : null;
+    const glyph = resolveEventGlyph(element.eventDefinitions.map(definition => definition.type));
+    const solid = glyph != null && isSolidGlyph(glyph, !CATCHING_EVENT_TYPES.includes(element.elementType));
+
+    return {
+        body: {
+            fill: SURFACE,
+            stroke: STROKE,
+            // A thick single ring is what makes an end event an end event; an intermediate event is
+            // a thin double ring; a start event is a thin single ring.
+            strokeWidth: isEnd ? 3.5 : 1.5,
+            strokeDasharray,
+        },
+        ring: {
+            display: isRinged ? 'block' : 'none',
+            cx: element.geometry.width / 2,
+            cy: element.geometry.height / 2,
+            r: Math.max(radius - 3, 1),
+            fill: 'none',
+            stroke: STROKE,
+            strokeWidth: 1.5,
+            strokeDasharray,
+        },
+        icon: glyph == null
+            ? { display: 'none' }
+            : {
+                display: 'block',
+                d: glyph.d,
+                fill: solid ? STROKE : 'none',
+                stroke: solid ? 'none' : STROKE,
+                strokeWidth: 1.2,
+                refX: '50%',
+                refY: '50%',
+            },
+        label: externalLabelAttrs(element),
+    };
+}
+
+function isSolidGlyph(glyph: Glyph, throwing: boolean): boolean {
+    if (glyph.fill === 'solid') return true;
+    if (glyph.fill === 'outline') return false;
+
+    return throwing;
+}
+
+// -- gateways ----------------------------------------------------------------------------------
+
+function gatewayAttrs(element: BpmnViewElement): Record<string, any> {
+    const glyph = GATEWAY_GLYPHS[element.elementType] ?? null;
+
+    return {
+        body: { fill: SURFACE, stroke: STROKE, strokeWidth: 1.5 },
+        marker: glyph == null || !showsGatewayMarker(element)
+            ? { display: 'none' }
+            : {
+                display: 'block',
+                d: glyph.d,
+                fill: glyph.fill === 'solid' ? STROKE : 'none',
+                stroke: glyph.fill === 'solid' ? 'none' : STROKE,
+                strokeWidth: glyph.fill === 'solid' ? 0 : 2,
+                refX: '50%',
+                refY: '50%',
+            },
+        label: externalLabelAttrs(element),
+    };
+}
+
+/**
+ * Whether a gateway draws its own marker.
+ *
+ * BPMN makes the exclusive gateway's cross optional and records the choice in DI as
+ * `isMarkerVisible`; every other gateway always draws its marker. Where the document carries a
+ * shape for this gateway its answer is honoured exactly, so the canvas matches the modeller that
+ * wrote it. Where it does not -- a diagram Studio laid out itself -- the marker is drawn, because
+ * an unmarked diamond in a document with no DI at all is far more likely to be a missing fact than
+ * a deliberate one.
+ */
+function showsGatewayMarker(element: BpmnViewElement): boolean {
+    if (element.elementType !== 'exclusiveGateway') return true;
+    if (element.geometry.source === 'fallback') return element.isMarkerVisible ?? true;
+
+    return element.isMarkerVisible === true;
+}
+
+// -- tasks, subprocesses and call activities ---------------------------------------------------
+
+function activityAttrs(element: BpmnViewElement, context: BuildContext): Record<string, any> {
+    const expanded = isExpandedContainer(element, context);
+    const typeGlyph = TASK_TYPE_GLYPHS[element.elementType] ?? null;
+    const markers = activityMarkers(element, expanded);
+    const name = element.name ?? element.binding?.displayName ?? null;
+    const label = {
+        display: 'block',
+        text: wrapOnWords(name ?? '', element.geometry.width - ACTIVITY_LABEL_INSET, ACTIVITY_LABEL_FONT_SIZE, ACTIVITY_LABEL_MAX_LINES),
+        fill: TEXT,
+        fontSize: ACTIVITY_LABEL_FONT_SIZE,
+        lineHeight: ACTIVITY_LABEL_LINE_HEIGHT,
+        textWrap: {
+            width: -ACTIVITY_LABEL_INSET,
+            height: ACTIVITY_LABEL_LINE_HEIGHT * ACTIVITY_LABEL_MAX_LINES,
+            ellipsis: true,
+        },
+    };
+
+    return {
+        body: {
+            fill: expanded ? CONTAINER_SURFACE : SURFACE,
+            stroke: element.kind === 'unknown' ? MUTED : STROKE,
+            // A call activity's thick border is BPMN's way of saying "this runs another process".
+            strokeWidth: element.elementType === 'callActivity' ? 3.5 : 1.5,
+            strokeDasharray: element.kind === 'unknown'
+                ? '5 4'
+                // An event subprocess is drawn with a dotted border, expanded or collapsed.
+                : element.isEventSubProcess ? '2 3' : null,
+        },
+        // BPMN's double border for a transaction subprocess.
+        innerBorder: { display: element.isTransaction ? 'block' : 'none' },
+        typeMarker: typeGlyph == null
+            ? { display: 'none' }
+            : {
+                display: 'block',
+                d: typeGlyph.d,
+                fill: typeGlyph.fill === 'solid' ? STROKE : 'none',
+                stroke: typeGlyph.fill === 'solid' ? 'none' : STROKE,
+                strokeWidth: 1.2,
+                refX: 14,
+                refY: 14,
+            },
+        // An expanded subprocess is a container: its name belongs in the corner, not written across
+        // the middle of the elements it holds.
+        label: expanded
+            ? { ...label, fontWeight: 600, textAnchor: 'start', textVerticalAnchor: 'top', refX: 10, refY: 8 }
+            : {
+                ...label,
+                fontWeight: 500,
+                textAnchor: 'middle',
+                textVerticalAnchor: 'middle',
+                refX: '50%',
+                refY: '50%',
+                // Lifted so the bound activity's name has room underneath it.
+                refY2: element.binding == null ? 0 : -10,
+            },
+        subLabel: subLabelAttrs(element, expanded),
+        ...markerAttrs(markers),
+    };
+}
+
+/**
+ * Whether a subprocess is drawn as a container rather than as a collapsed box.
+ *
+ * `isExpanded` is the document's own answer and is used whenever the document gives one. When it
+ * does not -- a document with no DI at all -- a subprocess whose body has elements is expanded,
+ * because that is what the fallback layout did with it: it sized the subprocess to hold its
+ * children and placed them inside. Drawing a collapse marker over them would describe a diagram
+ * other than the one on screen.
+ */
+function isExpandedContainer(element: BpmnViewElement, context: BuildContext): boolean {
+    if (element.isExpanded != null) return element.isExpanded;
+
+    return element.childScopeId != null && context.scopeIdsWithElements.has(element.childScopeId);
+}
+
+/** The second line inside a task: what Elsa actually runs, or why nothing does. */
+function subLabelAttrs(element: BpmnViewElement, expanded: boolean): Record<string, any> {
+    const binding = element.binding;
+
+    if (expanded || binding == null) return { display: 'none', text: '' };
+
+    const text = binding.state === 'bound'
+        ? binding.displayName ?? ''
+        : binding.state === 'unbound' ? 'Not bound' : 'Binding not resolved';
+
+    if (text.length === 0) return { display: 'none', text: '' };
+
+    return {
+        display: 'block',
+        text,
+        fill: binding.state === 'bound' ? MUTED : UNBOUND,
+        fontSize: 10,
+        fontStyle: binding.state === 'bound' ? 'normal' : 'italic',
+        textAnchor: 'middle',
+        textVerticalAnchor: 'top',
+        refX: '50%',
+        refY: '50%',
+        refY2: 10,
+        textWrap: { width: -16, height: 24, ellipsis: true },
+    };
+}
+
+// How a task's own name is typeset inside its box.
+const ACTIVITY_LABEL_FONT_SIZE = 11;
+/** How much of the box's width the name may not use, so it does not touch the border. */
+const ACTIVITY_LABEL_INSET = 16;
+const ACTIVITY_LABEL_MAX_LINES = 2;
+/**
+ * Stated rather than left to X6 to derive.
+ *
+ * X6 turns `textWrap.height` into a line budget by dividing it by a line height, and works that out
+ * from the font size only when one is passed under the key it reads -- which it is not, so it falls
+ * back to 14px and a 20px line whatever the label's actual size. Setting `lineHeight` explicitly on
+ * the label makes the budget mean what it says; without it a two-line name silently comes out as
+ * one line with its second half missing.
+ */
+const ACTIVITY_LABEL_LINE_HEIGHT = 15;
+
+/**
+ * A rough average character width, as a fraction of the font size, for the sans-serif faces
+ * MudBlazor themes use. Deliberately a little generous: a name that wraps one word early reads
+ * perfectly well, a name that spills out of its box does not.
+ */
+const AVERAGE_CHARACTER_WIDTH_RATIO = 0.5;
+
+/**
+ * Breaks a label on word boundaries, and truncates it here rather than leaving that to X6.
+ *
+ * Two things make this necessary. X6's `textWrap` splits an over-long line by *character* count, so
+ * "Announce Shipment" in a 100-wide task comes out as "Announce Shipm" / "ent", and it does not
+ * expose the `breakWord` option that would stop it. And when a wrapped text runs past the line
+ * budget X6 drops the overflowing lines outright -- its ellipsis only applies to text it wrapped
+ * itself -- so "Apply Discount Rules" would silently lose "Rules". Doing both here means a name is
+ * either shown whole or shown to have been shortened.
+ *
+ * A single word wider than the box is still left to X6, which is the one case where breaking
+ * through a word is the only thing to do.
+ */
+function wrapOnWords(text: string, width: number, fontSize: number, maxLines: number): string {
+    const perLine = Math.max(Math.floor(width / (fontSize * AVERAGE_CHARACTER_WIDTH_RATIO)), 1);
+    const lines: string[] = [];
+    let line = '';
+
+    for (const word of text.split(/\s+/).filter(candidate => candidate.length > 0)) {
+        const combined = line.length === 0 ? word : `${line} ${word}`;
+
+        if (line.length === 0 || combined.length <= perLine) line = combined;
+        else {
+            lines.push(line);
+            line = word;
+        }
+    }
+
+    if (line.length > 0) lines.push(line);
+    if (lines.length <= maxLines) return lines.join('\n');
+
+    const kept = lines.slice(0, maxLines - 1);
+    const last = lines.slice(maxLines - 1).join(' ');
+
+    kept.push(`${last.slice(0, Math.max(perLine - 1, 1)).trimEnd()}\u2026`);
+
+    return kept.join('\n');
+}
+
+function activityMarkers(element: BpmnViewElement, expanded: boolean): readonly Glyph[] {
+    const markers: Glyph[] = [];
+
+    if (element.childScopeId != null && !expanded) markers.push(ACTIVITY_MARKER_GLYPHS.collapsed);
+
+    if (element.loopCharacteristics != null) {
+        markers.push(element.loopCharacteristics.isSequential
+            ? ACTIVITY_MARKER_GLYPHS.multiInstanceSequential
+            : ACTIVITY_MARKER_GLYPHS.multiInstanceParallel);
+    }
+
+    if (element.isForCompensation) markers.push(ACTIVITY_MARKER_GLYPHS.compensation);
+
+    return markers;
+}
+
+/** The marker row along the bottom edge, centred, with a fixed number of slots in the shape. */
+const MARKER_SLOTS = ['markerA', 'markerB', 'markerC'] as const;
+const MARKER_SPACING = 18;
+
+function markerAttrs(markers: readonly Glyph[]): Record<string, any> {
+    const shown = markers.slice(0, MARKER_SLOTS.length);
+    const attrs: Record<string, any> = {};
+
+    MARKER_SLOTS.forEach((slot, index) => {
+        const glyph = shown[index];
+
+        if (glyph == null) {
+            attrs[slot] = { display: 'none' };
+            return;
+        }
+
+        attrs[slot] = {
+            display: 'block',
+            d: glyph.d,
+            fill: glyph.fill === 'solid' ? STROKE : 'none',
+            stroke: glyph.fill === 'solid' ? 'none' : STROKE,
+            strokeWidth: 1.2,
+            refX: '50%',
+            refX2: Math.round((index - (shown.length - 1) / 2) * MARKER_SPACING),
+            refY: '100%',
+            refY2: -11,
+        };
+    });
+
+    return attrs;
+}
+
+// -- labels ------------------------------------------------------------------------------------
+
+/**
+ * The label of an event or gateway, which BPMN draws outside the shape.
+ *
+ * When the document says where the label goes, it is put there. Those coordinates are absolute in
+ * the plane, so they are re-expressed relative to the node and rounded: X6 reads a `refX` strictly
+ * between 0 and 1 as a fraction of the node's width rather than as an offset in pixels, and an
+ * integer can never fall into that range. The document's own label width is used as the wrap
+ * width, which is how the diagram keeps the line breaks its author chose.
+ */
+function externalLabelAttrs(element: BpmnViewElement): Record<string, any> {
+    const text = element.name ?? '';
+
+    if (text.length === 0) return { display: 'none', text: '' };
+
+    const common = {
+        display: 'block',
+        text,
+        fill: TEXT,
+        fontSize: 11,
+        textAnchor: 'middle',
+    };
+    const label = element.labelGeometry;
+
+    if (label == null) {
+        return {
+            ...common,
+            textVerticalAnchor: 'top',
+            refX: '50%',
+            refY: '100%',
+            refY2: 6,
+            textWrap: { width: 120, height: 32, ellipsis: true },
+        };
+    }
+
+    return {
+        ...common,
+        textVerticalAnchor: 'middle',
+        refX: Math.round(label.x - element.geometry.x + label.width / 2),
+        refY: Math.round(label.y - element.geometry.y + label.height / 2),
+        textWrap: { width: Math.max(Math.round(label.width), 60), height: 40, ellipsis: true },
+    };
+}
+
+// -- stats -------------------------------------------------------------------------------------
+
+/**
+ * The attributes that draw -- or clear -- the instance-state badge on one element node.
+ *
+ * Exported because `updateBpmnElementStats` re-applies them to a live node, and the two paths have
+ * to agree: a badge built at load time and a badge built by a later update must be the same badge
+ * for the same stats, and a null badge has to actively clear what is on screen rather than leave
+ * the previous one there. A stale fault is worse than no fault at all.
+ */
+export function statsBadgeAttrs(badge: BpmnStatsBadge | null): Record<string, any> {
+    if (badge == null) {
+        return {
+            statsBadge: { display: 'none' },
+            statsLabel: { display: 'none', text: '' },
+        };
+    }
+
+    return {
+        statsBadge: {
+            display: 'block',
+            fill: BADGE_SURFACE_BY_TONE[badge.tone],
+            stroke: SURFACE,
+            strokeWidth: 1.5,
+        },
+        statsLabel: {
+            display: 'block',
+            text: badge.count == null ? '' : `${badge.count}`,
+            fill: BADGE_TEXT_BY_TONE[badge.tone],
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Containers
+// ---------------------------------------------------------------------------------------------
+
+function nodeForPool(pool: BpmnViewPool): Node.Metadata | null {
+    if (pool.geometry == null) return null;
+
+    return containerNode(
+        `${BPMN_POOL_CELL_PREFIX}${pool.id}`,
+        BPMN_POOL_SHAPE,
+        POOL_Z_INDEX,
+        pool.geometry,
+        pool.name,
+        pool.isHorizontal ?? true,
+        { cellKind: 'pool', id: pool.id, name: pool.name });
+}
+
+function nodeForLane(lane: BpmnViewLane): Node.Metadata | null {
+    if (lane.geometry == null) return null;
+
+    return containerNode(
+        `${BPMN_LANE_CELL_PREFIX}${lane.id}`,
+        BPMN_LANE_SHAPE,
+        LANE_Z_INDEX,
+        lane.geometry,
+        lane.name,
+        lane.isHorizontal ?? true,
+        { cellKind: 'lane', id: lane.id, name: lane.name });
+}
+
+const CONTAINER_HEADER_SIZE = 30;
+
+function containerNode(
+    id: string,
+    shape: string,
+    zIndex: number,
+    geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number },
+    name: string | null,
+    isHorizontal: boolean,
+    data: BpmnContainerCellData): Node.Metadata {
+    return {
+        id,
+        shape,
+        x: geometry.x,
+        y: geometry.y,
+        width: geometry.width,
+        height: geometry.height,
+        zIndex,
+        data,
+        attrs: {
+            body: { fill: CONTAINER_SURFACE, stroke: CONTAINER_STROKE, strokeWidth: 1.5 },
+            header: isHorizontal
+                ? { x: 0, y: 0, width: CONTAINER_HEADER_SIZE, refHeight: '100%', fill: HEADER_SURFACE, stroke: CONTAINER_STROKE, strokeWidth: 1.5 }
+                : { x: 0, y: 0, refWidth: '100%', height: CONTAINER_HEADER_SIZE, fill: HEADER_SURFACE, stroke: CONTAINER_STROKE, strokeWidth: 1.5 },
+            label: {
+                text: name ?? '',
+                fill: TEXT,
+                fontSize: 12,
+                fontWeight: 600,
+                textAnchor: 'middle',
+                textVerticalAnchor: 'middle',
+                ...(isHorizontal
+                    ? { transform: 'rotate(-90)', refX: CONTAINER_HEADER_SIZE / 2, refY: '50%' }
+                    : { refX: '50%', refY: CONTAINER_HEADER_SIZE / 2 }),
+            },
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Edges
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * One sequence flow, drawn through the document's own waypoints.
+ *
+ * The ends are pinned to the exact first and last waypoint through the `bpmnWaypoint` anchor, which
+ * expresses each as an offset from the node's own rectangle. So the line is the author's line, to
+ * the pixel, and it still belongs to the two nodes it joins rather than floating free of them. A
+ * flow the document draws no edge for -- a fallback layout, or partial DI -- falls back to X6's own
+ * centre-to-boundary routing, which reads as a plain straight line between two shapes rather than
+ * as something pretending to be authored geometry.
+ */
+function edgeForFlow(flow: BpmnViewFlow, context: BuildContext): Edge.Metadata {
+    const data: BpmnFlowCellData = {
+        cellKind: 'flow',
+        id: flow.id,
+        scopeId: flow.scopeId,
+        sourceElementId: flow.sourceElementId,
+        targetElementId: flow.targetElementId,
+        isDefault: flow.isDefault,
+        conditionOutcome: flow.conditionOutcome,
+    };
+    const source = context.elementsByScopedId.get(scopedKey(flow.scopeId, flow.sourceElementId)) ?? null;
+    const target = context.elementsByScopedId.get(scopedKey(flow.scopeId, flow.targetElementId)) ?? null;
+    const waypoints = flow.waypoints;
+
+    return {
+        id: flow.id,
+        shape: BPMN_FLOW_SHAPE,
+        zIndex: flowZIndex(depthOf(context, flow.scopeId)),
+        source: terminal(flow.sourceElementId, source, waypoints[0]),
+        target: terminal(flow.targetElementId, target, waypoints[waypoints.length - 1]),
+        vertices: waypoints.length > 2 ? waypoints.slice(1, -1).map(point => ({ x: point.x, y: point.y })) : [],
+        attrs: { line: flowLineAttrs(flow, source) },
+        labels: flow.name == null || flow.name.length === 0 ? [] : [edgeLabel(flow.name)],
+        data,
+    };
+}
+
+function edgeForAssociation(
+    sourceElementId: string,
+    targetElementId: string,
+    scopeId: string,
+    context: BuildContext): Edge.Metadata {
+    const data: BpmnFlowCellData = {
+        cellKind: 'association',
+        id: `${sourceElementId}->${targetElementId}`,
+        scopeId,
+        sourceElementId,
+        targetElementId,
+        isDefault: false,
+        conditionOutcome: null,
+    };
+
+    return {
+        id: `${BPMN_ASSOCIATION_CELL_PREFIX}${sourceElementId}:${targetElementId}`,
+        shape: BPMN_ASSOCIATION_SHAPE,
+        zIndex: flowZIndex(depthOf(context, scopeId)),
+        source: { cell: sourceElementId },
+        target: { cell: targetElementId },
+        data,
+    };
+}
+
+type EdgeTerminal = NonNullable<Edge.Metadata['source']>;
+
+function terminal(
+    elementId: string,
+    element: BpmnViewElement | null,
+    waypoint: { readonly x: number; readonly y: number } | undefined): EdgeTerminal {
+    if (waypoint == null || element == null) return { cell: elementId };
+
+    return {
+        cell: elementId,
+        anchor: {
+            name: BPMN_WAYPOINT_ANCHOR,
+            args: { dx: waypoint.x - element.geometry.x, dy: waypoint.y - element.geometry.y },
+        },
+        connectionPoint: 'anchor',
+    };
+}
+
+/**
+ * The line's own markers.
+ *
+ * The slash on a default flow is drawn wherever the document declares one. The diamond on a
+ * conditional flow is drawn only where BPMN puts one -- on a flow leaving an *activity* -- because
+ * a gateway's outgoing flows are conditional by construction and no modeller decorates them. The
+ * two rules are separate on purpose: a default flow leaving a gateway is the common case and keeps
+ * its marker.
+ */
+function flowLineAttrs(flow: BpmnViewFlow, source: BpmnViewElement | null): Record<string, any> {
+    const attrs: Record<string, any> = {
+        stroke: EDGE,
+        strokeWidth: 1.5,
+        targetMarker: { name: 'block', width: 10, height: 8 },
+        sourceMarker: null,
+    };
+
+    if (flow.isDefault) {
+        attrs.sourceMarker = { name: 'path', d: 'M 4 -5 L 10 5', fill: 'none', stroke: EDGE, strokeWidth: 1.5 };
+    } else if (flow.conditionOutcome != null && source != null && source.kind !== 'gateway') {
+        attrs.sourceMarker = { name: 'diamond', width: 16, height: 10, fill: SURFACE, stroke: EDGE, strokeWidth: 1.5 };
+    }
+
+    return attrs;
+}
+
+function edgeLabel(text: string): Record<string, any> {
+    return {
+        position: { distance: 0.5 },
+        attrs: {
+            text: { text, fill: MUTED, fontSize: 11, textAnchor: 'middle', textVerticalAnchor: 'middle' },
+            rect: { fill: SURFACE, stroke: 'none', rx: 2, ry: 2 },
+        },
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
@@ -124,6 +124,23 @@ export interface BpmnUndrawn {
     readonly reason: string;
 }
 
+/**
+ * A cell the mapping chose not to emit because its id was already taken.
+ *
+ * X6 keys its whole model by cell id, document-wide, and a second cell with an id already in use
+ * silently replaces the first rather than erroring. Element and flow ids are only guaranteed unique
+ * within the BPMN document as a whole -- which the view model already checks and reports as
+ * `duplicate-element-id` / `duplicate-flow-id` -- so a malformed document can still ask this mapping
+ * for two cells with the same id. Rather than let X6 pick a survivor arbitrarily, the mapping keeps
+ * the first cell it built for a given id and drops every later one, and it drops with it any edge
+ * that would otherwise attach to the wrong survivor.
+ */
+export interface BpmnCollision {
+    readonly kind: 'pool' | 'lane' | 'element' | 'flow' | 'association';
+    readonly id: string;
+    readonly reason: string;
+}
+
 export interface BpmnX6Cells {
     readonly nodes: readonly Node.Metadata[];
     readonly edges: readonly Edge.Metadata[];
@@ -134,6 +151,8 @@ export interface BpmnX6Cells {
      * edge that is linked to its two nodes needs no geometry of its own.
      */
     readonly undrawn: readonly BpmnUndrawn[];
+    /** Cells dropped because their id collided with a cell already emitted. See {@link BpmnCollision}. */
+    readonly collisions: readonly BpmnCollision[];
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -151,43 +170,144 @@ export interface BpmnX6Cells {
  *    association;
  *  * every boundary event's node names its host in `data.boundaryHostElementId`, and no boundary
  *    event is an X6 child of anything -- see `nodeForElement` for why;
- *  * every cell id is unique, so `fromJSON` cannot silently drop one.
+ *  * every cell id is unique, so `fromJSON` cannot silently drop one -- a document that would make
+ *    two cells share an id instead has the later one, and any edge that would attach to it, reported
+ *    in {@link BpmnX6Cells.collisions} and left off the canvas.
  */
 export function buildBpmnX6Cells(viewModel: BpmnViewModel): BpmnX6Cells {
     const context = createContext(viewModel);
     const nodes: Node.Metadata[] = [];
     const edges: Edge.Metadata[] = [];
     const undrawn: BpmnUndrawn[] = [];
+    const collisions: BpmnCollision[] = [];
+    const claimedCellIds = new Set<string>();
+    /** The scope+element pairs whose node survived onto the canvas -- see {@link flowSurvives}. */
+    const survivingScopedElementIds = new Set<string>();
+
+    // A cell id already claimed by an earlier cell in this pass replaces nothing: it is dropped and
+    // reported instead, so the diagram never depends on which of two colliding cells X6 happened to
+    // keep.
+    const claim = (id: string): boolean => {
+        if (claimedCellIds.has(id)) return false;
+
+        claimedCellIds.add(id);
+
+        return true;
+    };
 
     for (const pool of viewModel.pools) {
         const node = nodeForPool(pool);
 
-        if (node == null) undrawn.push({ kind: 'pool', id: pool.id, reason: 'The BPMN source places no shape for this pool.' });
-        else nodes.push(node);
+        if (node == null) {
+            undrawn.push({ kind: 'pool', id: pool.id, reason: 'The BPMN source places no shape for this pool.' });
+        } else if (!claim(String(node.id))) {
+            collisions.push({ kind: 'pool', id: pool.id, reason: `Cell id '${node.id}' is already used by an earlier cell; the first cell is kept and this pool is dropped.` });
+        } else {
+            nodes.push(node);
+        }
     }
 
     for (const lane of viewModel.lanes) {
         const node = nodeForLane(lane);
 
-        if (node == null) undrawn.push({ kind: 'lane', id: lane.id, reason: 'The BPMN source places no shape for this lane.' });
-        else nodes.push(node);
+        if (node == null) {
+            undrawn.push({ kind: 'lane', id: lane.id, reason: 'The BPMN source places no shape for this lane.' });
+        } else if (!claim(String(node.id))) {
+            collisions.push({ kind: 'lane', id: lane.id, reason: `Cell id '${node.id}' is already used by an earlier cell; the first cell is kept and this lane is dropped.` });
+        } else {
+            nodes.push(node);
+        }
     }
 
     for (const element of viewModel.elements) {
-        nodes.push(nodeForElement(element, context));
+        const node = nodeForElement(element, context);
+
+        if (!claim(String(node.id))) {
+            collisions.push({
+                kind: 'element',
+                id: element.id,
+                reason: `The element id '${element.id}' is already drawn by another element (BPMN requires element ids to be `
+                    + `document-unique); the first one is kept and the element in scope '${element.scopeId}' is dropped.`,
+            });
+            continue;
+        }
+
+        survivingScopedElementIds.add(scopedKey(element.scopeId, element.id));
+        nodes.push(node);
     }
 
     for (const flow of viewModel.flows) {
-        edges.push(edgeForFlow(flow, context));
+        if (!flowSurvives(flow.scopeId, flow.sourceElementId, flow.targetElementId, context, survivingScopedElementIds)) {
+            collisions.push({
+                kind: 'flow',
+                id: flow.id,
+                reason: `The flow '${flow.id}' connects an element id that was dropped as a duplicate; the flow is dropped `
+                    + 'rather than risk attaching it to the wrong element.',
+            });
+            continue;
+        }
+
+        const edge = edgeForFlow(flow, context);
+
+        if (!claim(String(edge.id))) {
+            collisions.push({ kind: 'flow', id: flow.id, reason: `Cell id '${edge.id}' is already used by an earlier cell; the first cell is kept and this flow is dropped.` });
+            continue;
+        }
+
+        edges.push(edge);
     }
 
     for (const association of viewModel.associations) {
         if (!association.targetResolved) continue;
 
-        edges.push(edgeForAssociation(association.sourceElementId, association.targetElementId, association.scopeId, context));
+        const associationId = `${association.sourceElementId}->${association.targetElementId}`;
+
+        if (!flowSurvives(association.scopeId, association.sourceElementId, association.targetElementId, context, survivingScopedElementIds)) {
+            collisions.push({
+                kind: 'association',
+                id: associationId,
+                reason: `The compensation association '${associationId}' connects an element id that was dropped as a `
+                    + 'duplicate; the association is dropped rather than risk attaching it to the wrong element.',
+            });
+            continue;
+        }
+
+        const edge = edgeForAssociation(association.sourceElementId, association.targetElementId, association.scopeId, context);
+
+        if (!claim(String(edge.id))) {
+            collisions.push({ kind: 'association', id: associationId, reason: `Cell id '${edge.id}' is already used by an earlier cell; the first cell is kept and this association is dropped.` });
+            continue;
+        }
+
+        edges.push(edge);
     }
 
-    return { nodes, edges, undrawn };
+    return { nodes, edges, undrawn, collisions };
+}
+
+/**
+ * Whether a flow's (or association's) two endpoints still resolve to a node that made it onto the
+ * canvas.
+ *
+ * An endpoint that the view model does not resolve at all (a dangling flow, already reported by the
+ * view model itself) is left alone here -- that is not this function's concern. What it catches is
+ * the narrower case: the endpoint *did* resolve to a specific element, but that element's node lost
+ * out to an earlier one with the same id, so drawing the edge now would attach it to a node that is
+ * not the element the document meant.
+ */
+function flowSurvives(
+    scopeId: string,
+    sourceElementId: string,
+    targetElementId: string,
+    context: BuildContext,
+    survivingScopedElementIds: ReadonlySet<string>): boolean {
+    const sourceKey = scopedKey(scopeId, sourceElementId);
+    const targetKey = scopedKey(scopeId, targetElementId);
+
+    if (context.elementsByScopedId.has(sourceKey) && !survivingScopedElementIds.has(sourceKey)) return false;
+    if (context.elementsByScopedId.has(targetKey) && !survivingScopedElementIds.has(targetKey)) return false;
+
+    return true;
 }
 
 interface BuildContext {
@@ -652,6 +772,8 @@ export function statsBadgeAttrs(badge: BpmnStatsBadge | null): Record<string, an
         return {
             statsBadge: { display: 'none' },
             statsLabel: { display: 'none', text: '' },
+            statsBadgeGroup: { 'aria-label': null },
+            statsBadgeTitle: { text: '' },
         };
     }
 
@@ -667,6 +789,10 @@ export function statsBadgeAttrs(badge: BpmnStatsBadge | null): Record<string, an
             text: badge.count == null ? '' : `${badge.count}`,
             fill: BADGE_TEXT_BY_TONE[badge.tone],
         },
+        // `<title>` is the SVG tooltip, and `aria-label` says the same thing to a screen reader --
+        // between them the badge's state is not colour alone.
+        statsBadgeGroup: { 'aria-label': badge.title },
+        statsBadgeTitle: { text: badge.title },
     };
 }
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/constants.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/constants.ts
@@ -1,0 +1,68 @@
+/**
+ * Names and layering constants shared by the pure cell builder and the X6 mount layer.
+ *
+ * Deliberately free of imports so that `cells.ts` -- the layer the fixture tests gate -- can be
+ * loaded without pulling `@antv/x6` into the test environment.
+ */
+
+/** The CSS class `createBpmnGraph` puts on the container so the BPMN custom properties resolve. */
+export const BPMN_DESIGNER_CLASS = 'elsa-bpmn-diagram-designer';
+
+// Node shapes, one per BPMN element family. Tasks, call activities and subprocesses share one
+// rectangle shape and differ by attrs: their geometry, markers and labels are the same structure.
+export const BPMN_EVENT_SHAPE = 'bpmn-event';
+export const BPMN_ACTIVITY_SHAPE = 'bpmn-activity';
+export const BPMN_GATEWAY_SHAPE = 'bpmn-gateway';
+export const BPMN_POOL_SHAPE = 'bpmn-pool';
+export const BPMN_LANE_SHAPE = 'bpmn-lane';
+
+// Edge shapes.
+export const BPMN_FLOW_SHAPE = 'bpmn-flow';
+export const BPMN_ASSOCIATION_SHAPE = 'bpmn-association';
+
+/**
+ * The node anchor that pins an edge end to the exact BPMN DI waypoint.
+ *
+ * See `shapes.ts` for why the built-in `topLeft` anchor cannot be used for this.
+ */
+export const BPMN_WAYPOINT_ANCHOR = 'bpmnWaypoint';
+
+/**
+ * Cell id prefixes for the things that are not flow elements.
+ *
+ * A BPMN element's node keeps its element id verbatim, because `selectBpmnElement`,
+ * `updateBpmnElementStats` and the instance overlay are all keyed by it and a translation table
+ * between the two is one more thing that can drift. Lanes, pools and compensation associations get
+ * a prefix instead: lane and pool ids share the document's id space with elements, and an
+ * association has no id of its own at all.
+ */
+export const BPMN_POOL_CELL_PREFIX = 'bpmn-pool:';
+export const BPMN_LANE_CELL_PREFIX = 'bpmn-lane:';
+export const BPMN_ASSOCIATION_CELL_PREFIX = 'bpmn-association:';
+
+/**
+ * Painting order.
+ *
+ * X6 paints by ascending `zIndex`, so the bands below encode what BPMN needs to be legible:
+ * containers behind their contents, sequence flows behind the shapes they join, boundary events in
+ * front of the host they sit on, and a nested scope in front of the subprocess that contains it.
+ * Everything is derived from the scope depth the view model reports, so an arbitrarily deep nesting
+ * keeps the same relative order without a special case.
+ */
+export const POOL_Z_INDEX = 0;
+export const LANE_Z_INDEX = 1;
+
+/** Elements of a scope at `depth`; the root scope is depth 0. */
+export function elementZIndex(depth: number): number {
+    return 10 * (depth + 1);
+}
+
+/** A boundary event draws in front of the host it is attached to, which is in its own scope. */
+export function boundaryZIndex(depth: number): number {
+    return elementZIndex(depth) + 5;
+}
+
+/** A scope's sequence flows draw behind that scope's elements but in front of its container. */
+export function flowZIndex(depth: number): number {
+    return elementZIndex(depth) - 5;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/dotnet-bpmn-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/dotnet-bpmn-designer.ts
@@ -1,0 +1,59 @@
+/**
+ * The bridge from the BPMN canvas back to .NET.
+ *
+ * The method names are the flowchart designer's -- `HandleActivitySelected`,
+ * `HandleActivityDoubleClick`, `HandleCanvasSelected`, exactly as
+ * `api/dotnet-flowchart-designer.ts` invokes them. That is deliberate and is the point of W9c's
+ * "no BPMN-specific contract": W10 raises the same `ActivitySelected` and `ActivityDoubleClick`
+ * events from a BPMN canvas as from a flowchart one, and anything downstream of those events --
+ * the properties pane, the activity picker, the instance viewer -- keeps working without knowing
+ * which canvas it is looking at.
+ *
+ * What differs is the payload. A flowchart node *is* an activity, so it sends one; a BPMN node is a
+ * diagram element that may or may not have one, so it sends the element and names the activity
+ * separately, which is null for a gateway, an event, or work nobody has bound yet.
+ */
+import type { DotNetComponentRef } from '../api/graph-bindings';
+
+/** What a click on a BPMN element tells .NET. */
+export interface BpmnElementSelection {
+    /** The BPMN element id. Unique in the document, and the key the instance overlay uses. */
+    readonly elementId: string;
+    /** The raw BPMN element type, e.g. `serviceTask`, `boundaryEvent`. */
+    readonly elementType: string;
+    /** The element family: `event`, `gateway`, `task`, `callActivity`, `subProcess`, `unknown`. */
+    readonly kind: string;
+    readonly name: string | null;
+    /** The Elsa activity bound to this element, or null when nothing is or should be. */
+    readonly activityId: string | null;
+    /** How the binding resolves, or null for an element that performs no work. */
+    readonly bindingState: string | null;
+    /** The process id of the scope the element lives in. */
+    readonly scopeId: string;
+    /** The `Elsa.BpmnProcess` activity that runs that scope. */
+    readonly scopeActivityId: string;
+    /** For a boundary event, the element it is attached to. */
+    readonly boundaryHostElementId: string | null;
+    /** For a subprocess, the process id of the scope it contains. */
+    readonly childScopeId: string | null;
+}
+
+export class DotNetBpmnDesigner {
+    constructor(private readonly componentRef: DotNetComponentRef) {
+    }
+
+    /** Raises `ActivitySelected` on the .NET component. */
+    async raiseElementSelected(selection: BpmnElementSelection): Promise<void> {
+        await this.componentRef.invokeMethodAsync('HandleActivitySelected', selection);
+    }
+
+    /** Raises `ActivityDoubleClick` on the .NET component. */
+    async raiseElementDoubleClick(selection: BpmnElementSelection): Promise<void> {
+        await this.componentRef.invokeMethodAsync('HandleActivityDoubleClick', selection);
+    }
+
+    /** Raises `CanvasSelected` on the .NET component, i.e. nothing is selected any more. */
+    async raiseCanvasSelected(): Promise<void> {
+        await this.componentRef.invokeMethodAsync('HandleCanvasSelected');
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/glyphs.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/glyphs.ts
@@ -1,0 +1,105 @@
+/**
+ * The SVG path data for BPMN's markers: event-definition icons, task-type icons, gateway markers
+ * and the activity markers that run along the bottom of a task or subprocess.
+ *
+ * Every path is authored centred on its own origin, in a nominal 16x16 box, so that a shape can
+ * place it with nothing but X6's `refX`/`refY` -- no per-node arithmetic, no transform strings, and
+ * the same glyph reusable at a corner, at the centre, or in the marker row.
+ *
+ * These live in the adapter rather than in `src/bpmn` on purpose: which shape a `timer` event
+ * definition draws is a fact about *this* canvas. A React Flow adapter would render the same
+ * definition as a React icon component, not as a path string, so there is nothing here for the two
+ * to share. What *is* canvas-neutral -- the element's kind, its event definitions, whether a
+ * boundary event interrupts -- comes from the view model and is never re-derived here.
+ */
+
+/**
+ * How a glyph is painted.
+ *
+ * `'direction'` is BPMN's own rule for event definitions: the same definition is drawn hollow on an
+ * event that catches it and solid on an event that throws it. `'outline'` and `'solid'` are for the
+ * glyphs where that rule does not apply -- a timer only ever catches, a terminate only ever ends --
+ * and for the markers that are not event definitions at all.
+ */
+export type GlyphFill = 'outline' | 'solid' | 'direction';
+
+export interface Glyph {
+    readonly d: string;
+    readonly fill: GlyphFill;
+}
+
+const outline = (d: string): Glyph => ({ d, fill: 'outline' });
+const solid = (d: string): Glyph => ({ d, fill: 'solid' });
+const directional = (d: string): Glyph => ({ d, fill: 'direction' });
+
+/**
+ * Event-definition icons, keyed by the lowercase `type` the payload carries on
+ * `BpmnElement.eventDefinitions` (`timer`, `message`, `error`, ... -- see `Bpmn.Model`).
+ *
+ * An unknown definition draws no icon rather than a wrong one; the event's ring still tells the
+ * reader what kind of event it is.
+ */
+export const EVENT_DEFINITION_GLYPHS: Readonly<Record<string, Glyph>> = {
+    message: directional('M -7 -5 L 7 -5 L 7 5 L -7 5 Z M -7 -5 L 0 1 L 7 -5'),
+    timer: outline('M 0 -7 A 7 7 0 1 0 0.01 -7 Z M 0 -4.5 L 0 0 L 3 2'),
+    error: directional('M -6 7 L -2 -4 L 2 1 L 6 -7 L 2 4 L -2 -1 Z'),
+    escalation: directional('M 0 -7 L 6 7 L 0 1 L -6 7 Z'),
+    cancel: directional('M -6.5 -5 L -5 -6.5 L 0 -1.5 L 5 -6.5 L 6.5 -5 L 1.5 0 L 6.5 5 L 5 6.5 L 0 1.5 L -5 6.5 L -6.5 5 L -1.5 0 Z'),
+    compensation: directional('M -7 0 L -1 -4.5 L -1 4.5 Z M -1 0 L 5 -4.5 L 5 4.5 Z'),
+    signal: directional('M 0 -6 L 7 6 L -7 6 Z'),
+    terminate: solid('M -7 0 A 7 7 0 1 0 7 0 A 7 7 0 1 0 -7 0 Z'),
+    conditional: outline('M -6 -7 L 6 -7 L 6 7 L -6 7 Z M -4 -4 L 4 -4 M -4 -1 L 4 -1 M -4 2 L 4 2 M -4 5 L 1 5'),
+    link: directional('M -7 -3 L 1 -3 L 1 -6 L 7 0 L 1 6 L 1 3 L -7 3 Z'),
+    multiple: directional('M 0 -7 L 7 -2 L 4 7 L -4 7 L -7 -2 Z'),
+    parallelmultiple: outline('M -2 -7 L 2 -7 L 2 -2 L 7 -2 L 7 2 L 2 2 L 2 7 L -2 7 L -2 2 L -7 2 L -7 -2 L -2 -2 Z'),
+};
+
+/** The task-type icon drawn in a task's top-left corner. A plain `task` draws none. */
+export const TASK_TYPE_GLYPHS: Readonly<Record<string, Glyph>> = {
+    userTask: outline('M 0 -6.5 A 2.8 2.8 0 1 0 0.01 -6.5 Z M -5.5 7 C -5.5 1 5.5 1 5.5 7'),
+    // An eight-tooth gear with a hub, generated rather than eyeballed so the teeth are even.
+    serviceTask: outline('M -1.18 -5.27 L -1.19 -7.51 L 1.19 -7.51 L 1.18 -5.27 L 2.89 -4.56 L 4.47 -6.15 L 6.15 -4.47 L 4.56 -2.89 L 5.27 -1.18 L 7.51 -1.19 L 7.51 1.19 L 5.27 1.18 L 4.56 2.89 L 6.15 4.47 L 4.47 6.15 L 2.89 4.56 L 1.18 5.27 L 1.19 7.51 L -1.19 7.51 L -1.18 5.27 L -2.89 4.56 L -4.47 6.15 L -6.15 4.47 L -4.56 2.89 L -5.27 1.18 L -7.51 1.19 L -7.51 -1.19 L -5.27 -1.18 L -4.56 -2.89 L -6.15 -4.47 L -4.47 -6.15 L -2.89 -4.56 Z M 2.6 0 A 2.6 2.6 0 1 0 -2.6 0 A 2.6 2.6 0 1 0 2.6 0 Z'),
+    scriptTask: outline('M -5 -7 L 5 -7 L 5 7 L -5 7 Z M -3 -4 L 3 -4 M -3 -1 L 3 -1 M -3 2 L 1 2'),
+    manualTask: outline('M -6.5 2 L -6.5 -1 C -6.5 -3 -3.5 -3 -3.5 -1 L -3.5 -5 C -3.5 -7 -0.5 -7 -0.5 -5 L -0.5 -4 C -0.5 -6 2.5 -6 2.5 -4 L 2.5 -3 C 2.5 -5 5.5 -5 5.5 -3 L 5.5 2 C 5.5 5 3 7 0 7 L -3 7 C -5 7 -6.5 5 -6.5 2 Z'),
+    businessRuleTask: outline('M -7 -5 L 7 -5 L 7 5 L -7 5 Z M -7 -2 L 7 -2 M -7 1.5 L 7 1.5 M -1 -2 L -1 5'),
+    sendTask: solid('M -7 -5 L 7 -5 L 7 5 L -7 5 Z'),
+    receiveTask: outline('M -7 -5 L 7 -5 L 7 5 L -7 5 Z M -7 -5 L 0 1 L 7 -5'),
+};
+
+/** The marker drawn in the middle of a gateway's diamond. */
+export const GATEWAY_GLYPHS: Readonly<Record<string, Glyph>> = {
+    exclusiveGateway: solid('M -6.5 -8 L 0 -3 L 6.5 -8 L 8 -6.5 L 3 0 L 8 6.5 L 6.5 8 L 0 3 L -6.5 8 L -8 6.5 L -3 0 L -8 -6.5 Z'),
+    parallelGateway: solid('M -2.5 -10 L 2.5 -10 L 2.5 -2.5 L 10 -2.5 L 10 2.5 L 2.5 2.5 L 2.5 10 L -2.5 10 L -2.5 2.5 L -10 2.5 L -10 -2.5 L -2.5 -2.5 Z'),
+    inclusiveGateway: outline('M 0 -9 A 9 9 0 1 0 0.01 -9 Z'),
+    eventBasedGateway: outline('M 0 -9.5 A 9.5 9.5 0 1 0 0.01 -9.5 Z M 0 -7.5 A 7.5 7.5 0 1 0 0.01 -7.5 Z M 0 -5 L 4.8 -1.5 L 3 4 L -3 4 L -4.8 -1.5 Z'),
+};
+
+/** The markers that run along the bottom edge of a task, subprocess or call activity. */
+export const ACTIVITY_MARKER_GLYPHS = {
+    /** A subprocess the diagram draws collapsed. */
+    collapsed: outline('M -6 -6 L 6 -6 L 6 6 L -6 6 Z M 0 -3.5 L 0 3.5 M -3.5 0 L 3.5 0'),
+    /** A parallel multi-instance activity. */
+    multiInstanceParallel: solid('M -5.5 -6 L -3 -6 L -3 6 L -5.5 6 Z M -1.25 -6 L 1.25 -6 L 1.25 6 L -1.25 6 Z M 3 -6 L 5.5 -6 L 5.5 6 L 3 6 Z'),
+    /** A sequential multi-instance activity. */
+    multiInstanceSequential: solid('M -6 -5.5 L 6 -5.5 L 6 -3 L -6 -3 Z M -6 -1.25 L 6 -1.25 L 6 1.25 L -6 1.25 Z M -6 3 L 6 3 L 6 5.5 L -6 5.5 Z'),
+    /** A compensation handler. */
+    compensation: solid('M -6.5 0 L -0.5 -4 L -0.5 4 Z M -0.5 0 L 5.5 -4 L 5.5 4 Z'),
+} satisfies Readonly<Record<string, Glyph>>;
+
+/**
+ * The glyph for one event's definitions.
+ *
+ * BPMN allows several definitions on one event; the first is drawn, and `multiple` /
+ * `parallelMultiple` is drawn when there is more than one and the document did not already say so.
+ * Definition type matching is case-insensitive because the payload's `type` is the library's
+ * spelling and this table's keys are ours.
+ */
+export function resolveEventGlyph(definitionTypes: readonly string[]): Glyph | null {
+    if (definitionTypes.length === 0) return null;
+
+    if (definitionTypes.length > 1) {
+        return EVENT_DEFINITION_GLYPHS.multiple;
+    }
+
+    return EVENT_DEFINITION_GLYPHS[definitionTypes[0].toLowerCase()] ?? null;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/graph-options.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/graph-options.ts
@@ -1,0 +1,80 @@
+/**
+ * The X6 graph configuration the BPMN canvas is created with.
+ *
+ * A separate, pure function on purpose. "Read-only" is the property this whole adapter rests on --
+ * W14, not W9c, is what makes a BPMN diagram editable -- and a property that only exists inside a
+ * `new Graph(...)` call can only be checked by reading the code. Here it can be asserted:
+ * `__tests__/graph-options.test.ts` walks every interaction flag and fails if one of them is
+ * anything other than `false`.
+ */
+import type { CellView, Options as GraphOptions } from '@antv/x6';
+
+/**
+ * Every interaction X6 knows how to offer, each one refused.
+ *
+ * Spelled out key by key rather than written `interacting: false` so that an X6 upgrade which adds
+ * a new interaction is a visible gap in this list and a failing test, rather than a new way to edit
+ * a diagram that nothing in Studio asked for.
+ */
+export const BPMN_READ_ONLY_INTERACTING: Record<CellView.InteractionNames, boolean> = {
+    nodeMovable: false,
+    edgeMovable: false,
+    edgeLabelMovable: false,
+    arrowheadMovable: false,
+    vertexMovable: false,
+    vertexAddable: false,
+    vertexDeletable: false,
+    useEdgeTools: false,
+    magnetConnectable: false,
+    stopDelegateOnDragging: false,
+    toolsAddable: false,
+};
+
+export interface BpmnGraphSettings {
+    /** Whether the canvas may be panned by dragging it. Defaults to true. */
+    readonly panning?: boolean;
+    /** Whether the mouse wheel zooms. Defaults to true. */
+    readonly mousewheel?: boolean;
+    /** Whether the background grid is drawn. Defaults to true. */
+    readonly grid?: boolean;
+}
+
+/**
+ * Builds the options for a read-only BPMN graph.
+ *
+ * Beyond the refused interactions, two things are deliberately absent and stay absent:
+ *
+ *  * **no connecting.** `validateConnection` and `validateMagnet` both refuse unconditionally, so
+ *    even a caller that later enables a magnet cannot draw an edge by accident.
+ *  * **no embedding.** BPMN containment -- a subprocess's body, a lane's membership -- is a fact of
+ *    the document, and X6's embedding would make it a fact of the canvas that dragging could
+ *    change. Boundary events and lane contents are positioned, never parented.
+ */
+export function createBpmnGraphOptions(settings?: BpmnGraphSettings): Partial<GraphOptions.Manual> {
+    return {
+        autoResize: true,
+        grid: settings?.grid === false
+            ? false
+            : { visible: true, size: 10, type: 'dot', args: { color: 'var(--elsa-bpmn-grid)', thickness: 1 } },
+        panning: { enabled: settings?.panning !== false },
+        mousewheel: {
+            enabled: settings?.mousewheel !== false,
+            factor: 1.05,
+            minScale: 0.2,
+            maxScale: 4,
+        },
+        interacting: { ...BPMN_READ_ONLY_INTERACTING },
+        connecting: {
+            allowBlank: false,
+            allowLoop: false,
+            allowNode: false,
+            allowEdge: false,
+            allowPort: false,
+            allowMulti: false,
+            validateMagnet: () => false,
+            validateConnection: () => false,
+        },
+        embedding: { enabled: false },
+        preventDefaultBlankAction: false,
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/graph-registry.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/graph-registry.ts
@@ -1,0 +1,45 @@
+/**
+ * The live BPMN graphs, keyed by container id.
+ *
+ * A registry of its own rather than an entry in `api/graph-bindings.ts`: that map's `GraphBinding`
+ * carries a `DesignerMode` and a `DotNetFlowchartDesigner`, and a BPMN canvas is neither. Widening
+ * `DesignerMode` with a fourth member would oblige every `getDesignerModePolicy` switch in the
+ * flowchart designer to answer for a mode it never renders, which is a larger change to working
+ * code than the separation costs.
+ *
+ * The consequence is that anything reached by graph id has to look in both maps; `api/find-graph.ts`
+ * is the single place that does.
+ */
+import type { Graph } from '@antv/x6';
+import type { BpmnViewModel } from '../../bpmn';
+import type { DotNetBpmnDesigner } from './dotnet-bpmn-designer';
+
+export interface BpmnGraphBinding {
+    readonly graphId: string;
+    readonly graph: Graph;
+    readonly interop: DotNetBpmnDesigner;
+    /** The view model the canvas currently draws, or null before the first load. */
+    viewModel: BpmnViewModel | null;
+    /**
+     * Non-zero while the adapter is selecting on .NET's behalf.
+     *
+     * Without it, `selectBpmnElement` would echo the selection straight back to the component that
+     * asked for it, which is how a properties pane ends up fighting the canvas for control of the
+     * selection.
+     */
+    suppressSelectionCallbacks: number;
+}
+
+export const bpmnGraphBindings: Record<string, BpmnGraphBinding> = {};
+
+/** Disposes a BPMN graph if the id names one. Returns whether it did. */
+export function disposeBpmnGraphBinding(graphId: string): boolean {
+    const binding = bpmnGraphBindings[graphId];
+
+    if (binding == null) return false;
+
+    binding.graph.dispose();
+    delete bpmnGraphBindings[graphId];
+
+    return true;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
@@ -115,10 +115,12 @@ function wireEvents(binding: BpmnGraphBinding): void {
  * Replaces whatever the canvas holds with the cells for this view model.
  *
  * Reports, loudly, when the canvas ends up holding fewer cells than the mapping produced. X6 keys
- * its model by cell id and a second cell with the same id replaces the first, so a document whose
- * element ids are not unique -- which the view model reports as `duplicate-element-id` but still
- * renders -- would otherwise lose a shape without a word. A diagram that is quietly missing an
- * element is exactly the failure this issue asks to be made to name itself.
+ * its model by cell id and a second cell with the same id replaces the first, so `cells.ts` itself
+ * never emits two cells that would collide -- a document whose element ids are not unique, which the
+ * view model reports as `duplicate-element-id` but still renders, has its duplicate dropped there and
+ * named in `cells.collisions`. This still checks the canvas against the mapping and still logs
+ * `cells.collisions`, so a divergence this layer did not anticipate is not left to be discovered as a
+ * diagram that is quietly missing an element.
  */
 export function loadBpmnDiagram(binding: BpmnGraphBinding, viewModel: BpmnViewModel): void {
     const cells = buildBpmnX6Cells(viewModel);
@@ -150,6 +152,10 @@ function reportDivergence(binding: BpmnGraphBinding, cells: BpmnX6Cells): void {
 
     for (const undrawn of cells.undrawn) {
         console.warn(`BPMN diagram '${binding.graphId}': the ${undrawn.kind} '${undrawn.id}' is not drawn. ${undrawn.reason}`);
+    }
+
+    for (const collision of cells.collisions) {
+        console.error(`BPMN diagram '${binding.graphId}': the ${collision.kind} '${collision.id}' is not drawn. ${collision.reason}`);
     }
 }
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
@@ -1,0 +1,237 @@
+/**
+ * The thin layer between the pure cell mapping and a live X6 graph: creating the canvas, putting
+ * cells on it, keeping the instance overlay current, and raising selection back to .NET.
+ *
+ * Everything that could be decided without a browser was decided in `cells.ts`, `graph-options.ts`
+ * and `stats.ts`. What is left here is the part that genuinely needs a `Graph`, which is why it is
+ * short and why the fixture tests do not need to run X6 to gate the mapping.
+ */
+import { Graph, type Model } from '@antv/x6';
+import { Selection } from '@antv/x6-plugin-selection';
+import type { BpmnActivityStats, BpmnElementStats, BpmnViewModel } from '../../bpmn';
+import type { DotNetComponentRef } from '../api/graph-bindings';
+import { whenCanvasHasHeight } from '../internal/canvas-ready';
+import {
+    buildBpmnX6Cells,
+    statsBadgeAttrs,
+    type BpmnElementCellData,
+    type BpmnX6Cells,
+} from './cells';
+import { BPMN_DESIGNER_CLASS } from './constants';
+import { DotNetBpmnDesigner, type BpmnElementSelection } from './dotnet-bpmn-designer';
+import { bpmnGraphBindings, type BpmnGraphBinding } from './graph-registry';
+import { createBpmnGraphOptions, type BpmnGraphSettings } from './graph-options';
+import { registerBpmnShapes } from './shapes';
+import { resolveBpmnStatsBadge } from './stats';
+
+/**
+ * Creates a read-only BPMN canvas in the given container and registers it under the container id.
+ *
+ * Only the Selection plugin is installed. The clipboard, history, transform, snapline and keyboard
+ * plugins the flowchart designer uses all exist to change a diagram, and W9c does not: leaving them
+ * off is a stronger guarantee than configuring them not to fire.
+ */
+export function createBpmnGraph(containerId: string, componentRef: DotNetComponentRef, settings?: BpmnGraphSettings): string {
+    const container = document.getElementById(containerId);
+
+    if (container == null) throw new Error(`Cannot create a BPMN graph: no element with id '${containerId}'.`);
+
+    // The class carries the custom properties every shape paints with, so the adapter is themed
+    // whatever wrapper it is hosted in.
+    container.classList.add(BPMN_DESIGNER_CLASS);
+    registerBpmnShapes();
+
+    const interop = new DotNetBpmnDesigner(componentRef);
+    const graph = new Graph({ container, ...createBpmnGraphOptions(settings) });
+
+    graph.use(new Selection({
+        enabled: true,
+        multiple: false,
+        movable: false,
+        rubberband: false,
+        rubberNode: false,
+        rubberEdge: false,
+        showNodeSelectionBox: true,
+        className: 'elsa-bpmn-selection',
+    }));
+
+    const binding: BpmnGraphBinding = {
+        graphId: containerId,
+        graph,
+        interop,
+        viewModel: null,
+        suppressSelectionCallbacks: 0,
+    };
+
+    bpmnGraphBindings[containerId] = binding;
+    wireEvents(binding);
+
+    return containerId;
+}
+
+function wireEvents(binding: BpmnGraphBinding): void {
+    const { graph, interop } = binding;
+
+    graph.on('node:click', ({ node }) => {
+        const data = elementData(node.getData());
+
+        // A lane or a pool is scenery. Clicking one means "nothing in particular", the same as
+        // clicking the canvas, rather than selecting a container the document does not treat as an
+        // element. (Containers are also `pointerEvents: 'none'`, so this is belt and braces.)
+        if (data == null) {
+            graph.cleanSelection();
+            void interop.raiseCanvasSelected();
+            return;
+        }
+
+        if (!graph.isSelected(node)) graph.select(node);
+    });
+
+    graph.on('node:selected', ({ node }) => {
+        if (binding.suppressSelectionCallbacks > 0) return;
+
+        const data = elementData(node.getData());
+
+        if (data == null) return;
+
+        void interop.raiseElementSelected(toSelection(data));
+    });
+
+    graph.on('node:dblclick', ({ node }) => {
+        const data = elementData(node.getData());
+
+        if (data == null) return;
+
+        void interop.raiseElementDoubleClick(toSelection(data));
+    });
+
+    graph.on('blank:click', () => {
+        graph.cleanSelection();
+        void interop.raiseCanvasSelected();
+    });
+}
+
+/**
+ * Replaces whatever the canvas holds with the cells for this view model.
+ *
+ * Reports, loudly, when the canvas ends up holding fewer cells than the mapping produced. X6 keys
+ * its model by cell id and a second cell with the same id replaces the first, so a document whose
+ * element ids are not unique -- which the view model reports as `duplicate-element-id` but still
+ * renders -- would otherwise lose a shape without a word. A diagram that is quietly missing an
+ * element is exactly the failure this issue asks to be made to name itself.
+ */
+export function loadBpmnDiagram(binding: BpmnGraphBinding, viewModel: BpmnViewModel): void {
+    const cells = buildBpmnX6Cells(viewModel);
+
+    binding.viewModel = viewModel;
+    // `Node.Metadata`/`Edge.Metadata` are what X6 accepts through `addNode`/`addEdge`; `fromJSON`
+    // declares the stricter `Cell.Properties`, which the same objects satisfy at run time.
+    binding.graph.fromJSON({ cells: [...cells.nodes, ...cells.edges] } as Model.FromJSONData);
+
+    reportDivergence(binding, cells);
+
+    void whenCanvasHasHeight(binding.graph, () => bpmnGraphBindings[binding.graphId] === binding).then(ready => {
+        if (!ready) return;
+
+        binding.graph.zoomToFit({ padding: 24, minScale: 0.2, maxScale: 1 });
+    });
+}
+
+function reportDivergence(binding: BpmnGraphBinding, cells: BpmnX6Cells): void {
+    const nodeCount = binding.graph.getNodes().length;
+    const edgeCount = binding.graph.getEdges().length;
+
+    if (nodeCount !== cells.nodes.length || edgeCount !== cells.edges.length) {
+        console.error(
+            `BPMN diagram '${binding.graphId}': the view model maps to ${cells.nodes.length} nodes and ${cells.edges.length} edges, `
+            + `but the canvas holds ${nodeCount} and ${edgeCount}. X6 replaces a cell whose id is already taken, so the diagram on `
+            + 'screen is missing something the document contains -- most likely two elements sharing an id.');
+    }
+
+    for (const undrawn of cells.undrawn) {
+        console.warn(`BPMN diagram '${binding.graphId}': the ${undrawn.kind} '${undrawn.id}' is not drawn. ${undrawn.reason}`);
+    }
+}
+
+/**
+ * Replaces the element-keyed instance overlay wholesale.
+ *
+ * The map is authoritative: an element the map no longer mentions loses its badge. Merging instead
+ * would leave a fault, or a block, on screen after the instance that produced it moved on -- a
+ * stale diagram that reads as a live one.
+ */
+export function updateBpmnElementStats(
+    binding: BpmnGraphBinding,
+    elementStats: Readonly<Record<string, BpmnElementStats>> | null | undefined): void {
+    for (const node of binding.graph.getNodes()) {
+        const data = elementData(node.getData());
+
+        if (data == null) continue;
+
+        const stats = elementStats?.[data.elementId] ?? null;
+
+        node.setData({ ...data, stats }, { overwrite: true });
+        node.attr(statsBadgeAttrs(resolveBpmnStatsBadge(stats, data.activityStats)));
+    }
+}
+
+/** Updates the activity-keyed overlay for one Elsa activity, on every element bound to it. */
+export function updateBpmnActivityStats(
+    binding: BpmnGraphBinding,
+    activityId: string,
+    activityStats: BpmnActivityStats | null | undefined): void {
+    const resolved = activityStats ?? null;
+
+    for (const node of binding.graph.getNodes()) {
+        const data = elementData(node.getData());
+
+        if (data == null || data.activityId !== activityId) continue;
+
+        node.setData({ ...data, activityStats: resolved }, { overwrite: true });
+        node.attr(statsBadgeAttrs(resolveBpmnStatsBadge(data.stats, resolved)));
+    }
+}
+
+/**
+ * Selects one element on .NET's behalf.
+ *
+ * The selection callback is suppressed while it happens: the caller already knows what it asked
+ * for, and echoing it back is how a properties pane and a canvas end up in a loop.
+ */
+export function selectBpmnElement(binding: BpmnGraphBinding, elementId: string, center = false): void {
+    const cell = binding.graph.getCellById(elementId);
+
+    if (cell == null) {
+        console.warn(`BPMN diagram '${binding.graphId}': no cell for element '${elementId}' to select.`);
+        return;
+    }
+
+    binding.suppressSelectionCallbacks += 1;
+
+    try {
+        binding.graph.resetSelection(cell);
+
+        if (center) binding.graph.centerCell(cell);
+    } finally {
+        binding.suppressSelectionCallbacks -= 1;
+    }
+}
+
+function elementData(data: unknown): BpmnElementCellData | null {
+    return (data as BpmnElementCellData | null)?.cellKind === 'element' ? data as BpmnElementCellData : null;
+}
+
+function toSelection(data: BpmnElementCellData): BpmnElementSelection {
+    return {
+        elementId: data.elementId,
+        elementType: data.elementType,
+        kind: data.kind,
+        name: data.name,
+        activityId: data.activityId,
+        bindingState: data.bindingState,
+        scopeId: data.scopeId,
+        scopeActivityId: data.scopeActivityId,
+        boundaryHostElementId: data.boundaryHostElementId,
+        childScopeId: data.childScopeId,
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/palette.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/palette.ts
@@ -1,0 +1,40 @@
+/**
+ * The colours the BPMN shapes paint with, as CSS custom properties.
+ *
+ * Every value is a `var(...)` reference resolved by `css/designer.bpmn.css`, which is scoped to the
+ * class `createBpmnGraph` puts on the container. SVG presentation attributes accept custom
+ * properties, so a theme change repaints the canvas without the adapter being told -- the same
+ * mechanism `internal/state-machine-shapes.ts` already relies on.
+ */
+import type { BpmnStatsTone } from './stats';
+
+export const CANVAS = 'var(--elsa-bpmn-canvas)';
+export const GRID = 'var(--elsa-bpmn-grid)';
+export const STROKE = 'var(--elsa-bpmn-stroke)';
+export const SURFACE = 'var(--elsa-bpmn-surface)';
+export const TEXT = 'var(--elsa-bpmn-text)';
+export const MUTED = 'var(--elsa-bpmn-muted)';
+export const EDGE = 'var(--elsa-bpmn-edge)';
+export const CONTAINER_SURFACE = 'var(--elsa-bpmn-container-surface)';
+export const CONTAINER_STROKE = 'var(--elsa-bpmn-container-stroke)';
+export const HEADER_SURFACE = 'var(--elsa-bpmn-header-surface)';
+/** The colour an element whose work is not bound, or not resolvable, is called out in. */
+export const UNBOUND = 'var(--elsa-bpmn-unbound)';
+
+export const BADGE_SURFACE_BY_TONE: Readonly<Record<BpmnStatsTone, string>> = {
+    faulted: 'var(--elsa-bpmn-badge-faulted)',
+    canceled: 'var(--elsa-bpmn-badge-canceled)',
+    blocked: 'var(--elsa-bpmn-badge-blocked)',
+    active: 'var(--elsa-bpmn-badge-active)',
+    completed: 'var(--elsa-bpmn-badge-completed)',
+    idle: 'var(--elsa-bpmn-badge-idle)',
+};
+
+export const BADGE_TEXT_BY_TONE: Readonly<Record<BpmnStatsTone, string>> = {
+    faulted: 'var(--elsa-bpmn-badge-faulted-text)',
+    canceled: 'var(--elsa-bpmn-badge-canceled-text)',
+    blocked: 'var(--elsa-bpmn-badge-blocked-text)',
+    active: 'var(--elsa-bpmn-badge-active-text)',
+    completed: 'var(--elsa-bpmn-badge-completed-text)',
+    idle: 'var(--elsa-bpmn-badge-idle-text)',
+};

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/shapes.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/shapes.ts
@@ -1,0 +1,300 @@
+/**
+ * The X6 shape, edge and anchor registrations the BPMN cells refer to by name.
+ *
+ * Registration is structure only: every shape declares its markup and the defaults that make an
+ * unset attribute harmless, and `cells.ts` supplies everything that varies per element. Splitting
+ * it that way is what lets the mapping be tested without a browser -- nothing here needs to run for
+ * `buildBpmnX6Cells` to produce the right cells.
+ *
+ * All colours are CSS custom properties resolved by `css/designer.bpmn.css`; see `palette.ts`.
+ */
+import { Graph, Point } from '@antv/x6';
+import {
+    BPMN_ACTIVITY_SHAPE,
+    BPMN_ASSOCIATION_SHAPE,
+    BPMN_EVENT_SHAPE,
+    BPMN_FLOW_SHAPE,
+    BPMN_GATEWAY_SHAPE,
+    BPMN_LANE_SHAPE,
+    BPMN_POOL_SHAPE,
+    BPMN_WAYPOINT_ANCHOR,
+} from './constants';
+import { CONTAINER_STROKE, CONTAINER_SURFACE, EDGE, HEADER_SURFACE, MUTED, STROKE, SURFACE, TEXT } from './palette';
+
+/** The badge circle and its number, shared by every element shape. */
+const STATS_MARKUP = [
+    { tagName: 'circle', selector: 'statsBadge' },
+    { tagName: 'text', selector: 'statsLabel' },
+];
+
+const STATS_ATTRS = {
+    statsBadge: {
+        display: 'none',
+        r: 9,
+        cx: 0,
+        cy: 0,
+        refX: '100%',
+        refY: 0,
+        pointerEvents: 'none',
+    },
+    statsLabel: {
+        display: 'none',
+        text: '',
+        fontSize: 10,
+        fontWeight: 600,
+        textAnchor: 'middle',
+        textVerticalAnchor: 'middle',
+        refX: '100%',
+        refY: 0,
+        pointerEvents: 'none',
+    },
+};
+
+/**
+ * Defaults for a text element.
+ *
+ * Every positional and typographic attribute is spelled out rather than left to the shape's
+ * ancestry. X6's built-in shapes carry an `attrs.text` entry that matches *every* `<text>` element
+ * in the markup by CSS selector, so a value left unset here would silently inherit the built-in
+ * label's centre-of-the-node placement.
+ */
+const textDefaults = (extra: Record<string, unknown> = {}) => ({
+    display: 'none',
+    text: '',
+    fill: TEXT,
+    fontSize: 12,
+    fontWeight: 400,
+    fontFamily: 'inherit',
+    textAnchor: 'middle',
+    textVerticalAnchor: 'middle',
+    refX: '50%',
+    refY: '50%',
+    pointerEvents: 'none',
+    ...extra,
+});
+
+/** Defaults for a glyph path: hidden, and painted from the centre of whatever placed it. */
+const glyphDefaults = {
+    display: 'none',
+    d: '',
+    fill: 'none',
+    stroke: STROKE,
+    strokeWidth: 1.2,
+    strokeLinejoin: 'round',
+    strokeLinecap: 'round',
+    pointerEvents: 'none',
+};
+
+/**
+ * Registers everything the BPMN adapter draws with. Idempotent: every registration passes X6's
+ * `force` flag, so calling it twice replaces rather than throws.
+ */
+export function registerBpmnShapes(): void {
+    registerWaypointAnchor();
+
+    // -- events ---------------------------------------------------------------------------------
+    // One shape for all five event types. What distinguishes them -- the second ring, the thick end
+    // stroke, the dashed non-interrupting boundary, the event-definition icon -- is attributes, so
+    // the same node can be re-attributed without being replaced.
+    Graph.registerNode(
+        BPMN_EVENT_SHAPE,
+        {
+            inherit: 'circle',
+            markup: [
+                { tagName: 'circle', selector: 'body' },
+                { tagName: 'circle', selector: 'ring' },
+                { tagName: 'path', selector: 'icon' },
+                { tagName: 'text', selector: 'label' },
+                ...STATS_MARKUP,
+            ],
+            attrs: {
+                body: {
+                    refCx: '50%',
+                    refCy: '50%',
+                    refR: '50%',
+                    fill: SURFACE,
+                    stroke: STROKE,
+                    strokeWidth: 1.5,
+                },
+                ring: { display: 'none', fill: 'none', stroke: STROKE, strokeWidth: 1.5, pointerEvents: 'none' },
+                icon: glyphDefaults,
+                label: textDefaults({ fontSize: 11, refY: '100%', refY2: 6, textVerticalAnchor: 'top' }),
+                ...STATS_ATTRS,
+            },
+        },
+        true);
+
+    // -- gateways -------------------------------------------------------------------------------
+    Graph.registerNode(
+        BPMN_GATEWAY_SHAPE,
+        {
+            inherit: 'polygon',
+            markup: [
+                { tagName: 'polygon', selector: 'body' },
+                { tagName: 'path', selector: 'marker' },
+                { tagName: 'text', selector: 'label' },
+                ...STATS_MARKUP,
+            ],
+            attrs: {
+                body: {
+                    refPoints: '0,0.5 0.5,0 1,0.5 0.5,1',
+                    fill: SURFACE,
+                    stroke: STROKE,
+                    strokeWidth: 1.5,
+                },
+                marker: glyphDefaults,
+                label: textDefaults({ fontSize: 11, refY: '100%', refY2: 6, textVerticalAnchor: 'top' }),
+                ...STATS_ATTRS,
+            },
+        },
+        true);
+
+    // -- tasks, subprocesses and call activities ------------------------------------------------
+    // These share one rectangle. A task, a collapsed subprocess, an expanded subprocess container
+    // and a call activity differ in border, markers and where the name sits -- all attributes --
+    // and never in structure, so a separate shape per element type would be three copies of this.
+    Graph.registerNode(
+        BPMN_ACTIVITY_SHAPE,
+        {
+            inherit: 'rect',
+            markup: [
+                { tagName: 'rect', selector: 'body' },
+                { tagName: 'rect', selector: 'innerBorder' },
+                { tagName: 'path', selector: 'typeMarker' },
+                { tagName: 'text', selector: 'label' },
+                { tagName: 'text', selector: 'subLabel' },
+                { tagName: 'path', selector: 'markerA' },
+                { tagName: 'path', selector: 'markerB' },
+                { tagName: 'path', selector: 'markerC' },
+                ...STATS_MARKUP,
+            ],
+            attrs: {
+                body: {
+                    refWidth: '100%',
+                    refHeight: '100%',
+                    rx: 10,
+                    ry: 10,
+                    fill: SURFACE,
+                    stroke: STROKE,
+                    strokeWidth: 1.5,
+                },
+                // BPMN's double border for a transaction subprocess.
+                innerBorder: {
+                    display: 'none',
+                    x: 4,
+                    y: 4,
+                    refWidth: -8,
+                    refHeight: -8,
+                    rx: 7,
+                    ry: 7,
+                    fill: 'none',
+                    stroke: STROKE,
+                    strokeWidth: 1.5,
+                    pointerEvents: 'none',
+                },
+                typeMarker: glyphDefaults,
+                label: textDefaults(),
+                subLabel: textDefaults({ fontSize: 10, fill: MUTED }),
+                markerA: glyphDefaults,
+                markerB: glyphDefaults,
+                markerC: glyphDefaults,
+                ...STATS_ATTRS,
+            },
+        },
+        true);
+
+    // -- pools and lanes ------------------------------------------------------------------------
+    // Containers are drawn, never structural: `pointerEvents: 'none'` keeps them out of hit-testing
+    // entirely, so a click inside a lane reaches the element under the pointer or, where there is
+    // none, the canvas itself. That is the whole of "pools and lanes contain elements visually
+    // only" as far as X6 is concerned -- there is no embedding to undo, and nothing that could
+    // reparent an element by dragging it.
+    for (const shape of [BPMN_POOL_SHAPE, BPMN_LANE_SHAPE]) {
+        Graph.registerNode(
+            shape,
+            {
+                inherit: 'rect',
+                markup: [
+                    { tagName: 'rect', selector: 'body' },
+                    { tagName: 'rect', selector: 'header' },
+                    { tagName: 'text', selector: 'label' },
+                ],
+                attrs: {
+                    body: {
+                        refWidth: '100%',
+                        refHeight: '100%',
+                        fill: CONTAINER_SURFACE,
+                        stroke: CONTAINER_STROKE,
+                        strokeWidth: 1.5,
+                        pointerEvents: 'none',
+                    },
+                    header: { fill: HEADER_SURFACE, stroke: CONTAINER_STROKE, strokeWidth: 1.5, pointerEvents: 'none' },
+                    label: textDefaults({ display: 'block', fontWeight: 600 }),
+                },
+            },
+            true);
+    }
+
+    // -- sequence flows -------------------------------------------------------------------------
+    // `normal` router and connector: the vertices are the document's own waypoints, so anything
+    // that re-routes them would be drawing a line the author did not.
+    Graph.registerEdge(
+        BPMN_FLOW_SHAPE,
+        {
+            inherit: 'edge',
+            attrs: {
+                line: {
+                    stroke: EDGE,
+                    strokeWidth: 1.5,
+                    targetMarker: { name: 'block', width: 10, height: 8 },
+                },
+            },
+            router: { name: 'normal' },
+            connector: { name: 'normal' },
+        },
+        true);
+
+    // -- compensation associations --------------------------------------------------------------
+    // Dashed with an open arrowhead, and routed by X6: the payload records an association as a
+    // property of the boundary event rather than as an element, so there is no id for the document's
+    // BPMNEdge to be matched by and no waypoints to draw it from.
+    Graph.registerEdge(
+        BPMN_ASSOCIATION_SHAPE,
+        {
+            inherit: 'edge',
+            attrs: {
+                line: {
+                    stroke: EDGE,
+                    strokeWidth: 1.5,
+                    strokeDasharray: '4 4',
+                    targetMarker: { name: 'block', width: 8, height: 8, open: true },
+                },
+            },
+            router: { name: 'normal' },
+            connector: { name: 'normal' },
+        },
+        true);
+}
+
+/**
+ * Pins an edge end to an exact point, expressed relative to the node's own rectangle.
+ *
+ * X6's built-in `topLeft` anchor cannot do this job: it measures the node's *rendered* bounding
+ * box, and BPMN nodes draw their name outside the shape, so the box it would measure is the shape
+ * plus its label and the offset would land somewhere the document never mentioned. Reading
+ * `cell.getBBox()` instead uses the geometry the view model gave the node and nothing else, so the
+ * anchor is the document's waypoint to the pixel and stays correct whether or not the node has been
+ * rendered yet.
+ */
+function registerWaypointAnchor(): void {
+    Graph.registerAnchor(
+        BPMN_WAYPOINT_ANCHOR,
+        function bpmnWaypoint(view, _magnet, _ref, args) {
+            const bbox = view.cell.getBBox();
+            const dx = typeof args?.dx === 'number' ? args.dx : 0;
+            const dy = typeof args?.dy === 'number' ? args.dy : 0;
+
+            return new Point(bbox.x + dx, bbox.y + dy);
+        },
+        true);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/shapes.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/shapes.ts
@@ -21,13 +21,30 @@ import {
 } from './constants';
 import { CONTAINER_STROKE, CONTAINER_SURFACE, EDGE, HEADER_SURFACE, MUTED, STROKE, SURFACE, TEXT } from './palette';
 
-/** The badge circle and its number, shared by every element shape. */
+/**
+ * The badge circle and its number, shared by every element shape, grouped so the badge carries one
+ * `aria-label` and one `<title>` tooltip rather than leaving its state -- faulted, cancelled,
+ * blocked -- to be read off its colour alone.
+ */
 const STATS_MARKUP = [
-    { tagName: 'circle', selector: 'statsBadge' },
-    { tagName: 'text', selector: 'statsLabel' },
+    {
+        tagName: 'g',
+        selector: 'statsBadgeGroup',
+        children: [
+            { tagName: 'title', selector: 'statsBadgeTitle' },
+            { tagName: 'circle', selector: 'statsBadge' },
+            { tagName: 'text', selector: 'statsLabel' },
+        ],
+    },
 ];
 
 const STATS_ATTRS = {
+    statsBadgeGroup: {
+        'aria-label': null,
+    },
+    statsBadgeTitle: {
+        text: '',
+    },
     statsBadge: {
         display: 'none',
         r: 9,

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/stats.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/stats.ts
@@ -1,0 +1,78 @@
+/**
+ * The instance-state badge: how the two stats maps the view model resolves onto an element turn
+ * into one badge on the canvas.
+ *
+ * The visual language is the flowchart designer's -- `Components/ActivityWrappers/V1` and `V2`'s `ActivityWrapper.razor`
+ * puts a MudBadge on the activity, coloured error / warning / info / success and captioned with a
+ * count -- so that an instance diagram reads the same whichever designer drew it. What is new here
+ * is `canceled`: `BpmnElementStats` reports a cancelled token, the flowchart's `ActivityStats` has
+ * no such concept, and a cancelled element must not be shown as a faulted one. That is the case
+ * this module is most careful about, and the one `__tests__/stats.test.ts` checks in both
+ * directions.
+ */
+import type { BpmnActivityStats, BpmnElementStats } from '../../bpmn';
+
+/**
+ * What the badge says, in the order it is decided.
+ *
+ * The order is a precedence, not a preference: a fault outranks everything because losing it is the
+ * one mistake that makes a broken instance look healthy; a cancellation outranks the running and
+ * completed states because a cancelled element did not complete; `idle` is the state of an element
+ * the overlay knows about but that has not run.
+ */
+export type BpmnStatsTone = 'faulted' | 'canceled' | 'blocked' | 'active' | 'completed' | 'idle';
+
+export interface BpmnStatsBadge {
+    readonly tone: BpmnStatsTone;
+    /** The number in the badge. Null when no counter applies, which draws an empty dot. */
+    readonly count: number | null;
+    /** A human-readable summary, used as the node's tooltip. */
+    readonly title: string;
+}
+
+const TONE_TITLES: Readonly<Record<BpmnStatsTone, string>> = {
+    faulted: 'Faulted',
+    canceled: 'Canceled',
+    blocked: 'Blocked',
+    active: 'Running',
+    completed: 'Completed',
+    idle: 'Not started',
+};
+
+/**
+ * Resolves one element's badge, or null when the overlay says nothing about it at all.
+ *
+ * Null and "everything is zero" are different answers on purpose: a workflow definition that was
+ * never run carries no stats and gets no badges, while an instance in which one element has not yet
+ * been reached carries a zeroed entry and gets an `idle` badge. Collapsing the two would make a
+ * diagram of a running instance look like a diagram of a definition.
+ */
+export function resolveBpmnStatsBadge(
+    elementStats: BpmnElementStats | null | undefined,
+    activityStats: BpmnActivityStats | null | undefined): BpmnStatsBadge | null {
+    if (elementStats == null && activityStats == null) return null;
+
+    const started = firstNumber(elementStats?.started, activityStats?.started);
+    const completed = firstNumber(elementStats?.completed, activityStats?.completed);
+    const active = firstNumber(elementStats?.active, activityStats?.uncompleted);
+
+    if (elementStats?.faulted === true || activityStats?.faulted === true) return badge('faulted', started ?? completed);
+    if (elementStats?.canceled === true) return badge('canceled', started ?? completed);
+    if (elementStats?.blocked === true || activityStats?.blocked === true) return badge('blocked', started ?? completed);
+    if ((active ?? 0) > 0) return badge('active', active);
+    if ((completed ?? 0) > 0) return badge('completed', completed);
+
+    return badge('idle', completed ?? started ?? 0);
+}
+
+function badge(tone: BpmnStatsTone, count: number | null): BpmnStatsBadge {
+    return { tone, count, title: count == null ? TONE_TITLES[tone] : `${TONE_TITLES[tone]} (${count})` };
+}
+
+function firstNumber(...values: readonly (number | null | undefined)[]): number | null {
+    for (const value of values) {
+        if (typeof value === 'number' && Number.isFinite(value)) return value;
+    }
+
+    return null;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/canvas-ready.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/canvas-ready.ts
@@ -1,0 +1,29 @@
+import {Graph} from '@antv/x6';
+
+/**
+ * Resolves once the graph's container has a non-zero height, or false if the graph went away first.
+ *
+ * Blazor renders the designer's container before the layout that gives it a height, and a
+ * `centerContent` or `zoomToFit` against a zero-height container silently centres on nothing. The
+ * `isCurrent` predicate is what stops a stale load from stealing the viewport of the graph that
+ * replaced it: the caller answers whether the binding it started with is still the live one.
+ */
+export function whenCanvasHasHeight(graph: Graph, isCurrent: () => boolean): Promise<boolean> {
+    const container = graph.container;
+
+    return new Promise(resolve => {
+        const checkSize = () => {
+            if (!container.isConnected || !isCurrent()) {
+                resolve(false);
+                return;
+            }
+
+            if (container.getBoundingClientRect().height == 0)
+                window.requestAnimationFrame(checkSize);
+            else
+                resolve(true);
+        };
+
+        checkSize();
+    });
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/internal/init.ts
@@ -4,6 +4,7 @@ import {Activity} from "../models";
 import {ActivityShape, FlowchartEdgeShape, SequenceEdgeShape} from '../api/designer-mode';
 import {createDesignerPortGroups, designerPortMarkup} from './designer-ports';
 import {registerStateMachineShapes} from './state-machine-shapes';
+import {registerBpmnShapes} from '../bpmn/shapes';
 
 export function initialize() {
     Shape.HTML.register({
@@ -63,5 +64,6 @@ export function initialize() {
     );
 
     registerStateMachineShapes();
+    registerBpmnShapes();
 
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-// Two suites, both under src/bpmn:
+// Two suites:
 //
 //  - `*.test.ts`, run in a jsdom environment. src/bpmn/di-reader.ts parses BPMN DI with the platform
 //    `DOMParser`, which is what the browser gives it at runtime; jsdom is the one test environment
@@ -11,7 +11,10 @@ import { defineConfig } from 'vitest/config';
 //    asked with a type-level assertion rather than a runtime one -- see
 //    src/bpmn/__tests__/process-payload.test-d.ts.
 //
-// The designer and react-designer bundles have no test suite; they are covered by the .NET side.
+// Covered: src/bpmn, and the pure half of the X6 BPMN adapter under src/designer/bpmn -- its cell
+// mapping, badge policy and graph options are all plain functions precisely so that they can be
+// tested here rather than only in a browser. The rest of the designer and react-designer bundles
+// have no test suite; they are covered by the .NET side.
 export default defineConfig({
     test: {
         environment: 'jsdom',

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/webpack.config.js
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = {
             patterns: [
                 {from: 'css/designer.v1.css', to: './'},
                 {from: 'css/designer.v2.css', to: './'},
+                {from: 'css/designer.bpmn.css', to: './'},
                 {from: 'css/designer.v2.css', to: './designer.css'}, // Default
             ],
         }),


### PR DESCRIPTION
Closes #998. Part of elsa-workflows/elsa-core#7909 (W9c). Depends on #1009 (W9a), merged.

## What changed

A read-only X6 adapter that renders the canvas-neutral BPMN view model from W9a. It lives beside the flowchart designer, not inside it, under `src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/`, with the JS interop surface in `src/designer/api/bpmn-designer.ts` and theming in `css/designer.bpmn.css`.

- **Shapes per element kind**: events (single ring for start, double for intermediate, thick for end, filled for terminate, with an icon per event definition), tasks (rounded rectangle with the task-type marker and the bound Elsa activity's name beneath), gateways (diamond with the gateway marker), subprocesses (collapsed marker or expanded container, transactions double-bordered, event subprocesses dotted), boundary events astride their host, pools and lanes with rotated headers.
- **Edges** from BPMN DI waypoints verbatim, with the default-flow slash and the conditional-flow diamond, plus dashed compensation associations.
- **Stats overlay** from the element-keyed map, in the flowchart's badge language, with a distinct tone for cancellation.
- **Interop**: `createBpmnGraph`, `buildBpmnDiagram`, `loadBpmnDiagram`, `updateBpmnElementStats`, `updateBpmnActivityStats`, `selectBpmnElement`, `disposeBpmnGraph`; zoom-to-fit and center reuse the existing functions. Selection and double-click reach .NET under the flowchart designer's existing method names, carrying the element id, the bound activity id and the scope activity id, so W10 wires them without a BPMN-specific contract.
- **Read-only**: every X6 interaction is explicitly off (a test pins the key list so an X6 upgrade cannot silently enable one), connecting refuses, embedding is off, and only the selection plugin is installed.

The mapping is a pure function, `buildBpmnX6Cells(viewModel)`, so every W9a fixture gates it without a browser: one node per element keyed by the element id, one per placed lane and pool, one edge per flow, unique ids, boundary events recorded as siblings with a host reference (never X6 children, so hit-testing on the shared border selects the boundary event). `loadBpmnDiagram` compares the graph's cells against the mapping after load and reports any shortfall, because X6 silently replaces a cell whose id is taken.

## Shared infrastructure touched

Supporting a second graph registry meant small edits to shared X6 files: the wait for a laid-out container moved from `load-graph.ts` into `internal/canvas-ready.ts`, and `zoomToFit`, `centerContent` and `disposeGraph` now resolve a graph through `api/find-graph.ts` across both registries. Those three now no-op on an unknown id instead of throwing on destructuring; no .NET caller depended on the throw and `DisposeGraphAsync` already swallowed it. The existing .NET contract test was updated to assert the same lifecycle guarantee against the moved code, and one test was added for the BPMN dispose fall-through.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib
npm test                                  # 233/233, 9 files, no type errors
npx tsc --noEmit -p tsconfig.json
npm run build && git status --short       # clean
cd src/framework/Elsa.Studio.DomInterop/ClientLib && npm install --force && npm run build
dotnet build Elsa.Studio.sln --configuration Release                                              # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 75/75
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 263/263
```

Headless verification: a throwaway Playwright harness loaded the built bundle with each of the seven fixtures; all rendered with zero console errors and node/edge counts matching the view model. Interactions were driven: clicking the shared host/boundary border selects the boundary event and names its host, dragging does not move a node, applying then clearing element stats turns the badge on and off. Five injected defects were each caught by the fixture suite.

**Outstanding for a human**: the side-by-side comparison of `camunda-order-process.bpmn` against Camunda Modeler. Headlessly it shows the start circle, the service task with a gear marker and the bound activity's name, the thick-ringed end event, and edges on the document's waypoints.

Review: two iterations on the standards and spec axes. One must-fix (a duplicated binding-lookup guard) extracted into a helper. Won't-fix, recorded: the thin interop wrappers over the mount layer are a deliberate pure/mount split; the shared-infrastructure edits ride in this PR because the second registry needs them and they are covered by the contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
