### PR TITLE
feat(workflows): open imported BPMN processes in a read-only BPMN designer

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/JsonObjectActivityTreeExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/JsonObjectActivityTreeExtensions.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+
+namespace Elsa.Studio.Workflows.Extensions;
+
+/// <summary>
+/// Provides extension methods for locating and replacing activities within a <see cref="JsonObject"/> activity tree.
+/// </summary>
+public static class JsonObjectActivityTreeExtensions
+{
+    /// <summary>
+    /// Recursively searches the specified scope's <c>activities</c> array for an activity with the given ID and,
+    /// when found, replaces it with a deep clone of <paramref name="replacement"/>.
+    /// </summary>
+    /// <param name="scope">The activity whose <c>activities</c> array is searched.</param>
+    /// <param name="id">The ID of the activity to replace.</param>
+    /// <param name="replacement">The activity to replace the matched activity with.</param>
+    /// <returns><c>true</c> if an activity with the specified ID was found and replaced; otherwise, <c>false</c>.</returns>
+    public static bool ReplaceActivity(this JsonObject scope, string id, JsonObject replacement)
+    {
+        if (scope["activities"] is not JsonArray activities)
+            return false;
+
+        for (var i = 0; i < activities.Count; i++)
+        {
+            if (activities[i] is not JsonObject child)
+                continue;
+
+            if (child.GetId() == id)
+            {
+                activities[i] = (JsonObject)replacement.DeepClone()!;
+                return true;
+            }
+
+            if (child.ReplaceActivity(id, replacement))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/BpmnDesignerSelectionMappingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/BpmnDesignerSelectionMappingTests.cs
@@ -1,0 +1,165 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Designer.Components;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Designer.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDesigner"/>'s mapping from a BPMN element selection back to the Elsa
+/// activity JSON the properties panel should show, and from an activity id to the element bound to
+/// it. Both walk the root <c>Elsa.BpmnProcess</c> activity's tree, recursing into nested BPMN scopes,
+/// so the fixtures below nest a scope inside the root the same way an embedded subprocess would.
+/// </summary>
+public class BpmnDesignerSelectionMappingTests
+{
+    [Fact]
+    public void FindActivityById_ReturnsTheBoundChildActivity_WhenTheIdNamesOneAtTheRoot()
+    {
+        var boundActivity = CreateActivity("write-line-1", "Elsa.WriteLine");
+        var root = CreateScope("root", ("ref-1", "write-line-1"), boundActivity);
+
+        var found = BpmnDesigner.FindActivityById(root, "write-line-1");
+
+        Assert.Same(boundActivity, found);
+    }
+
+    [Fact]
+    public void FindActivityById_ReturnsTheBoundChildActivity_WhenItIsNestedInAChildScope()
+    {
+        var boundActivity = CreateActivity("write-line-1", "Elsa.WriteLine");
+        var nestedScope = CreateScope("nested-scope", ("ref-1", "write-line-1"), boundActivity);
+        var root = CreateScope("root", ("ref-nested", "nested-scope"), nestedScope);
+
+        var found = BpmnDesigner.FindActivityById(root, "write-line-1");
+
+        Assert.Same(boundActivity, found);
+    }
+
+    [Fact]
+    public void FindActivityById_ReturnsTheRootScopeActivity_WhenTheIdNamesTheRootItself()
+    {
+        var root = CreateScope("root");
+
+        var found = BpmnDesigner.FindActivityById(root, "root");
+
+        Assert.Same(root, found);
+    }
+
+    [Fact]
+    public void FindActivityById_ReturnsTheNestedScopeActivity_WhenTheIdNamesTheNestedScopeItself()
+    {
+        var nestedScope = CreateScope("nested-scope");
+        var root = CreateScope("root", ("ref-nested", "nested-scope"), nestedScope);
+
+        var found = BpmnDesigner.FindActivityById(root, "nested-scope");
+
+        Assert.Same(nestedScope, found);
+    }
+
+    [Fact]
+    public void FindActivityById_ReturnsNull_WhenNothingInTheTreeCarriesTheId()
+    {
+        var root = CreateScope("root");
+
+        var found = BpmnDesigner.FindActivityById(root, "does-not-exist");
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void ResolveElementId_ReturnsTheBoundElementId_ThroughWorkBindingsAndTheProcessElements()
+    {
+        var boundActivity = CreateActivity("order-process:node-NotifyWarehouse", "Elsa.WriteLine");
+        var root = CreateScope(
+            "order-process",
+            ("node-NotifyWarehouse", "order-process:node-NotifyWarehouse"),
+            boundActivity,
+            ("NotifyWarehouse", "serviceTask", "node-NotifyWarehouse"),
+            ("StartEvent_1", "startEvent", null),
+            ("EndEvent_1", "endEvent", null));
+
+        var elementId = BpmnDesigner.ResolveElementId(root, "order-process:node-NotifyWarehouse");
+
+        Assert.Equal("NotifyWarehouse", elementId);
+    }
+
+    [Fact]
+    public void ResolveElementId_ReturnsNull_ForTheRootScopeActivityId()
+    {
+        var root = CreateScope("order-process", workBindings: [("node-NotifyWarehouse", "order-process:node-NotifyWarehouse")]);
+
+        var elementId = BpmnDesigner.ResolveElementId(root, "order-process");
+
+        Assert.Null(elementId);
+    }
+
+    [Fact]
+    public void ResolveElementId_ReturnsNull_ForAnActivityIdNoBindingNames()
+    {
+        var root = CreateScope("order-process", workBindings: [("node-NotifyWarehouse", "order-process:node-NotifyWarehouse")]);
+
+        var elementId = BpmnDesigner.ResolveElementId(root, "does-not-exist");
+
+        Assert.Null(elementId);
+    }
+
+    private static JsonObject CreateActivity(string id, string type) => new()
+    {
+        ["id"] = id,
+        ["type"] = type
+    };
+
+    /// <summary>
+    /// Builds an <c>Elsa.BpmnProcess</c> scope activity carrying <paramref name="workBindings"/>,
+    /// <paramref name="processElements"/> (each a BPMN element declaring an id, type and, optionally,
+    /// a binding ref) and the given bound child activities.
+    /// </summary>
+    private static JsonObject CreateScope(
+        string id,
+        (string Ref, string ActivityId)[]? workBindings = null,
+        JsonObject[]? boundActivities = null,
+        (string ElementId, string ElementType, string? BindingRef)[]? processElements = null)
+    {
+        var workBindingsObject = new JsonObject();
+
+        foreach (var (bindingRef, activityId) in workBindings ?? [])
+            workBindingsObject[bindingRef] = activityId;
+
+        var elements = new JsonArray();
+
+        foreach (var (elementId, elementType, bindingRef) in processElements ?? [])
+        {
+            elements.Add(new JsonObject
+            {
+                ["elementId"] = elementId,
+                ["elementType"] = elementType,
+                ["bindingRef"] = bindingRef
+            });
+        }
+
+        var activities = new JsonArray();
+
+        foreach (var activity in boundActivities ?? [])
+            activities.Add(activity);
+
+        return new JsonObject
+        {
+            ["id"] = id,
+            ["type"] = "Elsa.BpmnProcess",
+            ["workBindings"] = workBindingsObject,
+            ["process"] = new JsonObject { ["elements"] = elements },
+            ["activities"] = activities
+        };
+    }
+
+    // Overload used by the tests that only care about a single work binding and its bound activity.
+    private static JsonObject CreateScope(string id, (string Ref, string ActivityId) workBinding, JsonObject boundActivity) =>
+        CreateScope(id, [workBinding], [boundActivity]);
+
+    private static JsonObject CreateScope(
+        string id,
+        (string Ref, string ActivityId) workBinding,
+        JsonObject boundActivity,
+        params (string ElementId, string ElementType, string? BindingRef)[] processElements) =>
+        CreateScope(id, [workBinding], [boundActivity], processElements);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor
@@ -1,0 +1,4 @@
+﻿@inherits StudioComponentBase
+<div style="width:100%; height:100%">
+    <div id="@_containerId" class="graph-container"></div>
+</div>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Studio.Workflows.Designer.Interop;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Designer.Services;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+
+namespace Elsa.Studio.Workflows.Designer.Components;
+
+/// <summary>
+/// A Blazor component that renders the read-only BPMN designer: the X6 canvas that draws an
+/// <c>Elsa.BpmnProcess</c> activity's diagram. Owns the JS interop to the BPMN adapter
+/// (<c>src/designer/api/bpmn-designer.ts</c>), mirroring how <see cref="FlowchartDesigner"/> owns
+/// the flowchart canvas's.
+/// </summary>
+public partial class BpmnDesigner : IAsyncDisposable
+{
+    private readonly string _containerId = $"bpmn-container-{Guid.NewGuid():N}";
+    private DotNetObjectReference<BpmnDesigner>? _componentRef;
+    private BpmnGraphApi? _graphApi;
+    private JsonObject? _activity;
+    private readonly PendingActionsQueue _pendingGraphActions;
+
+    /// <inheritdoc />
+    public BpmnDesigner()
+    {
+        _pendingGraphActions = new(() => new(_graphApi != null!), () => Logger);
+    }
+
+    /// The root <c>Elsa.BpmnProcess</c> activity to render.
+    [Parameter] public JsonObject Activity { get; set; } = null!;
+
+    /// The imported BPMN document's source XML, for BPMN DI geometry. Null when there is none, in
+    /// which case the adapter's own fallback layout applies.
+    [Parameter] public string? SourceXml { get; set; }
+
+    /// The activity stats to render.
+    [Parameter] public IDictionary<string, ActivityStats>? ActivityStats { get; set; }
+
+    /// An event raised when an activity is selected -- the bound child activity for a bound element,
+    /// or the scope's own <c>Elsa.BpmnProcess</c> activity otherwise.
+    [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
+
+    /// An event raised when an activity is double-clicked. Same mapping as <see cref="ActivitySelected"/>.
+    [Parameter] public EventCallback<JsonObject> ActivityDoubleClick { get; set; }
+
+    /// An event raised when the canvas, a lane or a pool is selected, i.e. nothing in particular.
+    [Parameter] public EventCallback CanvasSelected { get; set; }
+
+    [Inject] private DesignerJsInterop DesignerJsInterop { get; set; } = null!;
+    [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
+    [Inject] private IActivityDisplaySettingsRegistry ActivityDisplaySettingsRegistry { get; set; } = null!;
+    [Inject] private ILogger<BpmnDesigner> Logger { get; set; } = null!;
+
+    /// <summary>
+    /// Invoked from JavaScript when a BPMN element is selected.
+    /// </summary>
+    [JSInvokable]
+    public async Task HandleActivitySelected(BpmnElementSelection selection)
+    {
+        if (!ActivitySelected.HasDelegate)
+            return;
+
+        var activity = ResolveSelectedActivity(selection);
+
+        if (activity != null)
+            await ActivitySelected.InvokeAsync(activity);
+    }
+
+    /// <summary>
+    /// Invoked from JavaScript when a BPMN element is double-clicked.
+    /// </summary>
+    [JSInvokable]
+    public async Task HandleActivityDoubleClick(BpmnElementSelection selection)
+    {
+        if (!ActivityDoubleClick.HasDelegate)
+            return;
+
+        var activity = ResolveSelectedActivity(selection);
+
+        if (activity != null)
+            await ActivityDoubleClick.InvokeAsync(activity);
+    }
+
+    /// <summary>
+    /// Invoked from JavaScript when the canvas, a lane or a pool is selected.
+    /// </summary>
+    [JSInvokable]
+    public async Task HandleCanvasSelected()
+    {
+        if (CanvasSelected.HasDelegate)
+            await CanvasSelected.InvokeAsync();
+    }
+
+    /// <summary>
+    /// Loads the specified root activity into the graph.
+    /// </summary>
+    /// <param name="activity">The root <c>Elsa.BpmnProcess</c> activity.</param>
+    /// <param name="sourceXml">The imported BPMN document's source XML, or null.</param>
+    /// <param name="activityStats">A map of activity stats.</param>
+    public async Task LoadBpmnAsync(JsonObject activity, string? sourceXml, IDictionary<string, ActivityStats>? activityStats)
+    {
+        _activity = activity;
+        SourceXml = sourceXml;
+        ActivityStats = activityStats;
+
+        await ActivityRegistry.EnsureLoadedAsync();
+
+        var payload = new JsonObject
+        {
+            ["activity"] = activity.DeepClone(),
+            ["sourceXml"] = sourceXml,
+            ["activityDescriptors"] = BuildActivityDescriptors()
+        };
+
+        var diagnostics = await ScheduleGraphActionAsync(() => _graphApi!.LoadDiagramAsync(payload));
+
+        foreach (var diagnostic in diagnostics.Where(d => d.Severity == "error"))
+            Logger.LogWarning("BPMN diagram '{ActivityId}' reported an error: {Message}", activity.GetId(), diagnostic.Message);
+
+        if (activityStats != null)
+        {
+            foreach (var (activityId, stats) in activityStats)
+                await ScheduleGraphActionAsync(() => _graphApi!.UpdateActivityStatsAsync(activityId, stats));
+        }
+    }
+
+    /// <summary>
+    /// Updates the stats of the specified activity's bound elements.
+    /// </summary>
+    /// <param name="activityId">The activity ID.</param>
+    /// <param name="stats">The updated stats.</param>
+    public async Task UpdateActivityStatsAsync(string activityId, ActivityStats stats) =>
+        await ScheduleGraphActionAsync(() => _graphApi!.UpdateActivityStatsAsync(activityId, stats));
+
+    /// <summary>
+    /// Selects the element bound to the specified activity, through <c>workBindings</c>. A no-op for
+    /// an id that names the root or a scope, since neither is bound work.
+    /// </summary>
+    /// <param name="activityId">The activity ID.</param>
+    public async Task SelectActivityAsync(string activityId)
+    {
+        if (_activity == null)
+            return;
+
+        var elementId = ResolveElementId(_activity, activityId);
+
+        if (elementId != null)
+            await ScheduleGraphActionAsync(() => _graphApi!.SelectElementAsync(elementId, true));
+    }
+
+    /// Zoom the canvas to fit all elements.
+    public async Task ZoomToFitAsync() => await ScheduleGraphActionAsync(() => _graphApi!.ZoomToFitAsync());
+
+    /// Center the canvas content.
+    public async Task CenterContentAsync() => await ScheduleGraphActionAsync(() => _graphApi!.CenterContentAsync());
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _componentRef = DotNetObjectReference.Create(this);
+            _graphApi = await DesignerJsInterop.CreateBpmnGraphAsync(_containerId, _componentRef);
+            await _pendingGraphActions.ProcessAsync();
+        }
+    }
+
+    private JsonNode? BuildActivityDescriptors()
+    {
+        var descriptors = ActivityRegistry.List().Select(d =>
+        {
+            var settings = ActivityDisplaySettingsRegistry.GetSettings(d.TypeName);
+            return new ActivityDescriptorDto(d.TypeName, d.Version, d.Name, d.DisplayName ?? d.Name, d.Category, d.Description, settings.Color, settings.Icon);
+        }).ToList();
+
+        return JsonSerializer.SerializeToNode(descriptors, GetSerializerOptions());
+    }
+
+    private JsonObject? ResolveSelectedActivity(BpmnElementSelection selection)
+    {
+        if (_activity == null)
+            return null;
+
+        var targetId = selection.ActivityId ?? selection.ScopeActivityId;
+        return FindActivityById(_activity, targetId);
+    }
+
+    /// <summary>
+    /// Finds the activity with the specified id, in <paramref name="root"/> itself or, recursively,
+    /// among the activities bound to it and to any nested BPMN scope. Used to resolve both a bound
+    /// element's activity and a scope's own <c>Elsa.BpmnProcess</c> activity by the same lookup.
+    /// </summary>
+    internal static JsonObject? FindActivityById(JsonObject root, string id)
+    {
+        if (root.GetId() == id)
+            return root;
+
+        foreach (var activity in root.GetActivities())
+        {
+            var found = FindActivityById(activity, id);
+
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps an Elsa activity id back to the BPMN element bound to it, through the owning scope's
+    /// <c>workBindings</c> and its process definition's elements. Returns null for an id that is not
+    /// bound work -- the root, a scope, or an id this document does not carry -- so the caller can
+    /// treat that as a no-op.
+    /// </summary>
+    internal static string? ResolveElementId(JsonObject scope, string activityId)
+    {
+        if (scope["workBindings"] is JsonObject workBindings)
+        {
+            var bindingRef = workBindings.FirstOrDefault(binding => binding.Value?.GetValue<string>() == activityId).Key;
+
+            if (bindingRef != null &&
+                scope["process"] is JsonObject process &&
+                process["elements"] is JsonArray elements)
+            {
+                var element = elements.OfType<JsonObject>().FirstOrDefault(e => e["bindingRef"]?.GetValue<string>() == bindingRef);
+
+                if (element != null)
+                    return element["elementId"]?.GetValue<string>();
+            }
+        }
+
+        foreach (var activity in scope.GetActivities())
+        {
+            var found = ResolveElementId(activity, activityId);
+
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private async Task ScheduleGraphActionAsync(Func<Task> action) => await _pendingGraphActions.EnqueueAsync(action);
+    private async Task<T> ScheduleGraphActionAsync<T>(Func<Task<T>> action) => await _pendingGraphActions.EnqueueAsync(action);
+
+    private static JsonSerializerOptions GetSerializerOptions() => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_graphApi != null)
+            await _graphApi.DisposeGraphAsync();
+
+        _componentRef?.Dispose();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -182,6 +182,7 @@ public partial class BpmnDesigner : IAsyncDisposable
             _componentRef = DotNetObjectReference.Create(this);
             _graphApi = await DesignerJsInterop.CreateBpmnGraphAsync(_containerId, _componentRef);
             await _pendingGraphActions.ProcessAsync();
+            await LoadBpmnAsync(Activity, SourceXml, ActivityStats);
         }
     }
 
@@ -215,15 +216,9 @@ public partial class BpmnDesigner : IAsyncDisposable
         if (root.GetId() == id)
             return root;
 
-        foreach (var activity in root.GetActivities())
-        {
-            var found = FindActivityById(activity, id);
-
-            if (found != null)
-                return found;
-        }
-
-        return null;
+        return root.GetActivities()
+            .Select(activity => FindActivityById(activity, id))
+            .FirstOrDefault(found => found != null);
     }
 
     /// <summary>
@@ -249,15 +244,9 @@ public partial class BpmnDesigner : IAsyncDisposable
             }
         }
 
-        foreach (var activity in scope.GetActivities())
-        {
-            var found = ResolveElementId(activity, activityId);
-
-            if (found != null)
-                return found;
-        }
-
-        return null;
+        return scope.GetActivities()
+            .Select(activity => ResolveElementId(activity, activityId))
+            .FirstOrDefault(found => found != null);
     }
 
     private async Task ScheduleGraphActionAsync(Func<Task> action) => await _pendingGraphActions.EnqueueAsync(action);

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -6,6 +6,7 @@ using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Services;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
@@ -170,7 +171,7 @@ public partial class BpmnDesigner : IAsyncDisposable
         if (_activity.GetId() == id)
             _activity = (JsonObject)activity.DeepClone()!;
         else
-            ReplaceActivity(_activity, id, activity);
+            _activity.ReplaceActivity(id, activity);
 
         return Task.CompletedTask;
     }
@@ -270,35 +271,6 @@ public partial class BpmnDesigner : IAsyncDisposable
         return scope.GetActivities()
             .Select(activity => ResolveElementId(activity, activityId))
             .FirstOrDefault(found => found != null);
-    }
-
-    /// <summary>
-    /// Replaces the activity with the specified id, wherever in the tree it is -- the root's own
-    /// activities or, recursively, a nested BPMN scope's -- with a clone of <paramref name="replacement"/>.
-    /// Mirrors <c>BpmnDiagramDesigner</c>'s own replacement, kept private to this component since the
-    /// two do not share an assembly.
-    /// </summary>
-    private static bool ReplaceActivity(JsonObject scope, string id, JsonObject replacement)
-    {
-        if (scope["activities"] is not JsonArray activities)
-            return false;
-
-        for (var i = 0; i < activities.Count; i++)
-        {
-            if (activities[i] is not JsonObject child)
-                continue;
-
-            if (child.GetId() == id)
-            {
-                activities[i] = (JsonObject)replacement.DeepClone()!;
-                return true;
-            }
-
-            if (ReplaceActivity(child, id, replacement))
-                return true;
-        }
-
-        return false;
     }
 
     private async Task ScheduleGraphActionAsync(Func<Task> action) => await _pendingGraphActions.EnqueueAsync(action);

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -153,6 +153,29 @@ public partial class BpmnDesigner : IAsyncDisposable
         await ScheduleGraphActionAsync(() => _graphApi!.UpdateActivityStatsAsync(activityId, stats));
 
     /// <summary>
+    /// Keeps the held activity tree in step with an edit made elsewhere (the properties panel): the
+    /// matching node -- the root itself or, recursively, a child bound to a BPMN element or to a
+    /// nested scope -- is replaced by a clone of <paramref name="activity"/>, the same rules
+    /// <c>BpmnDiagramDesigner</c> applies to its own copy. Without this, <see cref="ResolveSelectedActivity"/>
+    /// and <see cref="SelectActivityAsync"/> would keep resolving from a pre-edit tree, since the
+    /// canvas itself is read-only and has nothing to reload. No JS call, no canvas reload.
+    /// </summary>
+    /// <param name="id">The id of the activity to replace.</param>
+    /// <param name="activity">The replacement activity.</param>
+    public Task UpdateActivityAsync(string id, JsonObject activity)
+    {
+        if (_activity == null)
+            return Task.CompletedTask;
+
+        if (_activity.GetId() == id)
+            _activity = (JsonObject)activity.DeepClone()!;
+        else
+            ReplaceActivity(_activity, id, activity);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
     /// Selects the element bound to the specified activity, through <c>workBindings</c>. A no-op for
     /// an id that names the root or a scope, since neither is bound work.
     /// </summary>
@@ -247,6 +270,35 @@ public partial class BpmnDesigner : IAsyncDisposable
         return scope.GetActivities()
             .Select(activity => ResolveElementId(activity, activityId))
             .FirstOrDefault(found => found != null);
+    }
+
+    /// <summary>
+    /// Replaces the activity with the specified id, wherever in the tree it is -- the root's own
+    /// activities or, recursively, a nested BPMN scope's -- with a clone of <paramref name="replacement"/>.
+    /// Mirrors <c>BpmnDiagramDesigner</c>'s own replacement, kept private to this component since the
+    /// two do not share an assembly.
+    /// </summary>
+    private static bool ReplaceActivity(JsonObject scope, string id, JsonObject replacement)
+    {
+        if (scope["activities"] is not JsonArray activities)
+            return false;
+
+        for (var i = 0; i < activities.Count; i++)
+        {
+            if (activities[i] is not JsonObject child)
+                continue;
+
+            if (child.GetId() == id)
+            {
+                activities[i] = (JsonObject)replacement.DeepClone()!;
+                return true;
+            }
+
+            if (ReplaceActivity(child, id, replacement))
+                return true;
+        }
+
+        return false;
     }
 
     private async Task ScheduleGraphActionAsync(Func<Task> action) => await _pendingGraphActions.EnqueueAsync(action);

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -121,8 +121,21 @@ public partial class BpmnDesigner : IAsyncDisposable
 
         var diagnostics = await ScheduleGraphActionAsync(() => _graphApi!.LoadDiagramAsync(payload));
 
-        foreach (var diagnostic in diagnostics.Where(d => d.Severity == "error"))
-            Logger.LogWarning("BPMN diagram '{ActivityId}' reported an error: {Message}", activity.GetId(), diagnostic.Message);
+        foreach (var diagnostic in diagnostics)
+        {
+            switch (diagnostic.Severity)
+            {
+                case "error":
+                    Logger.LogWarning("BPMN diagram '{ActivityId}' reported diagnostic {Code} on element '{ElementId}': {Message}", activity.GetId(), diagnostic.Code, diagnostic.ElementId, diagnostic.Message);
+                    break;
+                case "warning":
+                    Logger.LogInformation("BPMN diagram '{ActivityId}' reported diagnostic {Code} on element '{ElementId}': {Message}", activity.GetId(), diagnostic.Code, diagnostic.ElementId, diagnostic.Message);
+                    break;
+                default:
+                    Logger.LogDebug("BPMN diagram '{ActivityId}' reported diagnostic {Code} on element '{ElementId}': {Message}", activity.GetId(), diagnostic.Code, diagnostic.ElementId, diagnostic.Message);
+                    break;
+            }
+        }
 
         if (activityStats != null)
         {

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/BpmnGraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/BpmnGraphApi.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Models;
+using Microsoft.JSInterop;
+
+namespace Elsa.Studio.Workflows.Designer.Interop;
+
+/// <summary>
+/// Provides a wrapper around the BPMN canvas's JS interop surface (<c>src/designer/api/bpmn-designer.ts</c>).
+/// The graph id a BPMN canvas is registered under is its container id, the same convention the X6
+/// flowchart canvas uses, which is why zooming and centering below reuse the very same <c>zoomToFit</c>
+/// and <c>centerContent</c> functions <see cref="X6GraphApi"/> calls.
+/// </summary>
+public class BpmnGraphApi
+{
+    private readonly IJSObjectReference _module;
+    private readonly string _graphId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BpmnGraphApi"/> class.
+    /// </summary>
+    /// <param name="module">The JavaScript module reference.</param>
+    /// <param name="graphId">The id of the graph, which is the id of its container element.</param>
+    public BpmnGraphApi(IJSObjectReference module, string graphId)
+    {
+        _module = module;
+        _graphId = graphId;
+    }
+
+    /// <summary>
+    /// Loads the specified BPMN diagram input into the graph, replacing whatever it held.
+    /// </summary>
+    /// <param name="input">The <c>{ activity, sourceXml, activityDescriptors }</c> payload the view model builder reads.</param>
+    /// <returns>The view model's diagnostics, in document order.</returns>
+    public async Task<IReadOnlyList<BpmnDiagnostic>> LoadDiagramAsync(JsonObject input)
+    {
+        var inputElement = JsonSerializer.SerializeToElement(input, GetSerializerOptions());
+        var diagnostics = await InvokeAsync(module => module.InvokeAsync<BpmnDiagnostic[]>("loadBpmnDiagram", _graphId, inputElement));
+        return diagnostics;
+    }
+
+    /// <summary>
+    /// Updates the stats of every element bound to the specified activity.
+    /// </summary>
+    /// <param name="activityId">The Elsa activity id.</param>
+    /// <param name="stats">The stats to apply, or null to clear them.</param>
+    public async Task UpdateActivityStatsAsync(string activityId, ActivityStats? stats) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("updateBpmnActivityStats", _graphId, activityId, stats));
+
+    /// <summary>
+    /// Selects the specified element, optionally centering the viewport on it.
+    /// </summary>
+    /// <param name="elementId">The BPMN element id.</param>
+    /// <param name="center">Whether to center the viewport on the element.</param>
+    public async Task SelectElementAsync(string elementId, bool center = false) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("selectBpmnElement", _graphId, elementId, center));
+
+    /// Zoom the canvas to fit the content.
+    public async Task ZoomToFitAsync() => await InvokeAsync(module => module.InvokeVoidAsync("zoomToFit", _graphId));
+
+    /// Center the canvas content.
+    public async Task CenterContentAsync() => await InvokeAsync(module => module.InvokeVoidAsync("centerContent", _graphId));
+
+    /// Disposes the graph.
+    public async Task DisposeGraphAsync() => await TryInvokeAsync(module => module.InvokeVoidAsync("disposeBpmnGraph", _graphId));
+
+    private async Task InvokeAsync(Func<IJSObjectReference, ValueTask> func) => await func(_module);
+    private async Task<T> InvokeAsync<T>(Func<IJSObjectReference, ValueTask<T>> func) => await func(_module);
+
+    private async Task TryInvokeAsync(Func<IJSObjectReference, ValueTask> func)
+    {
+        try
+        {
+            await func(_module);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Ignore.
+        }
+    }
+
+    private static JsonSerializerOptions GetSerializerOptions()
+    {
+        var serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        serializerOptions.Converters.Add(new JsonStringEnumConverter());
+        return serializerOptions;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/DesignerJsInterop.cs
@@ -61,6 +61,20 @@ public class DesignerJsInterop(
     }
 
     /// <summary>
+    /// Creates a new read-only BPMN graph and returns its API wrapper. The graph id is the container id.
+    /// </summary>
+    /// <param name="containerId">The ID of the container element.</param>
+    /// <param name="componentRef">A reference to the <see cref="BpmnDesigner"/> component.</param>
+    public async ValueTask<BpmnGraphApi> CreateBpmnGraphAsync(string containerId, DotNetObjectReference<BpmnDesigner> componentRef)
+    {
+        return await TryInvokeAsync(async module =>
+        {
+            var graphId = await module.InvokeAsync<string>("createBpmnGraph", containerId, componentRef);
+            return new BpmnGraphApi(module, graphId);
+        });
+    }
+
+    /// <summary>
     /// Provides the task.
     /// </summary>
     public async Task UpdateActivitySizeAsync(string elementId, JsonObject activity, Elsa.Api.Client.Shared.Models.Size? size = null, int? portCount = null)

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnDiagnostic.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnDiagnostic.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Studio.Workflows.Designer.Models;
+
+/// <summary>
+/// One thing worth telling the user about a BPMN document, in document order. Mirrors the
+/// TypeScript <c>BpmnDiagnostic</c> that <c>loadBpmnDiagram</c> returns.
+/// </summary>
+/// <param name="Code">The diagnostic code, e.g. <c>missing-source-xml</c> or <c>unbound-work</c>.</param>
+/// <param name="Severity">One of <c>info</c>, <c>warning</c> or <c>error</c>.</param>
+/// <param name="Message">A human-readable description of the diagnostic.</param>
+/// <param name="ElementId">The BPMN element the diagnostic is about, if any.</param>
+/// <param name="ScopeId">The BPMN process scope the diagnostic is about, if any.</param>
+public record BpmnDiagnostic(string Code, string Severity, string Message, string? ElementId, string? ScopeId);

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnElementSelection.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnElementSelection.cs
@@ -1,0 +1,28 @@
+namespace Elsa.Studio.Workflows.Designer.Models;
+
+/// <summary>
+/// What a click, double-click, or selection on a BPMN element tells .NET. Mirrors the TypeScript
+/// <c>BpmnElementSelection</c> that <c>HandleActivitySelected</c> and <c>HandleActivityDoubleClick</c>
+/// receive from the BPMN canvas.
+/// </summary>
+/// <param name="ElementId">The BPMN element id. Unique in the document.</param>
+/// <param name="ElementType">The raw BPMN element type, e.g. <c>serviceTask</c>, <c>boundaryEvent</c>.</param>
+/// <param name="Kind">The element family: <c>event</c>, <c>gateway</c>, <c>task</c>, <c>callActivity</c>, <c>subProcess</c>, <c>unknown</c>.</param>
+/// <param name="Name">The element's document name, if any.</param>
+/// <param name="ActivityId">The Elsa activity bound to this element, or null when nothing is or should be.</param>
+/// <param name="BindingState">How the binding resolves, or null for an element that performs no work.</param>
+/// <param name="ScopeId">The process id of the scope the element lives in.</param>
+/// <param name="ScopeActivityId">The <c>Elsa.BpmnProcess</c> activity that runs that scope.</param>
+/// <param name="BoundaryHostElementId">For a boundary event, the element it is attached to.</param>
+/// <param name="ChildScopeId">For a subprocess, the process id of the scope it contains.</param>
+public record BpmnElementSelection(
+    string ElementId,
+    string ElementType,
+    string Kind,
+    string? Name,
+    string? ActivityId,
+    string? BindingState,
+    string ScopeId,
+    string ScopeActivityId,
+    string? BoundaryHostElementId,
+    string? ChildScopeId);

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerDiagnosticsLoggingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerDiagnosticsLoggingTests.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDesigner.LoadBpmnAsync"/>'s handling of the view model's diagnostics: every
+/// diagnostic the JS adapter reports must be logged, at a severity that reflects the diagnostic's own
+/// severity, rather than only "error" diagnostics being logged and the rest silently dropped.
+/// </summary>
+public sealed class BpmnDesignerDiagnosticsLoggingTests : BunitContext, IAsyncLifetime
+{
+    private readonly CapturingLogger<BpmnDesigner> _logger = new();
+
+    public BpmnDesignerDiagnosticsLoggingTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddWorkflowsCore();
+        Services.AddWorkflowsDesigner();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+        Services.AddSingleton<ILogger<BpmnDesigner>>(_logger);
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task LoadBpmnAsync_LogsEveryDiagnostic_AtASeverityThatReflectsItsOwn()
+    {
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult(
+        [
+            new BpmnDiagnostic("BPMN001", "error", "Missing start event", "Process_1", null),
+            new BpmnDiagnostic("BPMN002", "warning", "Unbound lane", "Lane_1", null),
+            new BpmnDiagnostic("BPMN003", "info", "Documentation ignored", "Doc_1", null)
+        ]);
+
+        var activity = CreateActivity();
+        var cut = Render<BpmnDesigner>(parameters => parameters.Add(p => p.Activity, activity));
+
+        await cut.InvokeAsync(() => cut.Instance.LoadBpmnAsync(activity, null, null));
+
+        Assert.Contains(_logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("BPMN001") && e.Message.Contains("Process_1"));
+        Assert.Contains(_logger.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("BPMN002") && e.Message.Contains("Lane_1"));
+        Assert.Contains(_logger.Entries, e => e.Level == LogLevel.Debug && e.Message.Contains("BPMN003") && e.Message.Contains("Doc_1"));
+    }
+
+    private static JsonObject CreateActivity() => new()
+    {
+        ["id"] = "root",
+        ["type"] = "Elsa.BpmnProcess",
+        ["activities"] = new JsonArray()
+    };
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = default) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerFirstRenderLoadTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerFirstRenderLoadTests.cs
@@ -1,33 +1,34 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Bunit;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Studio.Extensions;
 using Elsa.Studio.Localization;
-using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Components;
 using Elsa.Studio.Workflows.Designer.Extensions;
 using Elsa.Studio.Workflows.Designer.Models;
-using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
 using Xunit;
 
 namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
-/// Covers <see cref="BpmnDesignerWrapper"/>'s switch on <see cref="DesignerOptions.UseReactFlow"/>:
-/// while it is set, W9b's React Flow adapter for BPMN does not exist yet, so the wrapper must show a
-/// clear notice rather than the X6 canvas -- and, per the issue, rather than the JSON fallback or a
-/// crash. Otherwise it must render the X6 canvas.
+/// Covers <see cref="BpmnDesigner"/>'s first-render path: an imported BPMN workflow's root activity,
+/// supplied as the <see cref="BpmnDesigner.Activity"/> parameter, must be loaded into the graph as
+/// soon as the canvas is created, without the caller having to make an explicit
+/// <see cref="BpmnDesigner.LoadBpmnAsync"/> call -- otherwise the canvas opens empty until something
+/// else happens to reload it.
 /// </summary>
-public sealed class BpmnDesignerWrapperTests : BunitContext, IAsyncLifetime
+public sealed class BpmnDesignerFirstRenderLoadTests : BunitContext, IAsyncLifetime
 {
-    public BpmnDesignerWrapperTests()
+    public BpmnDesignerFirstRenderLoadTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
         Services.AddMudServices();
         Services.AddLogging();
         Services.AddCoreInternal();
@@ -41,35 +42,30 @@ public sealed class BpmnDesignerWrapperTests : BunitContext, IAsyncLifetime
     async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
 
     [Fact]
-    public void RendersTheReactFlowNotice_WhenUseReactFlowIsSet()
+    public void Render_LoadsTheSuppliedRootActivity_OnFirstRender_WithoutAnExplicitLoadCall()
     {
-        Services.Configure<DesignerOptions>(o => o.UseReactFlow = true);
+        var handler = JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true);
+        handler.SetResult([]);
 
-        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity()));
+        var activity = CreateActivity("root");
 
-        Assert.Contains("mud-alert", cut.Markup);
-        Assert.DoesNotContain("graph-container", cut.Markup);
+        Render<BpmnDesigner>(parameters => parameters.Add(p => p.Activity, activity));
+
+        var invocation = Assert.Single(handler.Invocations);
+        var input = (JsonElement)invocation.Arguments[1]!;
+        var loadedActivityId = input.GetProperty("activity").GetProperty("id").GetString();
+
+        Assert.Equal("root", loadedActivityId);
     }
 
