### PR TITLE
feat(workflows): import and export BPMN from Studio

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Client/IBpmnInterchangeApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Client/IBpmnInterchangeApi.cs
@@ -1,0 +1,37 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Refit;
+
+namespace Elsa.Studio.Workflows.Client;
+
+/// <summary>
+/// Backend API for the BPMN interchange endpoints (<c>Elsa.Bpmn.Interchange</c>): analyzing, importing and
+/// exporting BPMN 2.0 documents.
+/// </summary>
+public interface IBpmnInterchangeApi
+{
+    /// <summary>
+    /// Reads a <c>.bpmn</c> document and reports the Info/Degraded/Dropped findings a read would produce, without
+    /// persisting anything.
+    /// </summary>
+    [Multipart]
+    [Post("/bpmn/analyze")]
+    Task<BpmnImportAnalysisModel> AnalyzeAsync([AliasAs("file")] StreamPart file, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads a <c>.bpmn</c> document and persists it as a draft workflow definition.
+    /// </summary>
+    [Multipart]
+    [Post("/bpmn/import")]
+    Task<BpmnImportResultModel> ImportAsync(
+        [AliasAs("file")] StreamPart file,
+        [AliasAs("DefinitionId")] string? definitionId,
+        [AliasAs("Name")] string? name,
+        [AliasAs("ProcessId")] string? processId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the BPMN 2.0 XML a workflow definition was imported from.
+    /// </summary>
+    [Get("/bpmn/definitions/{definitionId}/export")]
+    Task<HttpResponseMessage> ExportAsync(string definitionId, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IBpmnInterchangeService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IBpmnInterchangeService.cs
@@ -1,0 +1,47 @@
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+namespace Elsa.Studio.Workflows.Domain.Contracts;
+
+/// <summary>
+/// Analyzes, imports and exports BPMN 2.0 documents through the backend's <c>Elsa.Bpmn.Interchange</c> endpoints.
+/// </summary>
+public interface IBpmnInterchangeService
+{
+    /// <summary>
+    /// Reads a <c>.bpmn</c> document and reports the Info/Degraded/Dropped findings a read would produce, without
+    /// persisting anything.
+    /// </summary>
+    /// <param name="content">The BPMN 2.0 XML document.</param>
+    /// <param name="fileName">The uploaded file's name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The analysis on success, or the server's error messages on failure.</returns>
+    Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads a <c>.bpmn</c> document and persists it as a draft workflow definition.
+    /// </summary>
+    /// <param name="content">The BPMN 2.0 XML document.</param>
+    /// <param name="fileName">The uploaded file's name.</param>
+    /// <param name="definitionId">The workflow definition to update, or <see langword="null"/> to create a new one.</param>
+    /// <param name="name">The workflow definition's display name, defaulting to the process's own BPMN name or id.</param>
+    /// <param name="processId">The process to import when the document declares more than one.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The imported definition's identity and analysis on success, or the server's error messages on failure.</returns>
+    Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(
+        Stream content,
+        string fileName,
+        string? definitionId,
+        string? name,
+        string? processId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the BPMN 2.0 XML a workflow definition was imported from, ready to download.
+    /// </summary>
+    /// <param name="definitionId">The workflow definition id to export.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The file to download on success, or the classified refusal reason on failure.</returns>
+    Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -40,7 +40,13 @@ public static class ValidationApiExceptionExtensions
         return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) });
     }
 
-    private static ValidationErrors? GetValidationErrorsFromContent(string? content)
+    /// <summary>
+    /// Parses a FastEndpoints-shaped error body (an <c>errors</c> object/array/string, or a <c>detail</c>/<c>title</c>/
+    /// <c>message</c> fallback) into <see cref="ValidationErrors"/>, or <see langword="null"/> when <paramref name="content"/>
+    /// is empty or does not parse as JSON. Shared with callers that have a raw response body rather than an
+    /// <see cref="ApiException"/> to extract it from.
+    /// </summary>
+    public static ValidationErrors? GetValidationErrorsFromContent(string? content)
     {
         if (string.IsNullOrWhiteSpace(content))
             return null;

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -17,9 +17,9 @@ public static class ValidationApiExceptionExtensions
         var problemDetails = e.Content;
 
         if (problemDetails != null)
-            return problemDetails.ToValidationErrors();
+            return problemDetails.ToValidationErrors() with { StatusCode = e.StatusCode };
 
-        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? "The server responded with a Bad Request status code. That's all I know.") });
+        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? "The server responded with a Bad Request status code. That's all I know.") }, e.StatusCode);
     }
 
     /// <summary>
@@ -32,12 +32,12 @@ public static class ValidationApiExceptionExtensions
 
         var errors = GetValidationErrorsFromContent(e.Content);
         if (errors != null)
-            return errors;
+            return errors with { StatusCode = e.StatusCode };
 
         if (!string.IsNullOrWhiteSpace(e.Content))
-            return new ValidationErrors(new List<ValidationError> { new(e.Content) });
+            return new ValidationErrors(new List<ValidationError> { new(e.Content) }, e.StatusCode);
 
