### PR TITLE
fix: Execution Details drawer never opens from the Executions tab

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Tests/ActivityExecutionDetailsTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ActivityExecutionDetailsTests.cs
@@ -1,0 +1,148 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Resources.Resilience.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class ActivityExecutionDetailsTests : BunitContext, IAsyncLifetime
+{
+    private readonly ActivityExecutionServiceStub _executionService = new();
+
+    public ActivityExecutionDetailsTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityExecutionService>(_executionService);
+        Services.AddSingleton<IClipboard, ClipboardStub>();
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void RendersStateOutcomesAndOutputForTheSelectedExecution()
+    {
+        var record = new ActivityExecutionRecord
+        {
+            Id = "exec-1",
+            ActivityId = "WriteLine1",
+            ActivityNodeId = "Workflow1:WriteLine1",
+            ActivityType = "Elsa.WriteLine",
+            Status = ActivityStatus.Completed,
+            StartedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            ActivityState = new Dictionary<string, object?>
+            {
+                ["Text"] = "hello",
+                ["_internal"] = "hidden"
+            },
+            Payload = new Dictionary<string, object?>
+            {
+                ["Outcomes"] = "Done"
+            },
+            Outputs = new Dictionary<string, object?>
+            {
+                ["Result"] = "ok"
+            }
+        };
+
+        var cut = Render<ActivityExecutionDetails>(parameters => parameters
+            .Add(details => details.ActivityExecution, record));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("State", cut.Markup);
+            Assert.Contains("Text", cut.Markup);
+            Assert.Contains("hello", cut.Markup);
+            Assert.DoesNotContain("_internal", cut.Markup);
+            Assert.Contains("Outcomes", cut.Markup);
+            Assert.Contains("Done", cut.Markup);
+            Assert.Contains("Output", cut.Markup);
+            Assert.Contains("Result", cut.Markup);
+            Assert.Contains("ok", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void RendersRetryAttemptsWhenTheExecutionHasRetries()
+    {
+        _executionService.Retries = new PagedListResponse<RetryAttemptRecord>
+        {
+            Items =
+            [
+                new RetryAttemptRecord
+                {
+                    AttemptNumber = 1,
+                    RetryDelay = TimeSpan.FromSeconds(1),
+                    Details = new Dictionary<string, string?> { ["Reason"] = "timeout" }
+                }
+            ],
+            TotalCount = 1
+        };
+
+        var record = new ActivityExecutionRecord
+        {
+            Id = "exec-retry",
+            ActivityId = "HttpRequest1",
+            ActivityNodeId = "Workflow1:HttpRequest1",
+            ActivityType = "Elsa.HttpRequest",
+            Status = ActivityStatus.Completed,
+            StartedAt = DateTimeOffset.UtcNow
+        };
+
+        var cut = Render<ActivityExecutionDetails>(parameters => parameters
+            .Add(details => details.ActivityExecution, record));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Retry Attempts", cut.Markup);
+            Assert.Contains("timeout", cut.Markup);
+        });
+    }
+
+    private sealed class ActivityExecutionServiceStub : IActivityExecutionService
+    {
+        public PagedListResponse<RetryAttemptRecord> Retries { get; set; } = new();
+
+        public Task<ActivityExecutionReport> GetReportAsync(string workflowInstanceId, System.Text.Json.Nodes.JsonObject containerActivity, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<IEnumerable<ActivityExecutionRecord>> ListAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Enumerable.Empty<ActivityExecutionRecord>());
+
+        public Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Enumerable.Empty<ActivityExecutionRecordSummary>());
+
+        public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ActivityExecutionRecord?>(null);
+
+        public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<PagedListResponse<RetryAttemptRecord>> GetRetriesAsync(string activityInstanceId, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Retries);
+    }
+
+    private sealed class ClipboardStub : IClipboard
+    {
+        public Task CopyText(string text, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ActivityExecutionsTabTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ActivityExecutionsTabTests.cs
@@ -1,0 +1,76 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Localization.Time;
+using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class ActivityExecutionsTabTests : BunitContext, IAsyncLifetime
+{
+    public ActivityExecutionsTabTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<ITimeFormatter, TestTimeFormatter>();
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task ClickingAnExecutionRow_RaisesExecutionSelectedWithThatRecordId()
+    {
+        string? selectedId = null;
+        var summaries = new List<ActivityExecutionRecordSummary>
+        {
+            CreateSummary("exec-a"),
+            CreateSummary("exec-b")
+        };
+
+        var cut = Render<ActivityExecutionsTab>(parameters => parameters
+            .Add(tab => tab.ActivityExecutionSummaries, summaries)
+            .Add(tab => tab.VisiblePaneHeight, 400)
+            .Add(tab => tab.ExecutionSelected, id => selectedId = id));
+
+        var rows = cut.FindAll("tbody tr");
+        Assert.Equal(2, rows.Count);
+
+        await rows[1].ClickAsync();
+
+        cut.WaitForAssertion(() => Assert.Equal("exec-b", selectedId));
+    }
+
+    private static ActivityExecutionRecordSummary CreateSummary(string id)
+    {
+        return new ActivityExecutionRecordSummary
+        {
+            Id = id,
+            ActivityId = "WriteLine1",
+            ActivityNodeId = "Workflow1:WriteLine1",
+            ActivityType = "Elsa.WriteLine",
+            Status = ActivityStatus.Completed,
+            StartedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class TestTimeFormatter : ITimeFormatter
+    {
+        public string Format(DateTimeOffset? value, string format = "G", string emptyString = "") =>
+            value?.ToString(format) ?? emptyString;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExecutionDetailsDrawerRenderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExecutionDetailsDrawerRenderTests.cs
@@ -3,6 +3,7 @@ using Elsa.Api.Client.Resources.ActivityExecutions.Models;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Localization;
+using Elsa.Studio.Localization.Time;
 using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Microsoft.AspNetCore.Components;
@@ -16,13 +17,16 @@ namespace Elsa.Studio.Workflows.Tests;
 
 public sealed class ExecutionDetailsDrawerRenderTests : BunitContext, IAsyncLifetime
 {
+    private readonly ActivityExecutionServiceStub _executionService = new();
+
     public ExecutionDetailsDrawerRenderTests()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddMudServices();
         Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<ITimeFormatter, TestTimeFormatter>();
         Services.AddSingleton<IClipboard, ClipboardStub>();
-        Services.AddSingleton<IActivityExecutionService, ActivityExecutionServiceStub>();
+        Services.AddSingleton<IActivityExecutionService>(_executionService);
         Render<MudPopoverProvider>();
     }
 
@@ -30,63 +34,144 @@ public sealed class ExecutionDetailsDrawerRenderTests : BunitContext, IAsyncLife
     async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
 
     [Fact]
-    public void TemporaryDrawerMountedOpen_RendersExecutionDetails()
+    public void SelectingAnExecution_MountsTheOpenDrawerWithThatExecutionsDetails()
     {
-        var record = new ActivityExecutionRecord
+        var record = CreateRecord("exec-1", "hello", "Done", "ok");
+        _executionService.Record = record;
+
+        var cut = Render<ExecutionSelectionHost>(parameters => parameters
+            .Add(host => host.Summaries, [CreateSummary("exec-1"), CreateSummary("exec-2")]));
+
+        Assert.Empty(cut.FindAll("aside.execution-details-drawer"));
+
+        cut.FindAll("tbody tr")[0].Click();
+
+        cut.WaitForAssertion(() =>
         {
-            Id = "exec-1",
-            ActivityId = "WriteLine1",
-            ActivityNodeId = "Workflow1:WriteLine1",
-            ActivityType = "Elsa.WriteLine",
-            Status = ActivityStatus.Completed,
-            StartedAt = DateTimeOffset.UtcNow,
-            ActivityState = new Dictionary<string, object?> { ["Text"] = "hello" },
-            Payload = new Dictionary<string, object?> { ["Outcomes"] = "Done" },
-            Outputs = new Dictionary<string, object?> { ["Result"] = "ok" }
-        };
-
-        var cut = Render<ExecutionDetailsDrawerHarness>(parameters => parameters
-            .Add(harness => harness.ActivityExecution, record));
-
-        var drawer = cut.Find("aside.execution-details-drawer");
-        Assert.Contains("mud-drawer--open", drawer.ClassList);
-        Assert.Contains("mud-drawer-temporary", drawer.ClassList);
-        Assert.Contains("Execution Details", cut.Markup);
-        Assert.Contains("hello", cut.Markup);
-        Assert.Contains("Done", cut.Markup);
-        Assert.Contains("ok", cut.Markup);
+            var drawer = cut.Find("aside.execution-details-drawer");
+            Assert.Contains("mud-drawer--open", drawer.ClassList);
+            Assert.Contains("mud-drawer-temporary", drawer.ClassList);
+            Assert.Contains("Execution Details", cut.Markup);
+            Assert.Contains("hello", cut.Markup);
+            Assert.Contains("Done", cut.Markup);
+            Assert.Contains("ok", cut.Markup);
+        });
     }
 
-    private sealed class ExecutionDetailsDrawerHarness : ComponentBase
+    [Fact]
+    public void HeaderClose_DismissesTheDrawer()
     {
+        var cut = Render<DrawerHost>(parameters => parameters
+            .Add(host => host.InitiallyOpen, true)
+            .Add(host => host.ActivityExecution, CreateRecord("exec-1", "hello", "Done", "ok")));
+
+        Assert.NotEmpty(cut.FindAll("aside.execution-details-drawer"));
+
+        cut.Find("button[aria-label='Close']").Click();
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("aside.execution-details-drawer")));
+    }
+
+    [Fact]
+    public async Task OverlayDismissal_UnmountsTheDrawer()
+    {
+        var cut = Render<DrawerHost>(parameters => parameters
+            .Add(host => host.InitiallyOpen, true)
+            .Add(host => host.ActivityExecution, CreateRecord("exec-1", "hello", "Done", "ok")));
+
+        var drawer = cut.FindComponent<MudDrawer>();
+        await cut.InvokeAsync(() => drawer.Instance.OpenChanged.InvokeAsync(false));
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("aside.execution-details-drawer")));
+    }
+
+    private static ActivityExecutionRecord CreateRecord(string id, string text, string outcome, string output) => new()
+    {
+        Id = id,
+        ActivityId = "WriteLine1",
+        ActivityNodeId = "Workflow1:WriteLine1",
+        ActivityType = "Elsa.WriteLine",
+        Status = ActivityStatus.Completed,
+        StartedAt = DateTimeOffset.UtcNow,
+        ActivityState = new Dictionary<string, object?> { ["Text"] = text },
+        Payload = new Dictionary<string, object?> { ["Outcomes"] = outcome },
+        Outputs = new Dictionary<string, object?> { ["Result"] = output }
+    };
+
+    private static ActivityExecutionRecordSummary CreateSummary(string id) => new()
+    {
+        Id = id,
+        ActivityId = "WriteLine1",
+        ActivityNodeId = "Workflow1:WriteLine1",
+        ActivityType = "Elsa.WriteLine",
+        Status = ActivityStatus.Completed,
+        StartedAt = DateTimeOffset.UtcNow
+    };
+
+    /// <summary>
+    /// Owns drawer open-state the same way <c>WorkflowInstanceViewer</c> does.
+    /// </summary>
+    private sealed class DrawerHost : ComponentBase
+    {
+        [Parameter] public bool InitiallyOpen { get; set; }
         [Parameter] public ActivityExecutionRecord? ActivityExecution { get; set; }
+
+        private bool _open;
+
+        protected override void OnInitialized() => _open = InitiallyOpen;
 
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
         {
-            builder.OpenComponent<MudDrawer>(0);
-            builder.AddAttribute(1, "Open", true);
-            builder.AddAttribute(2, "Anchor", Anchor.End);
-            builder.AddAttribute(3, "Width", "600px");
-            builder.AddAttribute(4, "Elevation", 2);
-            builder.AddAttribute(5, "Overlay", true);
-            builder.AddAttribute(6, "Variant", DrawerVariant.Temporary);
-            builder.AddAttribute(7, "Class", "execution-details-drawer");
-            builder.AddAttribute(8, "ChildContent", (RenderFragment)(child =>
-            {
-                child.OpenComponent<MudText>(0);
-                child.AddAttribute(1, "Typo", Typo.h6);
-                child.AddAttribute(2, "ChildContent", (RenderFragment)(text => text.AddContent(0, "Execution Details")));
-                child.CloseComponent();
-                child.OpenComponent<ActivityExecutionDetails>(3);
-                child.AddAttribute(4, "ActivityExecution", ActivityExecution);
-                child.CloseComponent();
-            }));
+            builder.OpenComponent<ActivityExecutionDetailsDrawer>(0);
+            builder.AddAttribute(1, "Open", _open);
+            builder.AddAttribute(2, "ActivityExecution", ActivityExecution);
+            builder.AddAttribute(3, "OpenChanged", EventCallback.Factory.Create<bool>(this, OnOpenChanged));
             builder.CloseComponent();
         }
+
+        private void OnOpenChanged(bool open) => _open = open;
+    }
+
+    /// <summary>
+    /// Same wiring as <c>WorkflowInstanceViewer</c>: Executions-tab row click loads the record and opens the production drawer.
+    /// The full viewer also mounts Journal, the designer, and SignalR, which is not practical in bUnit.
+    /// </summary>
+    private sealed class ExecutionSelectionHost : ComponentBase
+    {
+        [Parameter] public ICollection<ActivityExecutionRecordSummary> Summaries { get; set; } = [];
+        [Inject] private IActivityExecutionService ActivityExecutionService { get; set; } = null!;
+
+        private bool _open;
+        private ActivityExecutionRecord? _record;
+
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<ActivityExecutionsTab>(0);
+            builder.AddAttribute(1, "ActivityExecutionSummaries", Summaries);
+            builder.AddAttribute(2, "VisiblePaneHeight", 400);
+            builder.AddAttribute(3, "ExecutionSelected", EventCallback.Factory.Create<string>(this, OnExecutionSelected));
+            builder.CloseComponent();
+
+            builder.OpenComponent<ActivityExecutionDetailsDrawer>(4);
+            builder.AddAttribute(5, "Open", _open);
+            builder.AddAttribute(6, "ActivityExecution", _record);
+            builder.AddAttribute(7, "OpenChanged", EventCallback.Factory.Create<bool>(this, OnOpenChanged));
+            builder.CloseComponent();
+        }
+
+        private async Task OnExecutionSelected(string executionId)
+        {
+            _record = await ActivityExecutionService.GetAsync(executionId);
+            _open = _record != null;
+        }
+
+        private void OnOpenChanged(bool open) => _open = open;
     }
 
     private sealed class ActivityExecutionServiceStub : IActivityExecutionService
     {
+        public ActivityExecutionRecord? Record { get; set; }
+
         public Task<ActivityExecutionReport> GetReportAsync(string workflowInstanceId, System.Text.Json.Nodes.JsonObject containerActivity, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
@@ -97,7 +182,7 @@ public sealed class ExecutionDetailsDrawerRenderTests : BunitContext, IAsyncLife
             Task.FromResult(Enumerable.Empty<ActivityExecutionRecordSummary>());
 
         public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) =>
-            Task.FromResult<ActivityExecutionRecord?>(null);
+            Task.FromResult(id == Record?.Id ? Record : null);
 
         public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
@@ -109,6 +194,12 @@ public sealed class ExecutionDetailsDrawerRenderTests : BunitContext, IAsyncLife
     private sealed class ClipboardStub : IClipboard
     {
         public Task CopyText(string text, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestTimeFormatter : ITimeFormatter
+    {
+        public string Format(DateTimeOffset? value, string format = "G", string emptyString = "") =>
+            value?.ToString(format) ?? emptyString;
     }
 
     private sealed class TestLocalizer : ILocalizer

--- a/src/modules/Elsa.Studio.Workflows.Tests/ExecutionDetailsDrawerRenderTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/ExecutionDetailsDrawerRenderTests.cs
@@ -1,0 +1,119 @@
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+public sealed class ExecutionDetailsDrawerRenderTests : BunitContext, IAsyncLifetime
+{
+    public ExecutionDetailsDrawerRenderTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IClipboard, ClipboardStub>();
+        Services.AddSingleton<IActivityExecutionService, ActivityExecutionServiceStub>();
+        Render<MudPopoverProvider>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void TemporaryDrawerMountedOpen_RendersExecutionDetails()
+    {
+        var record = new ActivityExecutionRecord
+        {
+            Id = "exec-1",
+            ActivityId = "WriteLine1",
+            ActivityNodeId = "Workflow1:WriteLine1",
+            ActivityType = "Elsa.WriteLine",
+            Status = ActivityStatus.Completed,
+            StartedAt = DateTimeOffset.UtcNow,
+            ActivityState = new Dictionary<string, object?> { ["Text"] = "hello" },
+            Payload = new Dictionary<string, object?> { ["Outcomes"] = "Done" },
+            Outputs = new Dictionary<string, object?> { ["Result"] = "ok" }
+        };
+
+        var cut = Render<ExecutionDetailsDrawerHarness>(parameters => parameters
+            .Add(harness => harness.ActivityExecution, record));
+
+        var drawer = cut.Find("aside.execution-details-drawer");
+        Assert.Contains("mud-drawer--open", drawer.ClassList);
+        Assert.Contains("mud-drawer-temporary", drawer.ClassList);
+        Assert.Contains("Execution Details", cut.Markup);
+        Assert.Contains("hello", cut.Markup);
+        Assert.Contains("Done", cut.Markup);
+        Assert.Contains("ok", cut.Markup);
+    }
+
+    private sealed class ExecutionDetailsDrawerHarness : ComponentBase
+    {
+        [Parameter] public ActivityExecutionRecord? ActivityExecution { get; set; }
+
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<MudDrawer>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Anchor", Anchor.End);
+            builder.AddAttribute(3, "Width", "600px");
+            builder.AddAttribute(4, "Elevation", 2);
+            builder.AddAttribute(5, "Overlay", true);
+            builder.AddAttribute(6, "Variant", DrawerVariant.Temporary);
+            builder.AddAttribute(7, "Class", "execution-details-drawer");
+            builder.AddAttribute(8, "ChildContent", (RenderFragment)(child =>
+            {
+                child.OpenComponent<MudText>(0);
+                child.AddAttribute(1, "Typo", Typo.h6);
+                child.AddAttribute(2, "ChildContent", (RenderFragment)(text => text.AddContent(0, "Execution Details")));
+                child.CloseComponent();
+                child.OpenComponent<ActivityExecutionDetails>(3);
+                child.AddAttribute(4, "ActivityExecution", ActivityExecution);
+                child.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
+    }
+
+    private sealed class ActivityExecutionServiceStub : IActivityExecutionService
+    {
+        public Task<ActivityExecutionReport> GetReportAsync(string workflowInstanceId, System.Text.Json.Nodes.JsonObject containerActivity, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<IEnumerable<ActivityExecutionRecord>> ListAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Enumerable.Empty<ActivityExecutionRecord>());
+
+        public Task<IEnumerable<ActivityExecutionRecordSummary>> ListSummariesAsync(string workflowInstanceId, string activityNodeId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Enumerable.Empty<ActivityExecutionRecordSummary>());
+
+        public Task<ActivityExecutionRecord?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ActivityExecutionRecord?>(null);
+
+        public Task<ActivityExecutionCallStack> GetCallStackAsync(string activityExecutionId, bool? includeCrossWorkflowChain = null, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<PagedListResponse<Elsa.Api.Client.Resources.Resilience.Models.RetryAttemptRecord>> GetRetriesAsync(string activityInstanceId, int? skip = null, int? take = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new PagedListResponse<Elsa.Api.Client.Resources.Resilience.Models.RetryAttemptRecord>());
+    }
+
+    private sealed class ClipboardStub : IClipboard
+    {
+        public Task CopyText(string text, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionDetailsDrawer.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionDetailsDrawer.razor
@@ -1,0 +1,27 @@
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+@* Mount only while open so MudBlazor 9 applies mud-drawer--open on first render.
+   Persistent + @bind-Open left the parent flag true while the drawer stayed closed/off-canvas. *@
+@if (Open)
+{
+    <MudDrawer Open="true"
+               Anchor="Anchor.End"
+               Width="600px"
+               Elevation="2"
+               Overlay="true"
+               OverlayAutoClose="true"
+               Variant="@DrawerVariant.Temporary"
+               Class="execution-details-drawer"
+               OpenChanged="OnOpenChanged">
+        <MudDrawerHeader>
+            <MudText Typo="Typo.h6">@Localizer["Execution Details"]</MudText>
+            <MudSpacer />
+            <MudIconButton Icon="@Icons.Material.Filled.Close" aria-label="@Localizer["Close"]" OnClick="@Close" />
+        </MudDrawerHeader>
+        <MudDivider />
+        <div style="padding: 16px; overflow-y: auto; height: calc(100vh - var(--mud-appbar-height) - 64px);">
+            <ActivityExecutionDetails ActivityExecution="@ActivityExecution" />
+        </div>
+    </MudDrawer>
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionDetailsDrawer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/Components/ActivityExecutionDetailsDrawer.razor.cs
@@ -1,0 +1,31 @@
+using Elsa.Api.Client.Resources.ActivityExecutions.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace Elsa.Studio.Workflows.Components.WorkflowInstanceViewer.Components;
+
+/// <summary>
+/// Right-side drawer that shows one activity execution's State, Outcomes, Output, and Retry Attempts.
+/// </summary>
+public partial class ActivityExecutionDetailsDrawer
+{
+    /// <summary>
+    /// Whether the drawer is open.
+    /// </summary>
+    [Parameter] public bool Open { get; set; }
+
+    /// <summary>
+    /// Raised when the drawer requests an open-state change (header close or overlay).
+    /// </summary>
+    [Parameter] public EventCallback<bool> OpenChanged { get; set; }
+
+    /// <summary>
+    /// The execution record to display.
+    /// </summary>
+    [Parameter] public ActivityExecutionRecord? ActivityExecution { get; set; }
+
+    private Task Close() => OnOpenChanged(false);
+
+    private Task OnOpenChanged(bool open) => OpenChanged.HasDelegate
+        ? OpenChanged.InvokeAsync(open)
+        : Task.CompletedTask;
+}

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
@@ -36,28 +36,7 @@
         </RadzenSplitter>
     </div>
 
-    @* Mount the drawer only while open so MudBlazor 9 applies mud-drawer--open on first render.
-       Persistent + @bind-Open left the parent flag true while the already-mounted drawer stayed closed/off-canvas. *@
-    @if (_isExecutionDetailsDrawerOpen)
-    {
-        <MudDrawer Open="true"
-                   Anchor="Anchor.End"
-                   Width="600px"
-                   Elevation="2"
-                   Overlay="true"
-                   OverlayAutoClose="true"
-                   Variant="@DrawerVariant.Temporary"
-                   Class="execution-details-drawer"
-                   OpenChanged="OnExecutionDetailsDrawerOpenChanged">
-            <MudDrawerHeader>
-                <MudText Typo="Typo.h6">@Localizer["Execution Details"]</MudText>
-                <MudSpacer />
-                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@CloseExecutionDetailsDrawer" />
-            </MudDrawerHeader>
-            <MudDivider />
-            <div style="padding: 16px; overflow-y: auto; height: calc(100vh - var(--mud-appbar-height) - 64px);">
-                <ActivityExecutionDetails ActivityExecution="@_selectedExecutionForDrawer" />
-            </div>
-        </MudDrawer>
-    }
+    <ActivityExecutionDetailsDrawer Open="_isExecutionDetailsDrawerOpen"
+                                    ActivityExecution="_selectedExecutionForDrawer"
+                                    OpenChanged="OnExecutionDetailsDrawerOpenChanged"/>
 </MudDrawerContainer>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor
@@ -2,8 +2,8 @@
 @using Orientation = Radzen.Orientation
 @inject ILocalizer Localizer
 
-<MudDrawerContainer Class="mud-height-full" Style="display: flex; flex-direction: row; position: relative; overflow: hidden;">
-    <div style="flex: 1; overflow: hidden;">
+<MudDrawerContainer Class="mud-height-full" Style="position: relative; overflow: hidden; min-height: calc(100vh - var(--mud-appbar-height));">
+    <div style="height: 100%; overflow: hidden;">
         <RadzenSplitter Orientation="Orientation.Horizontal" Style="height: calc(100vh - var(--mud-appbar-height));">
             <RadzenSplitterPane Size="20%" Min="100px">
                 <MudTabs Elevation="0" ApplyEffectsToContainer="true" KeepPanelsAlive="true" @bind-ActivePanelIndex="_leftPanelTabIndex">
@@ -36,20 +36,28 @@
         </RadzenSplitter>
     </div>
 
-    <MudDrawer @bind-Open="_isExecutionDetailsDrawerOpen"
-               Anchor="Anchor.Right"
-               Width="600px"
-               Height="100%"
-               Elevation="2"
-               Variant="@DrawerVariant.Persistent">
-        <MudDrawerHeader>
-            <MudText Typo="Typo.h6">@Localizer["Execution Details"]</MudText>
-            <MudSpacer />
-            <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@(() => _isExecutionDetailsDrawerOpen = false)" />
-        </MudDrawerHeader>
-        <MudDivider />
-        <div style="padding: 16px; overflow-y: auto; height: calc(100vh - var(--mud-appbar-height) - 64px);">
-            <ActivityExecutionDetails ActivityExecution="@_selectedExecutionForDrawer" />
-        </div>
-    </MudDrawer>
+    @* Mount the drawer only while open so MudBlazor 9 applies mud-drawer--open on first render.
+       Persistent + @bind-Open left the parent flag true while the already-mounted drawer stayed closed/off-canvas. *@
+    @if (_isExecutionDetailsDrawerOpen)
+    {
+        <MudDrawer Open="true"
+                   Anchor="Anchor.End"
+                   Width="600px"
+                   Elevation="2"
+                   Overlay="true"
+                   OverlayAutoClose="true"
+                   Variant="@DrawerVariant.Temporary"
+                   Class="execution-details-drawer"
+                   OpenChanged="OnExecutionDetailsDrawerOpenChanged">
+            <MudDrawerHeader>
+                <MudText Typo="Typo.h6">@Localizer["Execution Details"]</MudText>
+                <MudSpacer />
+                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@CloseExecutionDetailsDrawer" />
+            </MudDrawerHeader>
+            <MudDivider />
+            <div style="padding: 16px; overflow-y: auto; height: calc(100vh - var(--mud-appbar-height) - 64px);">
+                <ActivityExecutionDetails ActivityExecution="@_selectedExecutionForDrawer" />
+            </div>
+        </MudDrawer>
+    }
 </MudDrawerContainer>

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
@@ -234,11 +234,6 @@ public partial class WorkflowInstanceViewer : IAsyncDisposable
         StateHasChanged();
     }
 
-    private void CloseExecutionDetailsDrawer()
-    {
-        _isExecutionDetailsDrawerOpen = false;
-    }
-
     private void OnExecutionDetailsDrawerOpenChanged(bool open)
     {
         _isExecutionDetailsDrawerOpen = open;

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowInstanceViewer/WorkflowInstanceViewer.razor.cs
@@ -177,8 +177,7 @@ public partial class WorkflowInstanceViewer : IAsyncDisposable
         _programmaticallySelectedNodeId = record.ActivityNodeId;
         _selectedActivityNodeId = record.ActivityNodeId;
         _selectedExecutionForDrawer = record;
-        _isExecutionDetailsDrawerOpen = true;
-        StateHasChanged(); // Open drawer and highlight immediately.
+        OpenExecutionDetailsDrawer();
 
         await _workspace.SelectActivityByIdAsync(record.ActivityId, record.ActivityNodeId);
     }
@@ -225,9 +224,24 @@ public partial class WorkflowInstanceViewer : IAsyncDisposable
             _selectedActivityExecutionRecordId = record.Id;
             _selectedActivityNodeId = record.ActivityNodeId;
             _selectedExecutionForDrawer = record;
-            _isExecutionDetailsDrawerOpen = true;
-            StateHasChanged();
+            OpenExecutionDetailsDrawer();
         }
+    }
+
+    private void OpenExecutionDetailsDrawer()
+    {
+        _isExecutionDetailsDrawerOpen = true;
+        StateHasChanged();
+    }
+
+    private void CloseExecutionDetailsDrawer()
+    {
+        _isExecutionDetailsDrawerOpen = false;
+    }
+
+    private void OnExecutionDetailsDrawerOpenChanged(bool open)
+    {
+        _isExecutionDetailsDrawerOpen = open;
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Restore the Workflow Instance Viewer **Execution Details** drawer so clicking an Executions-tab row shows that execution's State, Outcomes, Output, and Retry Attempts. Fixes #1021.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem

After #750 replaced the inline execution details panel with a persistent right-anchored `MudDrawer`, clicking an Executions-tab row toggled `_isExecutionDetailsDrawerOpen` and `GET /elsa/api/activity-executions/{id}` returned 200, but the drawer never became visible.

The always-mounted Persistent drawer used `@bind-Open` against a nested `MudDrawerContainer` (itself inside `MudLayout`). In MudBlazor 9 that combination leaves the drawer off-canvas (`mud-drawer--closed` / `right: -width`) even after the parent flag is true.

### Solution

Smallest patch-safe change on `release/3.8.1`:

- Mount the drawer only while it should be open, with `Open="true"` on first render.
- Use `DrawerVariant.Temporary` so width, overlay, and `mud-drawer--open` apply immediately.
- Own that markup in `ActivityExecutionDetailsDrawer` (header close + overlay `OpenChanged`).
- Leave the details content (`ActivityExecutionDetails`) unchanged.

---

## Verification

Steps:
1. Create a workflow where an activity runs more than once (e.g. `WriteLine` inside `ForEach` over `["a","b","c"]`).
2. Run it to completion; open the instance; select that activity; open the **Executions** tab.
3. Click a row.

Expected outcome:

- The **Execution Details** drawer opens.
- It shows that execution's State (inputs), Outcomes, Output, and Retry Attempts (when present).
- Close (X or overlay) hides it; clicking another row opens details for that execution.

Unit tests (bUnit):

- Executions-tab row click raises `ExecutionSelected` with that record id.
- `ActivityExecutionDetails` renders State / Outcomes / Output and Retry Attempts.
- Production drawer: row select mounts `mud-drawer--open` with those details; header close and overlay `OpenChanged` unmount it.

A full `WorkflowInstanceViewer` render is not practical in bUnit (Journal, designer, SignalR). The selection host uses the same tab → load record → open drawer wiring as the viewer.

`dotnet test src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj` — 133 passed.

This environment has no running Elsa backend, so the instance-viewer click path was not exercised in a browser.

---

## Screenshots / Recordings (if applicable)

Not captured here (no Studio + Elsa backend in this environment). Please confirm on a local 3.8.1 host using the steps above.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcb200b-5f32-5d71-ab30-2b992b233013?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcb200b-5f32-5d71-ab30-2b992b233013&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

