### PR TITLE
fix: accept static feature catalog names for dashboard modules

### DIFF
--- a/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
+++ b/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
@@ -1,0 +1,98 @@
+using Elsa.Api.Client.Resources.Features.Models;
+using Elsa.Studio.Attributes;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Services;
+using Xunit;
+
+namespace Elsa.Studio.Core.Tests;
+
+public class DefaultFeatureServiceTests
+{
+    [Fact]
+    public async Task InitializeFeatures_EnablesCompanionsAdvertisedByStaticCatalogNames()
+    {
+        var dashboard = new WorkflowRuntimeDashboardFeature();
+        var structuredLogs = new StructuredLogsDashboardFeature();
+        var service = new DefaultFeatureService(
+            [dashboard, structuredLogs],
+            new CatalogRemoteFeatureProvider(
+                new FeatureDescriptor { FullName = "Elsa.WorkflowRuntimeDashboard" },
+                new FeatureDescriptor { FullName = "Elsa.StructuredLogsDashboard" }));
+
+        await service.InitializeFeaturesAsync();
+
+        Assert.True(dashboard.Initialized);
+        Assert.True(structuredLogs.Initialized);
+    }
+
+    [Fact]
+    public async Task InitializeFeatures_EnablesCompanionsAdvertisedByShellFeatureNames()
+    {
+        var dashboard = new WorkflowRuntimeDashboardFeature();
+        var service = new DefaultFeatureService(
+            [dashboard],
+            new CatalogRemoteFeatureProvider(
+                new FeatureDescriptor { FullName = WorkflowRuntimeDashboardFeature.RemoteFeatureName }));
+
+        await service.InitializeFeaturesAsync();
+
+        Assert.True(dashboard.Initialized);
+    }
+
+    [Fact]
+    public async Task InitializeFeatures_SkipsCompanionsMissingFromCatalog()
+    {
+        var dashboard = new WorkflowRuntimeDashboardFeature();
+        var service = new DefaultFeatureService(
+            [dashboard],
+            new CatalogRemoteFeatureProvider(new FeatureDescriptor { FullName = "Elsa.Secrets" }));
+
+        await service.InitializeFeaturesAsync();
+
+        Assert.False(dashboard.Initialized);
+    }
+
+    [Fact]
+    public async Task InitializeFeatures_AlwaysInitializesUngatedFeatures()
+    {
+        var local = new LocalFeature();
+        var service = new DefaultFeatureService(
+            [local],
+            new CatalogRemoteFeatureProvider());
+
+        await service.InitializeFeaturesAsync();
+
+        Assert.True(local.Initialized);
+    }
+
+    [RemoteFeature(RemoteFeatureName)]
+    private sealed class WorkflowRuntimeDashboardFeature : TrackingFeature
+    {
+        public const string RemoteFeatureName = "Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard";
+    }
+
+    [RemoteFeature("Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures.StructuredLogsDashboard")]
+    private sealed class StructuredLogsDashboardFeature : TrackingFeature;
+
+    private sealed class LocalFeature : TrackingFeature;
+
+    private abstract class TrackingFeature : IFeature
+    {
+        public bool Initialized { get; private set; }
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            Initialized = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CatalogRemoteFeatureProvider(params FeatureDescriptor[] features) : IRemoteFeatureProvider
+    {
+        public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(features.Any(feature => string.Equals(feature.FullName, featureName, StringComparison.Ordinal)));
+
+        public Task<IEnumerable<FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<FeatureDescriptor>>(features);
+    }
+}

--- a/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
+++ b/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
@@ -56,15 +56,19 @@ public class DefaultFeatureServiceTests
     public async Task InitializeFeatures_SkipsCompanionsWhenCatalogLastSegmentIsNotElsaPrefixed()
     {
         var dashboard = new WorkflowRuntimeDashboardFeature();
+        var identity = new IdentityFeature();
         var service = new DefaultFeatureService(
-            [dashboard],
+            [dashboard, identity],
             new CatalogRemoteFeatureProvider(
                 new FeatureDescriptor { FullName = "Acme.WorkflowRuntimeDashboard" },
-                new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Acme" }));
+                new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Acme" },
+                new FeatureDescriptor { FullName = "Acme.Identity" },
+                new FeatureDescriptor { Name = "Identity", Namespace = "Acme" }));
 
         await service.InitializeFeaturesAsync();
 
         Assert.False(dashboard.Initialized);
+        Assert.False(identity.Initialized);
     }
 
     [Fact]
@@ -88,6 +92,9 @@ public class DefaultFeatureServiceTests
 
     [RemoteFeature("Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures.StructuredLogsDashboard")]
     private sealed class StructuredLogsDashboardFeature : TrackingFeature;
+
+    [RemoteFeature("Elsa.Identity.ShellFeatures.Identity")]
+    private sealed class IdentityFeature : TrackingFeature;
 
     private sealed class LocalFeature : TrackingFeature;
 

--- a/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
+++ b/src/framework/Elsa.Studio.Core.Tests/DefaultFeatureServiceTests.cs
@@ -53,6 +53,21 @@ public class DefaultFeatureServiceTests
     }
 
     [Fact]