-        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) });
+        return new ValidationErrors(new List<ValidationError> { new(e.ReasonPhrase ?? e.Message) }, e.StatusCode);
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
@@ -1,0 +1,38 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The capability names and offending element ids a BPMN import's <c>422</c> "missing host capabilities" refusal
+/// carries, parsed out of the single sentence <c>BpmnInterchangeDocumentService.Import</c> raises in elsa-core, so
+/// the UI can list each separately instead of showing the raw sentence.
+/// </summary>
+public sealed record BpmnCapabilityRefusal(IReadOnlyList<string> CapabilityNames, IReadOnlyList<string> ElementIds)
+{
+    private const string CapabilitiesPrefix = "does not declare the following BPMN host capabilities the document requires:";
+    private const string ElementsPrefix = "Offending elements (combined across all missing capabilities above, not attributable to any one of them):";
+
+    /// <summary>
+    /// Parses <paramref name="message"/> into a <see cref="BpmnCapabilityRefusal"/> when it matches the capability
+    /// refusal's known shape, or returns <see langword="null"/> for any other message (including the two export
+    /// refusals, which use different wording, and unrelated failures).
+    /// </summary>
+    public static BpmnCapabilityRefusal? TryParse(string message)
+    {
+        var capabilitiesIndex = message.IndexOf(CapabilitiesPrefix, StringComparison.OrdinalIgnoreCase);
+        var elementsIndex = message.IndexOf(ElementsPrefix, StringComparison.OrdinalIgnoreCase);
+
+        if (capabilitiesIndex < 0 || elementsIndex < 0 || elementsIndex < capabilitiesIndex)
+            return null;
+
+        var capabilitiesText = message[(capabilitiesIndex + CapabilitiesPrefix.Length)..elementsIndex];
+        var elementsText = message[(elementsIndex + ElementsPrefix.Length)..];
+
+        var capabilityNames = SplitList(capabilitiesText);
+        var elementIds = SplitList(elementsText);
+
+        return capabilityNames.Count == 0 && elementIds.Count == 0 ? null : new BpmnCapabilityRefusal(capabilityNames, elementIds);
+    }
+
+    private static IReadOnlyList<string> SplitList(string text) => text
+        .Trim().Trim('.')
+        .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnExportFailure.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnExportFailure.cs
@@ -1,0 +1,7 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Why a BPMN export could not be produced, carrying both the classified <see cref="Reason"/> the UI should
+/// translate itself, and the server's own message as a fallback for <see cref="BpmnExportFailureReason.Unknown"/>.
+/// </summary>
+public record BpmnExportFailure(BpmnExportFailureReason Reason, string Message);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnExportFailureReason.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnExportFailureReason.cs
@@ -1,0 +1,21 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Why <c>bpmn/definitions/{definitionId}/export</c> refused to export a workflow definition, classified from the
+/// exception message <c>Elsa.Bpmn.Interchange.Services.BpmnInterchangeDocumentService.Export(WorkflowDefinition)</c>
+/// raises, so the UI can show its own short, localized wording instead of the raw diagnostic sentence.
+/// </summary>
+public enum BpmnExportFailureReason
+{
+    /// <summary>The workflow definition could not be found.</summary>
+    NotFound,
+
+    /// <summary>The definition does not currently carry BPMN source: it was never imported from BPMN, or a later save replaced its custom properties.</summary>
+    NotImportedFromBpmn,
+
+    /// <summary>The definition has changed since it was imported from BPMN, so the stored source no longer corresponds to it.</summary>
+    DefinitionChangedSinceImport,
+
+    /// <summary>The export failed for a reason that does not match either of the two refusals above.</summary>
+    Unknown
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportAnalysisModel.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportAnalysisModel.cs
@@ -1,0 +1,24 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// What a document contains and how much of it survives a read, as reported by the <c>bpmn/analyze</c> and
+/// <c>bpmn/import</c> endpoints. Mirrors <c>Elsa.Bpmn.Interchange.Endpoints.Bpmn.BpmnImportAnalysisModel</c> in
+/// elsa-core.
+/// </summary>
+public class BpmnImportAnalysisModel
+{
+    /// <summary>
+    /// The <c>id</c> of every <c>&lt;process&gt;</c> in the document, in document order.
+    /// </summary>
+    public IReadOnlyCollection<string> ProcessIds { get; set; } = [];
+
+    /// <summary>
+    /// How many of each BPMN local name were encountered, across all containers.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> ElementCounts { get; set; } = new Dictionary<string, int>();
+
+    /// <summary>
+    /// Every finding, in the order the reader produced it.
+    /// </summary>
+    public IReadOnlyCollection<BpmnImportIssueModel> Issues { get; set; } = [];
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportIssueModel.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportIssueModel.cs
@@ -1,0 +1,28 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// One element-scoped finding from a BPMN read, as reported by the <c>bpmn/analyze</c> and <c>bpmn/import</c>
+/// endpoints. Mirrors <c>Elsa.Bpmn.Interchange.Endpoints.Bpmn.BpmnImportIssueModel</c> in elsa-core.
+/// </summary>
+public class BpmnImportIssueModel
+{
+    /// <summary>
+    /// How much of the element's authored meaning survived the read: <c>Info</c>, <c>Degraded</c> or <c>Dropped</c>.
+    /// </summary>
+    public string Severity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// A sentence naming the element, what the document said, and what the reader did about it.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The BPMN id the finding is about, when it is about one element.
+    /// </summary>
+    public string? ElementId { get; set; }
+
+    /// <summary>
+    /// The process the finding occurred in, when it is scoped to one.
+    /// </summary>
+    public string? ProcessId { get; set; }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportIssueSeverity.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportIssueSeverity.cs
@@ -1,0 +1,18 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The <see cref="BpmnImportIssueModel.Severity"/> values the <c>bpmn/analyze</c> and <c>bpmn/import</c> endpoints
+/// send. Not an enum because the wire type is a plain string; these constants exist so callers match against a
+/// shared name instead of repeating the literals.
+/// </summary>
+public static class BpmnImportIssueSeverity
+{
+    /// <summary>The element's authored meaning could not be represented and will not run.</summary>
+    public const string Dropped = "Dropped";
+
+    /// <summary>The element ran, but not exactly as authored.</summary>
+    public const string Degraded = "Degraded";
+
+    /// <summary>The element was imported without loss; reported for visibility only.</summary>
+    public const string Info = "Info";
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportResultModel.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnImportResultModel.cs
@@ -1,0 +1,28 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The workflow definition a BPMN import produced, plus what the read cost. Mirrors
+/// <c>Elsa.Bpmn.Interchange.Endpoints.Bpmn.Import.Response</c> in elsa-core.
+/// </summary>
+public class BpmnImportResultModel
+{
+    /// <summary>
+    /// The persisted version's own id.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The workflow definition id, stable across versions.
+    /// </summary>
+    public string DefinitionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The persisted version number.
+    /// </summary>
+    public int Version { get; set; }
+
+    /// <summary>
+    /// The same analysis the <c>bpmn/analyze</c> endpoint would have produced for this document.
+    /// </summary>
+    public BpmnImportAnalysisModel Analysis { get; set; } = new();
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/BpmnImportBatch.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/BpmnImportBatch.cs
@@ -12,4 +12,25 @@ namespace Elsa.Studio.Workflows.Domain.Models;
 /// findings dialog was cancelled before anything was imported contributes no entry.
 /// </param>
 /// <param name="OtherFiles">Every selected file that was not a <c>.bpmn</c> file, unmodified.</param>
-public record BpmnImportBatch(IReadOnlyList<WorkflowImportResult> Results, IReadOnlyList<IBrowserFile> OtherFiles);
+public record BpmnImportBatch(IReadOnlyList<WorkflowImportResult> Results, IReadOnlyList<IBrowserFile> OtherFiles)
+{
+    /// <summary>
+    /// Filters <paramref name="results"/> down to the ones a caller should still report itself, i.e. everything
+    /// except a capability refusal, which <see cref="Elsa.Studio.Workflows.Services.BpmnImportUiService"/> already
+    /// reported in its own dialog. Callers typically pass the concatenation of <see cref="Results"/> with whatever
+    /// they imported from <see cref="OtherFiles"/>.
+    /// </summary>
+    /// <param name="results">The results to filter.</param>
+    /// <returns>The results that were not already reported in their own dialog.</returns>
+    public static IReadOnlyList<WorkflowImportResult> ReportableResults(IEnumerable<WorkflowImportResult> results) =>
+        results.Where(x => x.Failure?.FailureType != WorkflowImportFailureType.CapabilityRefusal).ToList();
+
+    /// <summary>
+    /// Determines whether every result in <paramref name="results"/> was already reported in its own dialog (i.e.
+    /// every one was a capability refusal), meaning there is nothing left for the caller to summarize.
+    /// </summary>
+    /// <param name="results">The results to inspect.</param>
+    /// <returns><c>true</c> when <paramref name="results"/> is non-empty and none of it is reportable.</returns>
+    public static bool AllReported(IReadOnlyList<WorkflowImportResult> results) =>
+        results.Count > 0 && ReportableResults(results).Count == 0;
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/BpmnImportBatch.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/BpmnImportBatch.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Elsa.Studio.Workflows.Domain.Models;
+
+/// <summary>
+/// The outcome of running every <c>.bpmn</c> file in a mixed file selection through the interactive BPMN import
+/// flow, plus whichever files were not <c>.bpmn</c> and so were left for the caller to import through its own
+/// (JSON/ZIP) path.
+/// </summary>
+/// <param name="Results">
+/// One <see cref="WorkflowImportResult"/> per <c>.bpmn</c> file that was imported, in selection order. A file whose
+/// findings dialog was cancelled before anything was imported contributes no entry.
+/// </param>
+/// <param name="OtherFiles">Every selected file that was not a <c>.bpmn</c> file, unmodified.</param>
+public record BpmnImportBatch(IReadOnlyList<WorkflowImportResult> Results, IReadOnlyList<IBrowserFile> OtherFiles);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
@@ -1,6 +1,14 @@
+using System.Net;
+
 namespace Elsa.Studio.Workflows.Domain.Models;
 
 /// <summary>
 /// Represents a collection of validation errors.
 /// </summary>
-public record ValidationErrors(IReadOnlyCollection<ValidationError> Errors);
+/// <param name="Errors">The individual error messages.</param>
+/// <param name="StatusCode">
+/// The HTTP status code the failure was raised with, when known. Callers that need to tell one kind of failure
+/// from another by more than wording (e.g. a BPMN capability refusal, which is only ever a <c>422</c>) can gate on
+/// this instead of matching the error text.
+/// </param>
+public record ValidationErrors(IReadOnlyCollection<ValidationError> Errors, HttpStatusCode? StatusCode = null);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailureType.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/WorkflowImportFailureType.cs
@@ -6,5 +6,12 @@ namespace Elsa.Studio.Workflows.Domain.Models;
 public enum WorkflowImportFailureType
 {
     Exception,
-    InvalidSchema
+    InvalidSchema,
+
+    /// <summary>
+    /// A BPMN import was refused because this deployment does not declare a BPMN host capability the document
+    /// requires (a <c>422</c> from <c>bpmn/import</c>). The refusal's capability names and offending element ids
+    /// are shown in a dialog rather than a snackbar; see <see cref="Elsa.Studio.Workflows.Domain.Models.Bpmn.BpmnCapabilityRefusal"/>.
+    /// </summary>
+    CapabilityRefusal
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Client;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Extensions;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Refit;
+
+namespace Elsa.Studio.Workflows.Domain.Services;
+
+/// <inheritdoc />
+public class RemoteBpmnInterchangeService(IBackendApiClientProvider backendApiClientProvider) : IBpmnInterchangeService
+{
+    /// <inheritdoc />
+    public async Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        var file = new StreamPart(content, fileName, "application/xml");
+
+        try
+        {
+            var analysis = await api.AnalyzeAsync(file, cancellationToken);
+            return new(analysis);
+        }
+        catch (ApiException e)
+        {
+            return new(e.GetValidationErrors());
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(
+        Stream content,
+        string fileName,
+        string? definitionId,
+        string? name,
+        string? processId,
+        CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        var file = new StreamPart(content, fileName, "application/xml");
+
+        try
+        {
+            var result = await api.ImportAsync(file, definitionId, name, processId, cancellationToken);
+            return new(result);
+        }
+        catch (ApiException e)
+        {
+            return new(e.GetValidationErrors());
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        var response = await api.ExportAsync(definitionId, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            return new(new FileDownload($"{definitionId}.bpmn", stream));
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return new(new BpmnExportFailure(BpmnExportFailureReason.NotFound, "Workflow definition not found."));
+
+        var message = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(body)?.Errors.FirstOrDefault()?.ErrorMessage
+            ?? (string.IsNullOrWhiteSpace(body) ? response.ReasonPhrase ?? "The export could not be completed." : body);
+
+        if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
+            return new(new BpmnExportFailure(ClassifyExportRefusal(message), message));
+
+        return new(new BpmnExportFailure(BpmnExportFailureReason.Unknown, message));
+    }
+
+    /// <summary>
+    /// Classifies the two 422 refusals <c>BpmnInterchangeDocumentService.Export(WorkflowDefinition)</c> raises by
+    /// matching the distinguishing phrase each one carries, so the UI can show its own short wording instead of the
+    /// full diagnostic sentence. See that method's remarks in elsa-core for why each refusal reads the way it does.
+    /// </summary>
+    private static BpmnExportFailureReason ClassifyExportRefusal(string message)
+    {
+        if (message.Contains("has changed since it was imported from BPMN", StringComparison.OrdinalIgnoreCase))
+            return BpmnExportFailureReason.DefinitionChangedSinceImport;
+
+        if (message.Contains("does not currently carry BPMN source", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("not the definition version it was recorded against", StringComparison.OrdinalIgnoreCase))
+            return BpmnExportFailureReason.NotImportedFromBpmn;
+
+        return BpmnExportFailureReason.Unknown;
+    }
+
+    private async Task<IBpmnInterchangeApi> GetApiAsync(CancellationToken cancellationToken = default) =>
+        await backendApiClientProvider.GetApiAsync<IBpmnInterchangeApi>(cancellationToken);
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
 using Elsa.Studio.Services;
+using Elsa.Studio.Workflows.Client;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Providers;
 using Elsa.Studio.Workflows.Domain.Services;
@@ -51,6 +53,8 @@ public static class ServiceCollectionExtensions
             .AddScoped<IActivityResolver, StateMachineActivityResolver>()
             .AddScoped<IActivityResolver, DefaultActivityResolver>()
             .AddScoped<IWorkflowJsonDetector, CompatWorkflowJsonDetector>()
+            .AddScoped<IBpmnInterchangeService, RemoteBpmnInterchangeService>()
+            .AddRemoteApi<IBpmnInterchangeApi>()
             ;
 
         services.AddActivityDisplaySettingsProvider<DefaultActivityDisplaySettingsProvider>();

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
@@ -1,0 +1,50 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnCapabilityRefusal.TryParse"/>: it must recognize the exact sentence
+/// <c>BpmnInterchangeDocumentService.Import</c> raises for a missing-host-capability refusal (pinned by
+/// <see cref="RemoteBpmnInterchangeServiceTests.ImportAsync_ReturnsTheCapabilityRefusalMessage_On422"/>), and must
+/// not misclassify the two differently-worded export refusals or unrelated messages as the same thing.
+/// </summary>
+public class BpmnCapabilityRefusalTests
+{
+    [Fact]
+    public void TryParse_ExtractsCapabilityNamesAndElementIds_FromTheKnownRefusalMessage()
+    {
+        const string message =
+            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
+            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
+
+        var refusal = BpmnCapabilityRefusal.TryParse(message);
+
+        Assert.NotNull(refusal);
+        Assert.Equal(["ScopeSignalling"], refusal!.CapabilityNames);
+        Assert.Equal(["Gateway_1"], refusal.ElementIds);
+    }
+
+    [Fact]
+    public void TryParse_ExtractsMultipleCapabilityNamesAndElementIds()
+    {
+        const string message =
+            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling, CompensationHandling. "
+            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1, Task_2.";
+
+        var refusal = BpmnCapabilityRefusal.TryParse(message);
+
+        Assert.NotNull(refusal);
+        Assert.Equal(["ScopeSignalling", "CompensationHandling"], refusal!.CapabilityNames);
+        Assert.Equal(["Gateway_1", "Task_2"], refusal.ElementIds);
+    }
+
+    [Theory]
+    [InlineData("Workflow definition 'wf-1' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML.")]
+    [InlineData("Workflow definition 'wf-1' has changed since it was imported from BPMN (imported at version 1, currently at version 2).")]
+    [InlineData("Upload exactly one .bpmn file.")]
+    public void TryParse_ReturnsNull_ForMessagesThatAreNotTheCapabilityRefusal(string message)
+    {
+        Assert.Null(BpmnCapabilityRefusal.TryParse(message));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerProviderTests.cs
@@ -17,7 +17,7 @@ namespace Elsa.Studio.Workflows.Tests;
 /// </summary>
 public class BpmnDiagramDesignerProviderTests
 {
-    private readonly BpmnDiagramDesignerProvider _provider = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()));
+    private readonly BpmnDiagramDesignerProvider _provider = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()), null!, null!, null!, null!);
 
     [Fact]
     public void GetSupportsActivity_ReturnsTrueForBpmnProcessActivity()

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerTests.cs
@@ -16,7 +16,7 @@ namespace Elsa.Studio.Workflows.Tests;
 /// </summary>
 public class BpmnDiagramDesignerTests
 {
-    private readonly BpmnDiagramDesigner _designer = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()));
+    private readonly BpmnDiagramDesigner _designer = new(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()), null!, null!, null!, null!);
 
     [Fact]
     public async Task ReadRootActivityAsync_ReturnsTheLoadedActivityUnchanged()

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnFileRoutingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnFileRoutingTests.cs
@@ -1,0 +1,53 @@
+using Elsa.Studio.Workflows.Services;
+using Microsoft.AspNetCore.Components.Forms;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the <c>.bpmn</c> vs <c>.json</c> routing decision the shared import path makes: a <c>.bpmn</c> file
+/// dropped on the generic (JSON/ZIP) picker must be recognized so it can be routed through the interactive BPMN
+/// import flow instead of being silently skipped by the JSON parser.
+/// </summary>
+public class BpmnFileRoutingTests
+{
+    [Theory]
+    [InlineData("process.bpmn", true)]
+    [InlineData("process.BPMN", true)]
+    [InlineData("Process.Bpmn", true)]
+    [InlineData("process.json", false)]
+    [InlineData("process.zip", false)]
+    [InlineData("process.bpmn.json", false)]
+    [InlineData("bpmn", false)]
+    public void IsBpmnFileName_DetectsTheBpmnExtensionCaseInsensitively(string fileName, bool expected)
+    {
+        Assert.Equal(expected, BpmnImportUiService.IsBpmnFileName(fileName));
+    }
+
+    [Fact]
+    public void IsBpmnFile_DelegatesToTheFileName()
+    {
+        var service = new BpmnImportUiService(null!, null!, null!, null!);
+        var file = new FakeBrowserFile("order-process.bpmn");
+
+        Assert.True(service.IsBpmnFile(file));
+    }
+
+    [Fact]
+    public void IsBpmnFile_ReturnsFalseForNonBpmnFiles()
+    {
+        var service = new BpmnImportUiService(null!, null!, null!, null!);
+        var file = new FakeBrowserFile("order-process.json");
+
+        Assert.False(service.IsBpmnFile(file));
+    }
+
+    private sealed class FakeBrowserFile(string name) : IBrowserFile
+    {
+        public string Name { get; } = name;
+        public DateTimeOffset LastModified => DateTimeOffset.UtcNow;
+        public long Size => 0;
+        public string ContentType => "application/xml";
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportFindingsDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportFindingsDialogTests.cs
@@ -1,0 +1,129 @@
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnImportFindingsDialog"/>: it groups findings by severity with each finding's element id, and
+/// -- when the document declares more than one process -- withholds confirmation until one is chosen. A Dropped
+/// finding is the thing a user most needs to see before committing to the import, so the test pins that it renders
+/// rather than being summarized away.
+/// </summary>
+public sealed class BpmnImportFindingsDialogTests : BunitContext, IAsyncLifetime
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public BpmnImportFindingsDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task TheDialogRendersFindingsGroupedBySeverityWithElementIds()
+    {
+        var analysis = new BpmnImportAnalysisModel
+        {
+            ProcessIds = ["process-1"],
+            Issues =
+            [
+                new() { Severity = "Dropped", ElementId = "Gateway_1", Message = "The condition expression could not be represented." },
+                new() { Severity = "Degraded", ElementId = "Task_2", Message = "The timer definition was approximated." },
+                new() { Severity = "Info", ElementId = "StartEvent_1", Message = "The start event was imported." }
+            ]
+        };
+
+        await ShowDialogAsync(analysis);
+
+        Assert.Contains("Gateway_1", _dialogProvider.Markup);
+        Assert.Contains("The condition expression could not be represented.", _dialogProvider.Markup);
+        Assert.Contains("Task_2", _dialogProvider.Markup);
+        Assert.Contains("StartEvent_1", _dialogProvider.Markup);
+        Assert.Contains("Dropped (1)", _dialogProvider.Markup);
+        Assert.Contains("Degraded (1)", _dialogProvider.Markup);
+        Assert.Contains("Info (1)", _dialogProvider.Markup);
+    }
+
+    [Fact]
+    public async Task TheDialogClosesImmediately_WhenTheDocumentDeclaresExactlyOneProcess()
+    {
+        // A single process needs no prompt: the dialog pre-selects it so Import is enabled without the user having
+        // to choose anything.
+        var analysis = new BpmnImportAnalysisModel { ProcessIds = ["only-process"] };
+        var dialog = await ShowDialogAsync(analysis);
+
+        Assert.False(ImportButton().HasAttribute("disabled"));
+
+        await ClickImport();
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        Assert.False(result?.Canceled);
+        Assert.Equal("only-process", result?.Data);
+    }
+
+    [Fact]
+    public async Task TheDialogWithholdsConfirmation_UntilAProcessIsChosen_WhenThereAreSeveral()
+    {
+        var analysis = new BpmnImportAnalysisModel { ProcessIds = ["process-a", "process-b"] };
+        var dialog = await ShowDialogAsync(analysis);
+
+        Assert.True(ImportButton().HasAttribute("disabled"));
+
+        await SelectProcessAsync("process-b");
+        await ClickImport();
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        Assert.False(result?.Canceled);
+        Assert.Equal("process-b", result?.Data);
+    }
+
+    [Fact]
+    public async Task TheDialogCancelsWithoutClosingAsConfirmed()
+    {
+        var dialog = await ShowDialogAsync(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] });
+
+        await _dialogProvider.InvokeAsync(() => CancelButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        Assert.True(result?.Canceled);
+    }
+
+    private async Task<IDialogReference> ShowDialogAsync(BpmnImportAnalysisModel analysis)
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<BpmnImportFindingsDialog> { { x => x.Analysis, analysis } };
+        var dialog = await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<BpmnImportFindingsDialog>("Import BPMN", parameters));
+        _dialogProvider.WaitForElement("button");
+        return dialog;
+    }
+
+    private Task SelectProcessAsync(string processId) => _dialogProvider.InvokeAsync(() =>
+        _dialogProvider.FindComponent<MudSelect<string>>().Instance.ValueChanged.InvokeAsync(processId));
+
+    private Task ClickImport() => _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+    private AngleSharp.Dom.IElement ImportButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Import");
+
+    private AngleSharp.Dom.IElement CancelButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel");
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportRefusalDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportRefusalDialogTests.cs
@@ -1,0 +1,54 @@
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnImportRefusalDialog"/>: a BPMN import refused for missing host capabilities (a <c>422</c>
+/// from <c>bpmn/import</c>) is shown here instead of squeezed into a snackbar, so the test pins that the capability
+/// names and offending element ids the refusal carries actually render.
+/// </summary>
+public sealed class BpmnImportRefusalDialogTests : BunitContext, IAsyncLifetime
+{
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public BpmnImportRefusalDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task TheDialogRendersTheCapabilityNamesAndElementIds()
+    {
+        var refusal = new BpmnCapabilityRefusal(["ScopeSignalling", "CompensationHandling"], ["Gateway_1", "Task_2"]);
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<BpmnImportRefusalDialog> { { x => x.Refusal, refusal } };
+        await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<BpmnImportRefusalDialog>("Import refused", parameters));
+        _dialogProvider.WaitForElement("button");
+
+        Assert.Contains("ScopeSignalling", _dialogProvider.Markup);
+        Assert.Contains("CompensationHandling", _dialogProvider.Markup);
+        Assert.Contains("Gateway_1", _dialogProvider.Markup);
+        Assert.Contains("Task_2", _dialogProvider.Markup);
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Bunit;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
@@ -69,7 +70,120 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
         Assert.Equal("wf-1", definitionService.RequestedDefinitionId);
     }
 
+    [Fact]
+    public async Task ImportBpmnFilesAsync_SplitsBpmnFilesFromOtherFiles_AndImportsEachBpmnFileInOrder()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new BpmnImportResultModel { DefinitionId = "wf-1", Version = 1 })
+        };
+        var definitionService = new FakeWorkflowDefinitionService { DefinitionToReturn = new WorkflowDefinition { DefinitionId = "wf-1" } };
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var files = new IBrowserFile[]
+        {
+            new FakeBrowserFile("a.bpmn"),
+            new FakeBrowserFile("data.json"),
+            new FakeBrowserFile("b.bpmn")
+        };
+
+        var batchTask = _dialogProvider.InvokeAsync(() => service.ImportBpmnFilesAsync(files, definitionId: null));
+
+        // "a.bpmn"'s findings dialog.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        // "b.bpmn"'s findings dialog.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var batch = await batchTask.WaitAsync(Timeout);
+
+        Assert.Equal(2, batch.Results.Count);
+        Assert.Equal("a.bpmn", batch.Results[0].FileName);
+        Assert.Equal("b.bpmn", batch.Results[1].FileName);
+        Assert.True(batch.Results[0].IsSuccess);
+        Assert.True(batch.Results[1].IsSuccess);
+        var otherFile = Assert.Single(batch.OtherFiles);
+        Assert.Equal("data.json", otherFile.Name);
+    }
+
+    [Fact]
+    public async Task ImportFileAsync_ShowsTheRefusalDialogOnce_AndReturnsACapabilityRefusalResult_On422()
+    {
+        const string message =
+            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
+            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
+
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.UnprocessableEntity))
+        };
+        var definitionService = new FakeWorkflowDefinitionService();
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var file = new FakeBrowserFile("process.bpmn");
+
+        var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
+
+        // The findings dialog.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        // The refusal dialog, shown exactly once; closing it lets the import finish.
+        _dialogProvider.WaitForElement("button");
+        Assert.Contains("ScopeSignalling", _dialogProvider.Markup);
+        Assert.Contains("Gateway_1", _dialogProvider.Markup);
+        await _dialogProvider.InvokeAsync(() => CloseButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await importTask.WaitAsync(Timeout);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsSuccess);
+        Assert.Equal(WorkflowImportFailureType.CapabilityRefusal, result.Failure!.FailureType);
+        Assert.Null(definitionService.RequestedDefinitionId);
+
+        // The caller-side summary path excludes a result already reported in its own dialog.
+        Assert.Empty(BpmnImportBatch.ReportableResults([result]));
+    }
+
+    [Fact]
+    public async Task ImportFileAsync_DoesNotTreatA500AsACapabilityRefusal_EvenWithTheRefusalWording()
+    {
+        const string message =
+            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
+            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
+
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.InternalServerError))
+        };
+        var definitionService = new FakeWorkflowDefinitionService();
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var file = new FakeBrowserFile("process.bpmn");
+
+        var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
+
+        // The findings dialog; there is no refusal dialog to close afterwards because a 500 never counts as one.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await importTask.WaitAsync(Timeout);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsSuccess);
+        Assert.Equal(WorkflowImportFailureType.Exception, result.Failure!.FailureType);
+    }
+
     private AngleSharp.Dom.IElement ImportButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Import");
