### PR TITLE
fix(workflows): handle path segments whose port is a container's collection port

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Tests/BreadcrumbCollectionPortSegmentTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BreadcrumbCollectionPortSegmentTests.cs
@@ -1,0 +1,229 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.DomInterop.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers a path segment shape the instance viewer's journal drives <see cref="DiagramDesignerWrapper.SelectActivityByActivityIdAsync"/>
+/// with: a segment whose container is a <c>BpmnProcess</c> reached through its own collection of activities rather
+/// than a named embedded port. Elsa-core's path-segments endpoint (<c>Elsa.Workflows.Api</c>'s
+/// <c>WorkflowDefinitions/Graph/Segments</c> endpoint) reports that hop with <c>PortName</c> set to the reflected
+/// property name of the container's own activity list -- <c>"Activities"</c> -- because <see cref="Container"/>
+/// exposes its children through that collection property rather than through a single named port such as
+/// <c>Then</c> or <c>Else</c>. No activity descriptor declares a port by that name, so resolving it as an ordinary
+/// embedded port throws before the segment can ever be turned into a container to display or a breadcrumb to draw.
+/// </summary>
+public sealed class BreadcrumbCollectionPortSegmentTests : BunitContext, IAsyncLifetime
+{
+    private const string WorkflowDefinitionVersionId = "version-1";
+    private const string FlowchartNodeId = "Workflow1:flowchart-1";
+    private const string ProcessNodeId = "Workflow1:flowchart-1:process-1";
+    private const string NestedChildNodeId = "Workflow1:flowchart-1:process-1:nested-child";
+
+    public BreadcrumbCollectionPortSegmentTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddRemoteBackend();
+        Services.AddWorkflowsModule();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, TestActivityRegistry>();
+        Services.AddSingleton<IDomAccessor, NoOpDomAccessor>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    /// <summary>
+    /// Reproduces the shape reported as a suspected defect: selecting a leaf activity nested inside a
+    /// <c>BpmnProcess</c> container by activity id, the way the workflow instance viewer's journal does, when the
+    /// leaf is not in the currently displayed container and has to be resolved through a path segment fetched from
+    /// the backend. Before the fix, this throws -- either an <c>InvalidOperationException</c> from
+    /// <c>Enumerable.First</c> finding no port named <c>"Activities"</c>, or from casting the container's activity
+    /// list to a single embedded activity. After the fix, the process becomes the displayed container and the
+    /// breadcrumb falls back to the process's own display name rather than a "displayName: portName" pairing that
+    /// no port justifies.
+    /// </summary>
+    [Fact]
+    public async Task SelectingAnActivityNestedInsideABpmnProcessContainer_DoesNotThrow_AndFallsBackToTheContainersDisplayName()
+    {
+        var nestedChild = CreateWriteLine("nested-child", NestedChildNodeId);
+        var process = CreateBpmnProcess("process-1", ProcessNodeId, "Order Process", new JsonArray { nestedChild });
+        var root = CreateFlowchartWithContainer(process);
+
+        var pathSegmentsResponse = new GetPathSegmentsResponse(
+            new ActivityNode(nestedChild),
+            new ActivityNode(process),
+            new List<ActivityPathSegment>
+            {
+                new(process.GetNodeId(), process.GetId(), process.GetTypeName(), "Activities")
+            });
+
+        Services.AddSingleton<IWorkflowDefinitionService>(new StubWorkflowDefinitionService(
+            WorkflowDefinitionVersionId,
+            NestedChildNodeId,
+            pathSegmentsResponse));
+
+        Render<MudPopoverProvider>();
+        var cut = Render<DiagramDesignerWrapper>(parameters => parameters
+            .Add(x => x.WorkflowDefinitionVersionId, WorkflowDefinitionVersionId)
+            .Add(x => x.Activity, root)
+            .Add(x => x.WorkflowDefinition, new WorkflowDefinition
+            {
+                Id = WorkflowDefinitionVersionId,
+                DefinitionId = "definition-1",
+                Name = "Composed",
+                Root = root
+            }));
+
+        await cut.InvokeAsync(() => cut.Instance.SelectActivityByActivityIdAsync("nested-child", NestedChildNodeId));
+
+        var bpmnDesigner = cut.FindComponent<BpmnDesignerWrapper>();
+        Assert.Equal("process-1", bpmnDesigner.Instance.Activity.GetId());
+        Assert.Equal(["Root", "Order Process"], BreadcrumbTextsOf(cut));
+    }
+
+    private static IReadOnlyList<string> BreadcrumbTextsOf(IRenderedComponent<DiagramDesignerWrapper> cut) =>
+        cut.FindAll("li.mud-breadcrumb-item").Select(x => x.TextContent.Trim()).ToList();
+
+    private static JsonObject CreateFlowchartWithContainer(JsonObject container) => new()
+    {
+        ["id"] = "flowchart-1",
+        ["nodeId"] = FlowchartNodeId,
+        ["type"] = "Elsa.Flowchart",
+        ["version"] = 1,
+        ["activities"] = new JsonArray
+        {
+            CreateWriteLine("before", $"{FlowchartNodeId}:before"),
+            container,
+            CreateWriteLine("after", $"{FlowchartNodeId}:after")
+        },
+        ["connections"] = new JsonArray
+        {
+            CreateConnection("before", "Done", container.GetId()),
+            CreateConnection(container.GetId(), BpmnProcessConstants.DoneOutcomeName, "after")
+        }
+    };
+
+    /// <summary>
+    /// A <c>BpmnProcess</c> with no <c>process</c> payload: the shape the BPMN designer already renders as "no
+    /// content yet" rather than a diagram, which keeps this fixture focused on the segment-resolution defect rather
+    /// than on BPMN diagram fidelity.
+    /// </summary>
+    private static JsonObject CreateBpmnProcess(string id, string nodeId, string name, JsonArray activities) => new()
+    {
+        ["id"] = id,
+        ["nodeId"] = nodeId,
+        ["name"] = name,
+        ["type"] = BpmnProcessConstants.ActivityTypeName,
+        ["version"] = 1,
+        ["customProperties"] = new JsonObject
+        {
+            ["canStartWorkflow"] = false
+        },
+        ["workBindings"] = new JsonObject(),
+        ["activities"] = activities
+    };
+
+    private static JsonObject CreateWriteLine(string id, string nodeId) => new()
+    {
+        ["id"] = id,
+        ["nodeId"] = nodeId,
+        ["name"] = id,
+        ["type"] = "Elsa.WriteLine",
+        ["version"] = 1,
+        ["customProperties"] = new JsonObject
+        {
+            ["canStartWorkflow"] = false
+        }
+    };
+
+    private static JsonObject CreateConnection(string sourceId, string sourcePort, string targetId) => new()
+    {
+        ["source"] = new JsonObject { ["activity"] = sourceId, ["port"] = sourcePort },
+        ["target"] = new JsonObject { ["activity"] = targetId, ["port"] = "In" }
+    };
+
+    /// <summary>
+    /// Answers <see cref="IWorkflowDefinitionService.GetPathSegmentsAsync"/> with a canned response, and throws on
+    /// every other member -- the same shape as <see cref="ThrowingWorkflowDefinitionServiceBase"/>'s other stubs, so
+    /// an unexpected backend call fails loudly rather than returning something the test never configured.
+    /// </summary>
+    private sealed class StubWorkflowDefinitionService(string expectedId, string expectedChildNodeId, GetPathSegmentsResponse response)
+        : ThrowingWorkflowDefinitionServiceBase
+    {
+        public override Task<GetPathSegmentsResponse?> GetPathSegmentsAsync(string id, string? childNodeId = null, CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(expectedId, id);
+            Assert.Equal(expectedChildNodeId, childNodeId);
+            return Task.FromResult<GetPathSegmentsResponse?>(response);
+        }
+    }
+
+    private sealed class TestActivityRegistry : IActivityRegistry
+    {
+        private readonly IReadOnlyDictionary<string, ActivityDescriptor> _descriptors = new Dictionary<string, ActivityDescriptor>
+        {
+            ["Elsa.Flowchart"] = CreateDescriptor("Elsa.Flowchart", "Flowchart", isContainer: true),
+            [BpmnProcessConstants.ActivityTypeName] = CreateDescriptor(BpmnProcessConstants.ActivityTypeName, "BPMN Process", isContainer: true),
+            ["Elsa.WriteLine"] = CreateDescriptor("Elsa.WriteLine", "Write Line")
+        };
+
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => _descriptors.Values;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => _descriptors.GetValueOrDefault(activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => _descriptors.TryGetValue(activityType, out var descriptor) ? [descriptor] : [];
+
+        public void MarkStale()
+        {
+        }
+
+        private static ActivityDescriptor CreateDescriptor(string typeName, string displayName, bool isContainer = false) => new()
+        {
+            TypeName = typeName,
+            Name = typeName,
+            DisplayName = displayName,
+            Version = 1,
+            IsBrowsable = true,
+            IsContainer = isContainer
+        };
+    }
+
+    private sealed class NoOpDomAccessor : IDomAccessor
+    {
+        public Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(new DomRect());
+        public Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(0d);
+        public Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BreadcrumbCollectionPortSegmentTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BreadcrumbCollectionPortSegmentTests.cs
@@ -71,8 +71,11 @@ public sealed class BreadcrumbCollectionPortSegmentTests : BunitContext, IAsyncL
     [Fact]
     public async Task SelectingAnActivityNestedInsideABpmnProcessContainer_DoesNotThrow_AndFallsBackToTheContainersDisplayName()
     {
+        const string BindingRef = "node-nested-child";
+        const string ElementId = "NestedChild_1";
+
         var nestedChild = CreateWriteLine("nested-child", NestedChildNodeId);
-        var process = CreateBpmnProcess("process-1", ProcessNodeId, "Order Process", new JsonArray { nestedChild });
+        var process = CreateBpmnProcess("process-1", ProcessNodeId, "Order Process", new JsonArray { nestedChild }, BindingRef, ElementId);
         var root = CreateFlowchartWithContainer(process);
 
         var pathSegmentsResponse = new GetPathSegmentsResponse(
@@ -105,6 +108,11 @@ public sealed class BreadcrumbCollectionPortSegmentTests : BunitContext, IAsyncL
         var bpmnDesigner = cut.FindComponent<BpmnDesignerWrapper>();
         Assert.Equal("process-1", bpmnDesigner.Instance.Activity.GetId());
         Assert.Equal(["Root", "Order Process"], BreadcrumbTextsOf(cut));
+
+        // The observable selection: the BPMN canvas is told, through its JS interop, to select the element bound to
+        // "nested-child" -- not merely that the container displaying it happens to be right.
+        var selectInvocation = Assert.Single(JSInterop.Invocations["selectBpmnElement"]);
+        Assert.Equal(ElementId, selectInvocation.Arguments[1]);
     }
 
     private static IReadOnlyList<string> BreadcrumbTextsOf(IRenderedComponent<DiagramDesignerWrapper> cut) =>
@@ -130,11 +138,12 @@ public sealed class BreadcrumbCollectionPortSegmentTests : BunitContext, IAsyncL
     };
 
     /// <summary>
-    /// A <c>BpmnProcess</c> with no <c>process</c> payload: the shape the BPMN designer already renders as "no
-    /// content yet" rather than a diagram, which keeps this fixture focused on the segment-resolution defect rather
-    /// than on BPMN diagram fidelity.
+    /// A <c>BpmnProcess</c> with a minimal <c>process</c> payload binding one child activity to a BPMN element, so
+    /// that selecting the child by activity id has an observable JS selection to assert on -- rather than the empty
+    /// scope the BPMN designer renders as "no content yet", which would leave a selection call silently doing
+    /// nothing.
     /// </summary>
-    private static JsonObject CreateBpmnProcess(string id, string nodeId, string name, JsonArray activities) => new()
+    private static JsonObject CreateBpmnProcess(string id, string nodeId, string name, JsonArray activities, string bindingRef, string elementId) => new()
     {
         ["id"] = id,
         ["nodeId"] = nodeId,
@@ -145,7 +154,27 @@ public sealed class BreadcrumbCollectionPortSegmentTests : BunitContext, IAsyncL
         {
             ["canStartWorkflow"] = false
         },
-        ["workBindings"] = new JsonObject(),
+        ["process"] = new JsonObject
+        {
+            ["processId"] = "order-process",
+            ["name"] = name,
+            ["isExecutable"] = true,
+            ["elements"] = new JsonArray
+            {
+                new JsonObject { ["elementId"] = "StartEvent_1", ["elementType"] = "startEvent" },
+                new JsonObject { ["elementId"] = elementId, ["elementType"] = "task", ["name"] = "nested-child", ["bindingRef"] = bindingRef },
+                new JsonObject { ["elementId"] = "EndEvent_1", ["elementType"] = "endEvent" }
+            },
+            ["sequenceFlows"] = new JsonArray
+            {
+                new JsonObject { ["flowId"] = "Flow_1", ["sourceRef"] = "StartEvent_1", ["targetRef"] = elementId },
+                new JsonObject { ["flowId"] = "Flow_2", ["sourceRef"] = elementId, ["targetRef"] = "EndEvent_1" }
+            }
+        },
+        ["workBindings"] = new JsonObject
+        {
+            [bindingRef] = "nested-child"
+        },
         ["activities"] = activities
     };
 

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -412,6 +412,14 @@ public partial class DiagramDesignerWrapper
 
     private JsonObject? GetEmbeddedActivity(JsonObject activity, string portName)
     {
+        // A container's own collection of activities (e.g. a flowchart's or a BPMN process's "Activities"
+        // property) is reported as a path segment port by elsa-core's path-segments endpoint, but it holds the
+        // container's children directly on the container's own JSON rather than as a single embedded activity.
+        // Resolving it as an ordinary named port would call into a port provider that never declares such a port
+        // for these containers, so the container is its own "embedded activity" for that port instead.
+        if (IsCollectionPort(activity, portName))
+            return activity;
+
         var activityTypeName = activity.GetTypeName();
         var activityVersion = activity.GetVersion();
         var activityDescriptor = ActivityRegistry.Find(activityTypeName, activityVersion)!;
@@ -421,6 +429,11 @@ public partial class DiagramDesignerWrapper
 
         return activityInPort;
     }
+
+    /// Returns true if <paramref name="portName"/> names a collection property on <paramref name="activity"/>
+    /// (such as a container's own list of child activities) rather than a single embedded activity.
+    private static bool IsCollectionPort(JsonObject activity, string portName) =>
+        activity[portName.Camelize()] is JsonArray;
 
     private async Task UpdateBreadcrumbItemsAsync()
     {
@@ -485,8 +498,13 @@ public partial class DiagramDesignerWrapper
                 var portProviderContext = new PortProviderContext(activityDescriptor, activity);
                 var portProvider = ActivityPortService.GetProvider(portProviderContext);
                 var ports = portProvider.GetPorts(portProviderContext);
-                var embeddedPort = ports.First(x => x.Name == segment.PortName);
-                breadcrumbDisplayText = $"{activityDisplayText}: {embeddedPort.DisplayName ?? embeddedPort.Name}";
+
+                // A container's own collection port (e.g. "Activities") never appears among a descriptor's declared
+                // ports, so there is nothing to suffix the breadcrumb with; fall back to the activity's own display
+                // name rather than throwing.
+                var embeddedPort = ports.FirstOrDefault(x => x.Name == segment.PortName);
+                if (embeddedPort != null)
+                    breadcrumbDisplayText = $"{activityDisplayText}: {embeddedPort.DisplayName ?? embeddedPort.Name}";
             }
 
             var activityBreadcrumbItem = new BreadcrumbItem(


### PR DESCRIPTION
Closes #1018.

## The defect, reproduced

Selecting an activity by id through the path the instance viewer uses (`SelectActivityByActivityIdAsync` → `GetPathSegmentsAsync`) crashed the designer when the activity sat inside a container that is not a flowchart, such as a `BpmnProcess`. The server's path-segments endpoint names such a segment's port after the container's reflected child-list property, `PortName = "Activities"`. That comes from `PropertyBasedActivityResolver` over `Container.Activities`. No port provider yields that port, so:

- `GetEmbeddedActivity` resolved it through the embedded-port path and called `AsObject()` on the `activities` JSON array, throwing `InvalidOperationException`;
- `GetBreadcrumbItems` did `ports.First(...)` on a port that does not exist.

## What changed

Both changes are in `DiagramDesignerWrapper.razor.cs`:

- A segment whose port names a collection property on the container (its own list of child activities) now resolves to the container itself, instead of going through an embedded-port lookup. The children stay reachable through that list. Descriptor-declared embedded ports (`If.Then`, a flowchart in a sequence) resolve as before.
- Breadcrumb building no longer throws. When no descriptor port matches the segment's port, the crumb falls back to the activity's display name, as the issue asked.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run build
dotnet build Elsa.Studio.sln --configuration Release
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0   # 337/337
```

`BreadcrumbCollectionPortSegmentTests` stubs the path segments in the exact shape elsa-core's endpoint returns and selects through the instance-viewer path. It fails before the fix with `InvalidOperationException` and passes after, confirmed independently by the spec reviewer.

Review: one iteration on the standards and spec axes. Recorded as won't-fix: the breadcrumb fallback is deliberately generic, as the issue asked; and a private helper's doc comment has no `<summary>` tag, which the XML-doc rule only requires on public members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