+    public async Task InitializeFeatures_SkipsCompanionsWhenCatalogLastSegmentIsNotElsaPrefixed()
+    {
+        var dashboard = new WorkflowRuntimeDashboardFeature();
+        var service = new DefaultFeatureService(
+            [dashboard],
+            new CatalogRemoteFeatureProvider(
+                new FeatureDescriptor { FullName = "Acme.WorkflowRuntimeDashboard" },
+                new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Acme" }));
+
+        await service.InitializeFeaturesAsync();
+
+        Assert.False(dashboard.Initialized);
+    }
+
+    [Fact]
     public async Task InitializeFeatures_AlwaysInitializesUngatedFeatures()
     {
         var local = new LocalFeature();

--- a/src/framework/Elsa.Studio.Core/Services/DefaultFeatureService.cs
+++ b/src/framework/Elsa.Studio.Core/Services/DefaultFeatureService.cs
@@ -37,14 +37,9 @@ public class DefaultFeatureService : IFeatureService
         {
             var remoteFeatureName = feature.GetType().GetCustomAttribute<RemoteFeatureAttribute>()?.Name;
 
-            if (!string.IsNullOrWhiteSpace(remoteFeatureName))
-            {
-                // Check if the remote feature is enabled.
-                var remoteFeatureIsEnabled = remoteFeatures.Any(x => x.FullName == remoteFeatureName);
-
-                if (!remoteFeatureIsEnabled)
-                    continue;
-            }
+            if (!string.IsNullOrWhiteSpace(remoteFeatureName) &&
+                !RemoteFeatureCatalog.Contains(remoteFeatures, remoteFeatureName))
+                continue;
 
             await feature.InitializeAsync(cancellationToken);
         }

--- a/src/framework/Elsa.Studio.Core/Services/RemoteFeatureCatalog.cs
+++ b/src/framework/Elsa.Studio.Core/Services/RemoteFeatureCatalog.cs
@@ -1,0 +1,40 @@
+using Elsa.Api.Client.Resources.Features.Models;
+
+namespace Elsa.Studio.Services;
+
+/// <summary>
+/// Matches Studio remote feature names against the backend installed-feature catalog.
+/// </summary>
+/// <remarks>
+/// Dynamic/shell catalogs advertise the ShellFeatures CLR name
+/// (<c>Elsa.*.ShellFeatures.{FeatureId}</c>). Static feature catalogs advertise the
+/// CShells feature id as <c>Elsa.{FeatureId}</c> (for example
+/// <c>Elsa.WorkflowRuntimeDashboard</c>). Studio modules request the ShellFeatures name,
+/// so both catalog forms must resolve as the same installed feature.
+/// </remarks>
+internal static class RemoteFeatureCatalog
+{
+    public static bool Contains(IEnumerable<FeatureDescriptor> catalog, string featureName) =>
+        catalog.Any(feature => Matches(feature, featureName));
+
+    public static bool Matches(FeatureDescriptor feature, string featureName)
+    {
+        if (string.Equals(feature.FullName, featureName, StringComparison.Ordinal))
+            return true;
+
+        var requestedId = GetFeatureId(featureName);
+
+        if (!string.IsNullOrEmpty(feature.Name) &&
+            string.Equals(feature.Name, requestedId, StringComparison.Ordinal))
+            return true;
+
+        return !string.IsNullOrEmpty(feature.FullName) &&
+               string.Equals(GetFeatureId(feature.FullName), requestedId, StringComparison.Ordinal);
+    }
+
+    private static string GetFeatureId(string featureName)
+    {
+        var lastDot = featureName.LastIndexOf('.');
+        return lastDot < 0 ? featureName : featureName[(lastDot + 1)..];
+    }
+}

--- a/src/framework/Elsa.Studio.Core/Services/RemoteFeatureCatalog.cs
+++ b/src/framework/Elsa.Studio.Core/Services/RemoteFeatureCatalog.cs
@@ -11,6 +11,8 @@ namespace Elsa.Studio.Services;
 /// CShells feature id as <c>Elsa.{FeatureId}</c> (for example
 /// <c>Elsa.WorkflowRuntimeDashboard</c>). Studio modules request the ShellFeatures name,
 /// so both catalog forms must resolve as the same installed feature.
+/// Short-name fallback is restricted to the Elsa namespace so an unrelated
+/// <c>Acme.{FeatureId}</c> catalog entry cannot enable an Elsa Studio module.
 /// </remarks>
 internal static class RemoteFeatureCatalog
 {
@@ -25,11 +27,11 @@ internal static class RemoteFeatureCatalog
         var requestedId = GetFeatureId(featureName);
 
         if (!string.IsNullOrEmpty(feature.Name) &&
+            string.Equals(feature.Namespace, "Elsa", StringComparison.Ordinal) &&
             string.Equals(feature.Name, requestedId, StringComparison.Ordinal))
             return true;
 
-        return !string.IsNullOrEmpty(feature.FullName) &&
-               string.Equals(GetFeatureId(feature.FullName), requestedId, StringComparison.Ordinal);
+        return string.Equals(feature.FullName, $"Elsa.{requestedId}", StringComparison.Ordinal);
     }
 
     private static string GetFeatureId(string featureName)

--- a/src/framework/Elsa.Studio.Core/Services/RemoteFeatureProvider.cs
+++ b/src/framework/Elsa.Studio.Core/Services/RemoteFeatureProvider.cs
@@ -21,7 +21,7 @@ public class RemoteFeatureProvider(
     public async Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default)
     {
         var catalog = await GetCatalogAsync(cancellationToken);
-        return catalog.Any(feature => string.Equals(feature.FullName, featureName, StringComparison.Ordinal));
+        return RemoteFeatureCatalog.Contains(catalog, featureName);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetRegistrationTests.cs
+++ b/src/modules/Elsa.Studio.Dashboard.Tests/DashboardWidgetRegistrationTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Api.Client.Resources.Features.Models;
 using Elsa.Studio.Attributes;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Dashboard.Extensions;
@@ -8,6 +9,7 @@ using Elsa.Studio.Diagnostics.OpenTelemetry.Dashboard.Extensions;
 using Elsa.Studio.Diagnostics.OpenTelemetry.Dashboard.UI.Dashboard;
 using Elsa.Studio.Diagnostics.StructuredLogs.Dashboard.Extensions;
 using Elsa.Studio.Diagnostics.StructuredLogs.Dashboard.UI.Dashboard;
+using Elsa.Studio.Services;
 using Elsa.Studio.Workflows.Dashboard.Extensions;
 using Elsa.Studio.Workflows.Dashboard.Widgets;
 using Microsoft.AspNetCore.Components;
@@ -123,6 +125,39 @@ public class DashboardWidgetRegistrationTests
         AssertRemoteFeatureName<Elsa.Studio.Diagnostics.OpenTelemetry.Dashboard.Feature>("Elsa.Diagnostics.OpenTelemetry.ShellFeatures.OpenTelemetry");
     }
 
+    [Fact]
+    public async Task DefaultFeatureService_RegistersWidgetsWhenStaticCatalogAdvertisesShortNames()
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddDashboardModule()
+            .AddWorkflowsDashboardModule()
+            .AddStructuredLogsDashboardModule()
+            .AddConsoleLogsDashboardModule()
+            .AddOpenTelemetryDashboardModule();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var features = serviceProvider.GetRequiredService<IEnumerable<IFeature>>().Where(x => x.GetType().Namespace?.EndsWith(".Dashboard", StringComparison.Ordinal) == true).ToList();
+        var registry = serviceProvider.GetRequiredService<IDashboardWidgetRegistry>();
+        var featureService = new DefaultFeatureService(
+            features,
+            new CatalogRemoteFeatureProvider(
+                new FeatureDescriptor { FullName = "Elsa.WorkflowRuntimeDashboard" },
+                new FeatureDescriptor { FullName = "Elsa.StructuredLogsDashboard" },
+                new FeatureDescriptor { FullName = "Elsa.ConsoleLogsDashboard" },
+                new FeatureDescriptor { FullName = "Elsa.OpenTelemetry" }));
+
+        await featureService.InitializeFeaturesAsync();
+
+        var descriptors = registry.List();
+
+        AssertDescriptor<DashboardWorkflowMetricsWidget>(descriptors, "dashboard.workflow.metrics", DashboardWidgetZones.Metrics, 100, "WorkflowInstances");
+        AssertDescriptor<StructuredLogsDashboardWidget>(descriptors, "diagnostics.structured-logs", DashboardWidgetZones.DiagnosticsStatus, 100, "Diagnostics.StructuredLogs");
+        AssertDescriptor<ConsoleLogsDashboardWidget>(descriptors, "diagnostics.console-logs", DashboardWidgetZones.DiagnosticsStatus, 200, "Diagnostics.ConsoleLogs");
+        AssertDescriptor<OpenTelemetryDashboardWidget>(descriptors, "diagnostics.open-telemetry", DashboardWidgetZones.DiagnosticsStatus, 300, "OpenTelemetry.StorageDiagnostics");
+    }
+
     private sealed class TestWidget : IComponent
     {
         public void Attach(RenderHandle renderHandle)
@@ -152,6 +187,15 @@ public class DashboardWidgetRegistrationTests
         var attribute = typeof(TFeature).GetCustomAttributes(typeof(RemoteFeatureAttribute), false).OfType<RemoteFeatureAttribute>().Single();
 
         Assert.Equal(expectedName, attribute.Name);
+    }
+
+    private sealed class CatalogRemoteFeatureProvider(params FeatureDescriptor[] features) : IRemoteFeatureProvider
+    {
+        public Task<bool> IsEnabledAsync(string featureName, CancellationToken cancellationToken = default) =>
+            Task.FromResult(features.Any(feature => string.Equals(feature.FullName, featureName, StringComparison.Ordinal)));
+
+        public Task<IEnumerable<FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<FeatureDescriptor>>(features);
     }
 
     private static DirectoryInfo FindRepositoryRoot()

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
@@ -56,6 +56,23 @@ public class RemoteFeatureProviderTests
     }
 
     [Fact]
+    public async Task FeatureChecks_RejectNonElsaLastSegmentCollisions()
+    {
+        const string requestedName = "Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard";
+        var foreignFullName = new FeaturesApi
+        {
+            Features = new([new FeatureDescriptor { FullName = "Acme.WorkflowRuntimeDashboard" }], 1)
+        };
+        var foreignNamespace = new FeaturesApi
+        {
+            Features = new([new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Acme" }], 1)
+        };
+
+        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(foreignFullName)).IsEnabledAsync(requestedName));
+        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(foreignNamespace)).IsEnabledAsync(requestedName));
+    }
+
+    [Fact]
     public async Task AnonymousFeatureChecks_DoNotProbeTheProtectedBackend()
     {
         var api = new FeaturesApi();

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
@@ -25,6 +25,36 @@ public class RemoteFeatureProviderTests
         Assert.Equal(0, api.GetCalls);
     }
 