+    private AngleSharp.Dom.IElement CloseButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Close");
 
     private sealed class FakeBrowserFile(string name) : IBrowserFile
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -1,0 +1,141 @@
+using Bunit;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Services;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnImportUiService"/>'s per-file import flow. <see cref="ImportAsync_ReturnsAFailedResult_WhenTheImportedDefinitionCannotBeFound"/>
+/// pins that a successful import whose definition cannot be re-fetched is reported as a failure rather than as a
+/// success carrying a null <see cref="WorkflowImportResult.WorkflowDefinition"/>, which is what its two callers
+/// dereference unconditionally.
+/// </summary>
+public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public BpmnImportUiServiceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task ImportAsync_ReturnsAFailedResult_WhenTheImportedDefinitionCannotBeFound()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new BpmnImportResultModel { DefinitionId = "wf-1", Version = 1 })
+        };
+        var definitionService = new FakeWorkflowDefinitionService { DefinitionToReturn = null };
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var file = new FakeBrowserFile("process.bpmn");
+
+        var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await importTask.WaitAsync(Timeout);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsSuccess);
+        Assert.Null(result.WorkflowDefinition);
+        Assert.Equal(WorkflowImportFailureType.Exception, result.Failure!.FailureType);
+        Assert.Equal("wf-1", definitionService.RequestedDefinitionId);
+    }
+
+    private AngleSharp.Dom.IElement ImportButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Import");
+
+    private sealed class FakeBrowserFile(string name) : IBrowserFile
+    {
+        public string Name { get; } = name;
+        public DateTimeOffset LastModified => DateTimeOffset.UtcNow;
+        public long Size => 0;
+        public string ContentType => "application/xml";
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream();
+    }
+
+    private sealed class FakeBpmnInterchangeService : IBpmnInterchangeService
+    {
+        public Result<BpmnImportAnalysisModel, ValidationErrors> AnalyzeResult { get; set; } = new(new BpmnImportAnalysisModel());
+        public Result<BpmnImportResultModel, ValidationErrors> ImportResult { get; set; } = new(new BpmnImportResultModel());
+
+        public Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(AnalyzeResult);
+
+        public Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(Stream content, string fileName, string? definitionId, string? name, string? processId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(ImportResult);
+
+        public Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stub that only implements <see cref="FindByDefinitionIdAsync"/>; every other member throws to flag an
+    /// unexpected call.
+    /// </summary>
+    private sealed class FakeWorkflowDefinitionService : IWorkflowDefinitionService
+    {
+        public WorkflowDefinition? DefinitionToReturn { get; set; }
+        public string? RequestedDefinitionId { get; private set; }
+
+        public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default)
+        {
+            RequestedDefinitionId = definitionId;
+            return Task.FromResult(DefinitionToReturn);
+        }
+
+        public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -111,6 +111,58 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task ImportBpmnFilesAsync_FailsEveryFile_WhenMoreThanOneBpmnFileTargetsAnOpenDefinition()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService();
+        var definitionService = new FakeWorkflowDefinitionService();
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var files = new IBrowserFile[]
+        {
+            new FakeBrowserFile("a.bpmn"),
+            new FakeBrowserFile("b.bpmn")
+        };
+
+        var batch = await service.ImportBpmnFilesAsync(files, definitionId: "wf-1");
+
+        Assert.Equal(2, batch.Results.Count);
+        Assert.All(batch.Results, result => Assert.False(result.IsSuccess));
+        Assert.Equal("a.bpmn", batch.Results[0].FileName);
+        Assert.Equal("b.bpmn", batch.Results[1].FileName);
+        Assert.Equal(0, interchangeService.AnalyzeCallCount);
+        Assert.Equal(0, interchangeService.ImportCallCount);
+        Assert.Null(definitionService.RequestedDefinitionId);
+    }
+
+    [Fact]
+    public async Task ImportBpmnFilesAsync_ImportsTheSingleBpmnFile_IntoTheOpenDefinition()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new BpmnImportResultModel { DefinitionId = "wf-1", Version = 1 })
+        };
+        var definitionService = new FakeWorkflowDefinitionService { DefinitionToReturn = new WorkflowDefinition { DefinitionId = "wf-1" } };
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var files = new IBrowserFile[] { new FakeBrowserFile("a.bpmn") };
+
+        var batchTask = _dialogProvider.InvokeAsync(() => service.ImportBpmnFilesAsync(files, definitionId: "wf-1"));
+
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var batch = await batchTask.WaitAsync(Timeout);
+
+        var result = Assert.Single(batch.Results);
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, interchangeService.ImportCallCount);
+        Assert.Equal("wf-1", interchangeService.LastImportDefinitionId);
+    }
+
+    [Fact]
     public async Task ImportFileAsync_ShowsTheRefusalDialogOnce_AndReturnsACapabilityRefusalResult_On422()
     {
         const string message =
@@ -198,12 +250,22 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
     {
         public Result<BpmnImportAnalysisModel, ValidationErrors> AnalyzeResult { get; set; } = new(new BpmnImportAnalysisModel());
         public Result<BpmnImportResultModel, ValidationErrors> ImportResult { get; set; } = new(new BpmnImportResultModel());
+        public int AnalyzeCallCount { get; private set; }
+        public int ImportCallCount { get; private set; }
+        public string? LastImportDefinitionId { get; private set; }
 
-        public Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default) =>
-            Task.FromResult(AnalyzeResult);
+        public Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default)
+        {
+            AnalyzeCallCount++;
+            return Task.FromResult(AnalyzeResult);
+        }
 
