### PR TITLE
feat(workflows): recognise BPMN refusals by elsa-core's error code, not wording

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -1,4 +1,5 @@
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Refit;
 using System.Text.Json;
 
@@ -46,6 +47,13 @@ public static class ValidationApiExceptionExtensions
     /// is empty or does not parse as JSON. Shared with callers that have a raw response body rather than an
     /// <see cref="ApiException"/> to extract it from.
     /// </summary>
+    /// <remarks>
+    /// Also reads the envelope's additive <c>code</c> and <c>data</c> members (see e.g.
+    /// <see cref="Elsa.Studio.Workflows.Domain.Models.Bpmn.BpmnErrorCodes"/> and <c>doc/wiki/bpmn-workflows.md</c> in
+    /// elsa-core), so every caller shares one parser instead of a caller matching the message text itself. A body
+    /// without a <c>code</c> — an older server, or a refusal that never carries one — leaves <see cref="ValidationErrors.Code"/>
+    /// <see langword="null"/>, which every caller must treat as an unrecognized code and fall back to the message.
+    /// </remarks>
     public static ValidationErrors? GetValidationErrorsFromContent(string? content)
     {
         if (string.IsNullOrWhiteSpace(content))
@@ -63,13 +71,43 @@ public static class ValidationApiExceptionExtensions
             if (errors.Count == 0)
                 errors.AddRange(GetFallbackMessages(root).Select(x => new ValidationError(x)));
 
-            return errors.Count > 0 ? new ValidationErrors(errors) : null;
+            if (errors.Count == 0)
+                return null;
+
+            var code = TryGetProperty(root, "code", out var codeElement) && codeElement.ValueKind == JsonValueKind.String
+                ? codeElement.GetString()
+                : null;
+
+            var data = TryGetProperty(root, "data", out var dataElement) ? GetCapabilityRefusal(dataElement) : null;
+
+            return new ValidationErrors(errors, Code: code, Data: data);
         }
         catch (JsonException)
         {
             return null;
         }
     }
+
+    /// <summary>
+    /// Reads <paramref name="dataElement"/> into a <see cref="BpmnCapabilityRefusal"/> when it carries a
+    /// <c>capabilities</c> and/or <c>elementIds</c> string array — the only shape any <c>data</c> member sends
+    /// today (see <see cref="Elsa.Studio.Workflows.Domain.Models.Bpmn.BpmnErrorCodes.ImportCapabilityUnsupported"/>)
+    /// — or <see langword="null"/> for any other shape, including a code that carries no <c>data</c> at all.
+    /// </summary>
+    private static BpmnCapabilityRefusal? GetCapabilityRefusal(JsonElement dataElement)
+    {
+        if (dataElement.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var capabilityNames = TryGetProperty(dataElement, "capabilities", out var capabilitiesElement) ? GetStringArray(capabilitiesElement) : [];
+        var elementIds = TryGetProperty(dataElement, "elementIds", out var elementIdsElement) ? GetStringArray(elementIdsElement) : [];
+
+        return capabilityNames.Count == 0 && elementIds.Count == 0 ? null : new BpmnCapabilityRefusal(capabilityNames, elementIds);
+    }
+
+    private static IReadOnlyList<string> GetStringArray(JsonElement element) => element.ValueKind == JsonValueKind.Array
+        ? element.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!).ToList()
+        : [];
 
     private static IEnumerable<string> GetErrorMessages(JsonElement element)
     {

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Extensions/ValidationApiExceptionExtensions.cs
@@ -1,5 +1,4 @@
 using Elsa.Studio.Workflows.Domain.Models;
-using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Refit;
 using System.Text.Json;
 
@@ -53,6 +52,8 @@ public static class ValidationApiExceptionExtensions
     /// elsa-core), so every caller shares one parser instead of a caller matching the message text itself. A body
     /// without a <c>code</c> — an older server, or a refusal that never carries one — leaves <see cref="ValidationErrors.Code"/>
     /// <see langword="null"/>, which every caller must treat as an unrecognized code and fall back to the message.
+    /// <c>data</c> is left as raw JSON: interpreting it is up to whichever feature owns <c>code</c> (see e.g.
+    /// <see cref="Elsa.Studio.Workflows.Domain.Models.Bpmn.BpmnCapabilityRefusal.FromData"/>).
     /// </remarks>
     public static ValidationErrors? GetValidationErrorsFromContent(string? content)
     {
@@ -78,7 +79,9 @@ public static class ValidationApiExceptionExtensions
                 ? codeElement.GetString()
                 : null;
 
-            var data = TryGetProperty(root, "data", out var dataElement) ? GetCapabilityRefusal(dataElement) : null;
+            // Cloned so the element survives past this method's JsonDocument, which is disposed on return; the raw
+            // shape is handed back as-is; interpreting it is up to whichever feature owns `code`.
+            var data = TryGetProperty(root, "data", out var dataElement) ? dataElement.Clone() : (JsonElement?)null;
 
             return new ValidationErrors(errors, Code: code, Data: data);
         }
@@ -87,27 +90,6 @@ public static class ValidationApiExceptionExtensions
             return null;
         }
     }