-    [Fact]
-    public void RendersTheX6Canvas_WhenUseReactFlowIsNotSet()
+    private static JsonObject CreateActivity(string id) => new()
     {
-        Services.Configure<DesignerOptions>(o => o.UseReactFlow = false);
-
-        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity()));
-
-        Assert.Contains("graph-container", cut.Markup);
-        Assert.DoesNotContain("mud-alert", cut.Markup);
-    }
-
-    private static JsonObject CreateActivity() => new()
-    {
-        ["id"] = "root",
+        ["id"] = id,
         ["type"] = "Elsa.BpmnProcess",
         ["activities"] = new JsonArray()
     };
 
-    private class TestLocalizer : ILocalizer
+    private sealed class TestLocalizer : ILocalizer
     {
         public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
         public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerUpdateActivitySelectionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerUpdateActivitySelectionTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDesigner.UpdateActivityAsync"/>: after an edit lands here, the component's
+/// own held activity tree -- the one <c>HandleActivitySelected</c> and <c>HandleActivityDoubleClick</c>
+/// resolve a selection against -- must reflect it, or a later selection would hand the properties
+/// panel a pre-edit activity even though the edit was saved.
+/// </summary>
+public sealed class BpmnDesignerUpdateActivitySelectionTests : BunitContext, IAsyncLifetime
+{
+    public BpmnDesignerUpdateActivitySelectionTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddWorkflowsCore();
+        Services.AddWorkflowsDesigner();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task HandleActivitySelected_ReflectsAnEarlierUpdate_ForABoundChildActivity()
+    {
+        var boundActivity = CreateWriteLineActivity("write-line-1", "original text");
+        var root = CreateScope("root", ("ref-1", "write-line-1"), boundActivity);
+
+        JsonObject? selected = null;
+        var cut = Render<BpmnDesigner>(parameters => parameters
+            .Add(p => p.Activity, root)
+            .Add(p => p.ActivitySelected, EventCallback.Factory.Create<JsonObject>(this, activity => selected = activity)));
+
+        var updatedChild = CreateWriteLineActivity("write-line-1", "updated text");
+        await cut.InvokeAsync(() => cut.Instance.UpdateActivityAsync("write-line-1", updatedChild));
+
+        var selection = new BpmnElementSelection("NotifyWarehouse", "serviceTask", "task", "Notify Warehouse", "write-line-1", "bound", "root", "root", null, null);
+        await cut.InvokeAsync(() => cut.Instance.HandleActivitySelected(selection));
+
+        Assert.NotNull(selected);
+        Assert.Equal("updated text", selected!["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task HandleActivitySelected_ReflectsAnEarlierUpdate_ForTheRootScopeActivity()
+    {
+        var root = CreateScope("root");
+
+        JsonObject? selected = null;
+        var cut = Render<BpmnDesigner>(parameters => parameters
+            .Add(p => p.Activity, root)
+            .Add(p => p.ActivitySelected, EventCallback.Factory.Create<JsonObject>(this, activity => selected = activity)));
+
+        var updatedRoot = CreateScope("root");
+        updatedRoot["name"] = "updated-root";
+        await cut.InvokeAsync(() => cut.Instance.UpdateActivityAsync("root", updatedRoot));
+
+        var selection = new BpmnElementSelection("Process_1", "process", "unknown", null, null, null, "root", "root", null, null);
+        await cut.InvokeAsync(() => cut.Instance.HandleActivitySelected(selection));
+
+        Assert.NotNull(selected);
+        Assert.Equal("updated-root", selected!["name"]!.GetValue<string>());
+    }
+
+    private static JsonObject CreateWriteLineActivity(string id, string text) => new()
+    {
+        ["id"] = id,
+        ["type"] = "Elsa.WriteLine",
+        ["text"] = text
+    };
+
+    /// <summary>
+    /// Builds an <c>Elsa.BpmnProcess</c> scope activity carrying a single work binding and its bound
+    /// child activity, mirroring <c>BpmnDesignerSelectionMappingTests</c>' fixture shape.
+    /// </summary>
+    private static JsonObject CreateScope(string id, (string Ref, string ActivityId) workBinding, JsonObject boundActivity) =>
+        new()
+        {
+            ["id"] = id,
+            ["type"] = "Elsa.BpmnProcess",
+            ["workBindings"] = new JsonObject { [workBinding.Ref] = workBinding.ActivityId },
+            ["process"] = new JsonObject { ["elements"] = new JsonArray() },
+            ["activities"] = new JsonArray { boundActivity }
+        };
+
+    private static JsonObject CreateScope(string id) => new()
+    {
+        ["id"] = id,
+        ["type"] = "Elsa.BpmnProcess",
+        ["workBindings"] = new JsonObject(),
+        ["process"] = new JsonObject { ["elements"] = new JsonArray() },
+        ["activities"] = new JsonArray()
+    };
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = default) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerWrapperTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDesignerWrapper"/>'s switch on <see cref="DesignerOptions.UseReactFlow"/>:
+/// while it is set, W9b's React Flow adapter for BPMN does not exist yet, so the wrapper must show a
+/// clear notice rather than the X6 canvas -- and, per the issue, rather than the JSON fallback or a
+/// crash. Otherwise it must render the X6 canvas.
+/// </summary>
+public sealed class BpmnDesignerWrapperTests : BunitContext, IAsyncLifetime
+{
+    public BpmnDesignerWrapperTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddWorkflowsCore();
+        Services.AddWorkflowsDesigner();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void RendersTheReactFlowNotice_WhenUseReactFlowIsSet()
+    {
+        Services.Configure<DesignerOptions>(o => o.UseReactFlow = true);
+
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity()));
+
+        Assert.Contains("mud-alert", cut.Markup);
+        Assert.DoesNotContain("graph-container", cut.Markup);
+    }
+
+    [Fact]
+    public void RendersTheX6Canvas_WhenUseReactFlowIsNotSet()
+    {
+        Services.Configure<DesignerOptions>(o => o.UseReactFlow = false);
+
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity()));
+
+        Assert.Contains("graph-container", cut.Markup);
+        Assert.DoesNotContain("mud-alert", cut.Markup);
+    }
+
+    private static JsonObject CreateActivity() => new()
+    {
+        ["id"] = "root",
+        ["type"] = "Elsa.BpmnProcess",
+        ["activities"] = new JsonArray()
+    };
+
+    private class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = default) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerProviderTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.DiagramDesigners.Fallback;
+using Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.UI.Services;
+using Microsoft.Extensions.Localization;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDiagramDesignerProvider"/>: it claims an <c>Elsa.BpmnProcess</c> root and
+/// nothing else, and once registered, the diagram designer service picks it over the fallback for a
+/// BPMN root.
+/// </summary>
+public class BpmnDiagramDesignerProviderTests
+{
+    private readonly BpmnDiagramDesignerProvider _provider = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()));
+
+    [Fact]
+    public void GetSupportsActivity_ReturnsTrueForBpmnProcessActivity()
+    {
+        var activity = CreateActivity("Elsa.BpmnProcess");
+
+        Assert.True(_provider.GetSupportsActivity(activity));
+    }
+
+    [Theory]
+    [InlineData("Elsa.Flowchart")]
+    [InlineData("Elsa.WriteLine")]
+    [InlineData("Elsa.StateMachine")]
+    public void GetSupportsActivity_ReturnsFalseForNonBpmnActivities(string type)
+    {
+        var activity = CreateActivity(type);
+
+        Assert.False(_provider.GetSupportsActivity(activity));
+    }
+
+    [Fact]
+    public void GetEditor_ReturnsBpmnDiagramDesigner()
+    {
+        var editor = _provider.GetEditor();
+
+        Assert.IsType<BpmnDiagramDesigner>(editor);
+    }
+
+    [Fact]
+    public void DiagramDesignerService_ChoosesTheBpmnProviderOverTheFallback_ForABpmnRoot()
+    {
+        var service = new DefaultDiagramDesignerService([_provider, new FallbackDesignerProvider()]);
+        var activity = CreateActivity("Elsa.BpmnProcess");
+
+        Assert.True(service.HasDiagramDesigner(activity));
+        Assert.IsType<BpmnDiagramDesigner>(service.GetDiagramDesigner(activity));
+    }
+
+    [Fact]
+    public void DiagramDesignerService_StillChoosesTheFlowchartProvider_ForAFlowchartRoot()
+    {
+        var flowchartProvider = new FlowchartDiagramDesignerProvider(new TestLocalizer(), null!, Microsoft.Extensions.Options.Options.Create(new DesignerOptions()));
+        var service = new DefaultDiagramDesignerService([_provider, flowchartProvider, new FallbackDesignerProvider()]);
+        var activity = CreateActivity("Elsa.Flowchart");
+
+        Assert.IsType<FlowchartDiagramDesigner>(service.GetDiagramDesigner(activity));
+    }
+
+    private static JsonObject CreateActivity(string type) => new()
+    {
+        ["type"] = type
+    };
+
+    private class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
@@ -53,6 +53,27 @@ public class BpmnDiagramDesignerTests
         Assert.NotSame(updatedChild, resultChild);
     }
 