-        public Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(Stream content, string fileName, string? definitionId, string? name, string? processId, CancellationToken cancellationToken = default) =>
-            Task.FromResult(ImportResult);
+        public Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(Stream content, string fileName, string? definitionId, string? name, string? processId, CancellationToken cancellationToken = default)
+        {
+            ImportCallCount++;
+            LastImportDefinitionId = definitionId;
+            return Task.FromResult(ImportResult);
+        }
 
         public Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExportBpmnDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExportBpmnDialogTests.cs
@@ -1,0 +1,81 @@
+using Bunit;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="ExportBpmnDialog"/>: the design requires disclosing, before the download starts, that the
+/// exported file carries the definition's binding configuration and expressions.
+/// </summary>
+public sealed class ExportBpmnDialogTests : BunitContext, IAsyncLifetime
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+
+    public ExportBpmnDialogTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task TheDialogDisclosesThatTheExportCarriesBindingConfigurationAndExpressions()
+    {
+        await ShowDialogAsync();
+
+        Assert.Contains("binding configuration and expressions", _dialogProvider.Markup);
+    }
+
+    [Fact]
+    public async Task TheDialogClosesConfirmed_WhenExportIsClicked()
+    {
+        var dialog = await ShowDialogAsync();
+
+        await _dialogProvider.InvokeAsync(() => ExportButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        Assert.False(result?.Canceled);
+        Assert.True(result?.Data as bool?);
+    }
+
+    [Fact]
+    public async Task TheDialogCancels_WhenCancelIsClicked()
+    {
+        var dialog = await ShowDialogAsync();
+
+        await _dialogProvider.InvokeAsync(() => CancelButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await dialog.Result.WaitAsync(Timeout);
+        Assert.True(result?.Canceled);
+    }
+
+    private async Task<IDialogReference> ShowDialogAsync()
+    {
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var dialog = await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<ExportBpmnDialog>("Export BPMN"));
+        _dialogProvider.WaitForElement("button");
+        return dialog;
+    }
+
+    private AngleSharp.Dom.IElement ExportButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Export");
+    private AngleSharp.Dom.IElement CancelButton() => _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel");
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Client;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Domain.Services;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="RemoteBpmnInterchangeService"/>'s error mapping: the server's 400/422 payloads carry the
+/// message a user needs to see (capability names, offending element ids, or one of the two export refusals), so
+/// this pins that those messages actually reach the caller rather than being replaced by a generic failure.
+/// </summary>
+public class RemoteBpmnInterchangeServiceTests
+{
+    private readonly FakeBpmnInterchangeApi _api = new();
+    private readonly RemoteBpmnInterchangeService _service;
+
+    public RemoteBpmnInterchangeServiceTests()
+    {
+        _service = new(new TestBackendApiClientProvider(_api));
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ReturnsTheServersErrorMessage_WhenTheApiThrows()
+    {
+        _api.AnalyzeException = await CreateApiExceptionAsync(HttpStatusCode.BadRequest, """
+        {
+          "errors": {
+            "generalErrors": ["Upload exactly one .bpmn file."]
+          }
+        }
+        """);
+
+        var result = await _service.AnalyzeAsync(new MemoryStream(), "process.bpmn");
+
+        Assert.True(result.IsFailed);
+        var error = Assert.Single(result.Failure!.Errors);
+        Assert.Equal("Upload exactly one .bpmn file.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ReturnsTheCapabilityRefusalMessage_On422()
+    {
+        const string message =
+            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
+            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
+
+        _api.ImportException = await CreateApiExceptionAsync(HttpStatusCode.UnprocessableEntity, $$"""
+        {
+          "errors": {
+            "generalErrors": ["{{message}}"]
+          }
+        }
+        """);
+
+        var result = await _service.ImportAsync(new MemoryStream(), "process.bpmn", definitionId: null, name: null, processId: null);
+
+        Assert.True(result.IsFailed);
+        var error = Assert.Single(result.Failure!.Errors);
+        Assert.Equal(message, error.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExportAsync_ReturnsNotFound_WhenTheDefinitionDoesNotExist()
+    {
+        _api.ExportResponse = new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") };
+
+        var result = await _service.ExportAsync("missing-definition");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.NotFound, result.Failure!.Reason);
+    }
+
+    [Fact]
+    public async Task ExportAsync_ClassifiesNotImportedFromBpmn()
+    {
+        const string message = "Workflow definition 'wf-1' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML.";
+        _api.ExportResponse = UnprocessableEntity(message);
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.NotImportedFromBpmn, result.Failure!.Reason);
+        Assert.Equal(message, result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task ExportAsync_ClassifiesDefinitionChangedSinceImport()
+    {
+        const string message = "Workflow definition 'wf-1' has changed since it was imported from BPMN (imported at version 1, currently at version 2).";
+        _api.ExportResponse = UnprocessableEntity(message);
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.DefinitionChangedSinceImport, result.Failure!.Reason);
+    }
+
+    [Fact]
+    public async Task ExportAsync_ReturnsTheDownload_OnSuccess()
+    {
+        const string xml = "<definitions />";
+        _api.ExportResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes(xml))
+        };
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("wf-1.bpmn", result.Success!.FileName);
+        using var reader = new StreamReader(result.Success.Content);
+        Assert.Equal(xml, await reader.ReadToEndAsync());
+    }
+
+    private static HttpResponseMessage UnprocessableEntity(string message) => new(HttpStatusCode.UnprocessableEntity)
+    {
+        Content = new StringContent($$"""
+        {
+          "errors": {
+            "generalErrors": ["{{message}}"]
+          }
+        }
+        """)
+    };
+
+    private static async Task<ApiException> CreateApiExceptionAsync(HttpStatusCode statusCode, string content)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/bpmn/analyze");
+        using var response = new HttpResponseMessage(statusCode)
+        {
+            RequestMessage = request,
+            Content = new StringContent(content)
+        };
+
+        return await ApiException.Create(request, HttpMethod.Post, response, new RefitSettings());
+    }
+
+    private class FakeBpmnInterchangeApi : IBpmnInterchangeApi
+    {
+        public ApiException? AnalyzeException { get; set; }
+        public ApiException? ImportException { get; set; }
+        public HttpResponseMessage? ExportResponse { get; set; }
+
+        public Task<BpmnImportAnalysisModel> AnalyzeAsync(StreamPart file, CancellationToken cancellationToken = default) =>
+            AnalyzeException != null ? throw AnalyzeException : Task.FromResult(new BpmnImportAnalysisModel());
+
+        public Task<BpmnImportResultModel> ImportAsync(StreamPart file, string? definitionId, string? name, string? processId, CancellationToken cancellationToken = default) =>
+            ImportException != null ? throw ImportException : Task.FromResult(new BpmnImportResultModel());
+
+        public Task<HttpResponseMessage> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExportResponse ?? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") });
+    }
+
+    private class TestBackendApiClientProvider(IBpmnInterchangeApi api) : IBackendApiClientProvider
+    {
+        public Uri Url { get; } = new("https://localhost");
+
+        public ValueTask<T> GetApiAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(CancellationToken cancellationToken = default) where T : class
+        {
+            if (typeof(T) == typeof(IBpmnInterchangeApi))
+                return ValueTask.FromResult((T)api);
+
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
@@ -15,7 +15,7 @@ namespace Elsa.Studio.Workflows.Tests;
 /// message a user needs to see (capability names, offending element ids, or one of the two export refusals), so
 /// this pins that those messages actually reach the caller rather than being replaced by a generic failure.
 /// </summary>
-public class RemoteBpmnInterchangeServiceTests
+public class RemoteBpmnInterchangeServiceTests : IDisposable
 {
     private readonly FakeBpmnInterchangeApi _api = new();
     private readonly RemoteBpmnInterchangeService _service;
@@ -24,6 +24,8 @@ public class RemoteBpmnInterchangeServiceTests
     {
         _service = new(new TestBackendApiClientProvider(_api));
     }
+
+    public void Dispose() => _api.Dispose();
 
     [Fact]
     public async Task AnalyzeAsync_ReturnsTheServersErrorMessage_WhenTheApiThrows()
@@ -36,7 +38,8 @@ public class RemoteBpmnInterchangeServiceTests
         }
         """);
 
-        var result = await _service.AnalyzeAsync(new MemoryStream(), "process.bpmn");
+        using var stream = new MemoryStream();
+        var result = await _service.AnalyzeAsync(stream, "process.bpmn");
 
         Assert.True(result.IsFailed);
         var error = Assert.Single(result.Failure!.Errors);
@@ -58,7 +61,8 @@ public class RemoteBpmnInterchangeServiceTests
         }
         """);
 
-        var result = await _service.ImportAsync(new MemoryStream(), "process.bpmn", definitionId: null, name: null, processId: null);
+        using var stream = new MemoryStream();
+        var result = await _service.ImportAsync(stream, "process.bpmn", definitionId: null, name: null, processId: null);
 
         Assert.True(result.IsFailed);
         var error = Assert.Single(result.Failure!.Errors);
@@ -141,8 +145,10 @@ public class RemoteBpmnInterchangeServiceTests
         return await ApiException.Create(request, HttpMethod.Post, response, new RefitSettings());
     }
 
-    private class FakeBpmnInterchangeApi : IBpmnInterchangeApi
+    private class FakeBpmnInterchangeApi : IBpmnInterchangeApi, IDisposable
     {
+        private readonly HttpResponseMessage _defaultExportResponse = new(HttpStatusCode.OK) { Content = new StringContent("") };
+
         public ApiException? AnalyzeException { get; set; }
         public ApiException? ImportException { get; set; }
         public HttpResponseMessage? ExportResponse { get; set; }
@@ -154,7 +160,13 @@ public class RemoteBpmnInterchangeServiceTests
             ImportException != null ? throw ImportException : Task.FromResult(new BpmnImportResultModel());
 
         public Task<HttpResponseMessage> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
-            Task.FromResult(ExportResponse ?? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") });
+            Task.FromResult(ExportResponse ?? _defaultExportResponse);
+
+        public void Dispose()
+        {
+            _defaultExportResponse.Dispose();
+            ExportResponse?.Dispose();
+        }
     }
 
     private class TestBackendApiClientProvider(IBpmnInterchangeApi api) : IBackendApiClientProvider

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -91,6 +91,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     [Inject] private IBackendApiClientProvider BackendApiClientProvider { get; set; } = null!;
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
     [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = null!;
+    [Inject] private IBpmnImportUiService BpmnImportUiService { get; set; } = null!;
     [Inject] private IOptions<WorkflowDefinitionOptions> WorkflowDefinitionOptions { get; set; } = null!;
 
     /// <summary>
@@ -695,7 +696,30 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 return Task.CompletedTask;
             }
         };
-        var importResults = (await WorkflowDefinitionImporter.ImportFilesAsync(files, options)).ToList();
+
+        // A .bpmn file cannot be parsed as JSON, so it is routed through the same interactive BPMN import flow the
+        // definitions list uses, updating the definition currently open here rather than creating a new one.
+        var bpmnFiles = files.Where(BpmnImportUiService.IsBpmnFile).ToList();
+        var otherFiles = files.Where(file => !BpmnImportUiService.IsBpmnFile(file)).ToList();
+
+        var importResults = new List<WorkflowImportResult>();
+
+        if (otherFiles.Count > 0)
+            importResults.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(otherFiles, options));
+
+        foreach (var bpmnFile in bpmnFiles)
+        {
+            var bpmnResult = await BpmnImportUiService.ImportFileAsync(bpmnFile, options.DefinitionId);
+
+            if (bpmnResult == null)
+                continue;
+
+            importResults.Add(bpmnResult);
+
+            if (bpmnResult.IsSuccess)
+                await SetImportedWorkflowDefinitionAsync(bpmnResult.WorkflowDefinition!);
+        }
+
         var failedImports = importResults.Where(x => !x.IsSuccess).ToList();
         var successfulImports = importResults.Where(x => x.IsSuccess).ToList();
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -699,35 +699,34 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
         // A .bpmn file cannot be parsed as JSON, so it is routed through the same interactive BPMN import flow the
         // definitions list uses, updating the definition currently open here rather than creating a new one.
-        var bpmnFiles = files.Where(BpmnImportUiService.IsBpmnFile).ToList();
-        var otherFiles = files.Where(file => !BpmnImportUiService.IsBpmnFile(file)).ToList();
+        var bpmnBatch = await BpmnImportUiService.ImportBpmnFilesAsync(files, options.DefinitionId);
 
-        var importResults = new List<WorkflowImportResult>();
+        var importResults = new List<WorkflowImportResult>(bpmnBatch.Results);
 
-        if (otherFiles.Count > 0)
-            importResults.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(otherFiles, options));
+        if (bpmnBatch.OtherFiles.Count > 0)
+            importResults.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(bpmnBatch.OtherFiles, options));
 