-
-    /// <summary>
-    /// Reads <paramref name="dataElement"/> into a <see cref="BpmnCapabilityRefusal"/> when it carries a
-    /// <c>capabilities</c> and/or <c>elementIds</c> string array — the only shape any <c>data</c> member sends
-    /// today (see <see cref="Elsa.Studio.Workflows.Domain.Models.Bpmn.BpmnErrorCodes.ImportCapabilityUnsupported"/>)
-    /// — or <see langword="null"/> for any other shape, including a code that carries no <c>data</c> at all.
-    /// </summary>
-    private static BpmnCapabilityRefusal? GetCapabilityRefusal(JsonElement dataElement)
-    {
-        if (dataElement.ValueKind != JsonValueKind.Object)
-            return null;
-
-        var capabilityNames = TryGetProperty(dataElement, "capabilities", out var capabilitiesElement) ? GetStringArray(capabilitiesElement) : [];
-        var elementIds = TryGetProperty(dataElement, "elementIds", out var elementIdsElement) ? GetStringArray(elementIdsElement) : [];
-
-        return capabilityNames.Count == 0 && elementIds.Count == 0 ? null : new BpmnCapabilityRefusal(capabilityNames, elementIds);
-    }
-
-    private static IReadOnlyList<string> GetStringArray(JsonElement element) => element.ValueKind == JsonValueKind.Array
-        ? element.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!).ToList()
-        : [];
 
     private static IEnumerable<string> GetErrorMessages(JsonElement element)
     {

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
@@ -1,38 +1,9 @@
 namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
 
 /// <summary>
-/// The capability names and offending element ids a BPMN import's <c>422</c> "missing host capabilities" refusal
-/// carries, parsed out of the single sentence <c>BpmnInterchangeDocumentService.Import</c> raises in elsa-core, so
-/// the UI can list each separately instead of showing the raw sentence.
+/// The capability names and offending element ids a BPMN import's <c>422</c> <see cref="BpmnErrorCodes.ImportCapabilityUnsupported"/>
+/// refusal carries, read from the error envelope's <c>data.capabilities</c> and <c>data.elementIds</c> (see
+/// <see cref="Elsa.Studio.Workflows.Domain.Extensions.ValidationApiExceptionExtensions.GetValidationErrorsFromContent"/>),
+/// so the UI can list each separately instead of showing the raw message.
 /// </summary>
-public sealed record BpmnCapabilityRefusal(IReadOnlyList<string> CapabilityNames, IReadOnlyList<string> ElementIds)
-{
-    private const string CapabilitiesPrefix = "does not declare the following BPMN host capabilities the document requires:";
-    private const string ElementsPrefix = "Offending elements (combined across all missing capabilities above, not attributable to any one of them):";
-
-    /// <summary>
-    /// Parses <paramref name="message"/> into a <see cref="BpmnCapabilityRefusal"/> when it matches the capability
-    /// refusal's known shape, or returns <see langword="null"/> for any other message (including the two export
-    /// refusals, which use different wording, and unrelated failures).
-    /// </summary>
-    public static BpmnCapabilityRefusal? TryParse(string message)
-    {
-        var capabilitiesIndex = message.IndexOf(CapabilitiesPrefix, StringComparison.OrdinalIgnoreCase);
-        var elementsIndex = message.IndexOf(ElementsPrefix, StringComparison.OrdinalIgnoreCase);
-
-        if (capabilitiesIndex < 0 || elementsIndex < 0 || elementsIndex < capabilitiesIndex)
-            return null;
-
-        var capabilitiesText = message[(capabilitiesIndex + CapabilitiesPrefix.Length)..elementsIndex];
-        var elementsText = message[(elementsIndex + ElementsPrefix.Length)..];
-
-        var capabilityNames = SplitList(capabilitiesText);
-        var elementIds = SplitList(elementsText);
-
-        return capabilityNames.Count == 0 && elementIds.Count == 0 ? null : new BpmnCapabilityRefusal(capabilityNames, elementIds);
-    }
-
-    private static IReadOnlyList<string> SplitList(string text) => text
-        .Trim().Trim('.')
-        .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-}
+public sealed record BpmnCapabilityRefusal(IReadOnlyList<string> CapabilityNames, IReadOnlyList<string> ElementIds);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnCapabilityRefusal.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
 
 /// <summary>
@@ -6,4 +8,43 @@ namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
 /// <see cref="Elsa.Studio.Workflows.Domain.Extensions.ValidationApiExceptionExtensions.GetValidationErrorsFromContent"/>),
 /// so the UI can list each separately instead of showing the raw message.
 /// </summary>
-public sealed record BpmnCapabilityRefusal(IReadOnlyList<string> CapabilityNames, IReadOnlyList<string> ElementIds);
+public sealed record BpmnCapabilityRefusal(IReadOnlyList<string> CapabilityNames, IReadOnlyList<string> ElementIds)
+{
+    /// <summary>
+    /// Reads <paramref name="dataElement"/> (a <see cref="Models.ValidationErrors.Data"/> carried alongside
+    /// <see cref="BpmnErrorCodes.ImportCapabilityUnsupported"/>) into a <see cref="BpmnCapabilityRefusal"/> when it
+    /// carries a <c>capabilities</c> and/or <c>elementIds</c> string array — the only shape any <c>data</c> member
+    /// sends today — or <see langword="null"/> for any other shape, including a code that carries no <c>data</c> at
+    /// all.
+    /// </summary>
+    public static BpmnCapabilityRefusal? FromData(JsonElement? dataElement)
+    {
+        if (dataElement is not { ValueKind: JsonValueKind.Object } element)
+            return null;
+
+        var capabilityNames = TryGetProperty(element, "capabilities", out var capabilitiesElement) ? GetStringArray(capabilitiesElement) : [];
+        var elementIds = TryGetProperty(element, "elementIds", out var elementIdsElement) ? GetStringArray(elementIdsElement) : [];
+
+        return capabilityNames.Count == 0 && elementIds.Count == 0 ? null : new BpmnCapabilityRefusal(capabilityNames, elementIds);
+    }
+
+    private static IReadOnlyList<string> GetStringArray(JsonElement element) => element.ValueKind == JsonValueKind.Array
+        ? element.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!).ToList()
+        : [];
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement property)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var candidate in element.EnumerateObject())
+                if (string.Equals(candidate.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    property = candidate.Value;
+                    return true;
+                }
+        }
+
+        property = default;
+        return false;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnErrorCodes.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnErrorCodes.cs
@@ -1,0 +1,70 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The stable, machine-readable codes Studio recognizes on a BPMN interchange refusal's error envelope, mirroring
+/// elsa-core's own <c>Elsa.Bpmn.Interchange.BpmnErrorCodes</c> (the source of truth for these values and for exactly
+/// which endpoint sends each one, in what shape). See that type, and its accompanying
+/// <c>doc/wiki/bpmn-workflows.md</c> "Error codes on refusals" section, for the full envelope this code lives
+/// alongside (<c>statusCode</c>, <c>message</c>, <c>errors</c>, plus the additive <c>code</c> and <c>data</c>
+/// <see cref="Elsa.Studio.Workflows.Domain.Models.ValidationErrors"/> also carries).
+/// </summary>
+/// <remarks>
+/// Only <see cref="ImportCapabilityUnsupported"/>, <see cref="ExportNotImported"/>, <see cref="ExportSourceStale"/>
+/// and <see cref="ExportSourceVersionUnknown"/> are consumed today, by <c>RemoteBpmnInterchangeService</c> and
+/// <c>BpmnImportUiService</c>. The three document-endpoint codes are mirrored ahead of the document GET/PUT
+/// endpoints Studio's designer will call next, so that work does not have to duplicate this constants list.
+/// </remarks>
+public static class BpmnErrorCodes
+{
+    /// <summary>
+    /// <c>bpmn/import</c> (and, once Studio calls it, the document <c>PUT</c>) refuses a document that needs a BPMN
+    /// host capability this deployment does not declare. Carries <c>data.capabilities</c> (the missing capability
+    /// names) and <c>data.elementIds</c> (the offending element ids, combined across every missing capability).
+    /// </summary>
+    public const string ImportCapabilityUnsupported = "bpmn.import.capability-unsupported";
+
+    /// <summary>
+    /// <c>bpmn/import</c> (and the document <c>PUT</c>) refuses a document whose work binding cannot be turned into
+    /// a runnable Elsa activity.
+    /// </summary>
+    public const string ImportBindingInvalid = "bpmn.import.binding-invalid";
+
+    /// <summary>
+    /// <c>bpmn/definitions/{id}/export</c> (and the document <c>GET</c>) refuses a workflow definition that does not
+    /// currently carry BPMN source — either it was never imported from BPMN, or a later save replaced its custom
+    /// properties wholesale.
+    /// </summary>
+    public const string ExportNotImported = "bpmn.export.not-imported";
+
+    /// <summary>
+    /// <c>bpmn/definitions/{id}/export</c> (and the document <c>GET</c>) refuses a workflow definition whose stored
+    /// BPMN source no longer corresponds to it — its version, or (for an unpublished draft saved in place) its
+    /// activity graph, has moved on since the source was recorded.
+    /// </summary>
+    public const string ExportSourceStale = "bpmn.export.source-stale";
+
+    /// <summary>
+    /// <c>bpmn/definitions/{id}/export</c> (and the document <c>GET</c>) refuses a workflow definition that carries
+    /// BPMN source but not the definition version it was recorded against, so whether that source is still current
+    /// cannot be verified. Not reachable through <c>Import</c> itself; only through custom properties edited or
+    /// migrated some other way.
+    /// </summary>
+    public const string ExportSourceVersionUnknown = "bpmn.export.source-version-unknown";
+
+    /// <summary>
+    /// The document <c>PUT</c> refuses to edit a workflow definition that no longer exists.
+    /// </summary>
+    public const string DocumentNotFound = "bpmn.document.not-found";
+
+    /// <summary>
+    /// The document <c>PUT</c> requires an <c>If-Match</c> request header and refuses a request that omits it or
+    /// sends the wildcard <c>*</c>.
+    /// </summary>
+    public const string DocumentPreconditionRequired = "bpmn.document.precondition-required";
+
+    /// <summary>
+    /// The document <c>PUT</c> refuses an <c>If-Match</c> header that does not match the workflow definition's
+    /// current ETag: the definition was written since the caller last read it.
+    /// </summary>
+    public const string DocumentPreconditionFailed = "bpmn.document.precondition-failed";
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using System.Text.Json;
 
 namespace Elsa.Studio.Workflows.Domain.Models;
 
@@ -19,11 +19,13 @@ namespace Elsa.Studio.Workflows.Domain.Models;
 /// unrecognized code — and fall back to <see cref="Errors"/>'s message.
 /// </param>
 /// <param name="Data">
-/// The structured data <see cref="Code"/> carries, when it carries any (today, only the missing capability names
-/// and offending element ids of a BPMN import's capability refusal). <see langword="null"/> otherwise.
+/// The raw <c>data</c> member <see cref="Code"/> carries, when it carries any (today, only a BPMN import's
+/// capability refusal, whose <c>capabilities</c> and <c>elementIds</c> are read by
+/// <see cref="Bpmn.BpmnCapabilityRefusal.FromData"/>). <see langword="null"/> otherwise. Left as raw JSON here
+/// because the shape is owned by whichever feature defines <see cref="Code"/>, not by this shared model.
 /// </param>
 public record ValidationErrors(
     IReadOnlyCollection<ValidationError> Errors,
     HttpStatusCode? StatusCode = null,
     string? Code = null,
-    BpmnCapabilityRefusal? Data = null);
+    JsonElement? Data = null);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/ValidationErrors.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 
 namespace Elsa.Studio.Workflows.Domain.Models;
 
