### PR TITLE
fix(ci): pack wasm-react against the local wasm tarball

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -101,11 +101,31 @@ jobs:
           npm version $VERSION --allow-same-version
           npm pack
       
-      # Build npm react wrapper package
+      # Build npm react wrapper package against the just-packed local wasm tarball.
+      # react-wrapper lives in the src/wrappers npm workspace. `npm version` /
+      # `npm run build` there re-resolves package-lock.json, which is still pinned
+      # to @elsa-workflows/elsa-studio-wasm@3.4.0 on feedz. That tarball 404s
+      # (3.8.0 succeeded while feedz still served it). Install the $VERSION tgz
+      # produced by the previous step so pack never hits the registry for wasm.
       - name: Pack elsa-studio-wasm-react npm package
         run: |
-          cd ./src/wrappers/wrappers/react-wrapper
-          npm version $VERSION --allow-same-version
+          set -euo pipefail
+          WASM_TGZ="${GITHUB_WORKSPACE}/packages/wasm/wwwroot/elsa-workflows-elsa-studio-wasm-${VERSION}.tgz"
+          if [[ ! -f "$WASM_TGZ" ]]; then
+            echo "Expected local wasm tarball at $WASM_TGZ" >&2
+            ls -la "${GITHUB_WORKSPACE}/packages/wasm/wwwroot" >&2 || true
+            exit 1
+          fi
+
+          cd ./src/wrappers
+          npm install "$WASM_TGZ" --workspace=@elsa-workflows/elsa-studio-wasm-react
+
+          cd ./wrappers/react-wrapper
+          # Avoid `npm version` here: in this workspace it refreshes the lockfile
+          # and can re-fetch the stale feedz pin. Set the packed versions directly.
+          npm pkg set "version=${VERSION}"
+          npm pkg set "dependencies.@elsa-workflows/elsa-studio-wasm=${VERSION}"
+          npm run copy:elsa-studio-wasm
           npm run build
           npm pack
       

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -71,26 +71,26 @@ jobs:
           fi
       - name: Set VERSION variable
         env:
-          # Never interpolate dispatcher-controlled version into bash source.
-          INPUT_VERSION: ${{ github.event.inputs.version }}
-          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+          # Dispatcher input via env — do not interpolate inputs.version into bash.
+          VERSION: ${{ github.event.inputs.version }}
+          PUBLISH: ${{ github.event.inputs.publish }}
         run: |
           set -euo pipefail
-          # Semver-ish: 3.8.1, 3.8.0-rc1, 3.8.0-preview.1. Rejects shell metacharacters.
-          VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+(\.[A-Za-z0-9]+)*)?(\+[A-Za-z0-9.]+)?$'
+          version_re='^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$'
 
-          if [[ "${INPUT_PUBLISH:-}" == "true" && -z "${INPUT_VERSION:-}" ]]; then
-            echo "workflow_dispatch publish requires a non-empty version override" >&2
-            echo "Refusing to publish the fallback ${{ env.base_version }}-preview.N build" >&2
-            exit 1
+          if [[ "${PUBLISH:-}" == "true" ]]; then
+            if [[ -z "${VERSION:-}" || ! "$VERSION" =~ $version_re ]]; then
+              echo "publish requires a valid version (e.g. 3.8.1). Refusing to ship ${{ env.base_version }}-preview.N" >&2
+              exit 1
+            fi
           fi
 
-          if [[ -n "${INPUT_VERSION:-}" ]]; then
-            if [[ ! "$INPUT_VERSION" =~ $VERSION_PATTERN ]]; then
+          if [[ -n "${VERSION:-}" ]]; then
+            if [[ ! "$VERSION" =~ $version_re ]]; then
               echo "Invalid version override. Expected a package version like 3.8.1 or 3.8.0-preview.1" >&2
               exit 1
             fi