-        foreach (var bpmnFile in bpmnFiles)
-        {
-            var bpmnResult = await BpmnImportUiService.ImportFileAsync(bpmnFile, options.DefinitionId);
+        foreach (var bpmnResult in bpmnBatch.Results.Where(x => x.IsSuccess))
+            if (bpmnResult.WorkflowDefinition is { } workflowDefinition)
+                await SetImportedWorkflowDefinitionAsync(workflowDefinition);
 
-            if (bpmnResult == null)
-                continue;
-
-            importResults.Add(bpmnResult);
-
-            if (bpmnResult.IsSuccess)
-                await SetImportedWorkflowDefinitionAsync(bpmnResult.WorkflowDefinition!);
-        }
-
-        var failedImports = importResults.Where(x => !x.IsSuccess).ToList();
-        var successfulImports = importResults.Where(x => x.IsSuccess).ToList();
+        // A capability refusal was already reported in its own dialog by BpmnImportUiService; excluding it here
+        // keeps the summary snackbar limited to the failures it did not already explain.
+        var reportableResults = importResults.Where(x => x.Failure?.FailureType != WorkflowImportFailureType.CapabilityRefusal).ToList();
+        var failedImports = reportableResults.Where(x => !x.IsSuccess).ToList();
+        var successfulImports = reportableResults.Where(x => x.IsSuccess).ToList();
 
         IsProgressing = false;
         _isDirty = false;
         StateHasChanged();
 