@@ -11,4 +12,18 @@ namespace Elsa.Studio.Workflows.Domain.Models;
 /// from another by more than wording (e.g. a BPMN capability refusal, which is only ever a <c>422</c>) can gate on
 /// this instead of matching the error text.
 /// </param>
-public record ValidationErrors(IReadOnlyCollection<ValidationError> Errors, HttpStatusCode? StatusCode = null);
+/// <param name="Code">
+/// The machine-readable code the error body carried, when the server sent one (see e.g.
+/// <see cref="Bpmn.BpmnErrorCodes"/> for the BPMN-specific codes). <see langword="null"/> for an older server that
+/// does not send a code yet, or for a failure that never carries one; callers must treat both the same way — as an
+/// unrecognized code — and fall back to <see cref="Errors"/>'s message.
+/// </param>
+/// <param name="Data">
+/// The structured data <see cref="Code"/> carries, when it carries any (today, only the missing capability names
+/// and offending element ids of a BPMN import's capability refusal). <see langword="null"/> otherwise.
+/// </param>
+public record ValidationErrors(
+    IReadOnlyCollection<ValidationError> Errors,
+    HttpStatusCode? StatusCode = null,
+    string? Code = null,
+    BpmnCapabilityRefusal? Data = null);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
@@ -70,31 +70,33 @@ public class RemoteBpmnInterchangeService(IBackendApiClientProvider backendApiCl
         if (response.StatusCode == HttpStatusCode.NotFound)
             return new(new BpmnExportFailure(BpmnExportFailureReason.NotFound, "Workflow definition not found."));
 
-        var message = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(body)?.Errors.FirstOrDefault()?.ErrorMessage
+        var validationErrors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(body);
+        var message = validationErrors?.Errors.FirstOrDefault()?.ErrorMessage
             ?? (string.IsNullOrWhiteSpace(body) ? response.ReasonPhrase ?? "The export could not be completed." : body);
 
         if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
-            return new(new BpmnExportFailure(ClassifyExportRefusal(message), message));
+            return new(new BpmnExportFailure(ClassifyExportRefusal(validationErrors?.Code), message));
 
         return new(new BpmnExportFailure(BpmnExportFailureReason.Unknown, message));
     }
 
     /// <summary>