+    [Theory]
+    [InlineData("Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard", "Elsa.WorkflowRuntimeDashboard")]
+    [InlineData("Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures.StructuredLogsDashboard", "Elsa.StructuredLogsDashboard")]
+    [InlineData("Elsa.Diagnostics.StructuredLogs.ShellFeatures.StructuredLogs", "Elsa.StructuredLogs")]
+    [InlineData("Elsa.ExternalAuthentication.ShellFeatures.ExternalAuthentication", "Elsa.ExternalAuthentication")]
+    [InlineData("Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard", "Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard")]
+    public async Task FeatureChecks_AcceptStaticCatalogNames(string requestedName, string catalogFullName)
+    {
+        var api = new FeaturesApi
+        {
+            Features = new([new FeatureDescriptor { FullName = catalogFullName }], 1)
+        };
+        var provider = new RemoteFeatureProvider(new BackendApiClientProvider(api));
+
+        Assert.True(await provider.IsEnabledAsync(requestedName));
+        Assert.False(await provider.IsEnabledAsync("Elsa.MissingFeature"));
+    }
+
+    [Fact]
+    public async Task FeatureChecks_AcceptCatalogNameAsFeatureId()
+    {
+        var api = new FeaturesApi
+        {
+            Features = new([new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Elsa" }], 1)
+        };
+        var provider = new RemoteFeatureProvider(new BackendApiClientProvider(api));
+
+        Assert.True(await provider.IsEnabledAsync("Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard"));
+    }
+
     [Fact]
     public async Task AnonymousFeatureChecks_DoNotProbeTheProtectedBackend()
     {
@@ -128,6 +158,7 @@ public class RemoteFeatureProviderTests
             [new FeatureDescriptor { FullName = "Elsa.ExternalAuthentication" }],
             1);
 
+        public ListResponse<FeatureDescriptor> Features { get; set; } = InstalledFeatures;
         public Queue<Func<CancellationToken, Task<ListResponse<FeatureDescriptor>>>> Responses { get; } = new();
         public int GetCalls { get; private set; }
         public int ListCalls { get; private set; }
@@ -144,7 +175,7 @@ public class RemoteFeatureProviderTests
             if (Responses.TryDequeue(out var response))
                 return response(cancellationToken);
 
-            return Task.FromResult(InstalledFeatures);
+            return Task.FromResult(Features);
         }
     }
 