+    [Fact]
+    public async Task UpdateActivityAsync_ReplacesTheRootActivity_WhenTheIdMatchesTheRoot()
+    {
+        var activity = LoadFixture();
+        await _designer.LoadRootActivityAsync(activity, null);
+
+        var rootId = activity["id"]!.GetValue<string>();
+        var updatedRoot = new JsonObject
+        {
+            ["id"] = rootId,
+            ["type"] = "Elsa.BpmnProcess",
+            ["name"] = "updated-root"
+        };
+
+        await _designer.UpdateActivityAsync(rootId, updatedRoot);
+        var result = await _designer.ReadRootActivityAsync();
+
+        Assert.Equal("updated-root", result["name"]!.GetValue<string>());
+        Assert.NotSame(updatedRoot, result);
+    }
+
     private static JsonObject LoadFixture()
     {
         var path = Path.Combine(AppContext.BaseDirectory, "DesignerAssets", "camunda-order-process.activity.json");

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Options;
+using Microsoft.Extensions.Localization;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDiagramDesigner"/>'s read path: the designer is read-only in this
+/// increment, so <see cref="BpmnDiagramDesigner.ReadRootActivityAsync"/> must hand back the exact
+/// document it was given -- never a projection rebuilt from the canvas's own view model (D4) -- and
+/// <see cref="BpmnDiagramDesigner.UpdateActivityAsync"/>'s only job is to keep that document in step
+/// with an edit made elsewhere (the properties panel), without touching the canvas.
+/// </summary>
+public class BpmnDiagramDesignerTests
+{
+    private readonly BpmnDiagramDesigner _designer = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()));
+
+    [Fact]
+    public async Task ReadRootActivityAsync_ReturnsTheLoadedActivityUnchanged()
+    {
+        var activity = LoadFixture();
+
+        await _designer.LoadRootActivityAsync(activity, null);
+        var result = await _designer.ReadRootActivityAsync();
+
+        Assert.Same(activity, result);
+        Assert.True(JsonNode.DeepEquals(activity, result));
+    }
+
+    [Fact]
+    public async Task UpdateActivityAsync_ReplacesTheMatchingChildActivity_LeavingTheRestOfTheTreeAlone()
+    {
+        var activity = LoadFixture();
+        await _designer.LoadRootActivityAsync(activity, null);
+
+        var originalChild = activity["activities"]![0]!.AsObject();
+        var childId = originalChild["id"]!.GetValue<string>();
+        var updatedChild = new JsonObject
+        {
+            ["id"] = childId,
+            ["type"] = "Elsa.WriteLine",
+            ["text"] = "updated"
+        };
+
+        await _designer.UpdateActivityAsync(childId, updatedChild);
+        var result = await _designer.ReadRootActivityAsync();
+
+        var resultChild = result["activities"]![0]!.AsObject();
+        Assert.Equal("updated", resultChild["text"]!.GetValue<string>());
+        Assert.NotSame(updatedChild, resultChild);
+    }
+
+    private static JsonObject LoadFixture()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "DesignerAssets", "camunda-order-process.activity.json");
+        var json = File.ReadAllText(path);
+        return JsonNode.Parse(json)!.AsObject();
+    }
+
+    private class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
@@ -48,6 +48,9 @@
         <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\designer\api\create-graph.ts"
               Link="DesignerAssets\create-graph.ts"
               CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\bpmn\__fixtures__\camunda-order-process.activity.json"