-    /// Classifies the two 422 refusals <c>BpmnInterchangeDocumentService.Export(WorkflowDefinition)</c> raises by
-    /// matching the distinguishing phrase each one carries, so the UI can show its own short wording instead of the
-    /// full diagnostic sentence. See that method's remarks in elsa-core for why each refusal reads the way it does.
+    /// Classifies the 422 refusals <c>BpmnInterchangeDocumentService.Export(WorkflowDefinition)</c> raises by their
+    /// machine-readable <paramref name="code"/> (see <see cref="BpmnErrorCodes"/>), rather than by matching a phrase
+    /// in the message, so a rewording of the message never breaks this classification. A <see langword="null"/> or
+    /// unrecognized code — including an older server that does not send one yet — falls back to
+    /// <see cref="BpmnExportFailureReason.Unknown"/>, which shows the server's own message.
     /// </summary>
-    private static BpmnExportFailureReason ClassifyExportRefusal(string message)
+    private static BpmnExportFailureReason ClassifyExportRefusal(string? code) => code switch
     {
-        if (message.Contains("has changed since it was imported from BPMN", StringComparison.OrdinalIgnoreCase))
-            return BpmnExportFailureReason.DefinitionChangedSinceImport;
-
-        if (message.Contains("does not currently carry BPMN source", StringComparison.OrdinalIgnoreCase)
-            || message.Contains("not the definition version it was recorded against", StringComparison.OrdinalIgnoreCase))
-            return BpmnExportFailureReason.NotImportedFromBpmn;
-
-        return BpmnExportFailureReason.Unknown;
-    }
+        BpmnErrorCodes.ExportNotImported => BpmnExportFailureReason.NotImportedFromBpmn,
+        // Not reachable through Import or the document PUT themselves (both always record a source version
+        // alongside the source text); Studio has no wording of its own for this case, distinct from
+        // ExportNotImported's, so it maps to the same "not imported" message.
+        BpmnErrorCodes.ExportSourceVersionUnknown => BpmnExportFailureReason.NotImportedFromBpmn,
+        BpmnErrorCodes.ExportSourceStale => BpmnExportFailureReason.DefinitionChangedSinceImport,
+        _ => BpmnExportFailureReason.Unknown
+    };
 
     private async Task<IBpmnInterchangeApi> GetApiAsync(CancellationToken cancellationToken = default) =>
         await backendApiClientProvider.GetApiAsync<IBpmnInterchangeApi>(cancellationToken);

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
@@ -6,15 +6,16 @@ namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
 /// Covers how a <see cref="BpmnCapabilityRefusal"/> is built: from the coded error envelope's <c>data.capabilities</c>