-        if (importResults.Count == 0)
+        if (importResults.Count > 0 && reportableResults.Count == 0)
+        {
+            // Every result was a capability refusal, each already explained in its own dialog; nothing left to summarize.
+            return;
+        }
+
+        if (reportableResults.Count == 0)
         {
             UserMessageService.ShowSnackbarTextMessage(Localizer["No workflows were imported."], Severity.Info);
             return;
@@ -735,8 +734,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
         if (successfulImports.Count == 1)
             UserMessageService.ShowSnackbarTextMessage(Localizer["Successfully imported 1 workflow definition."], Severity.Success, ConfigureSnackbar);
-        else if (importResults.Count > 1)
-            UserMessageService.ShowSnackbarTextMessage(Localizer["Successfully imported {0} workflow definitions.", importResults.Count], Severity.Success, ConfigureSnackbar);
+        else if (reportableResults.Count > 1)
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Successfully imported {0} workflow definitions.", reportableResults.Count], Severity.Success, ConfigureSnackbar);
 
         if (failedImports.Count == 1)
             UserMessageService.ShowSnackbarTextMessage(Localizer["Failed to import 1 workflow definition: {0}", failedImports[0].Failure!.ErrorMessage], Severity.Error, ConfigureSnackbar);

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -710,9 +710,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
             if (bpmnResult.WorkflowDefinition is { } workflowDefinition)
                 await SetImportedWorkflowDefinitionAsync(workflowDefinition);
 
-        // A capability refusal was already reported in its own dialog by BpmnImportUiService; excluding it here
-        // keeps the summary snackbar limited to the failures it did not already explain.
-        var reportableResults = importResults.Where(x => x.Failure?.FailureType != WorkflowImportFailureType.CapabilityRefusal).ToList();
+        var reportableResults = BpmnImportBatch.ReportableResults(importResults);
         var failedImports = reportableResults.Where(x => !x.IsSuccess).ToList();
         var successfulImports = reportableResults.Where(x => x.IsSuccess).ToList();
 
@@ -720,7 +718,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         _isDirty = false;
         StateHasChanged();
 
-        if (importResults.Count > 0 && reportableResults.Count == 0)
+        if (BpmnImportBatch.AllReported(importResults))
         {
             // Every result was a capability refusal, each already explained in its own dialog; nothing left to summarize.
             return;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -706,9 +706,8 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         if (bpmnBatch.OtherFiles.Count > 0)
             importResults.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(bpmnBatch.OtherFiles, options));
 
-        foreach (var bpmnResult in bpmnBatch.Results.Where(x => x.IsSuccess))
-            if (bpmnResult.WorkflowDefinition is { } workflowDefinition)
-                await SetImportedWorkflowDefinitionAsync(workflowDefinition);
+        foreach (var bpmnResult in bpmnBatch.Results.Where(x => x.IsSuccess && x.WorkflowDefinition != null))
+            await SetImportedWorkflowDefinitionAsync(bpmnResult.WorkflowDefinition!);
 
         var reportableResults = BpmnImportBatch.ReportableResults(importResults);
         var failedImports = reportableResults.Where(x => !x.IsSuccess).ToList();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor
@@ -1,0 +1,54 @@
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="4">
+            <MudText Typo="Typo.body2">@Localizer["Review these findings before importing. Anything Dropped could not be represented and will not run; Degraded findings ran, but not exactly as authored."]</MudText>
+
+            @if (RequiresProcessSelection)
+            {
+                <MudSelect T="string" Label="@Localizer["Process"]" @bind-Value="_selectedProcessId" Variant="Variant.Outlined" Required="true">
+                    @foreach (var processId in Analysis.ProcessIds)
+                    {
+                        <MudSelectItem Value="@processId">@processId</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
+            @if (Groups.Count == 0)
+            {
+                <MudAlert Severity="Severity.Success">@Localizer["No findings. This document reads without loss."]</MudAlert>
+            }
+            else
+            {
+                @foreach (var group in Groups)
+                {
+                    <div>
+                        <MudText Typo="Typo.subtitle2" Color="@group.Color">@group.Title (@group.Issues.Count)</MudText>
+                        <MudList T="string" Dense="true">
+                            @foreach (var issue in group.Issues)
+                            {
+                                <MudListItem>
+                                    <MudText Typo="Typo.body2">
+                                        @if (!string.IsNullOrEmpty(issue.ElementId))
+                                        {
+                                            <b>[@issue.ElementId]</b>
+                                            @:
+                                        }
+                                        @issue.Message
+                                    </MudText>
+                                </MudListItem>
+                            }
+                        </MudList>
+                    </div>
+                }
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="OnCancelClicked">@Localizer["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" Disabled="@(!CanConfirm)" OnClick="OnConfirmClicked">@Localizer["Import"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor.cs
@@ -25,9 +25,9 @@ public partial class BpmnImportFindingsDialog
 
     private IReadOnlyList<IssueGroup> Groups => new[]
     {
-        new IssueGroup(Localizer["Dropped"], Color.Error, IssuesOfSeverity("Dropped")),
-        new IssueGroup(Localizer["Degraded"], Color.Warning, IssuesOfSeverity("Degraded")),
-        new IssueGroup(Localizer["Info"], Color.Info, IssuesOfSeverity("Info"))
+        new IssueGroup(Localizer["Dropped"], Color.Error, IssuesOfSeverity(BpmnImportIssueSeverity.Dropped)),
+        new IssueGroup(Localizer["Degraded"], Color.Warning, IssuesOfSeverity(BpmnImportIssueSeverity.Degraded)),
+        new IssueGroup(Localizer["Info"], Color.Info, IssuesOfSeverity(BpmnImportIssueSeverity.Info))
     }.Where(group => group.Issues.Count > 0).ToList();
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportFindingsDialog.razor.cs
@@ -1,0 +1,48 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+
+/// <summary>
+/// Shows the Info/Degraded/Dropped findings a BPMN import would produce, grouped by severity with each finding's
+/// element id, and -- when the document declares more than one process -- collects which one to import. Closes
+/// with the chosen process id (or <see langword="null"/> when the document declares exactly one) on confirmation.
+/// </summary>
+public partial class BpmnImportFindingsDialog
+{
+    private string? _selectedProcessId;
+
+    /// <summary>
+    /// The analysis to display.
+    /// </summary>
+    [Parameter] public BpmnImportAnalysisModel Analysis { get; set; } = new();
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private bool RequiresProcessSelection => Analysis.ProcessIds.Count > 1;
+    private bool CanConfirm => !RequiresProcessSelection || !string.IsNullOrEmpty(_selectedProcessId);
+
+    private IReadOnlyList<IssueGroup> Groups => new[]
+    {
+        new IssueGroup(Localizer["Dropped"], Color.Error, IssuesOfSeverity("Dropped")),
+        new IssueGroup(Localizer["Degraded"], Color.Warning, IssuesOfSeverity("Degraded")),
+        new IssueGroup(Localizer["Info"], Color.Info, IssuesOfSeverity("Info"))
+    }.Where(group => group.Issues.Count > 0).ToList();
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        if (Analysis.ProcessIds.Count == 1)
+            _selectedProcessId = Analysis.ProcessIds.First();
+    }
+
+    private IReadOnlyList<BpmnImportIssueModel> IssuesOfSeverity(string severity) =>
+        Analysis.Issues.Where(issue => string.Equals(issue.Severity, severity, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    private void OnCancelClicked() => MudDialog.Cancel();
+
+    private void OnConfirmClicked() => MudDialog.Close(DialogResult.Ok(_selectedProcessId));
+
+    private sealed record IssueGroup(string Title, Color Color, IReadOnlyList<BpmnImportIssueModel> Issues);
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportRefusalDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportRefusalDialog.razor
@@ -1,0 +1,37 @@
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="4">
+            <MudText Typo="Typo.body2">@Localizer["This deployment does not support every BPMN capability the document requires, so the import was refused."]</MudText>
+
+            <div>
+                <MudText Typo="Typo.subtitle2">@Localizer["Missing capabilities"]</MudText>
+                <MudList T="string" Dense="true">
+                    @foreach (var capabilityName in Refusal.CapabilityNames)
+                    {
+                        <MudListItem>@capabilityName</MudListItem>
+                    }
+                </MudList>
+            </div>
+
+            @if (Refusal.ElementIds.Count > 0)
+            {
+                <div>
+                    <MudText Typo="Typo.subtitle2">@Localizer["Offending elements"]</MudText>
+                    <MudList T="string" Dense="true">
+                        @foreach (var elementId in Refusal.ElementIds)
+                        {
+                            <MudListItem>@elementId</MudListItem>
+                        }
+                    </MudList>
+                </div>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="OnCloseClicked">@Localizer["Close"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportRefusalDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/BpmnImportRefusalDialog.razor.cs
@@ -1,0 +1,21 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+
+/// <summary>
+/// Shows the capability names and offending element ids a BPMN import's <c>422</c> "missing host capabilities"
+/// refusal carries. Read-only: it only closes, it does not let the user retry or proceed anyway.
+/// </summary>
+public partial class BpmnImportRefusalDialog
+{
+    /// <summary>
+    /// The parsed refusal to display.
+    /// </summary>
+    [Parameter] public BpmnCapabilityRefusal Refusal { get; set; } = new([], []);
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private void OnCloseClicked() => MudDialog.Close(DialogResult.Ok(true));
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor
@@ -31,6 +31,10 @@
         <MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnFilesSelected" MaximumFileCount="Int32.MaxValue" />
     </div>
 
+    <div id="workflow-bpmn-file-upload-button-wrapper" class="d-none">
+        <MudFileUpload T="IReadOnlyList<IBrowserFile>" FilesChanged="@OnBpmnFilesSelected" MaximumFileCount="1" Accept=".bpmn" />
+    </div>
+
     <MudTable @ref="_table"
               T="WorkflowDefinitionRow"
               ServerData="ServerReload"
@@ -74,6 +78,9 @@
                 <MudMenu Icon="@Icons.Material.Filled.ArrowDropDown" Disabled="IsReadOnlyMode" Dense="true">
                     <MudTooltip Text="@Localizer["Upload JSON and/or ZIP files containing workflow data to import."]" Inline="false" Delay="1000">
                         <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="@OnImportClicked">@Localizer["Import"]</MudMenuItem>
+                    </MudTooltip>
+                    <MudTooltip Text="@Localizer["Upload a BPMN 2.0 (.bpmn) file to import as a new workflow."]" Inline="false" Delay="1000">
+                        <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="@OnImportBpmnClicked">@Localizer["Import BPMN"]</MudMenuItem>
                     </MudTooltip>
                 </MudMenu>
             </MudButtonGroup>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -442,11 +442,9 @@ public partial class WorkflowDefinitionList
         if (bpmnBatch.OtherFiles.Count > 0)
             results.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(bpmnBatch.OtherFiles));
 
-        // A capability refusal was already reported in its own dialog by BpmnImportUiService; excluding it here
-        // keeps the summary snackbar limited to the failures it did not already explain.
-        var reportableResults = results.Where(x => x.Failure?.FailureType != WorkflowImportFailureType.CapabilityRefusal).ToList();
+        var reportableResults = BpmnImportBatch.ReportableResults(results);
 
-        if (results.Count > 0 && reportableResults.Count == 0)
+        if (BpmnImportBatch.AllReported(results))
         {
             // Every result was a capability refusal, each already explained in its own dialog; nothing left to summarize.
             Reload();

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -411,14 +411,16 @@ public partial class WorkflowDefinitionList
         if (result == null)
             return;
 
-        if (result.IsSuccess)
+        if (result.IsSuccess && result.WorkflowDefinition is { } workflowDefinition)
         {
             UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow imported successfully."], Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
-            await EditAsync(result.WorkflowDefinition!.DefinitionId);
+            await EditAsync(workflowDefinition.DefinitionId);
         }
-        else
+        else if (result.Failure is { } failure && failure.FailureType != WorkflowImportFailureType.CapabilityRefusal)
         {
-            UserMessageService.ShowSnackbarTextMessage(Localizer["Failed to import BPMN document. Reason: {0}", result.Failure!.ErrorMessage], Severity.Error, options =>
+            // A capability refusal was already reported in its own dialog by BpmnImportUiService; a snackbar here
+            // would just repeat it.
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Failed to import BPMN document. Reason: {0}", failure.ErrorMessage], Severity.Error, options =>
             {
                 options.SnackbarVariant = Variant.Filled;
                 options.VisibleStateDuration = 10000;
@@ -433,30 +435,33 @@ public partial class WorkflowDefinitionList
         // A .bpmn file dropped on the generic (JSON/ZIP) picker cannot be parsed as either, so it is routed through
         // the same interactive BPMN import flow the dedicated "Import BPMN" button uses instead of silently
         // producing zero results.
-        var bpmnFiles = files.Where(BpmnImportUiService.IsBpmnFile).ToList();
-        var otherFiles = files.Where(file => !BpmnImportUiService.IsBpmnFile(file)).ToList();
+        var bpmnBatch = await BpmnImportUiService.ImportBpmnFilesAsync(files, definitionId: null);
 
-        var results = new List<WorkflowImportResult>();
+        var results = new List<WorkflowImportResult>(bpmnBatch.Results);
 
-        if (otherFiles.Count > 0)
-            results.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(otherFiles));
+        if (bpmnBatch.OtherFiles.Count > 0)
+            results.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(bpmnBatch.OtherFiles));
 
-        foreach (var bpmnFile in bpmnFiles)
+        // A capability refusal was already reported in its own dialog by BpmnImportUiService; excluding it here
+        // keeps the summary snackbar limited to the failures it did not already explain.
+        var reportableResults = results.Where(x => x.Failure?.FailureType != WorkflowImportFailureType.CapabilityRefusal).ToList();
+
+        if (results.Count > 0 && reportableResults.Count == 0)
         {
-            var bpmnResult = await BpmnImportUiService.ImportFileAsync(bpmnFile, definitionId: null);
-            if (bpmnResult != null)
-                results.Add(bpmnResult);
+            // Every result was a capability refusal, each already explained in its own dialog; nothing left to summarize.
+            Reload();
+            return;
         }
 
-        var successfulResultCount = results.Count(x => x.IsSuccess);
-        var failedResultCount = results.Count(x => !x.IsSuccess);
+        var successfulResultCount = reportableResults.Count(x => x.IsSuccess);
+        var failedResultCount = reportableResults.Count(x => !x.IsSuccess);
         var successfulWorkflowsTerm = successfulResultCount == 1 ? "workflow" : "workflows";
         var failedWorkflowsTerm = failedResultCount == 1 ? Localizer["workflow"] : Localizer["workflows"];
-        var reasons = string.Join(", ", results.Where(x => x.Failure != null).Select(x => x.Failure!.ErrorMessage));
-        var message = results.Count == 0 ? Localizer["No workflows found to import."] :
+        var reasons = string.Join(", ", reportableResults.Where(x => x.Failure != null).Select(x => x.Failure!.ErrorMessage));
+        var message = reportableResults.Count == 0 ? Localizer["No workflows found to import."] :
             successfulResultCount > 0 && failedResultCount == 0 ? Localizer["{0} {1} imported successfully.", successfulResultCount, successfulWorkflowsTerm] :
             successfulResultCount == 0 && failedResultCount > 0 ? Localizer["Failed to import {0} {1}. Reason: {2}", failedResultCount, failedWorkflowsTerm, reasons] : Localizer["{0} {1} imported successfully.", successfulResultCount, successfulWorkflowsTerm] + " " + Localizer["Failed to import {0} {1}. Reasons: {2}", failedResultCount, failedWorkflowsTerm, reasons];
-        var severity = results.Count == 0 ? Severity.Info : successfulResultCount > 0 && failedResultCount > 0 ? Severity.Warning : failedResultCount == 0 ? Severity.Success : Severity.Error;
+        var severity = reportableResults.Count == 0 ? Severity.Info : successfulResultCount > 0 && failedResultCount > 0 ? Severity.Warning : failedResultCount == 0 ? Severity.Success : Severity.Error;
         UserMessageService.ShowSnackbarTextMessage(message, severity, options =>
         {
             options.SnackbarVariant = Variant.Filled;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionList/WorkflowDefinitionList.razor.cs
@@ -39,6 +39,7 @@ public partial class WorkflowDefinitionList
     [Inject] private ICreateWorkflowDialogComponentProvider CreateWorkflowDialogComponentProvider { get; set; } = null!;
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
     [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = null!;
+    [Inject] private IBpmnImportUiService BpmnImportUiService { get; set; } = null!;
 
     private string SearchTerm { get; set; } = string.Empty;
     private bool IsReadOnlyMode { get; set; }
@@ -393,9 +394,60 @@ public partial class WorkflowDefinitionList
         return DomAccessor.ClickElementAsync("#workflow-file-upload-button-wrapper input[type=file]");
     }
 
+    private Task OnImportBpmnClicked()
+    {
+        return DomAccessor.ClickElementAsync("#workflow-bpmn-file-upload-button-wrapper input[type=file]");
+    }
+
+    private async Task OnBpmnFilesSelected(IReadOnlyList<IBrowserFile> files)
+    {
+        if (files.Count == 0)
+            return;
+
+        var result = await BpmnImportUiService.ImportFileAsync(files[0], definitionId: null);
+
+        // A null result means the user cancelled the findings dialog before anything was imported; there is
+        // nothing to report or reload.
+        if (result == null)
+            return;
+
+        if (result.IsSuccess)
+        {
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow imported successfully."], Severity.Success, options => { options.SnackbarVariant = Variant.Filled; });
+            await EditAsync(result.WorkflowDefinition!.DefinitionId);
+        }
+        else
+        {
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Failed to import BPMN document. Reason: {0}", result.Failure!.ErrorMessage], Severity.Error, options =>
+            {
+                options.SnackbarVariant = Variant.Filled;
+                options.VisibleStateDuration = 10000;
+            });
+        }
+
+        Reload();
+    }
+
     private async Task OnFilesSelected(IReadOnlyList<IBrowserFile> files)
     {
-        var results = (await WorkflowDefinitionImporter.ImportFilesAsync(files)).ToList();
+        // A .bpmn file dropped on the generic (JSON/ZIP) picker cannot be parsed as either, so it is routed through
+        // the same interactive BPMN import flow the dedicated "Import BPMN" button uses instead of silently
+        // producing zero results.
+        var bpmnFiles = files.Where(BpmnImportUiService.IsBpmnFile).ToList();
+        var otherFiles = files.Where(file => !BpmnImportUiService.IsBpmnFile(file)).ToList();
+
+        var results = new List<WorkflowImportResult>();
+
+        if (otherFiles.Count > 0)
+            results.AddRange(await WorkflowDefinitionImporter.ImportFilesAsync(otherFiles));
+
+        foreach (var bpmnFile in bpmnFiles)
+        {
+            var bpmnResult = await BpmnImportUiService.ImportFileAsync(bpmnFile, definitionId: null);
+            if (bpmnResult != null)
+                results.Add(bpmnResult);
+        }
+
         var successfulResultCount = results.Count(x => x.IsSuccess);
         var failedResultCount = results.Count(x => !x.IsSuccess);
         var successfulWorkflowsTerm = successfulResultCount == 1 ? "workflow" : "workflows";

--- a/src/modules/Elsa.Studio.Workflows/Contracts/IBpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Contracts/IBpmnImportUiService.cs
@@ -26,4 +26,15 @@ public interface IBpmnImportUiService
     /// was imported.
     /// </returns>
     Task<WorkflowImportResult?> ImportFileAsync(IBrowserFile file, string? definitionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Splits <paramref name="files"/> into <c>.bpmn</c> files and everything else, then runs <see cref="ImportFileAsync"/>
+    /// on each <c>.bpmn</c> file in turn. Shared by every entry point that accepts a mixed file selection, so the
+    /// split-then-import-then-merge sequence is written once.
+    /// </summary>
+    /// <param name="files">The selected files, of any kind.</param>
+    /// <param name="definitionId">The workflow definition to update, or <see langword="null"/> to create a new one.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The BPMN import results and the files that were not <c>.bpmn</c>, for the caller to import itself.</returns>
+    Task<BpmnImportBatch> ImportBpmnFilesAsync(IReadOnlyList<IBrowserFile> files, string? definitionId, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Workflows/Contracts/IBpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Contracts/IBpmnImportUiService.cs
@@ -1,0 +1,29 @@
+using Elsa.Studio.Workflows.Domain.Models;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Elsa.Studio.Workflows.Contracts;
+
+/// <summary>
+/// Runs the interactive BPMN import flow for a single <c>.bpmn</c> file: analyze, show the findings for
+/// confirmation (prompting for a process id when the document declares more than one), then import.
+/// </summary>
+public interface IBpmnImportUiService
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="file"/>'s name has a <c>.bpmn</c> extension,
+    /// case-insensitively.
+    /// </summary>
+    bool IsBpmnFile(IBrowserFile file);
+
+    /// <summary>
+    /// Analyzes <paramref name="file"/>, shows its findings for confirmation, and imports it once confirmed.
+    /// </summary>
+    /// <param name="file">The <c>.bpmn</c> file to import.</param>
+    /// <param name="definitionId">The workflow definition to update, or <see langword="null"/> to create a new one.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// The import outcome, or <see langword="null"/> when the user cancelled the confirmation dialog before anything
+    /// was imported.
+    /// </returns>
+    Task<WorkflowImportResult?> ImportFileAsync(IBrowserFile file, string? definitionId, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -2,7 +2,11 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Extensions;
@@ -18,7 +22,13 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 /// A diagram designer that displays an imported BPMN process, read-only. Editing lands in a later
 /// increment (W14); this designer only ever shows the diagram and forwards selection.
 /// </summary>
-public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerToolboxProvider
+public class BpmnDiagramDesigner(
+    ILocalizer localizer,
+    IOptions<DesignerOptions> designerOptions,
+    IDialogService dialogService,
+    IBpmnInterchangeService bpmnInterchangeService,
+    IFiles files,
+    IUserMessageService userMessageService) : IDiagramDesignerToolboxProvider
 {
     /// <summary>
     /// The custom property key elsa-core stores the imported BPMN document's source XML under.
@@ -29,6 +39,7 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
     private BpmnDesignerWrapper? _designerWrapper;
     private JsonObject _rootActivity = [];
     private string? _sourceXml;
+    private WorkflowDefinition? _workflowDefinition;
 
     /// <inheritdoc />
     public async Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap)
@@ -84,6 +95,7 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
 
         _rootActivity = activity;
         _sourceXml = GetSourceXml(context.WorkflowDefinition);
+        _workflowDefinition = context.WorkflowDefinition;
 
         return builder =>
         {
@@ -110,6 +122,7 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
 
         yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Zoom to fit"], Icons.Material.Outlined.FitScreen, localizer["Zoom to fit the screen"], OnZoomToFitClicked);
         yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Center"], Icons.Material.Filled.FilterCenterFocus, localizer["Center"], OnCenterClicked);
+        yield return DiagramDesignerToolbox.DisplayToolboxItem(localizer["Export"], Icons.Material.Outlined.Download, localizer["Export as BPMN 2.0 XML"], OnExportClicked);
     }
 
     private async Task InvokeDesignerActionAsync(Func<BpmnDesignerWrapper, Task> action)
@@ -120,6 +133,53 @@ public class BpmnDiagramDesigner(ILocalizer localizer, IOptions<DesignerOptions>
 
     private Task OnZoomToFitClicked() => _designerWrapper != null ? _designerWrapper.ZoomToFitAsync() : Task.CompletedTask;
     private Task OnCenterClicked() => _designerWrapper != null ? _designerWrapper.CenterContentAsync() : Task.CompletedTask;
+
+    private async Task OnExportClicked()
+    {
+        if (_workflowDefinition == null)
+            return;
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true,
+            CloseButton = true,
+            CloseOnEscapeKey = true
+        };
+
+        var dialog = await dialogService.ShowAsync<ExportBpmnDialog>(localizer["Export BPMN"], options);
+        var result = await dialog.Result;
+
+        if (result?.Canceled != false)
+            return;
+
+        var exportResult = await bpmnInterchangeService.ExportAsync(_workflowDefinition.DefinitionId);
+
+        if (!exportResult.IsSuccess)
+        {
+            userMessageService.ShowSnackbarTextMessage(DescribeExportFailure(exportResult.Failure!), Severity.Error);
+            return;
+        }
+
+        var download = exportResult.Success!;
+
+        if (download.Content.CanSeek)
+            download.Content.Seek(0, SeekOrigin.Begin);
+
+        await files.DownloadFileFromStreamAsync(download.FileName, download.Content);
+    }
+
+    /// <summary>
+    /// Renders the two 422 refusals in the user's own words, per this program's design; anything else falls back to
+    /// the server's own message.
+    /// </summary>
+    private string DescribeExportFailure(BpmnExportFailure failure) => failure.Reason switch
+    {
+        BpmnExportFailureReason.NotFound => localizer["Definition not found."],
+        BpmnExportFailureReason.NotImportedFromBpmn => localizer["This definition was not imported from BPMN."],
+        BpmnExportFailureReason.DefinitionChangedSinceImport => localizer["The definition changed since import; export reflects the imported document only."],
+        _ => localizer[failure.Message]
+    };
 
     /// <summary>
     /// Reads the imported BPMN document's source XML from the workflow definition's custom

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -150,7 +150,7 @@ public class BpmnDiagramDesigner(
         var dialog = await dialogService.ShowAsync<ExportBpmnDialog>(localizer["Export BPMN"], options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false)
+        if (result?.Canceled is not false)
             return;
 
         var exportResult = await bpmnInterchangeService.ExportAsync(_workflowDefinition.DefinitionId);

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
@@ -1,10 +1,14 @@
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.UI.Contracts;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Options;
+using MudBlazor;
 
 namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 
@@ -13,7 +17,13 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 /// designer instead of falling back to the JSON view.
 /// </summary>
 [UsedImplicitly]
-public class BpmnDiagramDesignerProvider(ILocalizer localizer, IOptions<DesignerOptions> designerOptions) : IDiagramDesignerProvider
+public class BpmnDiagramDesignerProvider(
+    ILocalizer localizer,
+    IOptions<DesignerOptions> designerOptions,
+    IDialogService dialogService,
+    IBpmnInterchangeService bpmnInterchangeService,
+    IFiles files,
+    IUserMessageService userMessageService) : IDiagramDesignerProvider
 {
     /// <inheritdoc />
     public double Priority => 10;
@@ -22,5 +32,5 @@ public class BpmnDiagramDesignerProvider(ILocalizer localizer, IOptions<Designer
     public bool GetSupportsActivity(JsonObject activity) => activity.GetTypeName() == "Elsa.BpmnProcess";
 
     /// <inheritdoc />
-    public IDiagramDesigner GetEditor() => new BpmnDiagramDesigner(localizer, designerOptions);
+    public IDiagramDesigner GetEditor() => new BpmnDiagramDesigner(localizer, designerOptions, dialogService, bpmnInterchangeService, files, userMessageService);
 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/ExportBpmnDialog.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/ExportBpmnDialog.razor
@@ -1,0 +1,13 @@
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+<MudDialog>
+    <DialogContent>
+        <MudText>@Localizer["The exported file contains this workflow's binding configuration and expressions."]</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="OnCancelClicked">@Localizer["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="OnExportClicked">@Localizer["Export"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/ExportBpmnDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/ExportBpmnDialog.razor.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// A confirmation dialog shown before a BPMN export download, disclosing that the exported file carries the
+/// definition's binding configuration and expressions.
+/// </summary>
+public partial class ExportBpmnDialog
+{
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private void OnCancelClicked() => MudDialog.Cancel();
+
+    private void OnExportClicked() => MudDialog.Close(DialogResult.Ok(true));
+}

--- a/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IWorkflowInstanceObserverFactory, WorkflowInstanceObserverFactory>()
             .AddScoped<IWorkflowCloningDialogService, WorkflowCloningDialogService>()
             .AddScoped<IWorkflowExportDialogService, WorkflowExportDialogService>()
+            .AddScoped<IBpmnImportUiService, BpmnImportUiService>()
             .AddDefaultUIHintHandlers()
             .AddDefaultActivityPortProviders()
             .AddWorkflowsCore()

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
@@ -56,7 +57,10 @@ public class BpmnImportUiService(
         {
             var failure = importResult.Failure!;
             var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
-            var refusal = BpmnCapabilityRefusal.TryParse(message);
+
+            // Only a 422 can be a capability refusal; matching the wording alone on any other status (e.g. a 500
+            // whose message happens to echo the refusal's phrasing) would misreport an unrelated failure as one.
+            var refusal = failure.StatusCode == HttpStatusCode.UnprocessableEntity ? BpmnCapabilityRefusal.TryParse(message) : null;
 
             if (refusal != null)
             {

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -53,15 +53,74 @@ public class BpmnImportUiService(
         var importResult = await bpmnInterchangeService.ImportAsync(content, file.Name, definitionId, name: null, processId.ProcessId, cancellationToken);
 
         if (!importResult.IsSuccess)
-            return Failed(file.Name, importResult.Failure!);
+        {
+            var failure = importResult.Failure!;
+            var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
+            var refusal = BpmnCapabilityRefusal.TryParse(message);
+
+            if (refusal != null)
+            {
+                await ShowRefusalDialogAsync(refusal);
+                return new()
+                {
+                    FileName = file.Name,
+                    Failure = new(message, WorkflowImportFailureType.CapabilityRefusal)
+                };
+            }
+
+            return Failed(file.Name, failure);
+        }
 
         var workflowDefinition = await workflowDefinitionService.FindByDefinitionIdAsync(importResult.Success!.DefinitionId, VersionOptions.Latest, cancellationToken);
+
+        if (workflowDefinition == null)
+        {
+            return new()
+            {
+                FileName = file.Name,
+                Failure = new(localizer["The document was imported, but the resulting workflow definition could not be loaded."], WorkflowImportFailureType.Exception)
+            };
+        }
 
         return new()
         {
             FileName = file.Name,
             WorkflowDefinition = workflowDefinition
         };
+    }
+
+    /// <inheritdoc />
+    public async Task<BpmnImportBatch> ImportBpmnFilesAsync(IReadOnlyList<IBrowserFile> files, string? definitionId, CancellationToken cancellationToken = default)
+    {
+        var bpmnFiles = files.Where(IsBpmnFile).ToList();
+        var otherFiles = files.Where(file => !IsBpmnFile(file)).ToList();
+
+        var results = new List<WorkflowImportResult>();
+
+        foreach (var bpmnFile in bpmnFiles)
+        {
+            var result = await ImportFileAsync(bpmnFile, definitionId, cancellationToken);
+            if (result != null)
+                results.Add(result);
+        }
+
+        return new(results, otherFiles);
+    }
+
+    private async Task ShowRefusalDialogAsync(BpmnCapabilityRefusal refusal)
+    {
+        var parameters = new DialogParameters<BpmnImportRefusalDialog> { { x => x.Refusal, refusal } };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            Position = DialogPosition.Center,
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true,
+            CloseButton = true
+        };
+
+        var dialog = await dialogService.ShowAsync<BpmnImportRefusalDialog>(localizer["Import refused"], parameters, options);
+        await dialog.Result;
     }
 
     private async Task<(bool Cancelled, string? ProcessId)> ShowFindingsDialogAsync(BpmnImportAnalysisModel analysis)

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -1,0 +1,93 @@
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.Services;
+
+/// <inheritdoc cref="IBpmnImportUiService" />
+public class BpmnImportUiService(
+    IDialogService dialogService,
+    ILocalizer localizer,
+    IBpmnInterchangeService bpmnInterchangeService,
+    IWorkflowDefinitionService workflowDefinitionService) : IBpmnImportUiService
+{
+    /// <summary>The maximum file size this flow reads into memory, matching <see cref="ImportOptions"/>'s own default.</summary>
+    private const int MaxAllowedSize = 1024 * 1024 * 10; // 10 MB
+
+    /// <inheritdoc />
+    public bool IsBpmnFile(IBrowserFile file) => IsBpmnFileName(file.Name);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="fileName"/> has a <c>.bpmn</c> extension, case-insensitively.
+    /// </summary>
+    public static bool IsBpmnFileName(string fileName) => fileName.EndsWith(".bpmn", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public async Task<WorkflowImportResult?> ImportFileAsync(IBrowserFile file, string? definitionId, CancellationToken cancellationToken = default)
+    {
+        // The document is read once and re-used for both calls: Analyze and Import read the same file through the
+        // same reader in elsa-core (see BpmnInterchangeDocumentService's remarks), so re-uploading whatever is still
+        // on disk for the second call risks it having changed between the two round trips.
+        await using var browserStream = file.OpenReadStream(MaxAllowedSize, cancellationToken);
+        using var content = new MemoryStream();
+        await browserStream.CopyToAsync(content, cancellationToken);
+
+        content.Seek(0, SeekOrigin.Begin);
+        var analysisResult = await bpmnInterchangeService.AnalyzeAsync(content, file.Name, cancellationToken);
+
+        if (!analysisResult.IsSuccess)
+            return Failed(file.Name, analysisResult.Failure!);
+
+        var processId = await ShowFindingsDialogAsync(analysisResult.Success!);
+
+        if (processId.Cancelled)
+            return null;
+
+        content.Seek(0, SeekOrigin.Begin);
+        var importResult = await bpmnInterchangeService.ImportAsync(content, file.Name, definitionId, name: null, processId.ProcessId, cancellationToken);
+
+        if (!importResult.IsSuccess)
+            return Failed(file.Name, importResult.Failure!);
+
+        var workflowDefinition = await workflowDefinitionService.FindByDefinitionIdAsync(importResult.Success!.DefinitionId, VersionOptions.Latest, cancellationToken);
+
+        return new()
+        {
+            FileName = file.Name,
+            WorkflowDefinition = workflowDefinition
+        };
+    }
+
+    private async Task<(bool Cancelled, string? ProcessId)> ShowFindingsDialogAsync(BpmnImportAnalysisModel analysis)
+    {
+        var parameters = new DialogParameters<BpmnImportFindingsDialog> { { x => x.Analysis, analysis } };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            Position = DialogPosition.Center,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
+            CloseButton = true
+        };
+
+        var dialog = await dialogService.ShowAsync<BpmnImportFindingsDialog>(localizer["Import BPMN"], parameters, options);
+        var result = await dialog.Result;
+
+        if (result?.Canceled != false)
+            return (true, null);
+
+        return (false, result.Data as string);
+    }
+
+    private static WorkflowImportResult Failed(string fileName, ValidationErrors errors) => new()
+    {
+        FileName = fileName,
+        Failure = new(string.Join(" ", errors.Errors.Select(error => error.ErrorMessage)), WorkflowImportFailureType.Exception)
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -101,6 +101,24 @@ public class BpmnImportUiService(
 
         var results = new List<WorkflowImportResult>();
 
+        // When updating an already-open workflow, a batch may contain at most one BPMN file: importing more than
+        // one would import each into the same definition, silently replacing the earlier ones.
+        if (definitionId != null && bpmnFiles.Count > 1)
+        {
+            var message = (string)localizer["Select a single BPMN file to update the open workflow; {0} were selected", bpmnFiles.Count];
+
+            foreach (var bpmnFile in bpmnFiles)
+            {
+                results.Add(new()
+                {
+                    FileName = bpmnFile.Name,
+                    Failure = new(message, WorkflowImportFailureType.Exception)
+                });
+            }
+
+            return new(results, otherFiles);
+        }
+
         foreach (var bpmnFile in bpmnFiles)
         {
             var result = await ImportFileAsync(bpmnFile, definitionId, cancellationToken);
@@ -142,7 +160,7 @@ public class BpmnImportUiService(
         var dialog = await dialogService.ShowAsync<BpmnImportFindingsDialog>(localizer["Import BPMN"], parameters, options);
         var result = await dialog.Result;
 
-        if (result?.Canceled != false)
+        if (result is null || result.Canceled)
             return (true, null);
 
         return (false, result.Data as string);


### PR DESCRIPTION
Closes #1007. Part of elsa-workflows/elsa-core#7909 (W19). Depends on #1011 (W10), merged.

## What changed

Studio can now import and export BPMN through the interchange endpoints elsa-core already ships (`bpmn/analyze`, `bpmn/import`, `bpmn/definitions/{id}/export`).

- **Client**: a Studio-local Refit interface `IBpmnInterchangeApi` and `IBpmnInterchangeService` / `RemoteBpmnInterchangeService` in `Elsa.Studio.Workflows.Core`, registered with `AddRemoteApi<T>` and resolved through `IBackendApiClientProvider`, following the pattern the diagnostics modules already use. DTOs mirror elsa-core's analysis, issue and import models.
- **Import BPMN** on the definitions list, beside the JSON import. Flow: pick a `.bpmn` file → analyze → a dialog listing the findings grouped Dropped / Degraded / Info with element ids → confirm → import (with a `ProcessId` prompt when the document declares several processes) → navigate to the new draft, which the BPMN designer from W10 renders. A `422` capability refusal opens its own dialog naming the missing capabilities and element ids; other failures keep the existing summary snackbar. The refusal is recognised only on `422`, never by wording alone.
- **Editor import** routes a `.bpmn` dropped on the editor's import to `import` with the current definition's id, so it updates in place, matching the endpoint's `DefinitionId` semantics.
- The shared import path now tells `.bpmn` from `.json` by extension, so a BPMN file no longer fails in the JSON parser. The split-and-import logic lives once, in `IBpmnImportUiService.ImportBpmnFilesAsync`, used by both entry points.
- **Export BPMN** as a toolbox item on the BPMN designer: a confirm dialog states that the exported file contains the definition's binding configuration and expressions (the disclosure the design requires), then downloads the stored source XML. The two `422` reasons are shown in plain words ("this definition was not imported from BPMN" / "the definition changed since import; export reflects the imported document only"), `404` as "definition not found".

## Known fragility, recorded

elsa-core returns both refusals as prose rather than structured payloads, so the export reason and the import refusal's capability names and element ids are recognised by matching the server's sentence, isolated in one method each with an explicit fallback and negative tests. A machine-readable error code on those endpoints would let Studio drop the matching; that is an elsa-core follow-up.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run build
cd src/framework/Elsa.Studio.DomInterop/ClientLib && npm run build
dotnet build Elsa.Studio.sln --configuration Release                                                                   # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 311/311
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 83/83
```

Tests cover: `.bpmn` vs `.json` routing; the mixed-selection batch (order and split); the analyze → findings → confirm → import sequence; the refusal dialog rendering names and ids and being shown exactly once with a `CapabilityRefusal` result excluded from the summary; a `500` carrying refusal wording not treated as a refusal; the null-lookup-after-import path returning a failure; the export dialog's disclosure and the `422`/`404` mapping.

**Outstanding for a human**: the manual round trip (import a Camunda file, see findings, confirm, open it, export, diff) needs an elsa-core host with `AddBpmnInterchange()`; no host enables it through configuration.

Review: three iterations on the standards and spec axes; eight must-fix findings resolved across two fixer rounds. Won't-fix, recorded: the prose-based refusal recognition (needs an elsa-core change), and the bundled fix commits (this PR squash-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
