### PR TITLE
feat(workflows): project BPMN diagnostics onto an element-keyed instance overlay

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDiagnosticEventNames.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDiagnosticEventNames.cs
@@ -1,0 +1,98 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The stable execution log <c>eventName</c> for each <c>Bpmn.Model.State.BpmnDiagnosticKind</c> member, and the
+/// <c>source</c> every one of them carries. Mirrors elsa-core's own
+/// <c>Elsa.Bpmn.Hosting.BpmnDiagnosticEventNames</c> -- the source of truth for these strings, and for the
+/// projection rules that decide which diagnostics are journaled at all -- so Studio has one place to keep in step
+/// with it rather than depending on <c>Bpmn.Model</c>'s own enum values, which it never references.
+/// </summary>
+public static class BpmnDiagnosticEventNames
+{
+    /// <summary>The <c>source</c> every execution log entry projected from a BPMN diagnostic carries.</summary>
+    public const string Source = "BPMN";
+
+    /// <summary>
+    /// A token arrived at an element via a sequence flow, or an element (a start event, or an error/cancel boundary
+    /// firing without an inbound flow) emitted a token of its own.
+    /// </summary>
+    public const string TokenEmitted = "TokenEmitted";
+
+    /// <summary>An element started bound work: a single unit, or one instance of a multi-instance loop.</summary>
+    public const string Scheduled = "Scheduled";
+
+    /// <summary>A token arrived at a join and is waiting for its siblings.</summary>
+    public const string Waiting = "Waiting";
+
+    /// <summary>A join fired after its arrivals were satisfied.</summary>
+    public const string Joined = "Joined";
+
+    /// <summary>An end event consumed a token, or a multi-instance loop consumed a finished instance's token.</summary>
+    public const string Consumed = "Consumed";
+
+    /// <summary>A unit of work was cancelled.</summary>
+    public const string Canceled = "Canceled";
+
+    /// <summary>A terminate end event ended the process.</summary>
+    public const string Terminated = "Terminated";
+
+    /// <summary>An element's behavior failed.</summary>
+    public const string BehaviorFailure = "BehaviorFailure";
+
+    /// <summary>
+    /// The scope itself finished. Never projected: unlike every other kind, it names neither an element nor a flow,
+    /// and the scope's own activity lifecycle already journals its completion.
+    /// </summary>
+    public const string Completed = "Completed";
+
+    /// <summary>A unit of work faulted.</summary>
+    public const string Faulted = "Faulted";
+
+    /// <summary>A host completion carrying an attached compensation boundary registered a compensable.</summary>
+    public const string CompensationRegistered = "CompensationRegistered";
+
+    /// <summary>A compensate throw/end event triggered a compensation replay.</summary>
+    public const string CompensationTriggered = "CompensationTriggered";
+
+    /// <summary>A compensation handler ran to completion for one registered compensable.</summary>
+    public const string Compensated = "Compensated";
+
+    /// <summary>A cancel end event began (or completed) cancelling a transaction scope.</summary>
+    public const string TransactionCancelled = "TransactionCancelled";
+
+    /// <summary>An escalation throw/end event staged an enclosing-scope signal notification.</summary>
+    public const string EscalationRaised = "EscalationRaised";
+
+    /// <summary>An escalation notification matched an attached boundary and fired it.</summary>
+    public const string EscalationCaught = "EscalationCaught";
+
+    /// <summary>An escalation reached a scope that could not catch it; a no-op, never a fault.</summary>
+    public const string EscalationUnhandled = "EscalationUnhandled";
+
+    /// <summary>
+    /// An interrupting escalation boundary matched a notification whose host had already terminalized; a no-op,
+    /// never a fault.
+    /// </summary>
+    public const string EscalationLate = "EscalationLate";
+
+    /// <summary>An event subprocess was activated by its start-event trigger.</summary>
+    public const string EventSubprocessActivated = "EventSubprocessActivated";
+
+    /// <summary>An event subprocess body ran to completion.</summary>
+    public const string EventSubprocessCompleted = "EventSubprocessCompleted";
+
+    /// <summary>
+    /// A call activity's bound child failed and the engine routed the call-activity failure ladder instead of
+    /// normal outbound flows.
+    /// </summary>
+    public const string CallActivityFailureRouted = "CallActivityFailureRouted";
+
+    /// <summary>A message, signal or timer triggered scope listener was armed.</summary>
+    public const string ScopeListenerArmed = "ScopeListenerArmed";
+
+    /// <summary>A message, signal or timer triggered scope listener fired.</summary>
+    public const string ScopeListenerFired = "ScopeListenerFired";
+
+    /// <summary>A message, signal or timer triggered scope listener was retired.</summary>
+    public const string ScopeListenerRetired = "ScopeListenerRetired";
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDiagnosticLogPayload.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDiagnosticLogPayload.cs
@@ -1,0 +1,21 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The payload every execution log entry projected from a BPMN diagnostic carries. Mirrors elsa-core's
+/// <c>Elsa.Bpmn.Hosting.BpmnDiagnosticLogPayload</c> -- the source of truth for this shape -- field for field, since
+/// that record is exactly what arrives, camelCase, as <see cref="Elsa.Api.Client.Resources.WorkflowInstances.Models.WorkflowExecutionLogRecord.Payload"/>
+/// for an entry whose <c>Source</c> is <see cref="BpmnDiagnosticEventNames.Source"/>.
+/// </summary>
+/// <param name="DiagnosticId">The diagnostic's id in the interpreter's own pinned id stream (<c>diag:N</c>).</param>
+/// <param name="ElementId">The BPMN element the diagnostic is about, or <c>null</c> when it names none.</param>
+/// <param name="FlowId">The BPMN sequence flow the diagnostic is about, or <c>null</c> when it names none.</param>
+/// <param name="TokenId">The token the diagnostic is about, or <c>null</c> when it names none.</param>
+/// <param name="Kind">The diagnostic kind's enum member name; see <see cref="BpmnDiagnosticEventNames"/>.</param>
+/// <param name="Details">Free-form key/value details the interpreter attached, carried verbatim.</param>
+public sealed record BpmnDiagnosticLogPayload(
+    string DiagnosticId,
+    string? ElementId,
+    string? FlowId,
+    string? TokenId,
+    string Kind,
+    IReadOnlyDictionary<string, string>? Details);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStats.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStats.cs
@@ -1,0 +1,35 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Instance state for one BPMN element or sequence flow, keyed by its BPMN document id -- an element id, or, for a
+/// sequence flow, a flow id, since element and flow ids are both document-unique.
+/// </summary>
+/// <remarks>
+/// This is a write-only projection derived from diagnostics: <see cref="BpmnElementStatsProjector"/> is the only
+/// thing that produces it, and nothing reads it back into the engine or edits it. It exists so a gateway, an
+/// intermediate event or a sequence flow -- none of which has an Elsa activity id under Option A -- has something
+/// for the instance viewer's overlay to show, alongside the existing activity-keyed <see cref="ActivityStats"/> for
+/// bound work. Mirrors the ClientLib's canvas-neutral <c>BpmnElementStats</c> interface (<c>src/bpmn/model.ts</c>),
+/// which owns the shape from the rendering side; every field here is nullable for the same reason that one is
+/// all-optional: a projection that cannot compute a field says nothing about it rather than reporting a zero.
+/// </remarks>
+public sealed class BpmnElementStats
+{
+    /// <summary>How many tokens have entered this element or been carried by this flow.</summary>
+    public int? Started { get; set; }
+
+    /// <summary>How many tokens have left this element having completed, or how many times this flow was taken.</summary>
+    public int? Completed { get; set; }
+
+    /// <summary>How many tokens are sitting on this element right now (a waiting catch event, an armed listener).</summary>
+    public int? Active { get; set; }
+
+    /// <summary>Whether a token is parked here waiting for something external (e.g. a join awaiting its siblings).</summary>
+    public bool? Blocked { get; set; }
+
+    /// <summary>Whether execution faulted at this element.</summary>
+    public bool? Faulted { get; set; }
+
+    /// <summary>Whether a token here was cancelled (an interrupted activity, a lost event race, a torn-down scope).</summary>
+    public bool? Canceled { get; set; }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
@@ -28,7 +28,17 @@ public static class BpmnElementStatsProjector
     public static IReadOnlyDictionary<string, BpmnElementStats> Project(IEnumerable<WorkflowExecutionLogRecord> journalEntries)
     {
         var stats = new Dictionary<string, BpmnElementStats>();
+        Fold(journalEntries, stats);
+        return stats;
+    }
 
+    /// <summary>
+    /// Folds <paramref name="journalEntries"/> into an already-populated element-keyed stats map, mutating it in
+    /// place, so a caller that has already folded earlier journal pages need only fold the new ones rather than
+    /// re-fold the whole history on every refresh.
+    /// </summary>
+    public static void Fold(IEnumerable<WorkflowExecutionLogRecord> journalEntries, Dictionary<string, BpmnElementStats> stats)
+    {
         foreach (var entry in journalEntries)
         {
             if (entry.Source != BpmnDiagnosticEventNames.Source)
@@ -45,8 +55,6 @@ public static class BpmnElementStatsProjector
             if (!string.IsNullOrEmpty(payload.FlowId))
                 ApplyToFlow(GetOrAdd(stats, payload.FlowId));
         }
-
-        return stats;
     }
 
     private static BpmnElementStats GetOrAdd(Dictionary<string, BpmnElementStats> stats, string id)

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using Elsa.Api.Client.Resources.WorkflowInstances.Models;
 
@@ -39,11 +40,8 @@ public static class BpmnElementStatsProjector
     /// </summary>
     public static void Fold(IEnumerable<WorkflowExecutionLogRecord> journalEntries, Dictionary<string, BpmnElementStats> stats)
     {
-        foreach (var entry in journalEntries)
+        foreach (var entry in journalEntries.Where(e => e.Source == BpmnDiagnosticEventNames.Source))
         {
-            if (entry.Source != BpmnDiagnosticEventNames.Source)
-                continue;
-
             if (!TryReadPayload(entry.Payload, out var payload))
                 continue;
 

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnElementStatsProjector.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Folds the BPMN diagnostics projected onto a workflow instance's journal (see
+/// <see cref="BpmnDiagnosticEventNames"/> and <see cref="BpmnDiagnosticLogPayload"/>) into a single element-keyed
+/// <see cref="BpmnElementStats"/> map.
+/// </summary>
+/// <remarks>
+/// The one place the mapping from a diagnostic kind to a stats change lives: nothing on the ClientLib side repeats
+/// it, so a BPMN element's badge and a sequence flow's "taken" styling always agree with what this class decided.
+/// Entries from a nested scope (each nested <c>BpmnProcess</c> writes diagnostics on its own activity) fold into
+/// the very same map, because BPMN element and flow ids are unique across the whole document, not merely within
+/// one scope.
+/// </remarks>
+public static class BpmnElementStatsProjector
+{
+    private static readonly JsonSerializerOptions PayloadSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    /// <summary>
+    /// Projects the BPMN diagnostic entries in <paramref name="journalEntries"/> into an element-keyed stats map.
+    /// Entries whose <c>Source</c> is not <see cref="BpmnDiagnosticEventNames.Source"/>, or whose payload does not
+    /// deserialize as a <see cref="BpmnDiagnosticLogPayload"/>, are ignored, so callers may pass an unfiltered
+    /// journal page.
+    /// </summary>
+    public static IReadOnlyDictionary<string, BpmnElementStats> Project(IEnumerable<WorkflowExecutionLogRecord> journalEntries)
+    {
+        var stats = new Dictionary<string, BpmnElementStats>();
+
+        foreach (var entry in journalEntries)
+        {
+            if (entry.Source != BpmnDiagnosticEventNames.Source)
+                continue;
+
+            if (!TryReadPayload(entry.Payload, out var payload))
+                continue;
+
+            if (!string.IsNullOrEmpty(payload.ElementId))
+                ApplyToElement(GetOrAdd(stats, payload.ElementId), payload.Kind);
+
+            // A diagnostic that names a flow id represents that flow having just been taken -- a sequence flow
+            // has no state beyond that -- regardless of which kind carried it (normally TokenEmitted).
+            if (!string.IsNullOrEmpty(payload.FlowId))
+                ApplyToFlow(GetOrAdd(stats, payload.FlowId));
+        }
+
+        return stats;
+    }
+
+    private static BpmnElementStats GetOrAdd(Dictionary<string, BpmnElementStats> stats, string id)
+    {
+        if (stats.TryGetValue(id, out var entry))
+            return entry;
+
+        entry = new BpmnElementStats();
+        stats[id] = entry;
+        return entry;
+    }
+
+    /// <summary>
+    /// Applies one diagnostic kind's effect on the element (or flow-target) it names. See the parenthetical list in
+    /// the design: token emitted/consumed change how many tokens are present; a join that is <c>Waiting</c> is
+    /// blocked, and stops being blocked once it is <c>Joined</c>; work being scheduled, completed or torn down
+    /// moves the same active/completed counters bound work's own <c>ActivityStats</c> reports, so an element with
+    /// no activity id still tells the same story.
+    /// </summary>
+    private static void ApplyToElement(BpmnElementStats stats, string kind)
+    {
+        switch (kind)
+        {
+            case BpmnDiagnosticEventNames.TokenEmitted:
+            case BpmnDiagnosticEventNames.Scheduled:
+            case BpmnDiagnosticEventNames.EventSubprocessActivated:
+            case BpmnDiagnosticEventNames.CompensationTriggered:
+            case BpmnDiagnosticEventNames.ScopeListenerArmed:
+                stats.Started = (stats.Started ?? 0) + 1;
+                stats.Active = (stats.Active ?? 0) + 1;
+                break;
+
+            case BpmnDiagnosticEventNames.Waiting:
+                // A join arrived and is waiting on its siblings: a token is present (blocked), not yet consumed.
+                stats.Blocked = true;
+                break;
+
+            case BpmnDiagnosticEventNames.Joined:
+                stats.Blocked = false;
+                stats.Completed = (stats.Completed ?? 0) + 1;
+                stats.Active = Decrement(stats.Active);
+                break;
+
+            case BpmnDiagnosticEventNames.Consumed:
+            case BpmnDiagnosticEventNames.Terminated:
+            case BpmnDiagnosticEventNames.EventSubprocessCompleted:
+            case BpmnDiagnosticEventNames.Compensated:
+            case BpmnDiagnosticEventNames.EscalationCaught:
+            case BpmnDiagnosticEventNames.ScopeListenerFired:
+                stats.Completed = (stats.Completed ?? 0) + 1;
+                stats.Active = Decrement(stats.Active);
+                break;
+
+            case BpmnDiagnosticEventNames.ScopeListenerRetired:
+                stats.Active = Decrement(stats.Active);
+                break;
+
+            case BpmnDiagnosticEventNames.Canceled:
+            case BpmnDiagnosticEventNames.TransactionCancelled:
+                stats.Canceled = true;
+                stats.Active = Decrement(stats.Active);
+                break;
+
+            case BpmnDiagnosticEventNames.Faulted:
+            case BpmnDiagnosticEventNames.BehaviorFailure:
+            case BpmnDiagnosticEventNames.CallActivityFailureRouted:
+                stats.Faulted = true;
+                break;
+
+            // CompensationRegistered, EscalationRaised, EscalationUnhandled and EscalationLate are bookkeeping
+            // that leaves no per-element state worth showing; EscalationUnhandled and EscalationLate are
+            // documented as never a fault, so they must not be folded into Faulted.
+            default:
+                break;
+        }
+    }
+
+    private static void ApplyToFlow(BpmnElementStats stats)
+    {
+        stats.Started = (stats.Started ?? 0) + 1;
+        stats.Completed = (stats.Completed ?? 0) + 1;
+    }
+
+    private static int Decrement(int? value) => Math.Max(0, (value ?? 0) - 1);
+
+    private static bool TryReadPayload(object? payload, out BpmnDiagnosticLogPayload result)
+    {
+        switch (payload)
+        {
+            case BpmnDiagnosticLogPayload direct:
+                result = direct;
+                return true;
+
+            case JsonElement { ValueKind: JsonValueKind.Object } element:
+                var deserialized = element.Deserialize<BpmnDiagnosticLogPayload>(PayloadSerializerOptions);
+
+                if (deserialized != null)
+                {
+                    result = deserialized;
+                    return true;
+                }
+
+                break;
+        }
+
+        result = null!;
+        return false;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IBpmnElementStatsSink.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IBpmnElementStatsSink.cs
@@ -1,0 +1,22 @@
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+namespace Elsa.Studio.Workflows.UI.Contracts;
+
+/// <summary>
+/// An optional capability an <see cref="IDiagramDesigner"/> may implement to accept the element-keyed instance
+/// overlay: a gateway, an intermediate event or a sequence flow has no Elsa activity id under BPMN's Option A, so
+/// <see cref="IDiagramDesigner.UpdateActivityStatsAsync"/> alone never lights one up.
+/// </summary>
+/// <remarks>
+/// Kept as a separate interface, rather than a member on <see cref="IDiagramDesigner"/> itself, so that every other
+/// diagram designer -- which has no BPMN element ids to key anything on -- is untouched by this projection.
+/// </remarks>
+public interface IBpmnElementStatsSink
+{
+    /// <summary>
+    /// Replaces the whole element-keyed instance overlay. The map is authoritative: an element or flow it no
+    /// longer mentions loses its badge or "taken" styling.
+    /// </summary>
+    /// <param name="elementStats">The stats, keyed by BPMN element id or, for a sequence flow, by flow id.</param>
+    Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats);
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
@@ -237,6 +237,8 @@ export interface BpmnViewFlow {
     readonly conditionOutcome: string | null;
     /** Whether this is the source gateway's default flow. */
     readonly isDefault: boolean;
+    /** Instance state keyed by this flow's own id -- whether, and how often, it has been taken. */
+    readonly stats: BpmnElementStats | null;
     /** Empty when the document carries no DI edge for this flow; see {@link geometrySource}. */
     readonly waypoints: readonly BpmnPoint[];
     readonly geometrySource: BpmnGeometrySource;

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
@@ -185,6 +185,7 @@ export function buildBpmnViewModel(input: BpmnViewModelInput): BpmnViewModel {
                 // is only set by documents that say it there instead; honour both so neither
                 // representation of the same fact goes missing.
                 isDefault: flow.isDefault === true || source.defaultFlowId === flow.flowId,
+                stats: input.elementStats?.[flow.flowId] ?? null,
                 waypoints: edge?.waypoints ?? [],
                 geometrySource: edge != null && edge.waypoints.length > 0 ? 'document' : 'fallback',
                 labelGeometry: toBounds(edge?.labelBounds ?? null),

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/stats.test.ts
@@ -7,9 +7,9 @@
  * Both are asserted here in both directions.
  */
 import { describe, expect, it } from 'vitest';
-import { statsBadgeAttrs } from '../cells';
-import { BADGE_SURFACE_BY_TONE } from '../palette';
-import { resolveBpmnStatsBadge } from '../stats';
+import { flowTakenLineAttrs, statsBadgeAttrs } from '../cells';
+import { BADGE_SURFACE_BY_TONE, EDGE } from '../palette';
+import { isBpmnFlowTaken, resolveBpmnStatsBadge } from '../stats';
 
 describe('resolveBpmnStatsBadge', () => {
     it('says nothing about an element the overlay says nothing about', () => {
@@ -112,5 +112,38 @@ describe('statsBadgeAttrs', () => {
 
         expect(attrs.statsBadgeTitle.text).toBe('Blocked (1)');
         expect(attrs.statsBadgeGroup['aria-label']).toBe('Blocked (1)');
+    });
+});
+
+describe('isBpmnFlowTaken', () => {
+    it('says no about a flow the overlay says nothing about', () => {
+        expect(isBpmnFlowTaken(null)).toBe(false);
+        expect(isBpmnFlowTaken(undefined)).toBe(false);
+        expect(isBpmnFlowTaken({})).toBe(false);
+    });
+
+    it('says yes once the flow has been taken, by either counter the projector might set', () => {
+        expect(isBpmnFlowTaken({ completed: 1 })).toBe(true);
+        expect(isBpmnFlowTaken({ started: 1 })).toBe(true);
+    });
+});
+
+describe('flowTakenLineAttrs', () => {
+    it('paints an untaken flow in the plain edge colour, at the plain width', () => {
+        expect(flowTakenLineAttrs(null)).toEqual({ stroke: EDGE, strokeWidth: 1.5 });
+        expect(flowTakenLineAttrs({})).toEqual({ stroke: EDGE, strokeWidth: 1.5 });
+    });
+
+    it('paints a taken flow in the same tone a completed node badge uses, thicker', () => {
+        const attrs = flowTakenLineAttrs({ completed: 1 });
+
+        expect(attrs.stroke).toBe(BADGE_SURFACE_BY_TONE.completed);
+        expect(attrs.strokeWidth).toBeGreaterThan(1.5);
+    });
+
+    it('returns both properties whichever way it decides, so a flow that stops being taken falls back instead of keeping its old colour', () => {
+        // updateBpmnElementStats merges this into the edge's existing `line` attrs rather than
+        // replacing them; a partial object here would leave a cleared flow looking taken forever.
+        expect(Object.keys(flowTakenLineAttrs(null)).sort()).toEqual(Object.keys(flowTakenLineAttrs({ completed: 1 })).sort());
     });
 });

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
@@ -62,7 +62,7 @@ import {
     TEXT,
     UNBOUND,
 } from './palette';
-import { resolveBpmnStatsBadge, type BpmnStatsBadge } from './stats';
+import { isBpmnFlowTaken, resolveBpmnStatsBadge, type BpmnStatsBadge } from './stats';
 
 const CATCHING_EVENT_TYPES: readonly string[] = ['startEvent', 'intermediateCatchEvent', BOUNDARY_EVENT_ELEMENT_TYPE];
 const RINGED_EVENT_TYPES: readonly string[] = ['intermediateCatchEvent', 'intermediateThrowEvent', BOUNDARY_EVENT_ELEMENT_TYPE];
@@ -113,6 +113,8 @@ export interface BpmnFlowCellData {
     readonly targetElementId: string;
     readonly isDefault: boolean;
     readonly conditionOutcome: string | null;
+    /** Instance state keyed by this flow's own id. Always null for an association. */
+    readonly stats: BpmnElementStats | null;
 }
 
 export type BpmnCellData = BpmnElementCellData | BpmnContainerCellData | BpmnFlowCellData;
@@ -888,6 +890,7 @@ function edgeForFlow(flow: BpmnViewFlow, context: BuildContext): Edge.Metadata {
         targetElementId: flow.targetElementId,
         isDefault: flow.isDefault,
         conditionOutcome: flow.conditionOutcome,
+        stats: flow.stats,
     };
     const source = context.elementsByScopedId.get(scopedKey(flow.scopeId, flow.sourceElementId)) ?? null;
     const target = context.elementsByScopedId.get(scopedKey(flow.scopeId, flow.targetElementId)) ?? null;
@@ -900,7 +903,7 @@ function edgeForFlow(flow: BpmnViewFlow, context: BuildContext): Edge.Metadata {
         source: terminal(flow.sourceElementId, source, waypoints[0]),
         target: terminal(flow.targetElementId, target, waypoints[waypoints.length - 1]),
         vertices: waypoints.length > 2 ? waypoints.slice(1, -1).map(point => ({ x: point.x, y: point.y })) : [],
-        attrs: { line: flowLineAttrs(flow, source) },
+        attrs: { line: { ...flowLineAttrs(flow, source), ...flowTakenLineAttrs(flow.stats) } },
         labels: flow.name == null || flow.name.length === 0 ? [] : [edgeLabel(flow.name)],
         data,
     };
@@ -919,6 +922,7 @@ function edgeForAssociation(
         targetElementId,
         isDefault: false,
         conditionOutcome: null,
+        stats: null,
     };
 
     return {
@@ -973,6 +977,25 @@ function flowLineAttrs(flow: BpmnViewFlow, source: BpmnViewElement | null): Reco
     }
 
     return attrs;
+}
+
+/**
+ * The line-only style override for whether a sequence flow has been taken, reusing the "completed"
+ * badge tone -- the same colour a node turns once its own token count says it is done -- so a taken
+ * flow reads as part of the same visual language rather than inventing a second one.
+ *
+ * Always returns both properties, never a partial object: a flow that stops being taken (the map no
+ * longer mentions it) must fall back to the plain, untaken line exactly as loudly as one that starts
+ * being taken lights up, since {@link updateBpmnElementStats} merges this into the edge's existing
+ * `line` attrs rather than replacing them wholesale.
+ */
+export function flowTakenLineAttrs(stats: BpmnElementStats | null | undefined): Record<string, any> {
+    const taken = isBpmnFlowTaken(stats);
+
+    return {
+        stroke: taken ? BADGE_SURFACE_BY_TONE.completed : EDGE,
+        strokeWidth: taken ? 2.5 : 1.5,
+    };
 }
 
 function edgeLabel(text: string): Record<string, any> {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
@@ -13,8 +13,10 @@ import type { DotNetComponentRef } from '../api/graph-bindings';
 import { whenCanvasHasHeight } from '../internal/canvas-ready';
 import {
     buildBpmnX6Cells,
+    flowTakenLineAttrs,
     statsBadgeAttrs,
     type BpmnElementCellData,
+    type BpmnFlowCellData,
     type BpmnX6Cells,
 } from './cells';
 import { BPMN_DESIGNER_CLASS } from './constants';
@@ -179,6 +181,17 @@ export function updateBpmnElementStats(
         node.setData({ ...data, stats }, { overwrite: true });
         node.attr(statsBadgeAttrs(resolveBpmnStatsBadge(stats, data.activityStats)));
     }
+
+    for (const edge of binding.graph.getEdges()) {
+        const data = flowData(edge.getData());
+
+        if (data == null) continue;
+
+        const stats = elementStats?.[data.id] ?? null;
+
+        edge.setData({ ...data, stats }, { overwrite: true });
+        edge.attr({ line: flowTakenLineAttrs(stats) });
+    }
 }
 
 /** Updates the activity-keyed overlay for one Elsa activity, on every element bound to it. */
@@ -225,6 +238,11 @@ export function selectBpmnElement(binding: BpmnGraphBinding, elementId: string, 
 
 function elementData(data: unknown): BpmnElementCellData | null {
     return (data as BpmnElementCellData | null)?.cellKind === 'element' ? data as BpmnElementCellData : null;
+}
+
+/** Only a sequence flow can be "taken"; an association's id is a synthetic pair, never a document id. */
+function flowData(data: unknown): BpmnFlowCellData | null {
+    return (data as BpmnFlowCellData | null)?.cellKind === 'flow' ? data as BpmnFlowCellData : null;
 }
 
 function toSelection(data: BpmnElementCellData): BpmnElementSelection {

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/stats.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/stats.ts
@@ -76,3 +76,14 @@ function firstNumber(...values: readonly (number | null | undefined)[]): number 
 
     return null;
 }
+
+/**
+ * Whether a sequence flow's own stats entry says it has been taken at least once.
+ *
+ * A flow has no state beyond that: `BpmnElementStatsProjector` (the C# side, the one place this
+ * mapping lives) marks a flow's entry the moment a token travels along it, by its own flow id, so
+ * either counter being positive is enough.
+ */
+export function isBpmnFlowTaken(stats: BpmnElementStats | null | undefined): boolean {
+    return (stats?.completed ?? 0) > 0 || (stats?.started ?? 0) > 0;
+}

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -6,6 +6,7 @@ using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Services;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.UI.Contracts;
 using Microsoft.AspNetCore.Components;
@@ -152,6 +153,14 @@ public partial class BpmnDesigner : IAsyncDisposable
     /// <param name="stats">The updated stats.</param>
     public async Task UpdateActivityStatsAsync(string activityId, ActivityStats stats) =>
         await ScheduleGraphActionAsync(() => _graphApi!.UpdateActivityStatsAsync(activityId, stats));
+
+    /// <summary>
+    /// Replaces the whole element-keyed instance overlay: a gateway, an intermediate event or a sequence flow, none
+    /// of which has an Elsa activity id, keyed instead by BPMN element id (or, for a flow, by flow id).
+    /// </summary>
+    /// <param name="elementStats">The stats to apply, keyed by BPMN element or flow id.</param>
+    public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats) =>
+        await ScheduleGraphActionAsync(() => _graphApi!.UpdateElementStatsAsync(elementStats));
 
     /// <summary>
     /// Keeps the held activity tree in step with an edit made elsewhere (the properties panel): the

--- a/src/modules/Elsa.Studio.Workflows.Designer/Interop/BpmnGraphApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Interop/BpmnGraphApi.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Microsoft.JSInterop;
 
 namespace Elsa.Studio.Workflows.Designer.Interop;
@@ -48,6 +49,14 @@ public class BpmnGraphApi
     /// <param name="stats">The stats to apply, or null to clear them.</param>
     public async Task UpdateActivityStatsAsync(string activityId, ActivityStats? stats) =>
         await InvokeAsync(module => module.InvokeVoidAsync("updateBpmnActivityStats", _graphId, activityId, stats));
+
+    /// <summary>
+    /// Replaces the whole element-keyed instance overlay: instance state for a gateway, an intermediate event or a
+    /// sequence flow, keyed by BPMN element id (or, for a flow, by flow id).
+    /// </summary>
+    /// <param name="elementStats">The stats to apply, or null (or empty) to clear the overlay entirely.</param>
+    public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats>? elementStats) =>
+        await InvokeAsync(module => module.InvokeVoidAsync("updateBpmnElementStats", _graphId, elementStats));
 
     /// <summary>
     /// Selects the specified element, optionally centering the viewport on it.

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerElementStatsMountRaceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDiagramDesignerElementStatsMountRaceTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.UI.Contexts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the element-stats mount race (issue's W13 follow-up): a refresh can name a
+/// <see cref="BpmnDiagramDesigner"/> before its <see cref="BpmnDesignerWrapper"/> -- and, in turn, the canvas
+/// underneath it -- has ever been rendered, most notably the one unconditional refresh a freshly opened instance
+/// gets on load, which runs before the designer has had a chance to render anything at all. That update must not
+/// be silently dropped: it is the only chance a finished instance (no observer-driven refresh to fall back on)
+/// ever gets to show its gateway, event and taken-flow overlay.
+/// </summary>
+public sealed class BpmnDiagramDesignerElementStatsMountRaceTests : BunitContext, IAsyncLifetime
+{
+    public BpmnDiagramDesignerElementStatsMountRaceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddWorkflowsCore();
+        Services.AddWorkflowsDesigner();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task UpdateElementStatsAsync_BeforeTheCanvasIsMounted_IsAppliedOnceItMounts()
+    {
+        var handler = JSInterop.SetupVoid("updateBpmnElementStats", _ => true);
+
+        var designer = new BpmnDiagramDesigner(new TestLocalizer(), Microsoft.Extensions.Options.Options.Create(new DesignerOptions()), null!, null!, null!, null!);
+        var activity = CreateActivity("root");
+        var elementStats = new Dictionary<string, BpmnElementStats>
+        {
+            ["Element_1"] = new() { Completed = 1 }
+        };
+
+        // Simulate the race: the refresh arrives before the designer's wrapper -- and its canvas -- has ever been
+        // rendered, exactly as it does today during DiagramDesignerWrapper.OnInitializedAsync's unconditional
+        // first refresh, which runs before the render tree that would mount BpmnDesignerWrapper exists yet.
+        await designer.UpdateElementStatsAsync(elementStats);
+
+        Assert.Empty(handler.Invocations);
+
+        // Mounting the designer's render fragment is what today's production code does next, once the render
+        // tree containing it is actually processed by the renderer.
+        var context = new DisplayContext(activity);
+        Render(designer.DisplayDesigner(context));
+
+        var invocation = Assert.Single(handler.Invocations);
+        var appliedStats = Assert.IsType<Dictionary<string, BpmnElementStats>>(invocation.Arguments[1]);
+        Assert.Equal(1, appliedStats["Element_1"].Completed);
+    }
+
+    /// <summary>
+    /// Creates a <c>BpmnProcess</c> root carrying one element, so <see cref="BpmnDesignerWrapper"/> mounts the
+    /// canvas rather than the "empty scope" notice.
+    /// </summary>
+    private static JsonObject CreateActivity(string id) => new()
+    {
+        ["id"] = id,
+        ["type"] = "Elsa.BpmnProcess",
+        ["version"] = 1,
+        ["activities"] = new JsonArray(),
+        ["process"] = new JsonObject
+        {
+            ["processId"] = "process",
+            ["elements"] = new JsonArray
+            {
+                new JsonObject { ["elementId"] = "Element_1", ["elementType"] = "task" }
+            }
+        }
+    };
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = default) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+        public void MarkStale()
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
@@ -180,6 +180,34 @@ public class BpmnElementStatsProjectorTests
         Assert.Equal(1, stats["task"].Started);
     }
 
+    [Fact(DisplayName = "Folding the same element's records across two refreshes matches a single pass over all of them")]
+    public void Fold_SameElementAcrossTwoRefreshes_MatchesASinglePassOverAllRecords()
+    {
+        // The join's Waiting record (refresh 1's whole take) lands first and marks it blocked; its later Joined
+        // record (refresh 2's whole take) must still clear that blocked flag rather than the map getting stuck on
+        // whatever refresh 1 last saw.
+        var waiting = DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join");
+        var joined = DiagnosticEntry(BpmnDiagnosticEventNames.Joined, elementId: "join");
+
+        var stats = new Dictionary<string, BpmnElementStats>();
+        BpmnElementStatsProjector.Fold([waiting], stats);
+        BpmnElementStatsProjector.Fold([joined], stats);
+
+        var expected = BpmnElementStatsProjector.Project([waiting, joined]);
+
+        Assert.Equal(expected.Keys.OrderBy(k => k), stats.Keys.OrderBy(k => k));
+        var expectedJoin = expected["join"];
+        var actualJoin = stats["join"];
+        Assert.Equal(expectedJoin.Started, actualJoin.Started);
+        Assert.Equal(expectedJoin.Completed, actualJoin.Completed);
+        Assert.Equal(expectedJoin.Active, actualJoin.Active);
+        Assert.Equal(expectedJoin.Blocked, actualJoin.Blocked);
+        Assert.Equal(expectedJoin.Faulted, actualJoin.Faulted);
+        Assert.Equal(expectedJoin.Canceled, actualJoin.Canceled);
+        Assert.False(actualJoin.Blocked);
+        Assert.Equal(1, actualJoin.Completed);
+    }
+
     private static bool IsTaken(BpmnElementStats stats) => (stats.Started ?? 0) > 0 || (stats.Completed ?? 0) > 0;
 
     private static WorkflowExecutionLogRecord DiagnosticEntry(

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnElementStatsProjector"/>: folding the BPMN diagnostics elsa-core projects onto a workflow
+/// instance's journal (see <see cref="BpmnDiagnosticEventNames"/> and <see cref="BpmnDiagnosticLogPayload"/>) into
+/// the element-keyed overlay the instance viewer's canvas reads.
+/// </summary>
+/// <remarks>
+/// The parallel-gateway scenario below is this item's own verification scenario (D1): a join waiting on a still
+/// blocked sibling, and a completed branch whose flows were taken, both visible with nothing bound to the gateway
+/// itself.
+/// </remarks>
+public class BpmnElementStatsProjectorTests
+{
+    [Fact(DisplayName = "A parallel split where one branch blocks: the join is waiting, and the completed branch's flows are taken")]
+    public void Project_ParallelSplitOneBranchBlocked_ShowsTheJoinWaitingAndTheCompletedBranchesFlowsTaken()
+    {
+        var entries = new[]
+        {
+            DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: "flow-split-completed"),
+            DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: "flow-completed-join"),
+            DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join"),
+        };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.True(stats["join"].Blocked);
+        Assert.True(IsTaken(stats["flow-split-completed"]));
+        Assert.True(IsTaken(stats["flow-completed-join"]));
+    }
+
+    [Fact(DisplayName = "A join firing clears its blocked flag and counts as completed")]
+    public void Project_Joined_ClearsBlockedAndCountsAsCompleted()
+    {
+        var entries = new[]
+        {
+            DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join"),
+            DiagnosticEntry(BpmnDiagnosticEventNames.Joined, elementId: "join"),
+        };
+
+        var stats = BpmnElementStatsProjector.Project(entries).Single(x => x.Key == "join").Value;
+
+        Assert.False(stats.Blocked);
+        Assert.Equal(1, stats.Completed);
+    }
+
+    [Fact(DisplayName = "A single diagnostic naming both an element and a flow updates both entries independently")]
+    public void Project_DiagnosticNamingBothAnElementAndAFlow_UpdatesBothEntries()
+    {
+        var entries = new[] { DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, elementId: "catch-event", flowId: "flow-into-catch") };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.Equal(1, stats["catch-event"].Started);
+        Assert.Equal(1, stats["catch-event"].Active);
+        Assert.True(IsTaken(stats["flow-into-catch"]));
+    }
+
+    [Theory(DisplayName = "Faulted and BehaviorFailure both mark the element faulted")]
+    [InlineData(nameof(BpmnDiagnosticEventNames.Faulted))]
+    [InlineData(nameof(BpmnDiagnosticEventNames.BehaviorFailure))]
+    [InlineData(nameof(BpmnDiagnosticEventNames.CallActivityFailureRouted))]
+    public void Project_FaultKinds_MarkTheElementFaulted(string kind)
+    {
+        var entries = new[] { DiagnosticEntry(kind, elementId: "task") };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.True(stats["task"].Faulted);
+    }
+
+    [Theory(DisplayName = "EscalationUnhandled and EscalationLate are documented as never a fault, and must not be folded into one")]
+    [InlineData(nameof(BpmnDiagnosticEventNames.EscalationUnhandled))]
+    [InlineData(nameof(BpmnDiagnosticEventNames.EscalationLate))]
+    public void Project_NeverFaultKinds_DoNotMarkTheElementFaulted(string kind)
+    {
+        var entries = new[] { DiagnosticEntry(kind, elementId: "boundary") };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.False(stats["boundary"].Faulted ?? false);
+    }
+
+    [Fact(DisplayName = "Canceled marks the element cancelled and decrements its active count")]
+    public void Project_Canceled_MarksCancelledAndDecrementsActive()
+    {
+        var entries = new[]
+        {
+            DiagnosticEntry(BpmnDiagnosticEventNames.Scheduled, elementId: "task"),
+            DiagnosticEntry(BpmnDiagnosticEventNames.Canceled, elementId: "task"),
+        };
+
+        var stats = BpmnElementStatsProjector.Project(entries)["task"];
+
+        Assert.True(stats.Canceled);
+        Assert.Equal(0, stats.Active);
+    }
+
+    [Fact(DisplayName = "Entries from a nested scope's own activity land in the same, single element-keyed map")]
+    public void Project_EntriesFromDifferentScopeActivities_FoldIntoTheSameMap()
+    {
+        // Diagnostics for the outer BpmnProcess scope and a nested one are both written on their own scope's
+        // activity id (never a child's), but element and flow ids are unique across the whole document, so the
+        // resulting map is global per instance rather than segregated by which scope wrote the entry.
+        var entries = new[]
+        {
+            DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, elementId: "outer-task", activityId: "outer-scope"),
+            DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "inner-join", activityId: "inner-scope"),
+        };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.Equal(2, stats.Count);
+        Assert.Equal(1, stats["outer-task"].Started);
+        Assert.True(stats["inner-join"].Blocked);
+    }
+
+    [Fact(DisplayName = "Entries whose Source is not BPMN are ignored, even if their event name coincides with a diagnostic kind")]
+    public void Project_NonBpmnSourcedEntries_AreIgnored()
+    {
+        var entry = DiagnosticEntry(BpmnDiagnosticEventNames.Faulted, elementId: "task") with { Source = "SomethingElse" };
+
+        var stats = BpmnElementStatsProjector.Project([entry]);
+
+        Assert.Empty(stats);
+    }
+
+    [Fact(DisplayName = "The scope's own terminal Completed diagnostic, which names neither an element nor a flow, contributes nothing")]
+    public void Project_ScopeCompletionDiagnostic_ContributesNothing()
+    {
+        var entries = new[] { DiagnosticEntry(BpmnDiagnosticEventNames.Completed) };
+
+        var stats = BpmnElementStatsProjector.Project(entries);
+
+        Assert.Empty(stats);
+    }
+
+    [Fact(DisplayName = "A payload that arrives as a JsonElement -- exactly how it comes over the wire -- is read the same as a payload constructed directly")]
+    public void Project_PayloadAsJsonElement_IsReadCorrectly()
+    {
+        var json = """{"diagnosticId":"diag:1","elementId":"join","flowId":null,"tokenId":null,"kind":"Waiting","details":{}}""";
+        var payload = JsonSerializer.Deserialize<JsonElement>(json);
+        var entry = new WorkflowExecutionLogRecord(
+            Id: "log-1",
+            ActivityInstanceId: "instance-1",
+            ParentActivityInstanceId: null,
+            ActivityId: "scope",
+            ActivityType: "Elsa.BpmnProcess",
+            ActivityTypeVersion: 1,
+            ActivityName: null,
+            NodeId: "scope-node",
+            Timestamp: DateTimeOffset.UtcNow,
+            Sequence: 1,
+            EventName: BpmnDiagnosticEventNames.Waiting,
+            Message: null,
+            Source: BpmnDiagnosticEventNames.Source,
+            ActivityState: null,
+            Payload: payload);
+
+        var stats = BpmnElementStatsProjector.Project([entry]);
+
+        Assert.True(stats["join"].Blocked);
+    }
+
+    private static bool IsTaken(BpmnElementStats stats) => (stats.Started ?? 0) > 0 || (stats.Completed ?? 0) > 0;
+
+    private static WorkflowExecutionLogRecord DiagnosticEntry(
+        string kind,
+        string? elementId = null,
+        string? flowId = null,
+        string activityId = "scope") => new(
+        Id: Guid.NewGuid().ToString(),
+        ActivityInstanceId: "instance-1",
+        ParentActivityInstanceId: null,
+        ActivityId: activityId,
+        ActivityType: "Elsa.BpmnProcess",
+        ActivityTypeVersion: 1,
+        ActivityName: null,
+        NodeId: $"{activityId}-node",
+        Timestamp: DateTimeOffset.UtcNow,
+        Sequence: 1,
+        EventName: kind,
+        Message: null,
+        Source: BpmnDiagnosticEventNames.Source,
+        ActivityState: null,
+        Payload: new BpmnDiagnosticLogPayload(Guid.NewGuid().ToString(), elementId, flowId, null, kind, new Dictionary<string, string>()));
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementStatsProjectorTests.cs
@@ -167,6 +167,19 @@ public class BpmnElementStatsProjectorTests
         Assert.True(stats["join"].Blocked);
     }
 
+    [Fact(DisplayName = "Fold mutates an already-populated map in place, combining new entries with what was already folded")]
+    public void Fold_AlreadyPopulatedMap_CombinesNewEntriesWithExistingOnes()
+    {
+        var stats = new Dictionary<string, BpmnElementStats>();
+        BpmnElementStatsProjector.Fold([DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join")], stats);
+
+        BpmnElementStatsProjector.Fold([DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, elementId: "task")], stats);
+
+        Assert.Equal(2, stats.Count);
+        Assert.True(stats["join"].Blocked);
+        Assert.Equal(1, stats["task"].Started);
+    }
+
     private static bool IsTaken(BpmnElementStats stats) => (stats.Started ?? 0) > 0 || (stats.Completed ?? 0) > 0;
 
     private static WorkflowExecutionLogRecord DiagnosticEntry(

--- a/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
@@ -86,7 +86,7 @@ public class DiagramDesignerWrapperElementStatsTests
         Assert.True(sink.ReceivedStats!["join"].Blocked);
     }
 
-    [Fact(DisplayName = "Pages through the journal until a short page ends it, bounded by a hard page cap")]
+    [Fact(DisplayName = "Pages through the journal until a short page ends it, within a single refresh's page cap")]
     public async Task RefreshElementStatsAsync_PagesThroughTheJournal()
     {
         var fullPage = Enumerable.Range(0, 200).Select(i => DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: $"flow-{i}")).ToArray();
@@ -104,6 +104,45 @@ public class DiagramDesignerWrapperElementStatsTests
         Assert.Equal(200, journal.Calls[1].Skip);
         Assert.True(sink.ReceivedStats!["join"].Blocked);
         Assert.Equal(201, sink.ReceivedStats!.Count);
+    }
+
+    [Fact(DisplayName = "A backlog bigger than one refresh's page cap is folded a cap's worth at a time, continued on the next refresh")]
+    public async Task RefreshElementStatsAsync_BacklogLargerThanPageCap_IsFoldedAcrossRefreshes()
+    {
+        // Three full pages of 200 records each, plus a short page that ends the journal -- 650 total -- against a
+        // page cap of 2, so no single refresh fetches more than 2 pages (400 records) at once.
+        var fullPages = Enumerable.Range(0, 3)
+            .Select(p => new PagedListResponse<WorkflowExecutionLogRecord>
+            {
+                Items = Enumerable.Range(0, 200)
+                    .Select(i => DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: $"flow-{p}-{i}"))
+                    .ToArray()
+            });
+        var shortPage = new PagedListResponse<WorkflowExecutionLogRecord>
+        {
+            Items = Enumerable.Range(0, 50).Select(i => DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: $"flow-tail-{i}")).ToArray()
+        };
+        var journal = new RecordingWorkflowInstanceService([.. fullPages, shortPage]);
+        var sink = new RecordingSinkDesigner();
+        var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
+
+        typeof(DiagramDesignerWrapper)
+            .GetField("_elementStatsMaxPagesPerRefresh", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(wrapper, 2);
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(2, journal.Calls.Count);
+        Assert.Equal(0, journal.Calls[0].Skip);
+        Assert.Equal(200, journal.Calls[1].Skip);
+        Assert.Equal(400, sink.ReceivedStats!.Count);
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(4, journal.Calls.Count);
+        Assert.Equal(400, journal.Calls[2].Skip);
+        Assert.Equal(600, journal.Calls[3].Skip);
+        Assert.Equal(650, sink.ReceivedStats!.Count);
     }
 
     [Fact(DisplayName = "A second refresh after new records arrive requests only the new records, and folds them alongside the old ones")]

--- a/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
@@ -126,9 +126,7 @@ public class DiagramDesignerWrapperElementStatsTests
         var sink = new RecordingSinkDesigner();
         var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
 
-        typeof(DiagramDesignerWrapper)
-            .GetField("_elementStatsMaxPagesPerRefresh", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(wrapper, 2);
+        wrapper.ElementStatsMaxPagesPerRefresh = 2;
 
         await wrapper.RefreshElementStatsAsync();
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
@@ -1,0 +1,262 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.UI.Contexts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="DiagramDesignerWrapper.RefreshElementStatsAsync"/>: the element-keyed BPMN overlay's own
+/// refresh channel, alongside the existing activity-keyed <see cref="DiagramDesignerWrapper.UpdateActivityStatsAsync"/>
+/// one. Exercises the wrapper directly (constructed with <c>new</c>, its injected properties and private fields set
+/// through reflection) rather than through bUnit rendering, since none of what is under test here depends on the
+/// render pipeline.
+/// </summary>
+public class DiagramDesignerWrapperElementStatsTests
+{
+    [Fact(DisplayName = "Does nothing when there is no workflow instance to read from")]
+    public async Task RefreshElementStatsAsync_NoWorkflowInstanceId_DoesNotCallTheJournal()
+    {
+        var journal = new RecordingWorkflowInstanceService();
+        var wrapper = CreateWrapper(journal, new RecordingSinkDesigner(), workflowInstanceId: null);
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Empty(journal.Calls);
+    }
+
+    [Fact(DisplayName = "Does nothing when the current designer does not accept an element-keyed overlay")]
+    public async Task RefreshElementStatsAsync_DesignerIsNotASink_DoesNotCallTheJournal()
+    {
+        var journal = new RecordingWorkflowInstanceService();
+        var wrapper = CreateWrapper(journal, new NonSinkDesigner(), workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Empty(journal.Calls);
+    }
+
+    [Fact(DisplayName = "Does nothing when the workflow carries no Elsa.BpmnProcess scope at all")]
+    public async Task RefreshElementStatsAsync_NoBpmnProcessInTheGraph_DoesNotCallTheJournal()
+    {
+        var journal = new RecordingWorkflowInstanceService();
+        var wrapper = CreateWrapper(journal, new RecordingSinkDesigner(), workflowInstanceId: "instance-1", includeBpmnProcess: false);
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Empty(journal.Calls);
+    }
+
+    [Fact(DisplayName = "Filters the journal by every Elsa.BpmnProcess activity id in the whole graph, including a nested scope")]
+    public async Task RefreshElementStatsAsync_FiltersByEveryBpmnProcessActivityId()
+    {
+        var journal = new RecordingWorkflowInstanceService(
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [] });
+        var wrapper = CreateWrapper(journal, new RecordingSinkDesigner(), workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+
+        var call = Assert.Single(journal.Calls);
+        Assert.Equal(new[] { "bpmn-outer", "bpmn-inner" }, call.Filter?.ActivityIds);
+    }
+
+    [Fact(DisplayName = "Folds the fetched journal and pushes the result to the current designer's sink")]
+    public async Task RefreshElementStatsAsync_FoldsTheJournal_AndPushesItToTheSink()
+    {
+        var entry = DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join");
+        var journal = new RecordingWorkflowInstanceService(
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [entry] });
+        var sink = new RecordingSinkDesigner();
+        var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(1, sink.UpdateCallCount);
+        Assert.True(sink.ReceivedStats!["join"].Blocked);
+    }
+
+    [Fact(DisplayName = "Pages through the journal until a short page ends it, bounded by a hard page cap")]
+    public async Task RefreshElementStatsAsync_PagesThroughTheJournal()
+    {
+        var fullPage = Enumerable.Range(0, 200).Select(i => DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, flowId: $"flow-{i}")).ToArray();
+        var shortPage = new[] { DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join") };
+        var journal = new RecordingWorkflowInstanceService(
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = fullPage },
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = shortPage });
+        var sink = new RecordingSinkDesigner();
+        var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(2, journal.Calls.Count);
+        Assert.Equal(0, journal.Calls[0].Skip);
+        Assert.Equal(200, journal.Calls[1].Skip);
+        Assert.True(sink.ReceivedStats!["join"].Blocked);
+        Assert.Equal(201, sink.ReceivedStats!.Count);
+    }
+
+    private static WorkflowExecutionLogRecord DiagnosticEntry(string kind, string? elementId = null, string? flowId = null) => new(
+        Id: Guid.NewGuid().ToString(),
+        ActivityInstanceId: "instance-1",
+        ParentActivityInstanceId: null,
+        ActivityId: "bpmn-outer",
+        ActivityType: BpmnProcessConstants.ActivityTypeName,
+        ActivityTypeVersion: 1,
+        ActivityName: null,
+        NodeId: "bpmn-outer-node",
+        Timestamp: DateTimeOffset.UtcNow,
+        Sequence: 1,
+        EventName: kind,
+        Message: null,
+        Source: BpmnDiagnosticEventNames.Source,
+        ActivityState: null,
+        Payload: new BpmnDiagnosticLogPayload(Guid.NewGuid().ToString(), elementId, flowId, null, kind, new Dictionary<string, string>()));
+
+    /// <summary>
+    /// Constructs a bare <see cref="DiagramDesignerWrapper"/> with its private <c>WorkflowInstanceService</c> and
+    /// <c>_activityGraph</c>/<c>_diagramDesigner</c> fields set through reflection, mirroring the
+    /// <c>SetDesigner</c>-style helpers <c>WorkflowInstanceDesignerDisconnectRefreshTests</c> already uses for the
+    /// same reason: none of this depends on the component ever being rendered.
+    /// </summary>
+    private static DiagramDesignerWrapper CreateWrapper(
+        IWorkflowInstanceService journal,
+        IDiagramDesigner designer,
+        string? workflowInstanceId,
+        bool includeBpmnProcess = true)
+    {
+        var wrapper = new DiagramDesignerWrapper();
+
+        typeof(DiagramDesignerWrapper)
+            .GetProperty(nameof(DiagramDesignerWrapper.WorkflowInstanceId))!
+            .SetValue(wrapper, workflowInstanceId);
+
+        typeof(DiagramDesignerWrapper)
+            .GetProperty("WorkflowInstanceService", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(wrapper, journal);
+
+        typeof(DiagramDesignerWrapper)
+            .GetField("_diagramDesigner", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(wrapper, designer);
+
+        var graph = BuildActivityGraph(includeBpmnProcess);
+        typeof(DiagramDesignerWrapper)
+            .GetField("_activityGraph", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(wrapper, graph);
+
+        return wrapper;
+    }
+
+    private static ActivityGraph BuildActivityGraph(bool includeBpmnProcess)
+    {
+        var root = Activity("root", "Elsa.Flowchart");
+        var rootNode = new ActivityNode(root);
+
+        if (includeBpmnProcess)
+        {
+            var outer = Activity("bpmn-outer", BpmnProcessConstants.ActivityTypeName);
+            var inner = Activity("bpmn-inner", BpmnProcessConstants.ActivityTypeName);
+            var outerNode = new ActivityNode(outer);
+            var innerNode = new ActivityNode(inner);
+
+            outerNode.Children.Add(innerNode);
+            innerNode.Parents.Add(outerNode);
+            rootNode.Children.Add(outerNode);
+            outerNode.Parents.Add(rootNode);
+        }
+
+        var graph = new ActivityGraph(root, new FixedActivityVisitor(rootNode));
+        graph.IndexAsync().GetAwaiter().GetResult();
+        return graph;
+    }
+
+    private static JsonObject Activity(string id, string typeName) => new()
+    {
+        ["id"] = id,
+        ["nodeId"] = $"{id}-node",
+        ["type"] = typeName
+    };
+
+    private sealed class FixedActivityVisitor(ActivityNode root) : IActivityVisitor
+    {
+        public Task<ActivityNode> VisitAsync(JsonObject activity, CancellationToken cancellationToken = default) => Task.FromResult(root);
+    }
+
+    /// <summary>A diagram designer that accepts the element-keyed overlay and records what it was given.</summary>
+    private sealed class RecordingSinkDesigner : IDiagramDesigner, IBpmnElementStatsSink
+    {
+        public IReadOnlyDictionary<string, BpmnElementStats>? ReceivedStats { get; private set; }
+        public int UpdateCallCount { get; private set; }
+
+        public Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats)
+        {
+            ReceivedStats = elementStats;
+            UpdateCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap) => throw new NotSupportedException();
+        public Task UpdateActivityAsync(string id, JsonObject activity) => throw new NotSupportedException();
+        public Task UpdateActivityStatsAsync(string id, ActivityStats stats) => throw new NotSupportedException();
+        public Task SelectActivityAsync(string id) => throw new NotSupportedException();
+        public Task<JsonObject> ReadRootActivityAsync() => throw new NotSupportedException();
+        public RenderFragment DisplayDesigner(DisplayContext context) => throw new NotSupportedException();
+    }
+
+    /// <summary>An ordinary diagram designer -- a flowchart's, say -- that does not accept an element-keyed overlay.</summary>
+    private sealed class NonSinkDesigner : IDiagramDesigner
+    {
+        public Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap) => throw new NotSupportedException();
+        public Task UpdateActivityAsync(string id, JsonObject activity) => throw new NotSupportedException();
+        public Task UpdateActivityStatsAsync(string id, ActivityStats stats) => throw new NotSupportedException();
+        public Task SelectActivityAsync(string id) => throw new NotSupportedException();
+        public Task<JsonObject> ReadRootActivityAsync() => throw new NotSupportedException();
+        public RenderFragment DisplayDesigner(DisplayContext context) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingWorkflowInstanceService : IWorkflowInstanceService
+    {
+        private readonly Queue<PagedListResponse<WorkflowExecutionLogRecord>> _pages;
+
+        public RecordingWorkflowInstanceService(params PagedListResponse<WorkflowExecutionLogRecord>[] pages) => _pages = new(pages);
+
+        public List<(JournalFilter? Filter, int? Skip, int? Take)> Calls { get; } = [];
+
+        public Task<PagedListResponse<WorkflowExecutionLogRecord>> GetJournalAsync(
+            string instanceId,
+            JournalFilter? filter = null,
+            int? skip = null,
+            int? take = null,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add((filter, skip, take));
+
+            var page = _pages.Count > 0
+                ? _pages.Dequeue()
+                : new PagedListResponse<WorkflowExecutionLogRecord> { Items = [] };
+
+            return Task.FromResult(page);
+        }
+
+        public Task<PagedListResponse<WorkflowInstanceSummary>> ListAsync(ListWorkflowInstancesRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task BulkDeleteAsync(IEnumerable<string> instanceIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task CancelAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task BulkCancelAsync(BulkCancelWorkflowInstancesRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowInstance?> GetAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> BulkExportAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> BulkImportAsync(IEnumerable<StreamPart> streamParts, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<ResolvedVariable>> GetVariablesAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperElementStatsTests.cs
@@ -106,6 +106,52 @@ public class DiagramDesignerWrapperElementStatsTests
         Assert.Equal(201, sink.ReceivedStats!.Count);
     }
 
+    [Fact(DisplayName = "A second refresh after new records arrive requests only the new records, and folds them alongside the old ones")]
+    public async Task RefreshElementStatsAsync_SecondRefreshWithNewRecords_RequestsOnlyTheNewRecordsAndFoldsBoth()
+    {
+        var firstEntry = DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join");
+        var secondEntry = DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, elementId: "task");
+        var journal = new RecordingWorkflowInstanceService(
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [firstEntry] },
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [secondEntry] });
+        var sink = new RecordingSinkDesigner();
+        var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(2, journal.Calls.Count);
+        Assert.Equal(0, journal.Calls[0].Skip);
+        Assert.Equal(1, journal.Calls[1].Skip);
+        Assert.True(sink.ReceivedStats!["join"].Blocked);
+        Assert.Equal(1, sink.ReceivedStats!["task"].Started);
+    }
+
+    [Fact(DisplayName = "A refresh after the displayed instance changes starts over, rather than carrying over the previous instance's high-water mark or stats")]
+    public async Task RefreshElementStatsAsync_InstanceChanges_StartsOver()
+    {
+        var firstInstanceEntry = DiagnosticEntry(BpmnDiagnosticEventNames.Waiting, elementId: "join");
+        var secondInstanceEntry = DiagnosticEntry(BpmnDiagnosticEventNames.TokenEmitted, elementId: "task");
+        var journal = new RecordingWorkflowInstanceService(
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [firstInstanceEntry] },
+            new PagedListResponse<WorkflowExecutionLogRecord> { Items = [secondInstanceEntry] });
+        var sink = new RecordingSinkDesigner();
+        var wrapper = CreateWrapper(journal, sink, workflowInstanceId: "instance-1");
+
+        await wrapper.RefreshElementStatsAsync();
+
+        typeof(DiagramDesignerWrapper)
+            .GetProperty(nameof(DiagramDesignerWrapper.WorkflowInstanceId))!
+            .SetValue(wrapper, "instance-2");
+        await wrapper.RefreshElementStatsAsync();
+
+        Assert.Equal(2, journal.Calls.Count);
+        Assert.Equal(0, journal.Calls[0].Skip);
+        Assert.Equal(0, journal.Calls[1].Skip);
+        Assert.DoesNotContain("join", sink.ReceivedStats!.Keys);
+        Assert.Equal(1, sink.ReceivedStats!["task"].Started);
+    }
+
     private static WorkflowExecutionLogRecord DiagnosticEntry(string kind, string? elementId = null, string? flowId = null) => new(
         Id: Guid.NewGuid().ToString(),
         ActivityInstanceId: "instance-1",

--- a/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperFinishedInstanceElementStatsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/DiagramDesignerWrapperFinishedInstanceElementStatsTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Resources.Resilience.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.DomInterop.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Elsa.Studio.Workflows.Shared.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Refit;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the case the mount race hid completely: a <b>finished</b> workflow instance never gets a
+/// <see cref="Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components.WorkflowInstanceDesigner"/>-driven
+/// observer tick (<c>UpdateObserverAsync</c> only creates one while the instance is running), so the one
+/// unconditional refresh <see cref="DiagramDesignerWrapper"/> already performs on load -- before it has ever
+/// rendered its <see cref="BpmnDesignerWrapper"/> -- is the only chance the overlay ever gets to reach the canvas.
+/// </summary>
+public sealed class DiagramDesignerWrapperFinishedInstanceElementStatsTests : BunitContext, IAsyncLifetime
+{
+    private const string ElementId = "join";
+
+    public DiagramDesignerWrapperFinishedInstanceElementStatsTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddRemoteBackend();
+        Services.AddWorkflowsModule();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, TestActivityRegistry>();
+        Services.AddSingleton<IDomAccessor, NoOpDomAccessor>();
+        Services.AddSingleton<IActivityExecutionService>(new StubActivityExecutionService());
+        Services.AddSingleton<IWorkflowInstanceService>(new StubWorkflowInstanceService(JournalEntry()));
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void OpeningAFinishedInstance_RefreshesTheElementOverlayExactlyOnce_WithNoObserverTicksAtAll()
+    {
+        var handler = JSInterop.SetupVoid("updateBpmnElementStats", _ => true);
+        var root = CreateBpmnRoot();
+
+        Render<MudPopoverProvider>();
+        Render<DiagramDesignerWrapper>(parameters => parameters
+            .Add(x => x.WorkflowDefinitionVersionId, "version-1")
+            .Add(x => x.Activity, root)
+            .Add(x => x.WorkflowDefinition, CreateDefinition(root))
+            .Add(x => x.WorkflowInstanceId, "instance-1"));
+
+        var invocation = Assert.Single(handler.Invocations);
+        var appliedStats = Assert.IsType<Dictionary<string, BpmnElementStats>>(invocation.Arguments[1]);
+        Assert.True(appliedStats[ElementId].Blocked);
+    }
+
+    private static WorkflowExecutionLogRecord JournalEntry() => new(
+        Id: Guid.NewGuid().ToString(),
+        ActivityInstanceId: "instance-1",
+        ParentActivityInstanceId: null,
+        ActivityId: "order-process",
+        ActivityType: BpmnProcessConstants.ActivityTypeName,
+        ActivityTypeVersion: 1,
+        ActivityName: null,
+        NodeId: "Workflow1:order-process",
+        Timestamp: DateTimeOffset.UtcNow,
+        Sequence: 1,
+        EventName: BpmnDiagnosticEventNames.Waiting,
+        Message: null,
+        Source: BpmnDiagnosticEventNames.Source,
+        ActivityState: null,
+        Payload: new BpmnDiagnosticLogPayload(Guid.NewGuid().ToString(), ElementId, null, null, BpmnDiagnosticEventNames.Waiting, new Dictionary<string, string>()));
+
+    private static JsonObject CreateBpmnRoot() => new()
+    {
+        ["id"] = "order-process",
+        ["nodeId"] = "Workflow1:order-process",
+        ["name"] = "Order Process",
+        ["type"] = BpmnProcessConstants.ActivityTypeName,
+        ["version"] = 1,
+        ["customProperties"] = new JsonObject { ["canStartWorkflow"] = true },
+        ["process"] = new JsonObject
+        {
+            ["processId"] = "order-process",
+            ["name"] = "Order Process",
+            ["isExecutable"] = true,
+            ["elements"] = new JsonArray
+            {
+                new JsonObject { ["elementId"] = "StartEvent_1", ["elementType"] = "startEvent" },
+                new JsonObject { ["elementId"] = ElementId, ["elementType"] = "parallelGateway" },
+                new JsonObject { ["elementId"] = "EndEvent_1", ["elementType"] = "endEvent" }
+            },
+            ["sequenceFlows"] = new JsonArray()
+        },
+        ["workBindings"] = new JsonObject(),
+        ["activities"] = new JsonArray()
+    };
+
+    private static WorkflowDefinition CreateDefinition(JsonObject root) => new()
+    {
+        Id = "version-1",
+        DefinitionId = "definition-1",
+        Name = "Order Process",
+        Root = root
+    };
+
+    private sealed class StubActivityExecutionService : IActivityExecutionService
+    {
+        public Task<ActivityExecutionReport> GetReportAsync(string workflowInstanceId, JsonObject containerActivity, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ActivityExecutionReport([]));
+
+        public Task<IEnumerable<ActivityExecutionRecord>> ListAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<PagedListResponse<RetryAttemptRecord>> GetRetriesAsync(string activityInstanceId, int? skip = null, int? take = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class StubWorkflowInstanceService(params WorkflowExecutionLogRecord[] entries) : IWorkflowInstanceService
+    {
+        public Task<PagedListResponse<WorkflowExecutionLogRecord>> GetJournalAsync(
+            string instanceId,
+            JournalFilter? filter = null,
+            int? skip = null,
+            int? take = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new PagedListResponse<WorkflowExecutionLogRecord> { Items = skip is null or 0 ? entries : [] });
+
+        public Task<PagedListResponse<WorkflowInstanceSummary>> ListAsync(ListWorkflowInstancesRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task BulkDeleteAsync(IEnumerable<string> instanceIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task CancelAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task BulkCancelAsync(BulkCancelWorkflowInstancesRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowInstance?> GetAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportAsync(string id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> BulkExportAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> BulkImportAsync(IEnumerable<Refit.StreamPart> streamParts, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<ResolvedVariable>> GetVariablesAsync(string instanceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class TestActivityRegistry : IActivityRegistry
+    {
+        private readonly IReadOnlyDictionary<string, ActivityDescriptor> _descriptors = new Dictionary<string, ActivityDescriptor>
+        {
+            [BpmnProcessConstants.ActivityTypeName] = new()
+            {
+                TypeName = BpmnProcessConstants.ActivityTypeName,
+                Name = BpmnProcessConstants.ActivityTypeName,
+                DisplayName = "BPMN Process",
+                Version = 1,
+                IsBrowsable = true,
+                IsContainer = true
+            }
+        };
+
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => _descriptors.Values;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => _descriptors.GetValueOrDefault(activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => _descriptors.TryGetValue(activityType, out var descriptor) ? [descriptor] : [];
+
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class NoOpDomAccessor : IDomAccessor
+    {
+        public Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(new DomRect());
+        public Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(0d);
+        public Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerElementStatsRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerElementStatsRefreshTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.RealTime.Messages;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Enums;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+using Elsa.Studio.Workflows.Contracts;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.UI.Contexts;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers that <see cref="WorkflowInstanceDesigner"/> refreshes the element-keyed BPMN overlay
+/// (<see cref="DiagramDesignerWrapper.RefreshElementStatsAsync"/>) on the very same event that already refreshes
+/// the activity-keyed one -- <see cref="IWorkflowInstanceObserver.ActivityExecutionLogUpdated"/> -- so a gateway or
+/// a sequence flow, which never appears in that message's own <c>Stats</c>, is refreshed on the same cadence.
+/// </summary>
+/// <remarks>
+/// The refresh added here rides the very same event subscription <c>WorkflowInstanceDesignerDisconnectRefreshTests</c>
+/// already proves is detached on disposal (the #992 guarantee): it is not a new timer with a disposal race of its
+/// own to pin, so this file's own coverage is limited to proving the new call is actually wired into that handler.
+/// </remarks>
+public sealed class WorkflowInstanceDesignerElementStatsRefreshTests : BunitContext, IAsyncLifetime
+{
+    public WorkflowInstanceDesignerElementStatsRefreshTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton<ILocalizer>(new TestLocalizer());
+        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub());
+        Services.AddSingleton(DispatchProxy.Create<IDiagramDesignerService, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IDomAccessor, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IActivityVisitor, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowInstanceObserverFactory, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowInstanceService, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IWorkflowDefinitionService, ThrowingProxy>());
+        Services.AddSingleton(DispatchProxy.Create<IActivityExecutionService, ThrowingProxy>());
+        Services.AddSingleton<IRemoteFeatureProvider>(new RemoteFeatureProviderStub());
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task OnActivityExecutionLogUpdated_RefreshesTheElementKeyedOverlay()
+    {
+        var cut = RenderDesigner();
+        var designer = new RecordingDiagramDesignerWrapper();
+        SetDesigner(cut.Instance, designer);
+
+        await InvokeOnActivityExecutionLogUpdated(cut.Instance, new ActivityExecutionLogUpdatedMessage([]));
+
+        Assert.Equal(1, designer.RefreshElementStatsCallCount);
+    }
+
+    [Fact]
+    public async Task OnActivityExecutionLogUpdated_RefreshesTheElementKeyedOverlay_AlongsideActivityStats()
+    {
+        // Both the pre-existing activity-keyed stats and the new element-keyed overlay are refreshed from the
+        // one message: the point of D1 is that a gateway or a flow, which never appears in message.Stats, is
+        // still covered by something driven from the very same journal update.
+        var stats = new ActivityExecutionStats { ActivityId = "activity-1", ActivityNodeId = "node-1" };
+        var cut = RenderDesigner();
+        var designer = new RecordingDiagramDesignerWrapper();
+        var innerDesigner = new RecordingActivityStatsDesigner();
+        SetDesigner(cut.Instance, designer);
+        SetInnerDiagramDesigner(designer, innerDesigner);
+
+        await InvokeOnActivityExecutionLogUpdated(cut.Instance, new ActivityExecutionLogUpdatedMessage([stats]));
+
+        Assert.Equal(1, innerDesigner.UpdateActivityStatsCallCount);
+        Assert.Equal(1, designer.RefreshElementStatsCallCount);
+    }
+
+    private IRenderedComponent<TestWorkflowInstanceDesigner> RenderDesigner()
+    {
+        var workflowInstance = new WorkflowInstance
+        {
+            Id = "instance-1",
+            DefinitionId = "definition-1",
+            Status = WorkflowStatus.Finished
+        };
+
+        return Render<TestWorkflowInstanceDesigner>(parameters => parameters
+            .Add(x => x.WorkflowInstance, workflowInstance));
+    }
+
+    /// <summary>
+    /// A <see cref="WorkflowInstanceDesigner"/> that skips its own markup and first-render setup, exactly like
+    /// <c>WorkflowInstanceDesignerDisconnectRefreshTests.TestWorkflowInstanceDesigner</c>: nothing under test here
+    /// depends on the real render tree, and rendering it for real would pull in dependencies (Radzen's splitter,
+    /// MudBlazor's tabs) this test has no reason to stub.
+    /// </summary>
+    private sealed class TestWorkflowInstanceDesigner : WorkflowInstanceDesigner
+    {
+        protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private static Task InvokeOnActivityExecutionLogUpdated(WorkflowInstanceDesigner instance, ActivityExecutionLogUpdatedMessage message)
+    {
+        var method = typeof(WorkflowInstanceDesigner).GetMethod("OnActivityExecutionLogUpdated", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(instance, [message])!;
+    }
+
+    /// <summary>
+    /// Attaches a bare <see cref="DiagramDesignerWrapper"/> subclass to <c>_designer</c>, mirroring
+    /// <c>WorkflowInstanceDesignerDisconnectRefreshTests.SetDesigner</c>.
+    /// </summary>
+    private static void SetDesigner(WorkflowInstanceDesigner instance, DiagramDesignerWrapper designer)
+    {
+        var field = typeof(WorkflowInstanceDesigner).GetField("_designer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(instance, designer);
+    }
+
+    /// <summary>Attaches a fake <see cref="IDiagramDesigner"/> to a wrapper's own private <c>_diagramDesigner</c> field.</summary>
+    private static void SetInnerDiagramDesigner(DiagramDesignerWrapper wrapper, IDiagramDesigner innerDesigner)
+    {
+        var field = typeof(DiagramDesignerWrapper).GetField("_diagramDesigner", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(wrapper, innerDesigner);
+    }
+
+    /// <summary>A <see cref="DiagramDesignerWrapper"/> whose element-stats refresh is counted instead of run for real.</summary>
+    private sealed class RecordingDiagramDesignerWrapper : DiagramDesignerWrapper
+    {
+        public int RefreshElementStatsCallCount { get; private set; }
+
+        public override Task RefreshElementStatsAsync()
+        {
+            RefreshElementStatsCallCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>The fake <see cref="IDiagramDesigner"/> a <see cref="DiagramDesignerWrapper"/> forwards to; records
+    /// activity-stats updates so the test can prove both overlays are refreshed from the one message.</summary>
+    private sealed class RecordingActivityStatsDesigner : IDiagramDesigner
+    {
+        public int UpdateActivityStatsCallCount { get; private set; }
+
+        public Task UpdateActivityStatsAsync(string id, ActivityStats stats)
+        {
+            UpdateActivityStatsCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap) => throw new NotSupportedException();
+        public Task UpdateActivityAsync(string id, JsonObject activity) => throw new NotSupportedException();
+        public Task SelectActivityAsync(string id) => throw new NotSupportedException();
+        public Task<JsonObject> ReadRootActivityAsync() => throw new NotSupportedException();
+        public RenderFragment DisplayDesigner(DisplayContext context) => throw new NotSupportedException();
+    }
+
+    private sealed class RemoteFeatureProviderStub : IRemoteFeatureProvider
+    {
+        public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<IEnumerable<Elsa.Api.Client.Resources.Features.Models.FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class ActivityRegistryStub : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor> List() => throw new NotSupportedException();
+        public Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor? Find(string activityType, int? version = null) => throw new NotSupportedException();
+        public IEnumerable<Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor> FindAll(string activityType) => throw new NotSupportedException();
+        public void MarkStale() => throw new NotSupportedException();
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    /// <summary>A <see cref="DispatchProxy"/> that throws for every call, for services this test never exercises.</summary>
+    private class ThrowingProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Unexpected call to {targetMethod!.DeclaringType!.Name}.{targetMethod.Name}.");
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerElementStatsRefreshTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowInstanceDesignerElementStatsRefreshTests.cs
@@ -141,7 +141,7 @@ public sealed class WorkflowInstanceDesignerElementStatsRefreshTests : BunitCont
     {
         public int RefreshElementStatsCallCount { get; private set; }
 
-        public override Task RefreshElementStatsAsync()
+        internal override Task RefreshElementStatsAsync()
         {
             RefreshElementStatsCallCount++;
             return Task.CompletedTask;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/WorkflowInstanceDesigner.razor.cs
@@ -290,6 +290,11 @@ public partial class WorkflowInstanceDesigner : IAsyncDisposable
             await _designer.UpdateActivityStatsAsync(activityId, Map(stats));
         }
 
+        // Refreshed on the same cadence as the activity-keyed stats above: a gateway, an intermediate event or a
+        // sequence flow has no activity id of its own, so it never appears in message.Stats, but the journal update
+        // that produced this message is exactly what its own BPMN diagnostics ride along on.
+        await _designer.RefreshElementStatsAsync();
+
         await InvokeAsync(StateHasChanged);
 
         // If we received an update for the selected activity, refresh the activity details.

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -48,6 +48,14 @@ public partial class BpmnDesignerWrapper
     private bool UseReactFlow => DesignerOptions.Value.UseReactFlow;
 
     /// <summary>
+    /// The latest element-keyed instance overlay handed to <see cref="UpdateElementStatsAsync"/>, retained so it
+    /// can be applied on <see cref="Designer"/> as soon as it exists (see <see cref="OnAfterRenderAsync"/>). Mirrors
+    /// <c>BpmnDiagramDesigner._pendingElementStats</c> one level up, since <see cref="Designer"/> can still be null
+    /// when a call arrives just after this wrapper itself has mounted.
+    /// </summary>
+    private IReadOnlyDictionary<string, BpmnElementStats>? _pendingElementStats;
+
+    /// <summary>
     /// Whether the scope being displayed has nothing to draw: no <c>process</c> payload at all, or one that declares
     /// no elements. That is what a <c>BpmnProcess</c> added from the toolbox looks like, and what a scope whose
     /// import produced nothing looks like.
@@ -100,8 +108,21 @@ public partial class BpmnDesignerWrapper
     /// </summary>
     public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats)
     {
+        _pendingElementStats = elementStats;
+
         if (Designer != null)
             await Designer.UpdateElementStatsAsync(elementStats);
+    }
+
+    /// <summary>
+    /// Applies a retained element-stats overlay that arrived before <see cref="Designer"/> existed, the moment it
+    /// does -- the same "drain pending work on first render" shape <see cref="Designer"/> itself uses for its own
+    /// initial <c>LoadBpmnAsync</c> call.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && Designer != null && _pendingElementStats != null)
+            await Designer.UpdateElementStatsAsync(_pendingElementStats);
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -115,6 +115,17 @@ public partial class BpmnDesignerWrapper
     }
 
     /// <summary>
+    /// Synchronously stakes the latest element-stats overlay for <see cref="OnAfterRenderAsync"/> to flush once
+    /// <see cref="Designer"/> exists, without going through <see cref="UpdateElementStatsAsync"/>'s async call.
+    /// </summary>
+    /// <remarks>
+    /// This is what lets <see cref="BpmnDiagramDesigner"/> hand a retained overlay to this wrapper the moment it is
+    /// captured -- from inside a synchronous component-reference-capture callback, where starting and discarding an
+    /// async call would swallow any exception it threw.
+    /// </remarks>
+    internal void SetPendingElementStats(IReadOnlyDictionary<string, BpmnElementStats> elementStats) => _pendingElementStats = elementStats;
+
+    /// <summary>
     /// Applies a retained element-stats overlay that arrived before <see cref="Designer"/> existed, the moment it
     /// does -- the same "drain pending work on first render" shape <see cref="Designer"/> itself uses for its own
     /// initial <c>LoadBpmnAsync</c> call.

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Elsa.Studio.Workflows.Designer.Components;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
 
@@ -92,6 +93,15 @@ public partial class BpmnDesignerWrapper
     {
         if (Designer != null)
             await Designer.UpdateActivityStatsAsync(id, stats);
+    }
+
+    /// <summary>
+    /// Updates the element-keyed instance overlay (gateways, events and sequence flows).
+    /// </summary>
+    public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats)
+    {
+        if (Designer != null)
+            await Designer.UpdateElementStatsAsync(elementStats);
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -41,6 +41,20 @@ public class BpmnDiagramDesigner(
     private string? _sourceXml;
     private WorkflowDefinition? _workflowDefinition;
 
+    /// <summary>
+    /// The latest element-keyed instance overlay handed to <see cref="UpdateElementStatsAsync"/>, retained so it
+    /// can be forwarded to <see cref="_designerWrapper"/> as soon as it mounts.
+    /// </summary>
+    /// <remarks>
+    /// A refresh can arrive before the canvas exists -- most notably the one unconditional refresh a freshly
+    /// opened instance gets on load (see <c>DiagramDesignerWrapper.LoadActivityCoreAsync</c>), which runs during
+    /// <c>OnInitializedAsync</c>, well before this designer's own <see cref="BpmnDesignerWrapper"/> has been
+    /// created. Dropping that refresh instead of retaining it would mean a finished instance -- one that never
+    /// gets a later observer-driven refresh to fall back on -- never gets its overlay at all. Only the latest
+    /// value is kept, matching the semantics <see cref="UpdateElementStatsAsync"/> already documents.
+    /// </remarks>
+    private IReadOnlyDictionary<string, BpmnElementStats>? _pendingElementStats;
+
     /// <inheritdoc />
     public async Task LoadRootActivityAsync(JsonObject activity, IDictionary<string, ActivityStats>? activityStatsMap)
     {
@@ -81,6 +95,7 @@ public class BpmnDiagramDesigner(
     /// <inheritdoc />
     public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats)
     {
+        _pendingElementStats = elementStats;
         await InvokeDesignerActionAsync(x => x.UpdateElementStatsAsync(elementStats));
     }
 
@@ -112,7 +127,18 @@ public class BpmnDiagramDesigner(
             builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivityStats), context.ActivityStats);
             builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivitySelected), context.ActivitySelectedCallback);
             builder.AddAttribute(sequence++, nameof(BpmnDesignerWrapper.ActivityDoubleClick), context.ActivityDoubleClickCallback);
-            builder.AddComponentReferenceCapture(sequence++, @ref => _designerWrapper = (BpmnDesignerWrapper)@ref);
+            builder.AddComponentReferenceCapture(sequence++, @ref =>
+            {
+                var isFirstMount = _designerWrapper == null;
+                _designerWrapper = (BpmnDesignerWrapper)@ref;
+
+                // Hand off the latest retained overlay the moment the wrapper exists, rather than only on the
+                // next explicit UpdateElementStatsAsync call, which -- for a finished instance -- may never come
+                // (see the remarks on _pendingElementStats). BpmnDesignerWrapper retains and re-applies it again
+                // in turn if its own canvas is not ready yet either.
+                if (isFirstMount && _pendingElementStats != null)
+                    _ = _designerWrapper.UpdateElementStatsAsync(_pendingElementStats);
+            });
 
             builder.CloseComponent();
         };

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -42,8 +42,9 @@ public class BpmnDiagramDesigner(
     private WorkflowDefinition? _workflowDefinition;
 
     /// <summary>
-    /// The latest element-keyed instance overlay handed to <see cref="UpdateElementStatsAsync"/>, retained so it
-    /// can be forwarded to <see cref="_designerWrapper"/> as soon as it mounts.
+    /// The latest element-keyed instance overlay handed to <see cref="UpdateElementStatsAsync"/>, held only until
+    /// <see cref="_designerWrapper"/> is captured -- from that point on, <see cref="BpmnDesignerWrapper"/> is the
+    /// one that retains and flushes it (see <see cref="BpmnDesignerWrapper.SetPendingElementStats"/>).
     /// </summary>
     /// <remarks>
     /// A refresh can arrive before the canvas exists -- most notably the one unconditional refresh a freshly
@@ -134,10 +135,12 @@ public class BpmnDiagramDesigner(
 
                 // Hand off the latest retained overlay the moment the wrapper exists, rather than only on the
                 // next explicit UpdateElementStatsAsync call, which -- for a finished instance -- may never come
-                // (see the remarks on _pendingElementStats). BpmnDesignerWrapper retains and re-applies it again
-                // in turn if its own canvas is not ready yet either.
+                // (see the remarks on _pendingElementStats). This is a synchronous field assignment, not an async
+                // call: this callback is itself synchronous, so starting and discarding a task here would swallow
+                // any exception it threw. BpmnDesignerWrapper's own awaited first-render flush is what actually
+                // delivers the value once its canvas is ready.
                 if (isFirstMount && _pendingElementStats != null)
-                    _ = _designerWrapper.UpdateElementStatsAsync(_pendingElementStats);
+                    _designerWrapper.SetPendingElementStats(_pendingElementStats);
             });
 
             builder.CloseComponent();

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -28,7 +28,7 @@ public class BpmnDiagramDesigner(
     IDialogService dialogService,
     IBpmnInterchangeService bpmnInterchangeService,
     IFiles files,
-    IUserMessageService userMessageService) : IDiagramDesignerToolboxProvider
+    IUserMessageService userMessageService) : IDiagramDesignerToolboxProvider, IBpmnElementStatsSink
 {
     /// <summary>
     /// The custom property key elsa-core stores the imported BPMN document's source XML under.
@@ -76,6 +76,12 @@ public class BpmnDiagramDesigner(
     public async Task SelectActivityAsync(string id)
     {
         await InvokeDesignerActionAsync(x => x.SelectActivityAsync(id));
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateElementStatsAsync(IReadOnlyDictionary<string, BpmnElementStats> elementStats)
+    {
+        await InvokeDesignerActionAsync(x => x.UpdateElementStatsAsync(elementStats));
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -36,8 +36,10 @@ public partial class DiagramDesignerWrapper
     private List<BreadcrumbItem> _breadcrumbItems = new();
     private IDictionary<string, ActivityStats> _activityStats =
         new Dictionary<string, ActivityStats>();
-    private IReadOnlyDictionary<string, BpmnElementStats> _elementStats =
-        new Dictionary<string, BpmnElementStats>();
+    private readonly Dictionary<string, BpmnElementStats> _elementStats = new();
+    private string? _elementStatsInstanceId;
+    private HashSet<string> _elementStatsBpmnProcessActivityIds = new();
+    private int _elementStatsHighWaterMark;
     private ActivityGraph _activityGraph = null!;
     private IDictionary<string, ActivityNode> _indexedActivityNodes =
         new Dictionary<string, ActivityNode>();
@@ -226,13 +228,13 @@ public partial class DiagramDesignerWrapper
     /// <see cref="Components.WorkflowInstanceViewer.Components.WorkflowInstanceDesigner"/> already refreshes
     /// <see cref="ActivityStats"/> on, so the two overlays stay in step.
     /// </remarks>
-    public virtual async Task RefreshElementStatsAsync()
+    internal virtual async Task RefreshElementStatsAsync()
     {
         if (WorkflowInstanceId == null || _diagramDesigner is not IBpmnElementStatsSink sink)
             return;
 
-        _elementStats = await FetchElementStatsAsync(WorkflowInstanceId);
-        await sink.UpdateElementStatsAsync(_elementStats);
+        var elementStats = await FetchElementStatsAsync(WorkflowInstanceId);
+        await sink.UpdateElementStatsAsync(elementStats);
     }
 
     /// <summary>
@@ -241,6 +243,17 @@ public partial class DiagramDesignerWrapper
     /// scope's own activity, and BPMN element and flow ids are unique across the whole document), and folds them
     /// into an element-keyed stats map.
     /// </summary>
+    /// <remarks>
+    /// Incremental: <see cref="_elementStatsHighWaterMark"/> is the number of matching journal records already
+    /// folded into <see cref="_elementStats"/>, so a tick only ever fetches the records that arrived since the
+    /// previous one, rather than re-fetching and re-folding the whole journal from the start every time. This is
+    /// only safe because the journal is append-only in the order the API returns it (see the <c>Sequence</c> on
+    /// <see cref="WorkflowExecutionLogRecord"/>): the high-water mark is a plain count of already-folded records,
+    /// not an id or timestamp, because <see cref="JournalFilter"/> has no way to filter by either. The map and
+    /// mark are reset whenever the displayed instance or the set of <c>Elsa.BpmnProcess</c> scope activity ids
+    /// changes, since a high-water mark from a different instance or a different filter has nothing to do with
+    /// the one about to be fetched.
+    /// </remarks>
     private async Task<IReadOnlyDictionary<string, BpmnElementStats>> FetchElementStatsAsync(string workflowInstanceId)
     {
         var bpmnProcessActivityIds = GetBpmnProcessActivityIds();
@@ -248,24 +261,34 @@ public partial class DiagramDesignerWrapper
         if (bpmnProcessActivityIds.Count == 0)
             return _elementStats;
 
+        if (workflowInstanceId != _elementStatsInstanceId
+            || !_elementStatsBpmnProcessActivityIds.SetEquals(bpmnProcessActivityIds))
+        {
+            _elementStats.Clear();
+            _elementStatsHighWaterMark = 0;
+            _elementStatsInstanceId = workflowInstanceId;
+            _elementStatsBpmnProcessActivityIds = new HashSet<string>(bpmnProcessActivityIds);
+        }
+
         var filter = new JournalFilter { ActivityIds = bpmnProcessActivityIds };
         var entries = new List<WorkflowExecutionLogRecord>();
         const int pageSize = 200;
-        const int maxPages = 50; // Bounded: at most 10,000 entries per refresh, regardless of instance size.
-        var skip = 0;
+        var skip = _elementStatsHighWaterMark;
 
-        for (var page = 0; page < maxPages; page++)
+        while (true)
         {
             var response = await WorkflowInstanceService.GetJournalAsync(workflowInstanceId, filter, skip, pageSize);
             entries.AddRange(response.Items);
+            skip += response.Items.Count;
 
             if (response.Items.Count < pageSize)
                 break;
-
-            skip += pageSize;
         }
 
-        return BpmnElementStatsProjector.Project(entries);
+        _elementStatsHighWaterMark = skip;
+        BpmnElementStatsProjector.Fold(entries, _elementStats);
+
+        return _elementStats;
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -1,12 +1,15 @@
 using System.Text.Json.Nodes;
 using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Workflows.Domain.Contexts;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Extensions;
 using Elsa.Studio.Workflows.DiagramDesigners;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.Models;
 using Elsa.Studio.Workflows.Shared.Args;
@@ -33,6 +36,8 @@ public partial class DiagramDesignerWrapper
     private List<BreadcrumbItem> _breadcrumbItems = new();
     private IDictionary<string, ActivityStats> _activityStats =
         new Dictionary<string, ActivityStats>();
+    private IReadOnlyDictionary<string, BpmnElementStats> _elementStats =
+        new Dictionary<string, BpmnElementStats>();
     private ActivityGraph _activityGraph = null!;
     private IDictionary<string, ActivityNode> _indexedActivityNodes =
         new Dictionary<string, ActivityNode>();
@@ -115,6 +120,9 @@ public partial class DiagramDesignerWrapper
 
     [Inject]
     private IWorkflowDefinitionService WorkflowDefinitionService { get; set; } = null!;
+
+    [Inject]
+    private IWorkflowInstanceService WorkflowInstanceService { get; set; } = null!;
 
     [Inject]
     private ISnackbar Snackbar { get; set; } = null!;
@@ -206,6 +214,69 @@ public partial class DiagramDesignerWrapper
     {
         await _diagramDesigner!.UpdateActivityStatsAsync(activityId, stats);
     }
+
+    /// <summary>
+    /// Refreshes the element-keyed BPMN instance overlay (gateways, events and sequence flows -- anything without
+    /// an Elsa activity id) from the workflow instance's journal, and pushes it to the current diagram designer.
+    /// </summary>
+    /// <remarks>
+    /// A no-op when there is no workflow instance to read from, or the current designer does not accept an
+    /// element-keyed overlay (<see cref="IBpmnElementStatsSink"/>) -- fetching and folding the journal for a
+    /// flowchart or state machine instance would be wasted work. Called on the same cadence
+    /// <see cref="Components.WorkflowInstanceViewer.Components.WorkflowInstanceDesigner"/> already refreshes
+    /// <see cref="ActivityStats"/> on, so the two overlays stay in step.
+    /// </remarks>
+    public virtual async Task RefreshElementStatsAsync()
+    {
+        if (WorkflowInstanceId == null || _diagramDesigner is not IBpmnElementStatsSink sink)
+            return;
+
+        _elementStats = await FetchElementStatsAsync(WorkflowInstanceId);
+        await sink.UpdateElementStatsAsync(_elementStats);
+    }
+
+    /// <summary>
+    /// Reads the BPMN diagnostics projected onto the journal of every <c>Elsa.BpmnProcess</c> scope anywhere in
+    /// the workflow (not merely the currently displayed container: a nested scope's diagnostics land on that
+    /// scope's own activity, and BPMN element and flow ids are unique across the whole document), and folds them
+    /// into an element-keyed stats map.
+    /// </summary>
+    private async Task<IReadOnlyDictionary<string, BpmnElementStats>> FetchElementStatsAsync(string workflowInstanceId)
+    {
+        var bpmnProcessActivityIds = GetBpmnProcessActivityIds();
+
+        if (bpmnProcessActivityIds.Count == 0)
+            return _elementStats;
+
+        var filter = new JournalFilter { ActivityIds = bpmnProcessActivityIds };
+        var entries = new List<WorkflowExecutionLogRecord>();
+        const int pageSize = 200;
+        const int maxPages = 50; // Bounded: at most 10,000 entries per refresh, regardless of instance size.
+        var skip = 0;
+
+        for (var page = 0; page < maxPages; page++)
+        {
+            var response = await WorkflowInstanceService.GetJournalAsync(workflowInstanceId, filter, skip, pageSize);
+            entries.AddRange(response.Items);
+
+            if (response.Items.Count < pageSize)
+                break;
+
+            skip += pageSize;
+        }
+
+        return BpmnElementStatsProjector.Project(entries);
+    }
+
+    /// <summary>
+    /// Every <c>Elsa.BpmnProcess</c> activity's own id, anywhere in the whole workflow -- the outermost scope and
+    /// every nested one -- since <c>BpmnScopeHost</c> only ever writes a diagnostic onto the scope's own activity.
+    /// </summary>
+    private ICollection<string> GetBpmnProcessActivityIds() =>
+        _activityGraph.ActivityNodeLookup.Values
+            .Where(node => node.Activity.GetTypeName() == BpmnProcessConstants.ActivityTypeName)
+            .Select(node => node.Activity.GetId())
+            .ToList();
 
     /// Reads the activity from the designer.
     public async Task<JsonObject> ReadActivityAsync()
@@ -457,6 +528,8 @@ public partial class DiagramDesignerWrapper
                 Uncompleted = x.UncompletedCount,
                 Metadata = x.Metadata
             });
+
+            await RefreshElementStatsAsync();
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -49,7 +49,7 @@ public partial class DiagramDesignerWrapper
     /// whatever was actually fetched, so the next tick picks up exactly where this one left off. Settable (rather
     /// than a plain <c>const</c>) only so a test can lower it to exercise the cap without paging 10,000 records.
     /// </summary>
-    private int _elementStatsMaxPagesPerRefresh = 50;
+    internal int ElementStatsMaxPagesPerRefresh { get; set; } = 50;
 
     private ActivityGraph _activityGraph = null!;
     private IDictionary<string, ActivityNode> _indexedActivityNodes =
@@ -263,7 +263,7 @@ public partial class DiagramDesignerWrapper
     /// not an id or timestamp, because <see cref="JournalFilter"/> has no way to filter by either. The map and
     /// mark are reset whenever the displayed instance or the set of <c>Elsa.BpmnProcess</c> scope activity ids
     /// changes, since a high-water mark from a different instance or a different filter has nothing to do with
-    /// the one about to be fetched. A single tick fetches at most <see cref="_elementStatsMaxPagesPerRefresh"/>
+    /// the one about to be fetched. A single tick fetches at most <see cref="ElementStatsMaxPagesPerRefresh"/>
     /// pages, so a backlog larger than that -- a first load, or a burst built up while the tab was backgrounded --
     /// is folded a page cap's worth at a time across successive refreshes rather than in one unbounded loop.
     /// </remarks>
@@ -288,7 +288,7 @@ public partial class DiagramDesignerWrapper
         const int pageSize = 200;
         var skip = _elementStatsHighWaterMark;
 
-        for (var page = 0; page < _elementStatsMaxPagesPerRefresh; page++)
+        for (var page = 0; page < ElementStatsMaxPagesPerRefresh; page++)
         {
             var response = await WorkflowInstanceService.GetJournalAsync(workflowInstanceId, filter, skip, pageSize);
             entries.AddRange(response.Items);

--- a/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Shared/Components/DiagramDesignerWrapper.razor.cs
@@ -40,6 +40,17 @@ public partial class DiagramDesignerWrapper
     private string? _elementStatsInstanceId;
     private HashSet<string> _elementStatsBpmnProcessActivityIds = new();
     private int _elementStatsHighWaterMark;
+
+    /// <summary>
+    /// The most journal pages a single <see cref="RefreshElementStatsAsync"/> tick will fetch, at 200 records a
+    /// page (see <c>pageSize</c> in <see cref="FetchElementStatsAsync"/>): 50 pages bounds one tick to 10,000
+    /// records. A backlog larger than that -- a first load of a long-running instance, or a burst built up while
+    /// the tab was backgrounded -- is not truncated, only spread across refreshes: the high-water mark advances by
+    /// whatever was actually fetched, so the next tick picks up exactly where this one left off. Settable (rather
+    /// than a plain <c>const</c>) only so a test can lower it to exercise the cap without paging 10,000 records.
+    /// </summary>
+    private int _elementStatsMaxPagesPerRefresh = 50;
+
     private ActivityGraph _activityGraph = null!;
     private IDictionary<string, ActivityNode> _indexedActivityNodes =
         new Dictionary<string, ActivityNode>();
@@ -252,7 +263,9 @@ public partial class DiagramDesignerWrapper
     /// not an id or timestamp, because <see cref="JournalFilter"/> has no way to filter by either. The map and
     /// mark are reset whenever the displayed instance or the set of <c>Elsa.BpmnProcess</c> scope activity ids
     /// changes, since a high-water mark from a different instance or a different filter has nothing to do with
-    /// the one about to be fetched.
+    /// the one about to be fetched. A single tick fetches at most <see cref="_elementStatsMaxPagesPerRefresh"/>
+    /// pages, so a backlog larger than that -- a first load, or a burst built up while the tab was backgrounded --
+    /// is folded a page cap's worth at a time across successive refreshes rather than in one unbounded loop.
     /// </remarks>
     private async Task<IReadOnlyDictionary<string, BpmnElementStats>> FetchElementStatsAsync(string workflowInstanceId)
     {
@@ -275,7 +288,7 @@ public partial class DiagramDesignerWrapper
         const int pageSize = 200;
         var skip = _elementStatsHighWaterMark;
 
-        while (true)
+        for (var page = 0; page < _elementStatsMaxPagesPerRefresh; page++)
         {
             var response = await WorkflowInstanceService.GetJournalAsync(workflowInstanceId, filter, skip, pageSize);
             entries.AddRange(response.Items);


### PR DESCRIPTION
Closes #1000. Part of elsa-workflows/elsa-core#7909 (W13, Studio half). The core half, which projects interpreter diagnostics into the journal, merged in elsa-workflows/elsa-core#8058.

## What changed

The BPMN instance viewer now lights up gateways, events and flows, not only bound tasks. Under the design's Option A, only bound work has an activity id, so the existing activity-keyed stats channel could never show where a token waits at a gateway.

- **Contract mirror** (`Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/`): `BpmnDiagnosticEventNames` and `BpmnDiagnosticLogPayload` mirror elsa-core's constants and payload one-to-one, with a pointer to the core files as the source of truth.
- **One mapping**: `BpmnElementStatsProjector` is the only place diagnostic kinds turn into element stats, keyed by BPMN element id or flow id. Covered states: token present, flow taken, gateway joined, boundary triggered, work completed, cancelled or torn down, and waiting shown as blocked. Entries from nested scopes land in the same map, since BPMN ids are document-unique.
- **Refresh**: `DiagramDesignerWrapper.RefreshElementStatsAsync` runs on the same observer tick as activity stats in `WorkflowInstanceDesigner`. It filters the journal by every `BpmnProcess` activity id, not by event names, because several kind names collide with generic lifecycle events. It is **incremental**: a high-water mark per instance and scope set means each tick fetches only new records, folded into the existing map. That is safe because the server orders the filtered journal by a per-instance sequence that survives resumes. Each tick pages at most 10,000 records, and a larger backlog continues on the next tick, so nothing is truncated. The refresh inherits the existing observer disposal (#992); no new timer.
- **Plumbing**: an optional `IBpmnElementStatsSink`, implemented only by `BpmnDiagramDesigner`, forwards through the wrapper and component to the X6 adapter's existing `updateBpmnElementStats`. `IDiagramDesigner` is not widened for every designer.
- **Rendering**: node badges already existed. Edges now render "taken" in the existing badge tone.
- **Write-only**: nothing is read back into the engine, and no element gains behaviour.

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run check:generated && npm test && npm run build   # 243/243
dotnet build Elsa.Studio.sln --configuration Release                                                                   # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 363/363
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 83/83
```

Tests cover:

- The issue's verification scenario, with journal records built exactly as elsa-core writes them: in a parallel split where one branch blocks, the join shows a waiting token, the blocked task shows blocked, and the completed branch's flows show taken.
- Nested-scope folding.
- An incremental refresh fetching only new records.
- A reset when the instance changes.
- A backlog larger than one tick's cap, fully folded across ticks.
- A later record for the same element overriding an earlier one across a refresh boundary, identical to a single pass.
- Wiring into the instance designer's observer.

Review: three iterations on the standards and spec axes, with four must-fix findings resolved: incremental reads, a bounded per-tick catch-up, the cross-boundary test, and internal test seams instead of reflection. Won't-fix: the mirror's `details` stays nullable, deliberately defensive when reading a payload off the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