-/// and <c>data.elementIds</c>, through <see cref="ValidationApiExceptionExtensions.GetValidationErrorsFromContent"/>,
-/// rather than by parsing the human-readable message (pinned by
+/// and <c>data.elementIds</c>, via <see cref="ValidationApiExceptionExtensions.GetValidationErrorsFromContent"/>'s raw
+/// <c>data</c> and <see cref="BpmnCapabilityRefusal.FromData"/>'s BPMN-owned mapping of it, rather than by parsing
+/// the human-readable message (pinned by
 /// <see cref="RemoteBpmnInterchangeServiceTests.ImportAsync_ReturnsTheCapabilityRefusalMessage_On422"/>, which a
 /// server may reword without notice).
 /// </summary>
 public class BpmnCapabilityRefusalTests
 {
     [Fact]
-    public void GetValidationErrorsFromContent_ExtractsCapabilityNamesAndElementIds_FromTheCodedEnvelope()
+    public void FromData_ExtractsCapabilityNamesAndElementIds_FromTheCodedEnvelope()
     {
         const string content = $$"""
         {
@@ -25,14 +26,15 @@ public class BpmnCapabilityRefusalTests
         """;
 
         var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
+        var refusal = BpmnCapabilityRefusal.FromData(errors!.Data);
 
-        Assert.NotNull(errors!.Data);
-        Assert.Equal(["ScopeSignalling"], errors.Data!.CapabilityNames);
-        Assert.Equal(["Gateway_1"], errors.Data.ElementIds);
+        Assert.NotNull(refusal);
+        Assert.Equal(["ScopeSignalling"], refusal!.CapabilityNames);
+        Assert.Equal(["Gateway_1"], refusal.ElementIds);
     }
 
     [Fact]
-    public void GetValidationErrorsFromContent_ExtractsMultipleCapabilityNamesAndElementIds()
+    public void FromData_ExtractsMultipleCapabilityNamesAndElementIds()
     {
         const string content = $$"""
         {
@@ -43,10 +45,11 @@ public class BpmnCapabilityRefusalTests
         """;
 
         var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
+        var refusal = BpmnCapabilityRefusal.FromData(errors!.Data);
 
-        Assert.NotNull(errors!.Data);
-        Assert.Equal(["ScopeSignalling", "CompensationHandling"], errors.Data!.CapabilityNames);
-        Assert.Equal(["Gateway_1", "Task_2"], errors.Data.ElementIds);
+        Assert.NotNull(refusal);
+        Assert.Equal(["ScopeSignalling", "CompensationHandling"], refusal!.CapabilityNames);
+        Assert.Equal(["Gateway_1", "Task_2"], refusal.ElementIds);
     }
 
     [Theory]
@@ -64,6 +67,7 @@ public class BpmnCapabilityRefusalTests
         var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
 
         Assert.Null(errors!.Data);
+        Assert.Null(BpmnCapabilityRefusal.FromData(errors.Data));
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnCapabilityRefusalTests.cs
@@ -1,50 +1,83 @@
+using Elsa.Studio.Workflows.Domain.Extensions;
 using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Xunit;
 
 namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
-/// Covers <see cref="BpmnCapabilityRefusal.TryParse"/>: it must recognize the exact sentence
-/// <c>BpmnInterchangeDocumentService.Import</c> raises for a missing-host-capability refusal (pinned by
-/// <see cref="RemoteBpmnInterchangeServiceTests.ImportAsync_ReturnsTheCapabilityRefusalMessage_On422"/>), and must
-/// not misclassify the two differently-worded export refusals or unrelated messages as the same thing.
+/// Covers how a <see cref="BpmnCapabilityRefusal"/> is built: from the coded error envelope's <c>data.capabilities</c>
+/// and <c>data.elementIds</c>, through <see cref="ValidationApiExceptionExtensions.GetValidationErrorsFromContent"/>,
+/// rather than by parsing the human-readable message (pinned by
+/// <see cref="RemoteBpmnInterchangeServiceTests.ImportAsync_ReturnsTheCapabilityRefusalMessage_On422"/>, which a
+/// server may reword without notice).
 /// </summary>
 public class BpmnCapabilityRefusalTests
 {
     [Fact]
-    public void TryParse_ExtractsCapabilityNamesAndElementIds_FromTheKnownRefusalMessage()
+    public void GetValidationErrorsFromContent_ExtractsCapabilityNamesAndElementIds_FromTheCodedEnvelope()
     {
-        const string message =
-            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
-            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
+        const string content = $$"""
+        {
+          "errors": { "generalErrors": ["This deployment does not declare a required capability."] },
+          "code": "{{BpmnErrorCodes.ImportCapabilityUnsupported}}",
+          "data": { "capabilities": ["ScopeSignalling"], "elementIds": ["Gateway_1"] }
+        }
+        """;
 
-        var refusal = BpmnCapabilityRefusal.TryParse(message);
+        var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
 
-        Assert.NotNull(refusal);
-        Assert.Equal(["ScopeSignalling"], refusal!.CapabilityNames);
-        Assert.Equal(["Gateway_1"], refusal.ElementIds);
+        Assert.NotNull(errors!.Data);
+        Assert.Equal(["ScopeSignalling"], errors.Data!.CapabilityNames);
+        Assert.Equal(["Gateway_1"], errors.Data.ElementIds);
     }
 
     [Fact]
-    public void TryParse_ExtractsMultipleCapabilityNamesAndElementIds()
+    public void GetValidationErrorsFromContent_ExtractsMultipleCapabilityNamesAndElementIds()
     {
-        const string message =
-            "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling, CompensationHandling. "
-            + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1, Task_2.";
+        const string content = $$"""
+        {
+          "errors": { "generalErrors": ["This deployment does not declare two required capabilities."] },
+          "code": "{{BpmnErrorCodes.ImportCapabilityUnsupported}}",
+          "data": { "capabilities": ["ScopeSignalling", "CompensationHandling"], "elementIds": ["Gateway_1", "Task_2"] }
+        }
+        """;
 
-        var refusal = BpmnCapabilityRefusal.TryParse(message);
+        var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
 
-        Assert.NotNull(refusal);
-        Assert.Equal(["ScopeSignalling", "CompensationHandling"], refusal!.CapabilityNames);
-        Assert.Equal(["Gateway_1", "Task_2"], refusal.ElementIds);
+        Assert.NotNull(errors!.Data);
+        Assert.Equal(["ScopeSignalling", "CompensationHandling"], errors.Data!.CapabilityNames);
+        Assert.Equal(["Gateway_1", "Task_2"], errors.Data.ElementIds);
     }
 
     [Theory]
-    [InlineData("Workflow definition 'wf-1' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML.")]
-    [InlineData("Workflow definition 'wf-1' has changed since it was imported from BPMN (imported at version 1, currently at version 2).")]
-    [InlineData("Upload exactly one .bpmn file.")]
-    public void TryParse_ReturnsNull_ForMessagesThatAreNotTheCapabilityRefusal(string message)
+    [InlineData(BpmnErrorCodes.ExportNotImported)]
+    [InlineData(BpmnErrorCodes.ImportBindingInvalid)]
+    public void GetValidationErrorsFromContent_LeavesDataNull_ForCodesThatCarryNone(string code)
     {
-        Assert.Null(BpmnCapabilityRefusal.TryParse(message));
+        var content = $$"""
+        {
+          "errors": { "generalErrors": ["Some refusal."] },
+          "code": "{{code}}"
+        }
+        """;
+
+        var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
+
+        Assert.Null(errors!.Data);
+    }
+
+    [Fact]
+    public void GetValidationErrorsFromContent_LeavesCodeAndDataNull_ForABodyWithNoCode()
+    {
+        const string content = """
+        {
+          "errors": { "generalErrors": ["This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling."] }
+        }
+        """;
+
+        var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(content);
+
+        Assert.Null(errors!.Code);
+        Assert.Null(errors.Data);
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -240,6 +240,37 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task ImportFileAsync_FallsBackToTheServerMessage_ForACapabilityRefusalCodeWithNoData()
+    {
+        const string message = "This deployment does not declare a required BPMN host capability.";
+
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.UnprocessableEntity, Code: BpmnErrorCodes.ImportCapabilityUnsupported))
+        };
+        var definitionService = new FakeWorkflowDefinitionService();
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var file = new FakeBrowserFile("process.bpmn");
+
+        var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
+
+        // The findings dialog; there is no refusal dialog to close afterwards because a coded refusal with no
+        // `data` cannot be read into a `BpmnCapabilityRefusal`, so it falls back to the ordinary failure path.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await importTask.WaitAsync(Timeout);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsSuccess);
+        Assert.Equal(WorkflowImportFailureType.Exception, result.Failure!.FailureType);
+        Assert.Equal(message, result.Failure.ErrorMessage);
+    }
+
+    [Fact]
     public async Task ImportFileAsync_DoesNotTreatAnUncodedMessage_AsACapabilityRefusal_EvenWithTheRefusalWording()
     {
         // An older server that has not been upgraded to send `code` yet: without it, the message is shown as an

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -163,7 +163,7 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task ImportFileAsync_ShowsTheRefusalDialogOnce_AndReturnsACapabilityRefusalResult_On422()
+    public async Task ImportFileAsync_ShowsTheRefusalDialogOnce_AndReturnsACapabilityRefusalResult_ForTheCodedRefusal()
     {
         const string message =
             "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
@@ -174,7 +174,11 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
         var interchangeService = new FakeBpmnInterchangeService
         {
             AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
-            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.UnprocessableEntity))
+            ImportResult = new(new ValidationErrors(
+                [new ValidationError(message)],
+                HttpStatusCode.UnprocessableEntity,
+                Code: BpmnErrorCodes.ImportCapabilityUnsupported,
+                Data: new BpmnCapabilityRefusal(["ScopeSignalling"], ["Gateway_1"])))
         };
         var definitionService = new FakeWorkflowDefinitionService();
         var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