+              Link="DesignerAssets\camunda-order-process.activity.json"
+              CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
@@ -1,0 +1,13 @@
+@inject ILocalizer Localizer
+
+<div style="height:100%">
+    @if (UseReactFlow)
+    {
+        <MudAlert Severity="Severity.Info">@Localizer["BPMN is not yet available on the React Flow canvas."]</MudAlert>
+    }
+    else
+    {
+        <BpmnDesigner @ref="@Designer" Activity="@Activity" SourceXml="@SourceXml" ActivityStats="@ActivityStats"
+            ActivitySelected="@ActivitySelected" ActivityDoubleClick="@ActivityDoubleClick" CanvasSelected="@OnCanvasSelected" />
+    }
+</div>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -60,6 +60,16 @@ public partial class BpmnDesignerWrapper
     }
 
     /// <summary>
+    /// Keeps the underlying designer's held activity tree in step with an edit made elsewhere (the
+    /// properties panel), without touching the canvas. See <see cref="BpmnDesigner.UpdateActivityAsync"/>.
+    /// </summary>
+    public async Task UpdateActivityAsync(string id, JsonObject activity)
+    {
+        if (Designer != null)
+            await Designer.UpdateActivityAsync(id, activity);
+    }
+
+    /// <summary>
     /// Updates the stats of the specified activity.
     /// </summary>
     public async Task UpdateActivityStatsAsync(string id, ActivityStats stats)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -1,0 +1,103 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.Domain.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// A wrapper around the <see cref="Designer.Components.BpmnDesigner"/> component that switches
