### PR TITLE
feat(workflows): author nested BPMN process scopes from the designer

### DIFF
--- a/src/modules/Elsa.Studio.ActivityPortProviders/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddActivityPortProvider<HttpEndpointPortProvider>();
         services.AddActivityPortProvider<SendHttpRequestPortProvider>();
         services.AddActivityPortProvider<FlowHttpRequestPortProvider>();
+        services.AddActivityPortProvider<BpmnProcessPortProvider>();
         
         return services;
     }

--- a/src/modules/Elsa.Studio.ActivityPortProviders/Providers/BpmnProcessPortProvider.cs
+++ b/src/modules/Elsa.Studio.ActivityPortProviders/Providers/BpmnProcessPortProvider.cs
@@ -1,0 +1,52 @@
+using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Workflows.Domain.Contexts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Domain.Providers;
+
+namespace Elsa.Studio.ActivityPortProviders.Providers;
+
+/// <summary>
+/// Provides the outcome ports of an <c>Elsa.BpmnProcess</c> node on a flowchart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// elsa-core's <c>BpmnProcess</c> declares no <c>[FlowNode]</c> outcomes, so its descriptor carries no ports at all
+/// and the node would otherwise fall back to the single synthesized port the flowchart mapper adds for an activity
+/// with none. That fallback is not enough: a BPMN scope completes with the interpreter's outcome name only -- never
+/// with <c>Outcomes.Default</c>, which is what makes an ordinary activity's null-port connection fire -- so the
+/// <c>Cancelled</c> outcome would have no port to connect from at all.
+/// </para>
+/// <para>
+/// The outcomes are <em>added</em> to whatever the descriptor already declares rather than substituted for it: a
+/// provider replaces the default one outright, so returning only these two would silently hide any port elsa-core
+/// declares later -- an embedded port that stopped rendering, with nothing to say why. Declaring the outcomes on the
+/// activity in elsa-core would then make this provider a no-op superset and it could be deleted; that is an
+/// elsa-core follow-up, not something Studio can do from here.
+/// </para>
+/// </remarks>
+public class BpmnProcessPortProvider : ActivityPortProviderBase
+{
+    /// <inheritdoc />
+    public override bool GetSupportsActivityType(PortProviderContext context) =>
+        context.ActivityDescriptor.TypeName == BpmnProcessConstants.ActivityTypeName;
+
+    /// <inheritdoc />
+    public override IEnumerable<Port> GetPorts(PortProviderContext context)
+    {
+        var declaredPorts = context.ActivityDescriptor.Ports.ToList();
+
+        foreach (var port in declaredPorts)
+            yield return port;
+
+        var declaredNames = declaredPorts.Select(x => x.Name).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var outcomeName in BpmnProcessConstants.OutcomeNames.Where(x => !declaredNames.Contains(x)))
+            yield return new()
+            {
+                Name = outcomeName,
+                DisplayName = outcomeName,
+                Type = PortType.Flow
+            };
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnProcessConstants.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnProcessConstants.cs
@@ -1,0 +1,42 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The identities Studio shares with elsa-core's <c>Elsa.Bpmn</c> module: the activity type name of a BPMN process
+/// scope, and the outcomes such a scope completes with. One class so the designer, the port provider and the node's
+/// display settings all name the same strings.
+/// </summary>
+public static class BpmnProcessConstants
+{
+    /// <summary>
+    /// The activity type name of a BPMN process scope: elsa-core's <c>Elsa.Bpmn.Activities.BpmnProcess</c>.
+    /// </summary>
+    public const string ActivityTypeName = "Elsa.BpmnProcess";
+
+    /// <summary>
+    /// The outcome a BPMN process completes with normally. Mirrors <c>Bpmn.Semantics.BpmnInterpreter.DoneOutcomeName</c>,
+    /// which Studio cannot reference: the interpreter runs server-side and Studio never takes a dependency on it.
+    /// </summary>
+    public const string DoneOutcomeName = "Done";
+
+    /// <summary>
+    /// The outcome a BPMN process completes with when a cancel end event cancelled a transaction. Mirrors
+    /// <c>Bpmn.Semantics.BpmnInterpreter.CancelledOutcomeName</c>.
+    /// </summary>
+    public const string CancelledOutcomeName = "Cancelled";
+
+    /// <summary>
+    /// Every outcome a BPMN process scope can complete with, and therefore every outcome port a
+    /// <c>Elsa.BpmnProcess</c> node offers on a flowchart.
+    /// </summary>
+    /// <remarks>
+    /// The interpreter's <c>Complete</c> continuation carries exactly one of these two — see the documentation of
+    /// <c>Bpmn.Semantics.BpmnContinuation.Complete.Outcome</c> — and elsa-core's <c>BpmnScopeHost</c> completes the
+    /// activity with that one name. A document's end events therefore contribute no further outcome names: a none,
+    /// terminate, message, escalation or compensate end event all complete the scope as <see cref="DoneOutcomeName"/>,
+    /// and only a cancel end event on a transaction produces <see cref="CancelledOutcomeName"/>. Nothing in the
+    /// <c>process</c> payload names an outcome of the scope itself either — a sequence flow's
+    /// <c>conditionOutcome</c> names an outcome of the <em>work</em> the flow's source started, which is matched
+    /// inside the scope and never surfaces on the enclosing flowchart.
+    /// </remarks>
+    public static IReadOnlyList<string> OutcomeNames { get; } = [DoneOutcomeName, CancelledOutcomeName];
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Models/DefaultActivityColors.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Models/DefaultActivityColors.cs
@@ -57,4 +57,8 @@ public static class DefaultActivityColors
     /// Gets or sets the diagnostics.
     /// </summary>
     public static string Diagnostics { get; set; } = "#ec407a";
+    /// <summary>
+    /// Gets or sets the BPMN colour, used by an <c>Elsa.BpmnProcess</c> scope wherever it is composed.
+    /// </summary>
+    public static string Bpmn { get; set; } = "#7c3aed";
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Providers/DefaultActivityDisplaySettingsProvider.cs
@@ -1,3 +1,4 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Elsa.Studio.Workflows.UI.Models;
 using JetBrains.Annotations;
@@ -40,6 +41,9 @@ public class DefaultActivityDisplaySettingsProvider : IActivityDisplaySettingsPr
         // Email
         ["Elsa.SendEmail"] = new(DefaultActivityColors.Email, Icons.Material.Outlined.Email),
         
+        // BPMN
+        [BpmnProcessConstants.ActivityTypeName] = new(DefaultActivityColors.Bpmn, Icons.Material.Outlined.Schema),
+
         // Flowchart
         ["Elsa.Flowchart"] = new(DefaultActivityColors.Flowchart, ElsaStudioIcons.Tabler.GitFork),
         ["Elsa.FlowNode"] = new(DefaultActivityColors.Flowchart, ElsaStudioIcons.Tabler.Hexagon),

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerWrapperTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDesignerWrapperTests.cs
@@ -17,10 +17,13 @@ using Xunit;
 namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
-/// Covers <see cref="BpmnDesignerWrapper"/>'s switch on <see cref="DesignerOptions.UseReactFlow"/>:
-/// while it is set, W9b's React Flow adapter for BPMN does not exist yet, so the wrapper must show a
-/// clear notice rather than the X6 canvas -- and, per the issue, rather than the JSON fallback or a
-/// crash. Otherwise it must render the X6 canvas.
+/// Covers <see cref="BpmnDesignerWrapper"/>'s two reasons for showing a notice instead of the X6 canvas.
+/// While <see cref="DesignerOptions.UseReactFlow"/> is set, W9b's React Flow adapter for BPMN does not
+/// exist yet, so the wrapper must show a clear notice rather than the X6 canvas -- and, per the issue,
+/// rather than the JSON fallback or a crash. And a scope with nothing in it -- what a <c>BpmnProcess</c>
+/// added to a flowchart from the toolbox is -- must say so rather than mount a canvas that would draw a
+/// blank page, since importing into a nested node is not supported server-side. Otherwise it must render
+/// the X6 canvas.
 /// </summary>
 public sealed class BpmnDesignerWrapperTests : BunitContext, IAsyncLifetime
 {
@@ -62,12 +65,70 @@ public sealed class BpmnDesignerWrapperTests : BunitContext, IAsyncLifetime
         Assert.DoesNotContain("mud-alert", cut.Markup);
     }
 
-    private static JsonObject CreateActivity() => new()
+    /// <summary>
+    /// The direction that could be mistaken for success: an empty scope on the canvas renders as a blank
+    /// page that looks exactly like a diagram that failed to load, and the only trace of the reason is a
+    /// console diagnostic. The notice is what tells the two apart.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void RendersTheEmptyScopeNotice_WhenTheScopeHasNoElements(int? elementCount)
     {
-        ["id"] = "root",
-        ["type"] = "Elsa.BpmnProcess",
-        ["activities"] = new JsonArray()
-    };
+        Services.Configure<DesignerOptions>(o => o.UseReactFlow = false);
+
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity(elementCount)));
+
+        Assert.Contains("This BPMN scope has no content yet.", cut.Markup);
+        Assert.DoesNotContain("graph-container", cut.Markup);
+    }
+
+    /// <summary>
+    /// The React Flow notice keeps precedence over the empty-scope notice: on that canvas nothing is drawn
+    /// either way, and naming the canvas is the more actionable of the two.
+    /// </summary>
+    [Fact]
+    public void RendersTheReactFlowNotice_ForAnEmptyScope_WhenUseReactFlowIsSet()
+    {
+        Services.Configure<DesignerOptions>(o => o.UseReactFlow = true);
+
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, CreateActivity(null)));
+
+        Assert.Contains("BPMN is not yet available on the React Flow canvas.", cut.Markup);
+        Assert.DoesNotContain("This BPMN scope has no content yet.", cut.Markup);
+    }
+
+    /// <summary>
+    /// Creates a <c>BpmnProcess</c> scope carrying <paramref name="elementCount"/> elements, or no
+    /// <c>process</c> payload at all when it is null -- what an empty scope created from the toolbox looks
+    /// like.
+    /// </summary>
+    private static JsonObject CreateActivity(int? elementCount = 1)
+    {
+        var activity = new JsonObject
+        {
+            ["id"] = "root",
+            ["type"] = "Elsa.BpmnProcess",
+            ["version"] = 1,
+            ["activities"] = new JsonArray()
+        };
+
+        if (elementCount == null)
+            return activity;
+
+        var elements = new JsonArray();
+
+        for (var i = 0; i < elementCount; i++)
+            elements.Add(new JsonObject { ["elementId"] = $"Element_{i}", ["elementType"] = "task" });
+
+        activity["process"] = new JsonObject
+        {
+            ["processId"] = "process",
+            ["elements"] = elements
+        };
+
+        return activity;
+    }
 
     private class TestLocalizer : ILocalizer
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnNestedScopeDrillDownTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnNestedScopeDrillDownTests.cs
@@ -1,0 +1,487 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.DomInterop.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Contexts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers drilling into a nested <c>Elsa.BpmnProcess</c> scope from the shared
+/// <see cref="DiagramDesignerWrapper"/>: from a flowchart that composes one, and from a BPMN root that contains an
+/// expanded subprocess. Both raise the scope through the same double-click path and both must land in the BPMN
+/// designer with the scope as its root, with a breadcrumb back to where they came from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The invariant these tests exist for is that drilling in and out is a <em>view</em> operation: the nested scope's
+/// JSON must come back byte-identical, because <c>customProperties.canStartWorkflow</c> -- what elsa-core's
+/// <c>BpmnProcess.IsRootScope</c> is backed by -- decides whether the scope's start events are indexed as ways into
+/// the workflow. A nested scope that comes back claiming root position is refused by the applier, and a root scope
+/// that comes back denying it silently stops answering the messages it used to answer. Neither shows up on the
+/// canvas, which is why the round trip is asserted on the document rather than on what is drawn.
+/// </para>
+/// <para>
+/// The workflow definition service is deliberately a stub that throws: everything these tests exercise resolves out
+/// of the graph the wrapper already holds, so a call to the backend would mean the wrapper had lost the node -- a
+/// failure that would otherwise show up only as a silent network round trip in production.
+/// </para>
+/// </remarks>
+public sealed class BpmnNestedScopeDrillDownTests : BunitContext, IAsyncLifetime
+{
+    private const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
+    private const string SourceXml = """<?xml version="1.0"?><definitions/>""";
+
+    public BpmnNestedScopeDrillDownTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddRemoteBackend();
+        Services.AddWorkflowsModule();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, TestActivityRegistry>();
+        Services.AddSingleton<IWorkflowDefinitionService, ThrowingWorkflowDefinitionService>();
+        Services.AddSingleton<IDomAccessor, NoOpDomAccessor>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void FlowchartRoot_ShowsTheFlowchartDesigner_AndNoBreadcrumbTrail()
+    {
+        var cut = RenderWrapper(CreateFlowchartWithNestedProcess());
+
+        Assert.NotNull(cut.FindComponent<FlowchartDesigner>());
+        Assert.Empty(cut.FindComponents<BpmnDesignerWrapper>());
+        Assert.Empty(BreadcrumbTextsOf(cut));
+    }
+
+    [Fact]
+    public async Task DoubleClickingANestedProcessOnAFlowchart_OpensTheBpmnDesignerOnThatScope()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        var bpmnDesigner = cut.FindComponent<BpmnDesignerWrapper>();
+        Assert.Equal("process-1", bpmnDesigner.Instance.Activity.GetId());
+        Assert.Empty(cut.FindComponents<FlowchartDesigner>());
+    }
+
+    [Fact]
+    public async Task DrillingIntoANestedProcess_ShowsABreadcrumbBackToTheFlowchart()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        Assert.Equal(["Root", "Order Process"], BreadcrumbTextsOf(cut));
+    }
+
+    /// <summary>
+    /// The scope's geometry lives in the definition's imported source XML, keyed by element id, so a nested scope
+    /// needs the very same document a root scope does. Losing it does not fail: the adapter silently falls back to
+    /// its own layout, and the diagram merely stops looking like the one that was imported.
+    /// </summary>
+    [Fact]
+    public async Task ANestedScope_StillReceivesTheDefinitionsImportedSourceXml()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        Assert.Equal(SourceXml, cut.FindComponent<BpmnDesignerWrapper>().Instance.SourceXml);
+    }
+
+    [Fact]
+    public async Task DrillingBackOut_ReturnsToTheFlowchart()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var cut = RenderWrapper(root);
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        await ClickRootBreadcrumbAsync(cut);
+
+        Assert.NotNull(cut.FindComponent<FlowchartDesigner>());
+        Assert.Empty(cut.FindComponents<BpmnDesignerWrapper>());
+        Assert.Empty(BreadcrumbTextsOf(cut));
+    }
+
+    /// <summary>
+    /// The round trip, including the read-back the editor performs while the nested scope is the displayed
+    /// container -- which is where a designer that rebuilt its document from a view model instead of handing back
+    /// the one it was given would quietly rewrite the scope.
+    /// </summary>
+    [Fact]
+    public async Task DrillingInAndOut_LeavesTheNestedProcessJsonUnchanged()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var before = NestedProcessOf(root).ToJsonString();
+        var cut = RenderWrapper(root);
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        await cut.InvokeAsync(() => cut.Instance.GetActivityAsync());
+        await ClickRootBreadcrumbAsync(cut);
+
+        var graph = await cut.Instance.GetActivityGraphAsync();
+        Assert.Equal(before, NestedProcessOf(graph.Activity).ToJsonString());
+    }
+
+    /// <summary>
+    /// Named separately from the byte comparison above: a future change that reordered or reformatted the JSON would
+    /// break that one for a reason nobody cares about, while this one only breaks if the flag itself moved.
+    /// </summary>
+    [Fact]
+    public async Task DrillingInAndOut_LeavesTheNestedScopeDenyingRootPosition()
+    {
+        var root = CreateFlowchartWithNestedProcess();
+        var cut = RenderWrapper(root);
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        await cut.InvokeAsync(() => cut.Instance.GetActivityAsync());
+        await ClickRootBreadcrumbAsync(cut);
+
+        var graph = await cut.Instance.GetActivityGraphAsync();
+        Assert.False(NestedProcessOf(graph.Activity)["customProperties"]!["canStartWorkflow"]!.GetValue<bool>());
+    }
+
+    /// <summary>
+    /// The direction that could be mistaken for success: a designer that <em>did</em> rewrite a scope would still
+    /// render, still drill out, and still save -- the workflow would simply start refusing to run, server-side, once
+    /// the applier saw a nested scope claiming root position. So the flag is asserted in both directions on one
+    /// document: after drilling through it, the subprocess still denies root position <em>and</em> the root scope
+    /// still claims it. A designer that normalised the flag either way would break exactly one of the two.
+    /// </summary>
+    [Fact]
+    public async Task DrillingIntoASubprocess_LeavesTheRootScopeClaimingRootPosition()
+    {
+        var root = CreateBpmnRootWithSubprocess();
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnBpmnAsync(cut, root, NestedProcessOf(root));
+        await cut.InvokeAsync(() => cut.Instance.GetActivityAsync());
+        await ClickRootBreadcrumbAsync(cut);
+
+        var graph = await cut.Instance.GetActivityGraphAsync();
+        Assert.True(graph.Activity["customProperties"]!["canStartWorkflow"]!.GetValue<bool>());
+        Assert.False(NestedProcessOf(graph.Activity)["customProperties"]!["canStartWorkflow"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task DoubleClickingASubprocessInsideABpmnRoot_RendersTheNestedScopeAsTheDesignersRoot()
+    {
+        var root = CreateBpmnRootWithSubprocess();
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnBpmnAsync(cut, root, NestedProcessOf(root));
+
+        var bpmnDesigner = cut.FindComponent<BpmnDesignerWrapper>();
+        Assert.Equal("subprocess-1", bpmnDesigner.Instance.Activity.GetId());
+        Assert.Equal(SourceXml, bpmnDesigner.Instance.SourceXml);
+        Assert.Equal(["Root", "Review Subprocess"], BreadcrumbTextsOf(cut));
+    }
+
+    /// <summary>
+    /// A scope added from the toolbox has no <c>process</c> at all, and importing into a nested node is not
+    /// supported server-side, so the only honest thing the designer can do is say so. A blank canvas would be
+    /// indistinguishable from a diagram that failed to load.
+    /// </summary>
+    [Fact]
+    public async Task DrillingIntoAnEmptyScope_ShowsTheEmptyStateNoticeRatherThanABlankCanvas()
+    {
+        var root = CreateFlowchartWithNestedProcess(emptyScope: true);
+        var cut = RenderWrapper(root);
+
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        Assert.NotNull(cut.FindComponent<BpmnDesignerWrapper>());
+        Assert.Contains("This BPMN scope has no content yet.", cut.Markup);
+    }
+
+    /// <summary>
+    /// With no canvas mounted there is nothing to read a document back from, which is the shape of scope most
+    /// likely to be handed back as an empty object. It still has to come back exactly as it went in.
+    /// </summary>
+    [Fact]
+    public async Task DrillingIntoAnEmptyScope_StillLeavesItsJsonUnchanged()
+    {
+        var root = CreateFlowchartWithNestedProcess(emptyScope: true);
+        var before = NestedProcessOf(root).ToJsonString();
+        var cut = RenderWrapper(root);
+        await DoubleClickOnFlowchartAsync(cut, NestedProcessOf(root));
+
+        await cut.InvokeAsync(() => cut.Instance.GetActivityAsync());
+        await ClickRootBreadcrumbAsync(cut);
+
+        var graph = await cut.Instance.GetActivityGraphAsync();
+        Assert.Equal(before, NestedProcessOf(graph.Activity).ToJsonString());
+    }
+
+    private IRenderedComponent<DiagramDesignerWrapper> RenderWrapper(JsonObject root)
+    {
+        Render<MudPopoverProvider>();
+        return Render<DiagramDesignerWrapper>(parameters => parameters
+            .Add(x => x.WorkflowDefinitionVersionId, "version-1")
+            .Add(x => x.Activity, root)
+            .Add(x => x.WorkflowDefinition, CreateDefinition(root)));
+    }
+
+    private static async Task DoubleClickOnFlowchartAsync(IRenderedComponent<DiagramDesignerWrapper> cut, JsonObject activity)
+    {
+        // What the X6 canvas sends: a deserialized copy of the node's activity, not the graph's own instance.
+        var designer = cut.FindComponent<FlowchartDesigner>();
+        await cut.InvokeAsync(() => designer.Instance.HandleActivityDoubleClick((JsonObject)activity.DeepClone()));
+    }
+
+    /// <summary>
+    /// What the BPMN canvas actually sends for an expanded subprocess shape: <c>ActivityId</c> is the work bound to
+    /// the element -- the nested scope itself -- while <c>ScopeActivityId</c> names the scope the element *lives in*,
+    /// which is the root. Getting those two the wrong way round would still resolve to a <c>BpmnProcess</c> here and
+    /// would open the wrong one on a real document, so the faithful shape is what is sent.
+    /// </summary>
+    private static async Task DoubleClickOnBpmnAsync(IRenderedComponent<DiagramDesignerWrapper> cut, JsonObject enclosingScope, JsonObject subprocess)
+    {
+        var designer = cut.FindComponent<BpmnDesigner>();
+        var selection = new BpmnElementSelection(
+            ElementId: "SubProcess_1",
+            ElementType: "subProcess",
+            Kind: "subProcess",
+            Name: "Review Subprocess",
+            ActivityId: subprocess.GetId(),
+            BindingState: "bound",
+            ScopeId: "order-process",
+            ScopeActivityId: enclosingScope.GetId(),
+            BoundaryHostElementId: null,
+            ChildScopeId: "review-process");
+
+        await cut.InvokeAsync(() => designer.Instance.HandleActivityDoubleClick(selection));
+    }
+
+    private static IReadOnlyList<string> BreadcrumbTextsOf(IRenderedComponent<DiagramDesignerWrapper> cut) =>
+        cut.FindAll("li.mud-breadcrumb-item").Select(x => x.TextContent.Trim()).ToList();
+
+    private static async Task ClickRootBreadcrumbAsync(IRenderedComponent<DiagramDesignerWrapper> cut)
+    {
+        var rootLink = cut.FindAll("a").First(x => x.TextContent.Contains("Root"));
+        await cut.InvokeAsync(() => rootLink.Click());
+    }
+
+    /// <summary>
+    /// The one nested <c>BpmnProcess</c> in <paramref name="container"/> -- the flowchart's composed process, or the
+    /// BPMN root's subprocess scope; both are children of the container's <c>activities</c>.
+    /// </summary>
+    private static JsonObject NestedProcessOf(JsonObject container) =>
+        container["activities"]!.AsArray().OfType<JsonObject>().Single(x => x.GetTypeName() == BpmnProcessConstants.ActivityTypeName);
+
+    private static WorkflowDefinition CreateDefinition(JsonObject root) => new()
+    {
+        Id = "version-1",
+        DefinitionId = "definition-1",
+        Name = "Composed",
+        Root = root,
+        CustomProperties = new Dictionary<string, object>
+        {
+            [SourceXmlCustomPropertyKey] = SourceXml
+        }
+    };
+
+    /// <summary>
+    /// A flowchart that runs a <c>WriteLine</c>, then a BPMN process, then another <c>WriteLine</c> on the process's
+    /// <c>Done</c> outcome -- the composition elsa-core's own composition test builds, spelled as the JSON Studio
+    /// receives.
+    /// </summary>
+    private static JsonObject CreateFlowchartWithNestedProcess(bool emptyScope = false)
+    {
+        var process = new JsonObject
+        {
+            ["id"] = "process-1",
+            ["nodeId"] = "Workflow1:flowchart-1:process-1",
+            ["name"] = "Order Process",
+            ["type"] = BpmnProcessConstants.ActivityTypeName,
+            ["version"] = 1,
+            ["customProperties"] = new JsonObject
+            {
+                ["canStartWorkflow"] = false
+            },
+            ["workBindings"] = new JsonObject(),
+            ["activities"] = new JsonArray()
+        };
+
+        if (!emptyScope)
+            process["process"] = CreateProcessPayload("order-process", "Order Process");
+
+        return new JsonObject
+        {
+            ["id"] = "flowchart-1",
+            ["nodeId"] = "Workflow1:flowchart-1",
+            ["type"] = "Elsa.Flowchart",
+            ["version"] = 1,
+            ["activities"] = new JsonArray
+            {
+                CreateWriteLine("before"),
+                process,
+                CreateWriteLine("after")
+            },
+            ["connections"] = new JsonArray
+            {
+                CreateConnection("before", "Done", "process-1"),
+                CreateConnection("process-1", BpmnProcessConstants.DoneOutcomeName, "after")
+            }
+        };
+    }
+
+    /// <summary>
+    /// A BPMN root scope containing an expanded subprocess, which is itself a nested <c>BpmnProcess</c> bound as
+    /// work -- the shape W10 already raises on double-click.
+    /// </summary>
+    private static JsonObject CreateBpmnRootWithSubprocess() => new()
+    {
+        ["id"] = "order-process",
+        ["nodeId"] = "Workflow1:order-process",
+        ["name"] = "Order Process",
+        ["type"] = BpmnProcessConstants.ActivityTypeName,
+        ["version"] = 1,
+        ["customProperties"] = new JsonObject
+        {
+            ["canStartWorkflow"] = true
+        },
+        ["process"] = CreateProcessPayload("order-process", "Order Process", new JsonObject
+        {
+            ["elementId"] = "SubProcess_1",
+            ["elementType"] = "subProcess",
+            ["name"] = "Review Subprocess",
+            ["bindingRef"] = "node-SubProcess_1"
+        }),
+        ["workBindings"] = new JsonObject
+        {
+            ["node-SubProcess_1"] = "subprocess-1"
+        },
+        ["activities"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["id"] = "subprocess-1",
+                ["nodeId"] = "Workflow1:order-process:subprocess-1",
+                ["name"] = "Review Subprocess",
+                ["type"] = BpmnProcessConstants.ActivityTypeName,
+                ["version"] = 1,
+                ["customProperties"] = new JsonObject
+                {
+                    ["canStartWorkflow"] = false
+                },
+                ["process"] = CreateProcessPayload("review-process", "Review Subprocess"),
+                ["workBindings"] = new JsonObject(),
+                ["activities"] = new JsonArray()
+            }
+        }
+    };
+
+    private static JsonObject CreateProcessPayload(string processId, string name, JsonObject? middleElement = null)
+    {
+        var elements = new JsonArray { new JsonObject { ["elementId"] = "StartEvent_1", ["elementType"] = "startEvent" } };
+
+        if (middleElement != null)
+            elements.Add(middleElement);
+
+        elements.Add(new JsonObject { ["elementId"] = "EndEvent_1", ["elementType"] = "endEvent" });
+
+        return new()
+        {
+            ["processId"] = processId,
+            ["name"] = name,
+            ["isExecutable"] = true,
+            ["elements"] = elements,
+            ["sequenceFlows"] = new JsonArray
+            {
+                new JsonObject { ["flowId"] = "Flow_1", ["sourceRef"] = "StartEvent_1", ["targetRef"] = "EndEvent_1" }
+            }
+        };
+    }
+
+    private static JsonObject CreateWriteLine(string id) => new()
+    {
+        ["id"] = id,
+        ["nodeId"] = $"Workflow1:flowchart-1:{id}",
+        ["name"] = id,
+        ["type"] = "Elsa.WriteLine",
+        ["version"] = 1,
+        ["customProperties"] = new JsonObject
+        {
+            ["canStartWorkflow"] = false
+        }
+    };
+
+    private static JsonObject CreateConnection(string sourceId, string sourcePort, string targetId) => new()
+    {
+        ["source"] = new JsonObject { ["activity"] = sourceId, ["port"] = sourcePort },
+        ["target"] = new JsonObject { ["activity"] = targetId, ["port"] = "In" }
+    };
+
+    private sealed class TestActivityRegistry : IActivityRegistry
+    {
+        private readonly IReadOnlyDictionary<string, ActivityDescriptor> _descriptors = new Dictionary<string, ActivityDescriptor>
+        {
+            ["Elsa.Flowchart"] = CreateDescriptor("Elsa.Flowchart", "Flowchart", isContainer: true),
+            [BpmnProcessConstants.ActivityTypeName] = CreateDescriptor(BpmnProcessConstants.ActivityTypeName, "BPMN Process", isContainer: true),
+            ["Elsa.WriteLine"] = CreateDescriptor("Elsa.WriteLine", "Write Line")
+        };
+
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => _descriptors.Values;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => _descriptors.GetValueOrDefault(activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => _descriptors.TryGetValue(activityType, out var descriptor) ? [descriptor] : [];
+
+        public void MarkStale()
+        {
+        }
+
+        private static ActivityDescriptor CreateDescriptor(string typeName, string displayName, bool isContainer = false) => new()
+        {
+            TypeName = typeName,
+            Name = typeName,
+            DisplayName = displayName,
+            Version = 1,
+            IsBrowsable = true,
+            IsContainer = isContainer
+        };
+    }
+
+    private sealed class NoOpDomAccessor : IDomAccessor
+    {
+        public Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(new DomRect());
+        public Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(0d);
+        public Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnProcessDisplaySettingsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnProcessDisplaySettingsTests.cs
@@ -1,0 +1,36 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Domain.Services;
+using Elsa.Studio.Workflows.UI.Models;
+using Elsa.Studio.Workflows.UI.Providers;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the marker an <c>Elsa.BpmnProcess</c> node carries wherever it is composed. Without settings of its own it
+/// falls back to the registry's generic cube and the platform's primary colour -- which renders perfectly well and
+/// tells the reader nothing, so the failure is invisible on the canvas and has to be asserted here.
+/// </summary>
+public class BpmnProcessDisplaySettingsTests
+{
+    private readonly DefaultActivityDisplaySettingsRegistry _registry = new([new DefaultActivityDisplaySettingsProvider()]);
+
+    [Fact]
+    public void ABpmnProcess_HasAMarkerOfItsOwn()
+    {
+        var settings = _registry.GetSettings(BpmnProcessConstants.ActivityTypeName);
+        var fallback = _registry.GetSettings("Some.Activity.Without.Settings");
+
+        Assert.NotEqual(fallback.Icon, settings.Icon);
+        Assert.NotEqual(fallback.Color, settings.Color);
+    }
+
+    [Fact]
+    public void ABpmnProcess_IsNotColouredAsAFlowchart()
+    {
+        var settings = _registry.GetSettings(BpmnProcessConstants.ActivityTypeName);
+
+        Assert.Equal(DefaultActivityColors.Bpmn, settings.Color);
+        Assert.NotEqual(DefaultActivityColors.Flowchart, settings.Color);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnProcessPortProviderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnProcessPortProviderTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.ActivityPortProviders.Providers;
+using Elsa.Studio.Workflows.Domain.Contexts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Domain.Providers;
+using Elsa.Studio.Workflows.Domain.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the outcome ports an <c>Elsa.BpmnProcess</c> node offers on a flowchart.
+/// </summary>
+/// <remarks>
+/// elsa-core's <c>BpmnProcess</c> declares no <c>[FlowNode]</c> outcomes, so its descriptor carries no ports and the
+/// flowchart mapper would synthesize the single default port it adds for any activity with none. That fallback is the
+/// case that looks like success: its id is literally <c>Done</c>, so the happy path connects and runs, and the
+/// missing piece -- a <c>Cancelled</c> port, which a scope completes with when a cancel end event cancelled a
+/// transaction -- is invisible until a document needs it. These tests pin both names, and pin that the provider
+/// really is the one the service picks, since a provider that never wins would leave the fallback in place while
+/// looking installed.
+/// </remarks>
+public class BpmnProcessPortProviderTests
+{
+    private readonly DefaultActivityPortService _portService = new([new BpmnProcessPortProvider(), new DefaultActivityPortProvider()]);
+
+    [Fact]
+    public void GetProvider_PicksTheBpmnProvider_ForABpmnProcess()
+    {
+        var provider = _portService.GetProvider(CreateContext(BpmnProcessConstants.ActivityTypeName));
+
+        Assert.IsType<BpmnProcessPortProvider>(provider);
+    }
+
+    [Fact]
+    public void GetProvider_LeavesEveryOtherActivityToTheDefaultProvider()
+    {
+        var provider = _portService.GetProvider(CreateContext("Elsa.WriteLine"));
+
+        Assert.IsType<DefaultActivityPortProvider>(provider);
+    }
+
+    [Fact]
+    public void GetPorts_YieldsTheInterpretersOwnCompletionOutcomes()
+    {
+        var ports = _portService.GetPorts(CreateContext(BpmnProcessConstants.ActivityTypeName)).ToList();
+
+        Assert.Equal(["Done", "Cancelled"], ports.Select(x => x.Name));
+        Assert.Equal(["Done", "Cancelled"], ports.Select(x => x.DisplayName));
+        Assert.All(ports, port => Assert.Equal(PortType.Flow, port.Type));
+    }
+
+    /// <summary>
+    /// The mapper only synthesizes its default port when the activity offers no flow port of its own, so having flow
+    /// ports here is what keeps a BPMN node off the fallback. A connection drawn from a fallback port would still
+    /// carry the name <c>Done</c> and still fire, which is exactly why this has to be asserted rather than observed.
+    /// </summary>
+    [Fact]
+    public void GetPorts_AreFlowPorts_SoTheFlowchartMapperDoesNotFallBackToItsDefaultPort()
+    {
+        var ports = _portService.GetPorts(CreateContext(BpmnProcessConstants.ActivityTypeName)).ToList();
+
+        Assert.Contains(ports, port => port.Type == PortType.Flow);
+    }
+
+    /// <summary>
+    /// A BPMN process never completes with <c>Outcomes.Default</c>, whose null name is what makes an ordinary
+    /// activity's null-port connection fire. Every port here must therefore be named.
+    /// </summary>
+    [Fact]
+    public void GetPorts_AreAllNamed_SoNoConnectionCanRelyOnTheNullPortShorthand()
+    {
+        var ports = _portService.GetPorts(CreateContext(BpmnProcessConstants.ActivityTypeName)).ToList();
+
+        Assert.All(ports, port => Assert.False(string.IsNullOrEmpty(port.Name)));
+    }
+
+    /// <summary>
+    /// A provider wins outright -- the default one is not consulted as well -- so anything the descriptor declares
+    /// has to be carried through here or it disappears from the node with nothing to say why. An embedded port that
+    /// stopped rendering is exactly the kind of loss that shows up as a missing feature rather than an error.
+    /// </summary>
+    [Fact]
+    public void GetPorts_CarriesThroughWhateverTheDescriptorAlreadyDeclares()
+    {
+        var declared = new Port { Name = "Body", DisplayName = "Body", Type = PortType.Embedded, IsBrowsable = true };
+        var context = CreateContext(BpmnProcessConstants.ActivityTypeName, declared);
+
+        var ports = _portService.GetPorts(context).ToList();
+
+        Assert.Equal(["Body", "Done", "Cancelled"], ports.Select(x => x.Name));
+        Assert.Same(declared, ports[0]);
+    }
+
+    /// <summary>
+    /// The day elsa-core declares the outcomes itself this provider becomes a no-op superset rather than a source of
+    /// two identical ports on the node.
+    /// </summary>
+    [Fact]
+    public void GetPorts_DoesNotRepeatAnOutcomeTheDescriptorAlreadyDeclares()
+    {
+        var declared = new Port { Name = "Done", DisplayName = "Done", Type = PortType.Flow };
+        var context = CreateContext(BpmnProcessConstants.ActivityTypeName, declared);
+
+        var ports = _portService.GetPorts(context).ToList();
+
+        Assert.Equal(["Done", "Cancelled"], ports.Select(x => x.Name));
+    }
+
+    private static PortProviderContext CreateContext(string activityTypeName, params Port[] declaredPorts) =>
+        new(new ActivityDescriptor { TypeName = activityTypeName, Name = activityTypeName, Version = 1, Ports = declaredPorts },
+            new JsonObject { ["id"] = "activity-1", ["type"] = activityTypeName, ["version"] = 1 });
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/ControlledWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/ControlledWorkflowDefinitionService.cs
@@ -14,7 +14,7 @@ namespace Elsa.Studio.Workflows.Tests.Support;
 /// <see cref="GetIsNameUniqueAsync"/> and <see cref="CreateNewDefinitionAsync(string,string?,string?,Action{SaveWorkflowDefinitionRequest}?,CancellationToken)"/>
 /// is unused by the tests that consume this stub and throws to flag an unexpected call.
 /// </summary>
-internal sealed class ControlledWorkflowDefinitionService : IWorkflowDefinitionService
+internal sealed class ControlledWorkflowDefinitionService : ThrowingWorkflowDefinitionServiceBase
 {
     private readonly Queue<PendingValidation> _pendingValidations = new();
 
@@ -29,7 +29,7 @@ internal sealed class ControlledWorkflowDefinitionService : IWorkflowDefinitionS
         return validation;
     }
 
-    public async Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default)
+    public override async Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default)
     {
         PendingValidation validation;
         lock (_pendingValidations)
@@ -40,7 +40,7 @@ internal sealed class ControlledWorkflowDefinitionService : IWorkflowDefinitionS
         return await validation.Result.Task.WaitAsync(cancellationToken);
     }
 
-    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default)
+    public override Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default)
     {
         CreateCallCount++;
         CreatedName = name;
@@ -57,25 +57,4 @@ internal sealed class ControlledWorkflowDefinitionService : IWorkflowDefinitionS
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource<bool> Result { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
-
-    public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-    public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/ThrowingWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/ThrowingWorkflowDefinitionService.cs
@@ -1,0 +1,47 @@
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+
+namespace Elsa.Studio.Workflows.Tests.Support;
+
+/// <summary>
+/// An <see cref="IWorkflowDefinitionService"/> stub whose every member throws, for tests asserting that a component
+/// resolves everything it needs from the graph it already holds. A backend round trip is not a failure the component
+/// would report -- it would simply be slower and, on a disconnected circuit, silently empty -- so the stub makes it
+/// loud.
+/// </summary>
+internal class ThrowingWorkflowDefinitionService : IWorkflowDefinitionService
+{
+    /// <summary>
+    /// The exception every member throws. Override to name the caller in the message.
+    /// </summary>
+    protected virtual Exception Unexpected([System.Runtime.CompilerServices.CallerMemberName] string? member = null) =>
+        new NotSupportedException($"'{member}' asked the backend for a node the designer should already hold.");
+
+    public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw Unexpected();
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/ThrowingWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/ThrowingWorkflowDefinitionService.cs
@@ -9,39 +9,42 @@ using Elsa.Studio.Workflows.Domain.Models;
 namespace Elsa.Studio.Workflows.Tests.Support;
 
 /// <summary>
-/// An <see cref="IWorkflowDefinitionService"/> stub whose every member throws, for tests asserting that a component
-/// resolves everything it needs from the graph it already holds. A backend round trip is not a failure the component
-/// would report -- it would simply be slower and, on a disconnected circuit, silently empty -- so the stub makes it
-/// loud.
+/// An <see cref="IWorkflowDefinitionService"/> base whose every member throws by default, for stubs that only
+/// need a handful of members to behave. A backend round trip is not a failure the component would report -- it
+/// would simply be slower and, on a disconnected circuit, silently empty -- so the base makes it loud. Members are
+/// virtual so a derived stub can override the ones it needs to control.
 /// </summary>
-internal class ThrowingWorkflowDefinitionService : IWorkflowDefinitionService
+internal class ThrowingWorkflowDefinitionServiceBase : IWorkflowDefinitionService
 {
-    /// <summary>
-    /// The exception every member throws. Override to name the caller in the message.
-    /// </summary>
-    protected virtual Exception Unexpected([System.Runtime.CompilerServices.CallerMemberName] string? member = null) =>
+    private static Exception Unexpected([System.Runtime.CompilerServices.CallerMemberName] string? member = null) =>
         new NotSupportedException($"'{member}' asked the backend for a node the designer should already hold.");
 
-    public Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
-    public Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<PagedListResponse<WorkflowDefinitionSummary>> ListAsync(ListWorkflowDefinitionsRequest request, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<IEnumerable<WorkflowDefinition>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<ActivityNode?> FindSubgraphAsync(string id, string? parentNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<bool> DeleteAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<bool> DeleteVersionAsync(WorkflowDefinitionVersion workflowDefinitionVersion, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<SaveWorkflowDefinitionResponse> PublishAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<long> BulkDeleteAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<long> BulkDeleteVersionsAsync(IEnumerable<WorkflowDefinitionVersion> workflowDefinitionVersions, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<BulkPublishWorkflowDefinitionsResponse> BulkPublishAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<BulkRetractWorkflowDefinitionsResponse> BulkRetractAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<bool> GetIsNameUniqueAsync(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<string> GenerateUniqueNameAsync(CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description = null, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<Result<WorkflowDefinition, ValidationErrors>> CreateNewDefinitionAsync(string name, string? description, string? rootActivityTemplateKey, Action<SaveWorkflowDefinitionRequest>? configureRequest = null, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<FileDownload> ExportDefinitionAsync(string definitionId, VersionOptions? versionOptions = null, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<FileDownload> BulkExportDefinitionsAsync(IEnumerable<string> ids, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<UpdateConsumingWorkflowReferencesResponse> UpdateReferencesAsync(string definitionId, CancellationToken cancellationToken = default) => throw Unexpected();
+    public virtual Task<ExecuteWorkflowResult> ExecuteAsync(string definitionId, ExecuteWorkflowDefinitionRequest? request, CancellationToken cancellationToken = default) => throw Unexpected();
 }
+
+/// <summary>
+/// An <see cref="IWorkflowDefinitionService"/> stub whose every member throws, for tests asserting that a component
+/// resolves everything it needs from the graph it already holds.
+/// </summary>
+internal sealed class ThrowingWorkflowDefinitionService : ThrowingWorkflowDefinitionServiceBase;

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
@@ -7,7 +7,7 @@
     }
     else if (IsEmptyScope)
     {
-        <MudAlert Severity="Severity.Info">@Localizer["This BPMN scope has no content yet. Import a BPMN document to create a process, or wait for BPMN editing."]</MudAlert>
+        <MudAlert Severity="Severity.Info">@Localizer["This BPMN scope has no content yet. A nested BPMN scope cannot be populated by importing a BPMN document; its content comes from the document the workflow was imported from, or from BPMN editing once that is available."]</MudAlert>
     }
     else
     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
@@ -5,6 +5,10 @@
     {
         <MudAlert Severity="Severity.Info">@Localizer["BPMN is not yet available on the React Flow canvas."]</MudAlert>
     }
+    else if (IsEmptyScope)
+    {
+        <MudAlert Severity="Severity.Info">@Localizer["This BPMN scope has no content yet. Import a BPMN document to create a process, or wait for BPMN editing."]</MudAlert>
+    }
     else
     {
         <BpmnDesigner @ref="@Designer" Activity="@Activity" SourceXml="@SourceXml" ActivityStats="@ActivityStats"

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -47,6 +47,22 @@ public partial class BpmnDesignerWrapper
     private bool UseReactFlow => DesignerOptions.Value.UseReactFlow;
 
     /// <summary>
+    /// Whether the scope being displayed has nothing to draw: no <c>process</c> payload at all, or one that declares
+    /// no elements. That is what a <c>BpmnProcess</c> added from the toolbox looks like, and what a scope whose
+    /// import produced nothing looks like.
+    /// </summary>
+    /// <remarks>
+    /// Read from the <see cref="Activity"/> parameter rather than from the field <see cref="LoadBpmnAsync"/> writes,
+    /// so the notice is decided by the same render pass that would otherwise mount the canvas. The wrapper is
+    /// re-created per displayed segment (<c>BpmnDiagramDesigner.DisplayDesigner</c> keys it on the designer
+    /// instance), so the parameter is always the scope currently being shown.
+    /// </remarks>
+    private bool IsEmptyScope => GetElementCount(Activity) == 0;
+
+    private static int GetElementCount(JsonObject? activity) =>
+        activity?["process"] is JsonObject process && process["elements"] is JsonArray elements ? elements.Count : 0;
+
+    /// <summary>
     /// Loads the specified root activity into the designer.
     /// </summary>
     public async Task LoadBpmnAsync(JsonObject activity, string? sourceXml, IDictionary<string, ActivityStats>? activityStats)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesignerProvider.cs
@@ -4,6 +4,7 @@ using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.UI.Contracts;
 using JetBrains.Annotations;
@@ -29,7 +30,7 @@ public class BpmnDiagramDesignerProvider(
     public double Priority => 10;
 
     /// <inheritdoc />
-    public bool GetSupportsActivity(JsonObject activity) => activity.GetTypeName() == "Elsa.BpmnProcess";
+    public bool GetSupportsActivity(JsonObject activity) => activity.GetTypeName() == BpmnProcessConstants.ActivityTypeName;
 
     /// <inheritdoc />
     public IDiagramDesigner GetEditor() => new BpmnDiagramDesigner(localizer, designerOptions, dialogService, bpmnInterchangeService, files, userMessageService);


### PR DESCRIPTION
Closes #1002. Part of elsa-workflows/elsa-core#7909 (W17, D11). Depends on #1011 (W10), merged.

## What changed

A `BpmnProcess` nested in a flowchart, or a subprocess scope inside a BPMN root, now opens in the BPMN designer by double-click with breadcrumbs back, and presents correctly on the flowchart.

- **Drill-down needed no production change.** A bunit test written first showed the shared wrapper already pushes a self-designer segment for any double-clicked activity with a registered designer, and W10 registered one for `Elsa.BpmnProcess`. The tests pin it: flowchart → BpmnProcess drill-in with breadcrumb and back; BPMN root → expanded subprocess drill-in; and a byte-identical round trip of the nested scope's JSON, including `canStartWorkflow`, which backs `BpmnProcess.IsRootScope`. The drill-down tests register a throwing `IWorkflowDefinitionService` so any accidental backend round trip fails loudly.
- **Outcome ports.** elsa-core's `BpmnProcess` declares no outcomes, so without help the flowchart node got only Studio's synthesized default port, which happened to be named `Done`; `Cancelled` was invisible. A `BpmnProcessPortProvider` now adds `Done` and `Cancelled` as flow ports, reading the names from one constants class verified against `Bpmn.Semantics` 0.2.0 by reflection (`BpmnInterpreter.DoneOutcomeName`, `CancelledOutcomeName`). The library produces no other completion outcome, so the "any outcome the document's end events produce" clause resolves to those two. The provider adds to the descriptor's ports rather than replacing them, so an outcome declared upstream later cannot be hidden, and it deduplicates.
- **Node presentation.** `Elsa.BpmnProcess` gets its own colour and icon through the default display-settings provider.
- **Empty scope.** Importing into a nested node is out of scope (the import endpoint creates or updates a whole definition). A scope with no `process` or no elements renders a localized notice instead of a blank canvas; the React Flow notice keeps precedence.

## Follow-ups outside this repo, recorded

- elsa-core: declaring `[FlowNode(Done, Cancelled)]` on `BpmnProcess` would make the port provider a no-op that can be deleted.
- elsa-core: `BpmnProcess` is `[Browsable(false)]`, so it never appears in Studio's activity picker; today a BPMN step inside a flowchart can only arrive from a code-first definition or the API.
- Studio, pre-existing: `DiagramDesignerWrapper.GetBreadcrumbItems` / `GetEmbeddedActivity` throw for backend-returned segments inside any container; untouched here.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run build
dotnet build Elsa.Studio.sln --configuration Release                                                                   # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 336/336
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 83/83
```

Mutation check: returning a rebuilt projection with `canStartWorkflow = true` from the designer fails exactly the three round-trip tests.

**Outstanding for a human**: the issue's run-through (WriteLine → BpmnProcess → WriteLine on `Done`, drill in and out, run) needs an elsa-core host with BPMN enabled and a way to compose the node, neither of which exists today.

Review: two iterations on the standards and spec axes; one must-fix (duplicated test stubs) resolved. Won't-fix, recorded: a cosmetic blank-line inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