@@ -204,8 +208,41 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task ImportFileAsync_DoesNotTreatA500AsACapabilityRefusal_EvenWithTheRefusalWording()
+    public async Task ImportFileAsync_FallsBackToTheServerMessage_ForA422WithAnUnrecognizedCode()
     {
+        const string message = "Some other 422 refusal that is not a capability refusal.";
+
+        var dialogService = Services.GetRequiredService<IDialogService>();
+        var localizer = Services.GetRequiredService<ILocalizer>();
+        var interchangeService = new FakeBpmnInterchangeService
+        {
+            AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
+            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.UnprocessableEntity, Code: BpmnErrorCodes.ImportBindingInvalid))
+        };
+        var definitionService = new FakeWorkflowDefinitionService();
+        var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
+        var file = new FakeBrowserFile("process.bpmn");
+
+        var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
+
+        // The findings dialog; there is no refusal dialog to close afterwards because this code is not the
+        // capability refusal's.
+        _dialogProvider.WaitForElement("button");
+        await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
+
+        var result = await importTask.WaitAsync(Timeout);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsSuccess);
+        Assert.Equal(WorkflowImportFailureType.Exception, result.Failure!.FailureType);
+        Assert.Equal(message, result.Failure.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ImportFileAsync_DoesNotTreatAnUncodedMessage_AsACapabilityRefusal_EvenWithTheRefusalWording()
+    {
+        // An older server that has not been upgraded to send `code` yet: without it, the message is shown as an
+        // ordinary failure rather than the dialog, even though its wording matches the capability refusal's.
         const string message =
             "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
             + "Offending elements (combined across all missing capabilities above, not attributable to any one of them): Gateway_1.";
@@ -215,7 +252,7 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
         var interchangeService = new FakeBpmnInterchangeService
         {
             AnalyzeResult = new(new BpmnImportAnalysisModel { ProcessIds = ["only-process"] }),
-            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.InternalServerError))
+            ImportResult = new(new ValidationErrors([new ValidationError(message)], HttpStatusCode.UnprocessableEntity))
         };
         var definitionService = new FakeWorkflowDefinitionService();
         var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);
@@ -223,7 +260,8 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
 
         var importTask = _dialogProvider.InvokeAsync(() => service.ImportFileAsync(file, definitionId: null));
 
-        // The findings dialog; there is no refusal dialog to close afterwards because a 500 never counts as one.
+        // The findings dialog; there is no refusal dialog to close afterwards because a body with no code never
+        // counts as one.
         _dialogProvider.WaitForElement("button");
         await _dialogProvider.InvokeAsync(() => ImportButton().ClickAsync(new MouseEventArgs()));
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Bunit;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
@@ -178,7 +179,7 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
                 [new ValidationError(message)],
                 HttpStatusCode.UnprocessableEntity,
                 Code: BpmnErrorCodes.ImportCapabilityUnsupported,