--- a/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
+++ b/src/modules/Elsa.Studio.ExternalAuthentication.Tests/Operations/RemoteFeatureProviderTests.cs
@@ -55,21 +55,22 @@ public class RemoteFeatureProviderTests
         Assert.True(await provider.IsEnabledAsync("Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard"));
     }
 
-    [Fact]
-    public async Task FeatureChecks_RejectNonElsaLastSegmentCollisions()
+    [Theory]
+    [InlineData("Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard", "Acme.WorkflowRuntimeDashboard", "WorkflowRuntimeDashboard")]
+    [InlineData("Elsa.Identity.ShellFeatures.Identity", "Acme.Identity", "Identity")]
+    public async Task FeatureChecks_RejectNonElsaLastSegmentCollisions(string requestedName, string foreignFullName, string foreignName)
     {
-        const string requestedName = "Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard";
-        var foreignFullName = new FeaturesApi
+        var fullNameCatalog = new FeaturesApi
         {
-            Features = new([new FeatureDescriptor { FullName = "Acme.WorkflowRuntimeDashboard" }], 1)
+            Features = new([new FeatureDescriptor { FullName = foreignFullName }], 1)
         };
-        var foreignNamespace = new FeaturesApi
+        var namespaceCatalog = new FeaturesApi
         {
-            Features = new([new FeatureDescriptor { Name = "WorkflowRuntimeDashboard", Namespace = "Acme" }], 1)
+            Features = new([new FeatureDescriptor { Name = foreignName, Namespace = "Acme" }], 1)
         };
 
-        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(foreignFullName)).IsEnabledAsync(requestedName));
-        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(foreignNamespace)).IsEnabledAsync(requestedName));
+        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(fullNameCatalog)).IsEnabledAsync(requestedName));
+        Assert.False(await new RemoteFeatureProvider(new BackendApiClientProvider(namespaceCatalog)).IsEnabledAsync(requestedName));
     }
 
     [Fact]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Studio now treats static feature catalog names such as `Elsa.WorkflowRuntimeDashboard` as the same installed feature as the ShellFeatures CLR name, so WorkflowRuntimeDashboard and StructuredLogs widgets render when Elsa Server uses `--feature-model static`.

