### PR TITLE
fix: AddOpenIdConnectAuth no longer throws on provider registration

### DIFF
--- a/src/modules/Elsa.Studio.Authentication.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Authentication.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -30,8 +30,10 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         StudioAuthenticationProvider provider)
     {
-        services.TryAddEnumerable(
-            ServiceDescriptor.Singleton(new StudioAuthenticationProviderRegistration(provider)));
+        // Instance descriptors have implementation type == service type. TryAddEnumerable
+        // rejects that shape on the first call (TryAddIndistinguishableTypeToEnumerable).
+        // AddSingleton still surfaces the marker through IEnumerable<T> for validation.
+        services.AddSingleton(new StudioAuthenticationProviderRegistration(provider));
         return services;
     }
 }

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Compatibility/StudioAuthenticationProviderRegistrationTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Compatibility/StudioAuthenticationProviderRegistrationTests.cs
@@ -1,0 +1,63 @@
+using Elsa.Studio.Authentication.Abstractions.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using ServerOpenIdConnect = Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions.ServiceCollectionExtensions;
+using WasmOpenIdConnect = Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.Extensions.ServiceCollectionExtensions;
+
+namespace Elsa.Studio.ExternalAuthentication.Tests.Compatibility;
+
+public class StudioAuthenticationProviderRegistrationTests
+{
+    [Fact]
+    public void AddStudioAuthenticationProviderRegistration_DoesNotThrowOnFirstCall()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Record.Exception(() =>
+            services.AddStudioAuthenticationProviderRegistration(StudioAuthenticationProvider.OpenIdConnect));
+
+        Assert.Null(exception);
+        using var provider = services.BuildServiceProvider();
+        Assert.Equal(
+            StudioAuthenticationProvider.OpenIdConnect,
+            Assert.Single(provider.GetServices<StudioAuthenticationProviderRegistration>()).Provider);
+    }
+
+    [Fact]
+    public void AddOpenIdConnectAuth_Server_DoesNotThrowOnRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Record.Exception(() =>
+            ServerOpenIdConnect.AddOpenIdConnectAuth(services, options =>
+            {
+                options.Authority = "https://login.microsoftonline.com/{tenant}/v2.0";
+                options.ClientId = "any-client-id";
+            }));
+
+        Assert.Null(exception);
+        using var provider = services.BuildServiceProvider();
+        Assert.Contains(
+            provider.GetServices<StudioAuthenticationProviderRegistration>(),
+            registration => registration.Provider == StudioAuthenticationProvider.OpenIdConnect);
+    }
+
+    [Fact]
+    public void AddOpenIdConnectAuth_Wasm_DoesNotThrowOnRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Record.Exception(() =>
+            WasmOpenIdConnect.AddOpenIdConnectAuth(services, options =>
+            {
+                options.Authority = "https://login.microsoftonline.com/{tenant}/v2.0";
+                options.ClientId = "any-client-id";
+            }));
+
+        Assert.Null(exception);
+        using var provider = services.BuildServiceProvider();
+        Assert.Contains(
+            provider.GetServices<StudioAuthenticationProviderRegistration>(),
+            registration => registration.Provider == StudioAuthenticationProvider.OpenIdConnect);
+    }
+}

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Elsa.Studio.ExternalAuthentication.Tests.csproj
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Elsa.Studio.ExternalAuthentication.Tests.csproj
@@ -28,6 +28,7 @@
         <ProjectReference Include="..\Elsa.Studio.ExternalAuthentication\Elsa.Studio.ExternalAuthentication.csproj" />
         <ProjectReference Include="..\Elsa.Studio.Authentication.UI\Elsa.Studio.Authentication.UI.csproj" />
         <ProjectReference Include="..\Elsa.Studio.Authentication.OpenIdConnect.BlazorServer\Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.csproj" />
+        <ProjectReference Include="..\Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm\Elsa.Studio.Authentication.OpenIdConnect.BlazorWasm.csproj" />
         <ProjectReference Include="..\Elsa.Studio.ExternalAuthentication.BlazorServer\Elsa.Studio.ExternalAuthentication.BlazorServer.csproj" />
         <ProjectReference Include="..\Elsa.Studio.ExternalAuthentication.BlazorWasm\Elsa.Studio.ExternalAuthentication.BlazorWasm.csproj" />
     </ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Stop `AddOpenIdConnectAuth` (Wasm and Server) from crashing on first registration in Elsa Studio 3.8.0.

Fixes https://github.com/elsa-workflows/elsa-studio/issues/1016

---

## Scope

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem

`AddStudioAuthenticationProviderRegistration` recorded the provider marker with `TryAddEnumerable(ServiceDescriptor.Singleton(new StudioAuthenticationProviderRegistration(...)))`.

`TryAddEnumerable` rejects descriptors whose implementation type equals the service type (`TryAddIndistinguishableTypeToEnumerable` / `ArgumentException`) **on the first call**. Both OIDC host extensions call this helper immediately, so `AddOpenIdConnectAuth` never reached `AddOidcAuthentication` / `AddOpenIdConnect`.

### Solution

Register the instance with `AddSingleton`, matching Elsa Identity, Login, and External Authentication. `GetServices<StudioAuthenticationProviderRegistration>()` still returns the marker for `StudioAuthenticationOptionsValidator`.

The factory form of `TryAddEnumerable` was not used: `ServiceDescriptor.Singleton<T>(_ => …)` still reports implementation type `T`, so it would throw the same exception.

---

## Verification

Local:

```
dotnet test src/modules/Elsa.Studio.ExternalAuthentication.Tests/Elsa.Studio.ExternalAuthentication.Tests.csproj --configuration Release
```

- New `StudioAuthenticationProviderRegistrationTests`: 3 passed (helper, Server `AddOpenIdConnectAuth`, Wasm `AddOpenIdConnectAuth`)
- Full External Authentication suite: 233 passed

Expected outcome:
- Helper and both `AddOpenIdConnectAuth` overloads register without throwing.
- The OpenID Connect marker is resolvable from DI.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90f5ab7b-024b-5594-bc8e-2b633f57216f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90f5ab7b-024b-5594-bc8e-2b633f57216f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