-                Data: new BpmnCapabilityRefusal(["ScopeSignalling"], ["Gateway_1"])))
+                Data: JsonDocument.Parse("""{ "capabilities": ["ScopeSignalling"], "elementIds": ["Gateway_1"] }""").RootElement))
         };
         var definitionService = new FakeWorkflowDefinitionService();
         var service = new BpmnImportUiService(dialogService, localizer, interchangeService, definitionService);

--- a/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
@@ -73,8 +73,9 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         var error = Assert.Single(result.Failure!.Errors);
         Assert.Equal(message, error.ErrorMessage);
         Assert.Equal(BpmnErrorCodes.ImportCapabilityUnsupported, result.Failure.Code);
-        Assert.Equal(["ScopeSignalling"], result.Failure.Data!.CapabilityNames);
-        Assert.Equal(["Gateway_1"], result.Failure.Data.ElementIds);
+        var refusal = BpmnCapabilityRefusal.FromData(result.Failure.Data);
+        Assert.Equal(["ScopeSignalling"], refusal!.CapabilityNames);
+        Assert.Equal(["Gateway_1"], refusal.ElementIds);
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
@@ -12,8 +12,11 @@ namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
 /// Covers <see cref="RemoteBpmnInterchangeService"/>'s error mapping: the server's 400/422 payloads carry the