Fixes https://github.com/elsa-workflows/elsa-studio/issues/1014

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem

With Elsa Server 3.8 configured as a static feature model (`dotnet new elsa-server --feature-model static`), Studio’s dashboard animation loads data but no widgets render.

`DefaultFeatureService` / `RemoteFeatureProvider` checked the catalog for exact `FullName` matches such as:

- `Elsa.Workflows.Runtime.Dashboard.ShellFeatures.WorkflowRuntimeDashboard`
- `Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures.StructuredLogsDashboard`

The static catalog advertises the CShells feature id as `Elsa.{FeatureId}` (`Elsa.WorkflowRuntimeDashboard`, `Elsa.StructuredLogsDashboard`). The mismatch skipped companion feature initialization, so widgets never registered.

Dynamic/shell catalogs still use the ShellFeatures CLR name, so Studio must accept both forms.

### Solution

Add `RemoteFeatureCatalog` matching:

1. Exact `FullName` (existing dynamic/shell catalogs)
2. `FullName == Elsa.{FeatureId}` (static catalog)
3. `Name == FeatureId` when `Namespace == Elsa`

Unrestricted last-segment matching is not used, so a foreign catalog entry such as `Acme.WorkflowRuntimeDashboard` does not enable an Elsa companion.

Companion `[RemoteFeature]` names are unchanged. This is a Studio-only fix; no server rename is required.

---

## Verification

Local `dotnet test -f net10.0`:

- `Elsa.Studio.Core.Tests` (includes static vs shell catalog cases and a negative `Acme.WorkflowRuntimeDashboard` collision test)
- `Elsa.Studio.ExternalAuthentication.Tests --filter RemoteFeatureProvider` (short-name accept + foreign-namespace reject)
- `Elsa.Studio.Dashboard.Tests` (widgets register when the catalog advertises Elsa-prefixed short names)

Manual check against a live `elsa-server --feature-model static` host was not run in this environment.

Expected outcome:

- Static Elsa-prefixed catalog names enable the same Studio modules as ShellFeatures CLR names.
- Exact long-name catalogs still enable those modules.
- A non-Elsa catalog entry with the same last segment does not enable dashboard companions.

---

## Screenshots / Recordings (if applicable)

N/A — feature-catalog matching; covered by unit tests.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b28bdf90-6ebc-50e2-b763-a736959639ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b28bdf90-6ebc-50e2-b763-a736959639ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