-            echo "VERSION=${INPUT_VERSION}" >> "$GITHUB_ENV"
+            echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           elif [[ "${{ github.ref }}" == refs/tags/* && "${{ github.event_name }}" == "release" && ("${{ github.event.action }}" == "published" || "${{ github.event.action }}" == "prereleased") ]]; then
             TAG_NAME=${{ github.ref }} # e.g., refs/tags/3.0.0
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Optional package version override (e.g. 3.8.1). Leave empty for default branch/tag versioning.'
+        description: 'Optional package version override (semver-ish, e.g. 3.8.1 or 3.8.0-preview.1). Required when publish is checked. Leave empty for default branch/tag versioning.'
         required: false
         type: string
       publish:
-        description: 'Publish packed artifacts (feedz, nuget.org, npmjs). Use with a version override to recover a tag whose workflow was broken.'
+        description: 'Publish packed artifacts (feedz, nuget.org, npmjs). Requires a non-empty version override so a blank dispatch cannot ship 3.8.0-preview.N.'
         required: false
         type: boolean
         default: false
@@ -70,15 +70,33 @@ jobs:
             git branch --remote --contains | grep origin/${BRANCH_NAME}
           fi
       - name: Set VERSION variable
+        env:
+          # Never interpolate dispatcher-controlled version into bash source.
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
         run: |
-          if [[ -n "${{ github.event.inputs.version }}" ]]; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          set -euo pipefail
+          # Semver-ish: 3.8.1, 3.8.0-rc1, 3.8.0-preview.1. Rejects shell metacharacters.
+          VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+(\.[A-Za-z0-9]+)*)?(\+[A-Za-z0-9.]+)?$'
+
+          if [[ "${INPUT_PUBLISH:-}" == "true" && -z "${INPUT_VERSION:-}" ]]; then
+            echo "workflow_dispatch publish requires a non-empty version override" >&2
+            echo "Refusing to publish the fallback ${{ env.base_version }}-preview.N build" >&2
+            exit 1
+          fi
+
+          if [[ -n "${INPUT_VERSION:-}" ]]; then
+            if [[ ! "$INPUT_VERSION" =~ $VERSION_PATTERN ]]; then
+              echo "Invalid version override. Expected a package version like 3.8.1 or 3.8.0-preview.1" >&2
+              exit 1
+            fi
+            echo "VERSION=${INPUT_VERSION}" >> "$GITHUB_ENV"
           elif [[ "${{ github.ref }}" == refs/tags/* && "${{ github.event_name }}" == "release" && ("${{ github.event.action }}" == "published" || "${{ github.event.action }}" == "prereleased") ]]; then
             TAG_NAME=${{ github.ref }} # e.g., refs/tags/3.0.0
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
-            echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
+            echo "VERSION=${TAG_NAME}" >> "$GITHUB_ENV"
           else
-            echo "VERSION=${{env.base_version}}-${PACKAGE_PREFIX}.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=${{ env.base_version }}-${PACKAGE_PREFIX}.${{ github.run_number }}" >> "$GITHUB_ENV"
           fi
       - uses: actions/setup-dotnet@v4
         with:
@@ -167,7 +185,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.version != '') }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -240,7 +258,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.version != '') }}
     permissions:
       contents: read
       id-token: write # Required: lets this job request the OIDC token npmjs.com exchanges for publish rights.
@@ -313,7 +331,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.version != '') }}
     steps:
       - name: Download Packages
         uses: actions/download-artifact@v4
@@ -329,7 +347,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.version != '') }}
     permissions:
       contents: read
       id-token: write # Required: lets this job request the OIDC token that nuget.org exchanges for a temporary API key.

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,6 +1,16 @@
 name: Packages
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional package version override (e.g. 3.8.1). Leave empty for default branch/tag versioning.'
+        required: false
+        type: string
+      publish:
+        description: 'Publish packed artifacts (feedz, nuget.org, npmjs). Use with a version override to recover a tag whose workflow was broken.'
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - 'main'
@@ -61,7 +71,9 @@ jobs:
           fi
       - name: Set VERSION variable
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* && "${{ github.event_name }}" == "release" && ("${{ github.event.action }}" == "published" || "${{ github.event.action }}" == "prereleased") ]]; then
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == refs/tags/* && "${{ github.event_name }}" == "release" && ("${{ github.event.action }}" == "published" || "${{ github.event.action }}" == "prereleased") ]]; then
             TAG_NAME=${{ github.ref }} # e.g., refs/tags/3.0.0
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
@@ -155,7 +167,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' || github.event_name == 'push'}}
+    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -228,7 +240,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     permissions:
       contents: read
       id-token: write # Required: lets this job request the OIDC token npmjs.com exchanges for publish rights.
@@ -301,7 +313,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' || github.event_name == 'push'}}
+    if: ${{ github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     steps:
       - name: Download Packages
         uses: actions/download-artifact@v4
@@ -317,7 +329,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     permissions:
       contents: read
       id-token: write # Required: lets this job request the OIDC token that nuget.org exchanges for a temporary API key.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Unblock the 3.8.1 Packages release: `elsa-studio-wasm-react` now packs against the just-built local `@elsa-workflows/elsa-studio-wasm@$VERSION` tarball instead of a missing feedz 3.4.0 download. Optional `workflow_dispatch` inputs let `release/3.8.1` pack/publish **3.8.1** without moving the tag.

Dispatch recovery is hardened: version is passed via step `env:` and validated before use; `publish` requires a non-empty validated version.

---

## Scope

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem

Tag 3.8.1 Packages failed in [run 34694394920](https://github.com/elsa-workflows/elsa-studio/actions/runs/34694394920) at **Pack elsa-studio-wasm-react npm package**:

```
npm error E404 GET https://f.feedz.io/elsa-workflows/elsa-3/npm/@elsa-workflows/elsa-studio-wasm/3.4.0/download
```

NuGet pack succeeded; npm/NuGet publish jobs were skipped.

`src/wrappers/wrappers/react-wrapper` is an npm workspace package. `src/wrappers/package-lock.json` pins `@elsa-workflows/elsa-studio-wasm` to feedz **3.4.0** (range `^3.4.0-rc1` in package.json). `npm version` in that workspace refreshes the lockfile and downloads that URL.

Tag 3.8.0 ([run 33962308303](https://github.com/elsa-workflows/elsa-studio/actions/runs/33962308303)) used the same lockfile pin and succeeded because feedz still served 3.4.0 on 2026-09-05. The same GET now 404s — registry change, not a lockfile/.npmrc drift between 3.8.0 and 3.8.1.

The Pack wasm step already produces `@elsa-workflows/elsa-studio-wasm@$VERSION` locally and never installed it into the wrapper.

**Re-running the failed tag workflow will keep failing:** tag `3.8.1` is still `b267a8b3`, which does not contain this workflow fix.

### Solution

Workflow-only (no hard-coded 3.8.1 in package.json):

1. Install the just-packed `elsa-workflows-elsa-studio-wasm-${VERSION}.tgz` into the wrappers workspace before react build/pack.
2. Set the packed react package version and wasm dependency to `$VERSION` via `npm pkg set` (avoids `npm version` re-resolving the stale lockfile pin).
3. Copy wasm assets, build, and pack as before.
4. Optional `workflow_dispatch` inputs, hardened after review:
   - `version` is passed through step `env:` (`INPUT_VERSION`) and must match a semver-ish package version (`3.8.1`, `3.8.0-preview.1`, `3.8.0-rc1`) before `GITHUB_ENV` is written. Shell metacharacters are rejected.
   - `publish` defaults to `false`. When true, all four publish job `if:`s also require `inputs.version != ''`, and the build job fail-fasts if publish is set without a version. A blank dispatch cannot ship `3.8.0-preview.N`.

Committed `package.json` still has `^3.4.0-rc1` for local/dev. The **published** tarball depends on `@elsa-workflows/elsa-studio-wasm@$VERSION`.

---

## Verification

Local npm pack path (dummy wasm tarball; no full CustomElements publish):

1. Packed a minimal `@elsa-workflows/elsa-studio-wasm@3.8.1` tgz at `packages/wasm/wwwroot/`.
2. Ran the new Pack react steps with `VERSION=3.8.1` and `GITHUB_WORKSPACE` set.
3. `npm install <local-tgz> --workspace=@elsa-workflows/elsa-studio-wasm-react` did **not** request feedz 3.4.0.
4. Packed `elsa-workflows-elsa-studio-wasm-react-3.8.1.tgz` with version `3.8.1` and wasm dep `3.8.1` (not `file:` / `^3.4.0-rc1`).

Dispatch hardening (local bash of the Set VERSION guards):

- Accepts `3.8.1`, `3.8.0-preview.1`, `3.8.0-rc1`, `3.8.0-rc.1`
- Rejects empty version + `publish=true`
- Rejects `$(whoami)`, `3.8.1; id`, backticks, `v3.8.1`, `3.8`
- Empty version + `publish=false` still falls back to preview versioning
- All four publish `if:`s require `inputs.publish && inputs.version != ''`

Not verified here: full `dotnet publish` CustomElements output, or live feedz/nuget.org/npmjs publish.

---

## Screenshots / Recordings (if applicable)

N/A (CI pack-path fix).

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] Local npm pack path verified
- [x] Dispatch version injection + blank-publish guards verified

---

## After merge: what to re-run

Do **not** re-run [34694394920](https://github.com/elsa-workflows/elsa-studio/actions/runs/34694394920) — that checkout is tag `3.8.1` @ `b267a8b3` (old workflow).

After this PR is merged to `release/3.8.1`:

1. Actions → **Packages** → **Run workflow**
2. Branch: `release/3.8.1`
3. `version`: `3.8.1` (required if publishing)
4. `publish`: checked only when you are ready to publish

Do **not** move the `3.8.1` tag. Do not create a new tag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8d3b0d-8fd9-5042-b690-1eab360ce859?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8d3b0d-8fd9-5042-b690-1eab360ce859&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