-/// message a user needs to see (capability names, offending element ids, or one of the two export refusals), so
-/// this pins that those messages actually reach the caller rather than being replaced by a generic failure.
+/// message a user needs to see (capability names, offending element ids, or one of the export refusals), and the
+/// export refusals are told apart by the envelope's machine-readable <c>code</c> (see <see cref="BpmnErrorCodes"/>)
+/// rather than by matching the message text, so a rewording of the message never breaks this classification. An
+/// unrecognized code, or a body with no code at all (an older server), falls back to showing the server's own
+/// message under <see cref="BpmnExportFailureReason.Unknown"/>.
 /// </summary>
 public class RemoteBpmnInterchangeServiceTests : IDisposable
 {
@@ -47,7 +50,7 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ImportAsync_ReturnsTheCapabilityRefusalMessage_On422()
+    public async Task ImportAsync_ReturnsTheCapabilityRefusalMessageAndCodedData_On422()
     {
         const string message =
             "This deployment does not declare the following BPMN host capabilities the document requires: ScopeSignalling. "
@@ -57,7 +60,9 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         {
           "errors": {
             "generalErrors": ["{{message}}"]
-          }
+          },
+          "code": "{{BpmnErrorCodes.ImportCapabilityUnsupported}}",
+          "data": { "capabilities": ["ScopeSignalling"], "elementIds": ["Gateway_1"] }
         }
         """);
 
@@ -67,6 +72,9 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         Assert.True(result.IsFailed);
         var error = Assert.Single(result.Failure!.Errors);
         Assert.Equal(message, error.ErrorMessage);
+        Assert.Equal(BpmnErrorCodes.ImportCapabilityUnsupported, result.Failure.Code);
+        Assert.Equal(["ScopeSignalling"], result.Failure.Data!.CapabilityNames);
+        Assert.Equal(["Gateway_1"], result.Failure.Data.ElementIds);
     }
 
     [Fact]
@@ -84,7 +92,7 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
     public async Task ExportAsync_ClassifiesNotImportedFromBpmn()
     {
         const string message = "Workflow definition 'wf-1' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML.";
-        _api.ExportResponse = UnprocessableEntity(message);
+        _api.ExportResponse = UnprocessableEntity(message, BpmnErrorCodes.ExportNotImported);
 
         var result = await _service.ExportAsync("wf-1");
 
@@ -97,12 +105,54 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
     public async Task ExportAsync_ClassifiesDefinitionChangedSinceImport()
     {
         const string message = "Workflow definition 'wf-1' has changed since it was imported from BPMN (imported at version 1, currently at version 2).";
-        _api.ExportResponse = UnprocessableEntity(message);
+        _api.ExportResponse = UnprocessableEntity(message, BpmnErrorCodes.ExportSourceStale);
 
         var result = await _service.ExportAsync("wf-1");
 
         Assert.True(result.IsFailed);
         Assert.Equal(BpmnExportFailureReason.DefinitionChangedSinceImport, result.Failure!.Reason);
+    }
+
+    [Fact]
+    public async Task ExportAsync_ClassifiesSourceVersionUnknownAsNotImportedFromBpmn()
+    {
+        // Studio has no wording of its own distinct from ExportNotImported's for this rarely-reachable case (see
+        // RemoteBpmnInterchangeService.ClassifyExportRefusal's remarks), so it maps to the same reason.
+        const string message = "Workflow definition 'wf-1' carries BPMN source but not the definition version it was recorded against.";
+        _api.ExportResponse = UnprocessableEntity(message, BpmnErrorCodes.ExportSourceVersionUnknown);
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.NotImportedFromBpmn, result.Failure!.Reason);
+    }
+
+    [Fact]
+    public async Task ExportAsync_FallsBackToUnknown_ForAnUnrecognizedCode()
+    {
+        const string message = "Something else went wrong.";
+        _api.ExportResponse = UnprocessableEntity(message, "bpmn.export.some-future-code");
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.Unknown, result.Failure!.Reason);
+        Assert.Equal(message, result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task ExportAsync_FallsBackToUnknown_ForA422WithNoCode()
+    {
+        // An older server that has not been upgraded to send `code` yet; the failure still surfaces the message,
+        // just without a specific reason.
+        const string message = "Workflow definition 'wf-1' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML.";
+        _api.ExportResponse = UnprocessableEntity(message, code: null);
+
+        var result = await _service.ExportAsync("wf-1");
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(BpmnExportFailureReason.Unknown, result.Failure!.Reason);
+        Assert.Equal(message, result.Failure.Message);
     }
 
     [Fact]
@@ -122,16 +172,21 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         Assert.Equal(xml, await reader.ReadToEndAsync());
     }
 
-    private static HttpResponseMessage UnprocessableEntity(string message) => new(HttpStatusCode.UnprocessableEntity)
+    private static HttpResponseMessage UnprocessableEntity(string message, string? code)
     {
-        Content = new StringContent($$"""
+        var codeProperty = code is null ? "" : $$""", "code": "{{code}}" """;
+
+        return new(HttpStatusCode.UnprocessableEntity)
         {
-          "errors": {
-            "generalErrors": ["{{message}}"]
-          }
-        }
-        """)
-    };
+            Content = new StringContent($$"""
+            {
+              "errors": {
+                "generalErrors": ["{{message}}"]
+              }{{codeProperty}}
+            }
+            """)
+        };
+    }
 
     private static async Task<ApiException> CreateApiExceptionAsync(HttpStatusCode statusCode, string content)
     {

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -61,15 +61,18 @@ public class BpmnImportUiService(
             // unrecognized one falls back to the ordinary failure path, showing the server's own message.
             if (failure.Code == BpmnErrorCodes.ImportCapabilityUnsupported)
             {
-                var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
-                var refusal = BpmnCapabilityRefusal.FromData(failure.Data) ?? new BpmnCapabilityRefusal([], []);
+                var refusal = BpmnCapabilityRefusal.FromData(failure.Data);
 
-                await ShowRefusalDialogAsync(refusal);
-                return new()
+                if (refusal != null)
                 {
-                    FileName = file.Name,
-                    Failure = new(message, WorkflowImportFailureType.CapabilityRefusal)
-                };
+                    var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
+                    await ShowRefusalDialogAsync(refusal);
+                    return new()
+                    {
+                        FileName = file.Name,
+                        Failure = new(message, WorkflowImportFailureType.CapabilityRefusal)
+                    };
+                }
             }
 
             return Failed(file.Name, failure);

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -62,7 +62,7 @@ public class BpmnImportUiService(
             if (failure.Code == BpmnErrorCodes.ImportCapabilityUnsupported)
             {
                 var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
-                var refusal = failure.Data ?? new BpmnCapabilityRefusal([], []);
+                var refusal = BpmnCapabilityRefusal.FromData(failure.Data) ?? new BpmnCapabilityRefusal([], []);
 
                 await ShowRefusalDialogAsync(refusal);
                 return new()

--- a/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
+++ b/src/modules/Elsa.Studio.Workflows/Services/BpmnImportUiService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Components.WorkflowDefinitionList;
@@ -56,14 +55,15 @@ public class BpmnImportUiService(
         if (!importResult.IsSuccess)
         {
             var failure = importResult.Failure!;
-            var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
 
-            // Only a 422 can be a capability refusal; matching the wording alone on any other status (e.g. a 500
-            // whose message happens to echo the refusal's phrasing) would misreport an unrelated failure as one.
-            var refusal = failure.StatusCode == HttpStatusCode.UnprocessableEntity ? BpmnCapabilityRefusal.TryParse(message) : null;
-
-            if (refusal != null)
+            // Recognized by the envelope's machine-readable code rather than by wording (or even just 422 status),
+            // so a server rewording of the message never breaks this. A body with no code (an older server) or an
+            // unrecognized one falls back to the ordinary failure path, showing the server's own message.
+            if (failure.Code == BpmnErrorCodes.ImportCapabilityUnsupported)
             {
+                var message = string.Join(" ", failure.Errors.Select(error => error.ErrorMessage));
+                var refusal = failure.Data ?? new BpmnCapabilityRefusal([], []);
+
                 await ShowRefusalDialogAsync(refusal);
                 return new()
                 {


### PR DESCRIPTION
Closes #1020. Part of elsa-workflows/elsa-core#7909. Builds on elsa-workflows/elsa-core#8067, which gave every BPMN interchange refusal a stable code.

## What changed

Studio recognised BPMN refusals by matching the server's sentences, which broke silently whenever the server reworded a message. It now reads the code.

- `BpmnErrorCodes` mirrors all eight elsa-core codes one-to-one, with a pointer to the core file as the source of truth. That includes the document-endpoint codes the binding UX (#1001) consumes next.
- The shared error parser (`ValidationApiExceptionExtensions.GetValidationErrorsFromContent`) extracts `code` and the raw `data` in the same pass as `errors`; it is still one parser. `ValidationErrors` gains `Code` and a feature-agnostic `Data` (`JsonElement?`). The BPMN interpretation, `capabilities` and `elementIds` into `BpmnCapabilityRefusal`, lives next to that type in `BpmnCapabilityRefusal.FromData`, so the shared model knows nothing about BPMN.
- The import capability refusal is recognised by `bpmn.import.capability-unsupported` alone, not by status plus wording. The export reasons map by code to the existing messages. `bpmn.export.source-version-unknown` maps to the "not imported from BPMN" message, since Studio has no distinct wording for it and it is only reachable by editing custom properties outside import.
- `BpmnCapabilityRefusal.TryParse` and the phrase classifier are deleted, not kept as a fallback.
- A body with no `code` (an older server) or an unrecognised code falls back to the server's message. The dialogs and text from #1007 are unchanged.

## Verification

```
dotnet build Elsa.Studio.sln --configuration Release
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0   # 363/363
```

Tests feed coded payloads in exactly the shape elsa-core sends. The capability refusal's names and element ids reach the refusal dialog. Each export reason reaches its message. An unknown code falls back to the server message, and so does an uncoded body.

Review: two iterations on the standards and spec axes. One must-fix was resolved: the shared error model and parser were decoupled from the BPMN-specific type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