+/// between the X6 canvas and, while <see cref="DesignerOptions.UseReactFlow"/> is in effect, a notice
+/// that BPMN is not yet available on the React Flow canvas -- exactly as <c>FlowchartDesignerWrapper</c>
+/// switches, except that dropping W9b's React Flow adapter here is a clear notice, not the JSON
+/// fallback and not a crash.
+/// </summary>
+public partial class BpmnDesignerWrapper
+{
+    /// <summary>
+    /// The root <c>Elsa.BpmnProcess</c> activity to display.
+    /// </summary>
+    [Parameter] public JsonObject Activity { get; set; } = null!;
+
+    /// <summary>
+    /// The imported BPMN document's source XML, for BPMN DI geometry.
+    /// </summary>
+    [Parameter] public string? SourceXml { get; set; }
+
+    /// <summary>
+    /// A map of activity stats.
+    /// </summary>
+    [Parameter] public IDictionary<string, ActivityStats>? ActivityStats { get; set; }
+
+    /// <summary>
+    /// An event raised when an activity is selected.
+    /// </summary>
+    [Parameter] public EventCallback<JsonObject> ActivitySelected { get; set; }
+
+    /// <summary>
+    /// An event raised when an activity is double-clicked.
+    /// </summary>
+    [Parameter] public EventCallback<JsonObject> ActivityDoubleClick { get; set; }
+
+    [Inject] private IOptions<DesignerOptions> DesignerOptions { get; set; } = null!;
+
+    private BpmnDesigner? Designer { get; set; }
+    private bool UseReactFlow => DesignerOptions.Value.UseReactFlow;
+
+    /// <summary>
+    /// Loads the specified root activity into the designer.
+    /// </summary>
+    public async Task LoadBpmnAsync(JsonObject activity, string? sourceXml, IDictionary<string, ActivityStats>? activityStats)
+    {
+        Activity = activity;
+        SourceXml = sourceXml;
+        ActivityStats = activityStats;
+
+        if (Designer != null)
+            await Designer.LoadBpmnAsync(activity, sourceXml, activityStats);
+    }
+
+    /// <summary>
+    /// Updates the stats of the specified activity.
+    /// </summary>
+    public async Task UpdateActivityStatsAsync(string id, ActivityStats stats)
+    {
+        if (Designer != null)
+            await Designer.UpdateActivityStatsAsync(id, stats);
+    }
+
+    /// <summary>
+    /// Selects the element bound to the specified activity.
+    /// </summary>
+    public async Task SelectActivityAsync(string id)
+    {
+        if (Designer != null)
+            await Designer.SelectActivityAsync(id);
+    }
+
+    /// <summary>
+    /// Zooms the designer to fit the content.
+    /// </summary>
+    public async Task ZoomToFitAsync()
+    {
+        if (Designer != null)
+            await Designer.ZoomToFitAsync();
+    }
+
+    /// <summary>
+    /// Centers the content of the designer.
+    /// </summary>
+    public async Task CenterContentAsync()
+    {
+        if (Designer != null)
+            await Designer.CenterContentAsync();
+    }
+
+    private async Task OnCanvasSelected()
+    {
+        if (ActivitySelected.HasDelegate)
+            await ActivitySelected.InvokeAsync(Activity);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -45,7 +45,11 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
     /// </remarks>
     public Task UpdateActivityAsync(string id, JsonObject activity)
     {
-        ReplaceActivity(_rootActivity, id, activity);
+        if (_rootActivity.GetId() == id)
+            _rootActivity = (JsonObject)activity.DeepClone()!;
+        else
+            ReplaceActivity(_rootActivity, id, activity);
+
         return Task.CompletedTask;
     }
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -38,19 +38,20 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
 
     /// <inheritdoc />
     /// <remarks>
-    /// The canvas is read-only and has nothing to react to, so this only keeps the in-memory root
-    /// activity in step: the matching child activity node is replaced by id, wherever in the tree it
-    /// is, so that <see cref="ReadRootActivityAsync"/> returns the edited tree. The canvas itself is
-    /// left untouched.
+    /// The canvas is read-only and has nothing to react to, so this keeps two copies of the in-memory
+    /// root activity in step: the matching child activity node is replaced by id, wherever in the tree
+    /// it is, so that <see cref="ReadRootActivityAsync"/> returns the edited tree, and the same
+    /// replacement is forwarded to the mounted <see cref="BpmnDesignerWrapper"/> so its own held tree
+    /// -- the one selection resolves from -- does not go stale. The canvas itself is left untouched.
     /// </remarks>
-    public Task UpdateActivityAsync(string id, JsonObject activity)
+    public async Task UpdateActivityAsync(string id, JsonObject activity)
     {
         if (_rootActivity.GetId() == id)
             _rootActivity = (JsonObject)activity.DeepClone()!;
         else
             ReplaceActivity(_rootActivity, id, activity);
 
-        return Task.CompletedTask;
+        await InvokeDesignerActionAsync(x => x.UpdateActivityAsync(id, activity));
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -8,7 +8,6 @@ using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.UI.Contexts;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Options;
 using MudBlazor;
 
@@ -103,28 +102,8 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
         if (designerOptions.Value.UseReactFlow)
             yield break;
 
-        yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
-        yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
-    }
-
-    private RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)
-    {
-        return builder =>
-        {
-            builder.OpenComponent<MudTooltip>(0);
-            builder.AddAttribute(1, nameof(MudTooltip.Text), description);
-            builder.AddAttribute(2, nameof(MudTooltip.Delay), 500d);
-            builder.AddAttribute(3, nameof(MudTooltip.ChildContent), (RenderFragment)(childBuilder =>
-            {
-                childBuilder.OpenComponent<MudIconButton>(0);
-                childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
-                childBuilder.AddAttribute(2, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, onClick));
-                childBuilder.AddAttribute(3, "aria-label", title);
-                childBuilder.CloseComponent();
-            }));
-
-            builder.CloseComponent();
-        };
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
     }
 
     private async Task InvokeDesignerActionAsync(Func<BpmnDesignerWrapper, Task> action)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -5,6 +5,7 @@ using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.UI.Contexts;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
@@ -49,7 +50,7 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
         if (_rootActivity.GetId() == id)
             _rootActivity = (JsonObject)activity.DeepClone()!;
         else
-            ReplaceActivity(_rootActivity, id, activity);
+            _rootActivity.ReplaceActivity(id, activity);
 
         await InvokeDesignerActionAsync(x => x.UpdateActivityAsync(id, activity));
     }
@@ -119,33 +120,6 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
 
     private Task OnZoomToFitClicked() => _designerWrapper != null ? _designerWrapper.ZoomToFitAsync() : Task.CompletedTask;
     private Task OnCenterClicked() => _designerWrapper != null ? _designerWrapper.CenterContentAsync() : Task.CompletedTask;
-
-    /// <summary>
-    /// Replaces the activity with the specified id, wherever in the tree it is -- the root's own
-    /// activities or, recursively, a nested BPMN scope's -- with a clone of <paramref name="replacement"/>.
-    /// </summary>
-    private static bool ReplaceActivity(JsonObject scope, string id, JsonObject replacement)
-    {
-        if (scope["activities"] is not JsonArray activities)
-            return false;
-
-        for (var i = 0; i < activities.Count; i++)
-        {
-            if (activities[i] is not JsonObject child)
-                continue;
-
-            if (child.GetId() == id)
-            {
-                activities[i] = (JsonObject)replacement.DeepClone()!;
-                return true;
-            }
-
-            if (ReplaceActivity(child, id, replacement))
-                return true;
-        }
-
-        return false;
-    }
 
     /// <summary>
     /// Reads the imported BPMN document's source XML from the workflow definition's custom

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.UI.Contexts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Options;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// A diagram designer that displays an imported BPMN process, read-only. Editing lands in a later
+/// increment (W14); this designer only ever shows the diagram and forwards selection.
+/// </summary>
+public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerToolboxProvider
+{
+    /// <summary>
+    /// The custom property key elsa-core stores the imported BPMN document's source XML under.
+    /// </summary>
+    private const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
+
+    private readonly Guid _id = Guid.NewGuid();
+    private BpmnDesignerWrapper? _designerWrapper;
+    private JsonObject _rootActivity = [];
+    private string? _sourceXml;
+
+    /// <inheritdoc />
+    public async Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap)
+    {
+        _rootActivity = activity;
+        await InvokeDesignerActionAsync(x => x.LoadBpmnAsync(activity, _sourceXml, activityStatsMap));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The canvas is read-only and has nothing to react to, so this only keeps the in-memory root
+    /// activity in step: the matching child activity node is replaced by id, wherever in the tree it
+    /// is, so that <see cref="ReadRootActivityAsync"/> returns the edited tree. The canvas itself is
+    /// left untouched.
+    /// </remarks>
+    public Task UpdateActivityAsync(string id, JsonObject activity)
+    {
+        ReplaceActivity(_rootActivity, id, activity);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateActivityStatsAsync(string id, ActivityStats stats)
+    {
+        await InvokeDesignerActionAsync(x => x.UpdateActivityStatsAsync(id, stats));
+    }
+
+    /// <inheritdoc />
+    public async Task SelectActivityAsync(string id)
+    {
+        await InvokeDesignerActionAsync(x => x.SelectActivityAsync(id));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns the whole root activity JSON exactly as it was given and since edited by
+    /// <see cref="UpdateActivityAsync"/>, never a projection rebuilt from the read-only view model:
+    /// the view model is the canvas's own concern and the document it was built from is what this
+    /// designer holds and hands back (D4).
+    /// </remarks>
+    public Task<JsonObject> ReadRootActivityAsync() => Task.FromResult(_rootActivity);
+
+    /// <inheritdoc />
+    public RenderFragment DisplayDesigner(DisplayContext context)
+    {
+        var activity = context.Activity;
+        var sequence = 0;
+
+        _rootActivity = activity;
+        _sourceXml = GetSourceXml(context.WorkflowDefinition);
+
+        return builder =>
+        {
+            builder.OpenComponent<BpmnDesignerWrapper>(sequence++);
+            builder.SetKey(_id);
+            builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.Activity), activity);
+            builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.SourceXml), _sourceXml);
+            builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivityStats), context.ActivityStats);
+            builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivitySelected), context.ActivitySelectedCallback);
+            builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivityDoubleClick), context.ActivityDoubleClickCallback);
+            builder.AddComponentReferenceCapture(sequence++, @ref => _designerWrapper = (BpmnDesignerWrapper)@ref);
+
+            builder.CloseComponent();
+        };
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<RenderFragment> GetToolboxItems(bool isReadOnly)
+    {
+        // The React Flow adapter for BPMN does not exist yet (W9b), so there is no canvas to zoom or
+        // center while it is in effect.
+        if (designerOptions.Value.UseReactFlow)
+            yield break;
+
+        yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
+        yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
+    }
+
+    private RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)
+    {
+        return builder =>
+        {
+            builder.OpenComponent<MudTooltip>(0);
+            builder.AddAttribute(1, nameof(MudTooltip.Text), description);
+            builder.AddAttribute(2, nameof(MudTooltip.Delay), 500d);
+            builder.AddAttribute(3, nameof(MudTooltip.ChildContent), (RenderFragment)(childBuilder =>
+            {
+                childBuilder.OpenComponent<MudIconButton>(0);
+                childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
+                childBuilder.AddAttribute(2, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, onClick));
+                childBuilder.AddAttribute(3, "aria-label", title);
+                childBuilder.CloseComponent();
+            }));
+
+            builder.CloseComponent();
+        };
+    }
+
+    private async Task InvokeDesignerActionAsync(Func<BpmnDesignerWrapper, Task> action)
+    {
+        if (_designerWrapper != null)
+            await action(_designerWrapper);
+    }
+
+    private Task OnZoomToFitClicked() => _designerWrapper != null ? _designerWrapper.ZoomToFitAsync() : Task.CompletedTask;
+    private Task OnCenterClicked() => _designerWrapper != null ? _designerWrapper.CenterContentAsync() : Task.CompletedTask;
+
+    /// <summary>
+    /// Replaces the activity with the specified id, wherever in the tree it is -- the root's own
+    /// activities or, recursively, a nested BPMN scope's -- with a clone of <paramref name="replacement"/>.
+    /// </summary>
+    private static bool ReplaceActivity(JsonObject scope, string id, JsonObject replacement)
+    {
+        if (scope["activities"] is not JsonArray activities)
+            return false;
+
+        for (var i = 0; i < activities.Count; i++)
+        {
+            if (activities[i] is not JsonObject child)
+                continue;
+
+            if (child.GetId() == id)
+            {
+                activities[i] = (JsonObject)replacement.DeepClone()!;
+                return true;
+            }
+
+            if (ReplaceActivity(child, id, replacement))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the imported BPMN document's source XML from the workflow definition's custom
+    /// properties, or null when there is none.
+    /// </summary>
+    private static string? GetSourceXml(WorkflowDefinition? workflowDefinition)
+    {
+        if (workflowDefinition == null || !workflowDefinition.CustomProperties.TryGetValue(SourceXmlCustomPropertyKey, out var value) || value == null!)
+            return null;
+
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.UI.Contracts;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// A diagram designer provider for an imported <c>Elsa.BpmnProcess</c> root, so it opens in the BPMN
+/// designer instead of falling back to the JSON view.
+/// </summary>
+[UsedImplicitly]
+public class BpmnDiagramDesignerProvider(ILocalizer localizer, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerProvider
+{
+    /// <inheritdoc />
+    public double Priority => 10;
+
+    /// <inheritdoc />
+    public bool GetSupportsActivity(JsonObject activity) => activity.GetTypeName() == "Elsa.BpmnProcess";
+
+    /// <inheritdoc />
+    public IDiagramDesigner GetEditor() => new BpmnDiagramDesigner(localizer, designerOptions);
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/DiagramDesignerToolbox.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/DiagramDesignerToolbox.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners;
+
+/// <summary>
+/// Renders the toolbox items shared by the diagram designers -- a tooltipped icon button that
+/// invokes an action when clicked.
+/// </summary>
+public static class DiagramDesignerToolbox
+{
+    /// <summary>
+    /// Renders a single toolbox item: a <see cref="MudIconButton"/> wrapped in a <see cref="MudTooltip"/>.
+    /// </summary>
+    /// <param name="title">The accessible label for the button.</param>
+    /// <param name="icon">The icon to display on the button.</param>
+    /// <param name="description">The tooltip text shown on hover.</param>
+    /// <param name="onClick">The action to invoke when the button is clicked.</param>
+    public static RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)
+    {
+        return builder =>
+        {
+            builder.OpenComponent<MudTooltip>(0);
+            builder.AddAttribute(1, nameof(MudTooltip.Text), description);
+            builder.AddAttribute(2, nameof(MudTooltip.Delay), 500d);
+            builder.AddAttribute(3, nameof(MudTooltip.ChildContent), (RenderFragment)(childBuilder =>
+            {
+                childBuilder.OpenComponent<MudIconButton>(0);
+                childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
+                childBuilder.AddAttribute(2, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(onClick.Target!, onClick));
+                childBuilder.AddAttribute(3, "aria-label", title);
+                childBuilder.CloseComponent();
+            }));
+
+            builder.CloseComponent();
+        };
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Flowcharts/FlowchartDiagramDesigner.cs
@@ -9,7 +9,6 @@ using Elsa.Studio.Workflows.UI.Contexts;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Options;
 using MudBlazor;
 
@@ -85,33 +84,13 @@ public class FlowchartDiagramDesigner(ILocalizer localizer, IDialogService dialo
     /// <inheritdoc />
     public IEnumerable<RenderFragment> GetToolboxItems(bool isReadonly)
     {
-        yield return DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
-        yield return DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
-        yield return DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Auto layout"], Icons.Material.Outlined.AutoAwesomeMosaic, localizer["Auto layout"], OnAutoLayoutClicked);
 
         // Exporting is available in both read-only and editable mode, but only the X6 designer can produce an image.
         if (!designerOptions.Value.UseReactFlow)
-            yield return DisplayToolboxItem(localizer["Export"], Icons.Material.Outlined.Download, localizer["Export as image"], OnExportClicked);
-    }
-
-    private RenderFragment DisplayToolboxItem(string title, string icon, string description, Func<Task> onClick)
-    {
-        return builder =>
-        {
-            builder.OpenComponent<MudTooltip>(0);
-            builder.AddAttribute(1, nameof(MudTooltip.Text), description);
-            builder.AddAttribute(2, nameof(MudTooltip.Delay), 500d);
-            builder.AddAttribute(3, nameof(MudTooltip.ChildContent), (RenderFragment)(childBuilder =>
-            {
-                childBuilder.OpenComponent<MudIconButton>(0);
-                childBuilder.AddAttribute(1, nameof(MudIconButton.Icon), icon);
-                childBuilder.AddAttribute(2, nameof(MudIconButton.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, onClick));
-                childBuilder.AddAttribute(3, "aria-label", title);
-                childBuilder.CloseComponent();
-            }));
-
-            builder.CloseComponent();
-        };
+            yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Export"], Icons.Material.Outlined.Download, localizer["Export as image"], OnExportClicked);
     }
 
     private async Task InvokeDesignerActionAsync(Func<FlowchartDesignerWrapper, Task> action)

--- a/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.Model
 using Elsa.Studio.Workflows.Components.WorkflowInstanceList.Models;
 using Elsa.Studio.Workflows.Contracts;
 using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 using Elsa.Studio.Workflows.DiagramDesigners.Fallback;
 using Elsa.Studio.Workflows.DiagramDesigners.Flowcharts;
 using Elsa.Studio.Workflows.DiagramDesigners.Sequences;
@@ -50,7 +51,8 @@ public static class ServiceCollectionExtensions
             .AddDiagramDesignerProvider<FallbackDesignerProvider>()
             .AddDiagramDesignerProvider<StateMachineDiagramDesignerProvider>()
             .AddDiagramDesignerProvider<FlowchartDiagramDesignerProvider>()
-            .AddDiagramDesignerProvider<SequenceDiagramDesignerProvider>();
+            .AddDiagramDesignerProvider<SequenceDiagramDesignerProvider>()
+            .AddDiagramDesignerProvider<BpmnDiagramDesignerProvider>();
 
         services.AddNotificationHandler<RefreshActivityRegistry>();
         services.AddScoped<IWidget, WorkflowDefinitionMetadataWidget>();


### PR DESCRIPTION
Closes #1006. Part of elsa-workflows/elsa-core#7909 (W10). Depends on #1010 (W9c), merged.

## What changed

An `Elsa.BpmnProcess` root now opens in a read-only BPMN designer instead of the JSON fallback.

- `DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider` matches `Elsa.BpmnProcess` above the fallback's priority and is registered beside the existing four providers.
- `BpmnDiagramDesigner : IDiagramDesigner, IDiagramDesignerToolboxProvider` mirrors the flowchart designer: it holds the whole root activity JSON and returns it untouched from `ReadRootActivityAsync` (D4), keeps the in-memory tree in step on `UpdateActivityAsync` without touching the canvas, forwards `UpdateActivityStatsAsync` to the adapter's activity-id path (which maps to the bound element through `workBindings`; element-keyed stats stay with W13), maps `SelectActivityAsync` to the bound element, and offers zoom-to-fit and center in the toolbox. No auto-layout, no export, no drop handler.
- `BpmnDesignerWrapper` switches on `DesignerOptions.UseReactFlow` like the flowchart wrapper; the React Flow branch renders a localized notice until the React Flow adapter exists.
- `Components/BpmnDesigner.razor(.cs)` owns the JS interop to the W9c adapter, following `FlowchartDesigner` for module import, `DotNetObjectReference` lifecycle, disposal and the circuit-disconnect guard. It passes the activity JSON, the source XML from the definition's `Bpmn:SourceXml` custom property, and the activity descriptors, and logs every returned diagnostic by severity.
- Selection mapping: a bound element raises `ActivitySelected` with the bound child activity's JSON, found recursively through nested `BpmnProcess` activities; anything else raises it with the scope's `BpmnProcess` JSON. Double-click is mapped the same way.
- The toolbox-item renderer that was duplicated between the flowchart and BPMN designers is now one shared `DiagramDesignerToolbox` helper used by both.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run build
dotnet build Elsa.Studio.sln --configuration Release                                                                   # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 275/275
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 83/83
```

New tests: provider chosen for `Elsa.BpmnProcess` and not for `Elsa.Flowchart`, fallback no longer chosen for a BPMN root; `ReadRootActivityAsync` deep-equals the loaded Camunda fixture; selection mapping (bound child vs scope); wrapper renders the notice under `UseReactFlow` and the X6 component otherwise; diagnostics logged at the level matching their severity (proven to fail without the fix).

**Outstanding for a human**: the manual "open an imported BPMN definition in the editor and see the diagram" check. No elsa-core host references `Elsa.Bpmn.Interchange` or exposes a BPMN feature toggle in configuration, so enabling it would need a code change there.

Review: two iterations on the standards and spec axes; two must-fix findings resolved (the duplicated toolbox renderer, the diagnostics filter). Won't-fix, recorded: `DisplayDesigner` reassigning the root activity on each render mirrors the flowchart designer and the host passes the current activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
