### PR TITLE
feat(workflows): bind BPMN tasks to Elsa activities from a Performed by section

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Client/IBpmnInterchangeApi.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Client/IBpmnInterchangeApi.cs
@@ -34,4 +34,27 @@ public interface IBpmnInterchangeApi
     /// </summary>
     [Get("/bpmn/definitions/{definitionId}/export")]
     Task<HttpResponseMessage> ExportAsync(string definitionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the whole <c>bpmnDefinitions</c> document a workflow definition was imported from, as the library's own
+    /// JSON (plain <c>System.Text.Json</c> defaults: camelCase names as <c>Bpmn.Model</c> declares them, integer enums),
+    /// with a strong <c>ETag</c> header naming the revision.
+    /// </summary>
+    /// <remarks>
+    /// Returned raw so the body is read verbatim, never through Studio's API-wide serializer conventions, and so the
+    /// <c>ETag</c> header can be read.
+    /// </remarks>
+    [Get("/bpmn/definitions/{definitionId}/document")]
+    Task<HttpResponseMessage> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes an edited <c>bpmnDefinitions</c> document back: the server writes it out as BPMN 2.0 XML and re-imports
+    /// it into the same definition as a draft, preserving the definition's non-BPMN metadata.
+    /// </summary>
+    /// <param name="definitionId">The workflow definition whose document this is.</param>
+    /// <param name="document">The document JSON, exactly the shape <see cref="GetDocumentAsync"/> returned.</param>
+    /// <param name="ifMatch">The <c>ETag</c> of the revision the edit was made against, sent back verbatim.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    [Put("/bpmn/definitions/{definitionId}/document")]
+    Task<HttpResponseMessage> PutDocumentAsync(string definitionId, [Body] HttpContent document, [Header("If-Match")] string ifMatch, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IBpmnInterchangeService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IBpmnInterchangeService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Domain.Models.Bpmn;
@@ -44,4 +45,24 @@ public interface IBpmnInterchangeService
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The file to download on success, or the classified refusal reason on failure.</returns>
     Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the whole <c>bpmnDefinitions</c> document a workflow definition was imported from, with the <c>ETag</c>
+    /// naming that revision.
+    /// </summary>
+    /// <param name="definitionId">The workflow definition id.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The document and its <c>ETag</c> on success, or the classified refusal on failure.</returns>
+    Task<Result<BpmnDocumentRevision, BpmnDocumentFailure>> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes an edited <c>bpmnDefinitions</c> document back, refused unless <paramref name="eTag"/> still names the
+    /// definition's current revision. The server re-imports it into the same definition as a draft.
+    /// </summary>
+    /// <param name="definitionId">The workflow definition id.</param>
+    /// <param name="document">The whole document, as read by <see cref="GetDocumentAsync"/> and edited in place.</param>
+    /// <param name="eTag">The <c>ETag</c> of the revision the edit was made against, sent as <c>If-Match</c>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The re-import's result and the new <c>ETag</c> on success, or the classified refusal on failure.</returns>
+    Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, JsonObject document, string eTag, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnActivityBindingDraft.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnActivityBindingDraft.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Humanizer;
+
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// The activity the BPMN "Performed by" section lets a user configure for one task: the activity JSON Studio's own
+/// input editors read and write — the very editors the flowchart's activity properties panel uses — and the
+/// <c>elsa:activityBinding</c> that JSON becomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The invariant.</b> Reading a binding into a draft and writing the draft back reconstructs every input the binding
+/// carried, value for value: an input's JSON moves between the binding and the activity as a JSON node, never through
+/// an encoder of Studio's own, so what the editors wrote is exactly what the server's activity serializer reads, the
+/// same as for an ordinary workflow-definition save.
+/// </para>
+/// <para>
+/// <b>Two spellings of one name.</b> The binding names an input the way the server does,
+/// <see cref="JsonNamingPolicy.CamelCase"/> applied to the property name; the input editors key the activity JSON with
+/// Humanizer's <c>Camelize</c>. The two agree for ordinary names and disagree for an acronym (<c>URL</c> is
+/// <c>url</c> to one and <c>uRL</c> to the other), so each input is mapped through its descriptor rather than by
+/// assuming either spelling.
+/// </para>
+/// <para>
+/// <b>Nothing is dropped quietly.</b> A binding input no descriptor input accounts for — possible only when Studio's
+/// activity catalogue is older than the server's — is written back exactly as it was read, so saving a draft never
+/// loses configuration Studio merely cannot display; the server remains the one that accepts or refuses it.
+/// </para>
+/// </remarks>
+public sealed class BpmnActivityBindingDraft
+{
+    private readonly IReadOnlyList<BpmnActivityBindingInput> _unmappedInputs;
+
+    private BpmnActivityBindingDraft(ActivityDescriptor descriptor, JsonObject activity, IReadOnlyList<BpmnActivityBindingInput> unmappedInputs)
+    {
+        Descriptor = descriptor;
+        Activity = activity;
+        _unmappedInputs = unmappedInputs;
+    }
+
+    /// <summary>The descriptor of the activity type the task is bound to.</summary>
+    public ActivityDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// The activity JSON the input editors edit in place. Never part of any workflow definition's own activity graph,
+    /// so editing it cannot change the graph an ordinary save would send.
+    /// </summary>
+    public JsonObject Activity { get; }
+
+    /// <summary>
+    /// A draft for a freshly picked activity type, carrying the descriptor's construction properties the way a
+    /// flowchart drop does.
+    /// </summary>
+    /// <param name="descriptor">The picked activity type.</param>
+    /// <param name="activityId">The id the editors key the activity on; any stable id for the task.</param>
+    public static BpmnActivityBindingDraft Create(ActivityDescriptor descriptor, string activityId)
+    {
+        var activity = CreateActivity(descriptor, activityId);
+
+        foreach (var property in descriptor.ConstructionProperties)
+            activity[property.Key.Camelize()] = JsonSerializer.SerializeToNode(property.Value);
+
+        return new(descriptor, activity, []);
+    }
+
+    /// <summary>A draft carrying every input <paramref name="binding"/> configures.</summary>
+    /// <param name="binding">The binding the document declares.</param>
+    /// <param name="descriptor">The descriptor of <see cref="BpmnActivityBinding.ActivityType"/>.</param>
+    /// <param name="activityId">The id the editors key the activity on; any stable id for the task.</param>
+    public static BpmnActivityBindingDraft FromBinding(BpmnActivityBinding binding, ActivityDescriptor descriptor, string activityId)
+    {
+        var activity = CreateActivity(descriptor, activityId);
+        var inputsByName = binding.Inputs.ToDictionary(input => input.Name, StringComparer.Ordinal);
+
+        foreach (var input in descriptor.Inputs)
+        {
+            if (inputsByName.Remove(BindingNameOf(input), out var bound))
+                activity[EditorNameOf(input)] = bound.Value?.DeepClone();
+        }
+
+        return new(descriptor, activity, binding.Inputs.Where(input => inputsByName.ContainsKey(input.Name)).ToList());
+    }
+
+    /// <summary>
+    /// The <c>elsa:activityBinding</c> element for the draft as it stands: one input per descriptor input the editors
+    /// have given a value, plus any input the draft carried through unmapped.
+    /// </summary>
+    public JsonObject ToBinding() => BpmnActivityBindingFormat.Create(Descriptor.TypeName, Inputs());
+
+    private IEnumerable<KeyValuePair<string, JsonNode?>> Inputs() =>
+        Descriptor.Inputs
+            .Select(input => KeyValuePair.Create(BindingNameOf(input), Activity[EditorNameOf(input)]))
+            .Concat(_unmappedInputs.Select(input => KeyValuePair.Create(input.Name, input.Value)));
+
+    private static JsonObject CreateActivity(ActivityDescriptor descriptor, string activityId) => new()
+    {
+        ["id"] = activityId,
+        ["type"] = descriptor.TypeName,
+        ["version"] = descriptor.Version
+    };
+
+    /// <summary>How elsa-core names the input in a binding: <c>JsonNamingPolicy.CamelCase</c> of the property name.</summary>
+    private static string BindingNameOf(InputDescriptor input) => JsonNamingPolicy.CamelCase.ConvertName(input.Name);
+
+    /// <summary>How Studio's input editors key the input in the activity JSON (see <c>InputsTab</c>).</summary>
+    private static string EditorNameOf(InputDescriptor input) => input.Name.Camelize();
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnActivityBindingFormat.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnActivityBindingFormat.cs
@@ -1,0 +1,209 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Studio's side of the <c>elsa:</c> BPMN vendor extension that records which Elsa activity performs a task the
+/// document describes but does not implement: reading and writing the <c>&lt;elsa:activityBinding&gt;</c> element in
+/// the library-format JSON document the <c>bpmn/definitions/{definitionId}/document</c> endpoints exchange.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A compatibility surface, owned by elsa-core.</b> Every name here mirrors elsa-core's
+/// <c>Elsa.Bpmn.Interchange.Binding.BpmnActivityBindingFormat</c>, and every rule <see cref="Read"/> applies mirrors
+/// that type's own <c>Read</c>. Changing any of them breaks every previously exported <c>.bpmn</c> file: the old
+/// element stops being recognised and reads back as a task nobody bound.
+/// </para>
+/// <para>
+/// <b>The JSON shape.</b> The document carries a BPMN element's retained vendor content as
+/// <c>extensions.extensionElements</c>: <c>Bpmn.Model</c>'s <c>BpmnExtensionElement</c>, a qualified <c>name</c>
+/// (<c>ns</c>, <c>localName</c>), an optional text <c>value</c>, <c>attributes</c> and <c>children</c>. The binding is
+/// one such element in <see cref="NamespaceUri"/>, with an unqualified <see cref="ActivityTypeAttributeName"/> attribute
+/// and one <see cref="InputElementName"/> child per configured input, whose unqualified
+/// <see cref="InputNameAttributeName"/> attribute names the input and whose text is that input's JSON.
+/// </para>
+/// <para>
+/// <b>No second encoder.</b> An input's text is exactly the JSON Studio's own input editors wrote into the activity
+/// (the same JSON an ordinary workflow-definition save sends to the server's activity serializer), so its shape is
+/// whatever that input declares: the <c>{"typeName":…,"expression":…}</c> wrapper for an <c>Input&lt;T&gt;</c>, the
+/// value's own JSON for a plain <c>[Input]</c> such as <c>Switch.Cases</c>. Nothing here interprets it.
+/// </para>
+/// </remarks>
+public static class BpmnActivityBindingFormat
+{
+    /// <summary>The namespace URI of the <c>elsa:</c> BPMN vendor extension.</summary>
+    public const string NamespaceUri = "https://elsaworkflows.io/schemas/bpmn/v1";
+
+    /// <summary>The local name of the binding element.</summary>
+    public const string BindingElementName = "activityBinding";
+
+    /// <summary>The local name of the attribute naming the Elsa activity type, e.g. <c>Elsa.WriteLine</c>.</summary>
+    public const string ActivityTypeAttributeName = "activityType";
+
+    /// <summary>The local name of a single-input child element.</summary>
+    public const string InputElementName = "input";
+
+    /// <summary>The local name of the attribute naming the input an <see cref="InputElementName"/> element configures.</summary>
+    public const string InputNameAttributeName = "name";
+
+    /// <summary>
+    /// Keeps an input's JSON text readable in the exported <c>.bpmn</c>: an expression such as <c>a &lt; b</c> is
+    /// written as-is rather than as <c>\u003C</c>. The XML writer escapes the text node itself, so relaxing JSON's
+    /// HTML-safe escaping changes nothing a reader sees once the text is parsed.
+    /// </summary>
+    private static readonly JsonSerializerOptions InputTextOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+    /// <summary>
+    /// The activity binding declared on <paramref name="element"/> — a <c>BpmnElement</c> of the document — or
+    /// <see langword="null"/> when it declares none. Like elsa-core's own <c>Find</c>, the first one wins.
+    /// </summary>
+    public static JsonObject? Find(JsonObject element) =>
+        GetExtensionElements(element)?.OfType<JsonObject>().FirstOrDefault(IsBinding);
+
+    /// <summary>
+    /// Builds the binding element declaring that an activity of <paramref name="activityType"/> performs the work, with
+    /// one input element per entry of <paramref name="inputs"/> whose value is not JSON <c>null</c>, ordered by name
+    /// so that writing the same configuration twice produces the same document — the rules elsa-core's own
+    /// <c>Write</c> applies.
+    /// </summary>
+    /// <param name="activityType">The activity registry's type name, e.g. <c>Elsa.WriteLine</c>; never a CLR name.</param>
+    /// <param name="inputs">Each input's camelCase name and its JSON, as the activity's own input editors wrote it.</param>
+    public static JsonObject Create(string activityType, IEnumerable<KeyValuePair<string, JsonNode?>> inputs)
+    {
+        var inputElements = inputs
+            .Where(input => input.Value is not null && input.Value.GetValueKind() != JsonValueKind.Null)
+            .OrderBy(input => input.Key, StringComparer.Ordinal)
+            .Select(input => (JsonNode)CreateElement(InputElementName, Attribute(InputNameAttributeName, input.Key), input.Value!.ToJsonString(InputTextOptions), []));
+
+        return CreateElement(BindingElementName, Attribute(ActivityTypeAttributeName, activityType), null, inputElements);
+    }
+
+    /// <summary>
+    /// Reads <paramref name="binding"/> with elsa-core's read rules: an <see cref="ActivityTypeAttributeName"/> is
+    /// required, every input names itself, no input is named twice, and every input's text is JSON.
+    /// </summary>
+    /// <exception cref="BpmnActivityBindingFormatException">The binding breaks one of those rules.</exception>
+    public static BpmnActivityBinding Read(JsonObject binding)
+    {
+        var activityType = AttributeOf(binding, ActivityTypeAttributeName)
+                           ?? throw new BpmnActivityBindingFormatException($"The <elsa:{BindingElementName}> element declares no '{ActivityTypeAttributeName}'.");
+
+        var inputs = new List<BpmnActivityBindingInput>();
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var input in (binding["children"] as JsonArray ?? []).OfType<JsonObject>().Where(child => HasName(child, InputElementName)))
+        {
+            var name = AttributeOf(input, InputNameAttributeName)
+                       ?? throw new BpmnActivityBindingFormatException($"An <elsa:{InputElementName}> element of the '{activityType}' binding declares no '{InputNameAttributeName}'.");
+
+            if (!names.Add(name))
+                throw new BpmnActivityBindingFormatException($"The '{activityType}' binding declares the input '{name}' more than once.");
+
+            inputs.Add(new(name, ParseInput(input["value"]?.GetValue<string>(), name, activityType)));
+        }
+
+        return new(activityType, inputs);
+    }
+
+    /// <summary>
+    /// Makes <paramref name="binding"/> the activity binding of <paramref name="element"/>, leaving every other
+    /// retained extension element, documentation entry, foreign attribute and foreign child exactly where it was. An
+    /// existing binding is replaced in place; any further ones are removed, since a reader taking the first of two
+    /// would silently apply the older one.
+    /// </summary>
+    public static void Attach(JsonObject element, JsonObject binding)
+    {
+        var extensionElements = GetOrCreateExtensionElements(element);
+        var existing = extensionElements.Select((node, index) => (Node: node, Index: index)).Where(entry => entry.Node is JsonObject candidate && IsBinding(candidate)).Select(entry => entry.Index).ToList();
+
+        if (existing.Count == 0)
+        {
+            extensionElements.Add(binding);
+            return;
+        }
+
+        for (var i = existing.Count - 1; i > 0; i--)
+            extensionElements.RemoveAt(existing[i]);
+
+        extensionElements[existing[0]] = binding;
+    }
+
+    private static bool IsBinding(JsonObject extensionElement) => HasName(extensionElement, BindingElementName);
+
+    private static bool HasName(JsonObject extensionElement, string localName) =>
+        extensionElement["name"] is JsonObject name
+        && name["ns"]?.GetValue<string>() == NamespaceUri
+        && name["localName"]?.GetValue<string>() == localName;
+
+    // An unprefixed XML attribute belongs to no namespace; comparing on the local name alone would also match a
+    // same-named attribute another vendor put in its own namespace.
+    private static string? AttributeOf(JsonObject extensionElement, string localName) =>
+        (extensionElement["attributes"] as JsonArray ?? [])
+        .OfType<JsonObject>()
+        .FirstOrDefault(attribute => attribute["name"] is JsonObject name
+                                     && string.IsNullOrEmpty(name["ns"]?.GetValue<string>())
+                                     && name["localName"]?.GetValue<string>() == localName)?["value"]?.GetValue<string>();
+
+    private static JsonNode? ParseInput(string? json, string name, string activityType)
+    {
+        try
+        {
+            return JsonNode.Parse(json ?? "null");
+        }
+        catch (JsonException exception)
+        {
+            throw new BpmnActivityBindingFormatException($"Input '{name}' of the '{activityType}' binding does not hold valid JSON: {exception.Message}");
+        }
+    }
+
+    private static JsonArray? GetExtensionElements(JsonObject element) => element["extensions"]?["extensionElements"] as JsonArray;
+
+    private static JsonArray GetOrCreateExtensionElements(JsonObject element)
+    {
+        if (element["extensions"] is not JsonObject extensions)
+            element["extensions"] = extensions = new() { ["documentation"] = new JsonArray(), ["foreignAttributes"] = new JsonArray(), ["foreignChildren"] = new JsonArray() };
+
+        if (extensions["extensionElements"] is not JsonArray extensionElements)
+            extensions["extensionElements"] = extensionElements = [];
+
+        return extensionElements;
+    }
+
+    private static JsonObject CreateElement(string localName, JsonObject attribute, string? value, IEnumerable<JsonNode> children) => new()
+    {
+        ["name"] = QualifiedName(NamespaceUri, localName),
+        ["value"] = value,
+        ["attributes"] = new JsonArray(attribute),
+        ["children"] = new JsonArray(children.ToArray())
+    };
+
+    private static JsonObject Attribute(string localName, string value) => new()
+    {
+        ["name"] = QualifiedName(null, localName),
+        ["value"] = value
+    };
+
+    private static JsonObject QualifiedName(string? ns, string localName) => new()
+    {
+        ["ns"] = ns,
+        ["localName"] = localName
+    };
+}
+
+/// <summary>An <c>elsa:activityBinding</c> as <see cref="BpmnActivityBindingFormat.Read"/> reads it.</summary>
+/// <param name="ActivityType">The activity registry's type name the binding names.</param>
+/// <param name="Inputs">Each configured input, in document order.</param>
+public sealed record BpmnActivityBinding(string ActivityType, IReadOnlyList<BpmnActivityBindingInput> Inputs);
+
+/// <summary>One configured input of a <see cref="BpmnActivityBinding"/>.</summary>
+/// <param name="Name">The input's camelCase property name, as the activity declares it.</param>
+/// <param name="Value">The input's JSON, parsed.</param>
+public sealed record BpmnActivityBindingInput(string Name, JsonNode? Value);
+
+/// <summary>
+/// An <c>elsa:activityBinding</c> breaks one of the rules elsa-core refuses it for at import; see
+/// <see cref="BpmnActivityBindingFormat.Read"/>.
+/// </summary>
+public sealed class BpmnActivityBindingFormatException(string message) : Exception(message);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Nodes;
+
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Reads the library-format <c>bpmnDefinitions</c> document the <c>bpmn/definitions/{definitionId}/document</c>
+/// endpoints exchange (<c>Bpmn.Model</c> payload format 1.0.0; Studio's generated <c>BpmnDefinitions</c> type in the
+/// Designer ClientLib's <c>src/bpmn/types.generated.ts</c> describes it). The document is held as a
+/// <see cref="JsonObject"/> and edited in place, so everything Studio does not touch — foreign extensions, foreign
+/// attributes, documentation, BPMN DI — goes back to the server exactly as it came.
+/// </summary>
+public static class BpmnDefinitionsDocument
+{
+    /// <summary>The <c>elementType</c> of an embedded subprocess, a transaction and an event subprocess alike.</summary>
+    public const string SubProcessElementType = "subProcess";
+
+    /// <summary>
+    /// The BPMN element with <paramref name="elementId"/>, from any process's <c>elements</c>, or
+    /// <see langword="null"/> when the document has none.
+    /// </summary>
+    /// <remarks>
+    /// Only the elements of the document's own <c>&lt;process&gt;</c> elements are here. The body of a subprocess is
+    /// not part of this document at all — <c>Bpmn.Interchange</c>'s reader carries it only in the work bindings it
+    /// returns alongside, which the document endpoints do not send — so an element inside one is never found; see
+    /// <see cref="FindSubProcessIds"/>.
+    /// </remarks>
+    public static JsonObject? FindElement(JsonObject document, string elementId) =>
+        Elements(document).FirstOrDefault(element => element["elementId"]?.GetValue<string>() == elementId);
+
+    /// <summary>
+    /// The id of every subprocess — embedded, transaction or event subprocess — the document's processes declare.
+    /// </summary>
+    /// <remarks>
+    /// Writing such a document back through the document <c>PUT</c> loses every one of these bodies: the body is not
+    /// in the document (see <see cref="FindElement"/>), and elsa-core writes the XML from the document alone, which
+    /// <c>BpmnXmlWriter</c> documents as writing each subprocess empty. A caller that would <c>PUT</c> must refuse
+    /// while this is non-empty rather than discard the content silently.
+    /// </remarks>
+    public static IReadOnlyList<string> FindSubProcessIds(JsonObject document) =>
+        Elements(document)
+            .Where(element => element["elementType"]?.GetValue<string>() == SubProcessElementType)
+            .Select(element => element["elementId"]?.GetValue<string>() ?? string.Empty)
+            .ToList();
+
+    private static IEnumerable<JsonObject> Elements(JsonObject document) =>
+        (document["processes"] as JsonArray ?? [])
+        .OfType<JsonObject>()
+        .SelectMany(process => (process["elements"] as JsonArray ?? []).OfType<JsonObject>());
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentFailure.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentFailure.cs
@@ -1,0 +1,66 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// Why a document <c>GET</c> or <c>PUT</c> did not succeed: the <see cref="Reason"/> classified from the error
+/// envelope's machine-readable code (see <see cref="BpmnErrorCodes"/>), and the server's own message, which the UI
+/// shows as-is wherever it has no wording of its own.
+/// </summary>
+/// <param name="Reason">The classified reason.</param>
+/// <param name="Message">The server's message, or a description of the failure when the server sent none.</param>
+/// <param name="CapabilityRefusal">
+/// The missing capabilities and offending element ids, for <see cref="BpmnDocumentFailureReason.CapabilityUnsupported"/>.
+/// </param>
+public sealed record BpmnDocumentFailure(BpmnDocumentFailureReason Reason, string Message, BpmnCapabilityRefusal? CapabilityRefusal = null);
+
+/// <summary>Why a document <c>GET</c> or <c>PUT</c> did not succeed.</summary>
+public enum BpmnDocumentFailureReason
+{
+    /// <summary>The workflow definition does not exist (<c>404</c>, <see cref="BpmnErrorCodes.DocumentNotFound"/>).</summary>
+    NotFound,
+
+    /// <summary>
+    /// The definition carries no BPMN document to read (<see cref="BpmnErrorCodes.ExportNotImported"/>, or the
+    /// rarely reachable <see cref="BpmnErrorCodes.ExportSourceVersionUnknown"/>).
+    /// </summary>
+    NotImportedFromBpmn,
+
+    /// <summary>
+    /// The definition's graph was changed outside BPMN since its document was imported, so the stored document no
+    /// longer describes it and cannot be edited until it is re-imported (<see cref="BpmnErrorCodes.ExportSourceStale"/>).
+    /// </summary>
+    SourceStale,
+
+    /// <summary>The <c>PUT</c> carried no usable <c>If-Match</c> (<c>428</c>, <see cref="BpmnErrorCodes.DocumentPreconditionRequired"/>).</summary>
+    PreconditionRequired,
+
+    /// <summary>
+    /// The definition was written since the document was read, so the edit was made against a revision that is no
+    /// longer current (<c>412</c>, <see cref="BpmnErrorCodes.DocumentPreconditionFailed"/>).
+    /// </summary>
+    PreconditionFailed,
+
+    /// <summary>The server refused a work binding the document declares (<see cref="BpmnErrorCodes.ImportBindingInvalid"/>).</summary>
+    BindingInvalid,
+
+    /// <summary>
+    /// The document needs a BPMN host capability the server does not declare
+    /// (<see cref="BpmnErrorCodes.ImportCapabilityUnsupported"/>).
+    /// </summary>
+    CapabilityUnsupported,
+
+    /// <summary>
+    /// The <c>GET</c> succeeded but its response carried no <c>ETag</c>, so no edit could ever be written back. Across
+    /// origins this means the server's CORS policy does not expose the <c>ETag</c> header.
+    /// </summary>
+    MissingETag,
+
+    /// <summary>
+    /// Refused by Studio before anything was sent: the document declares a subprocess, whose body the document does
+    /// not carry, so a <c>PUT</c> would have the server write that subprocess empty. See
+    /// <see cref="BpmnDefinitionsDocument.FindSubProcessIds"/>.
+    /// </summary>
+    SubProcessContentNotCarried,
+
+    /// <summary>Any other failure; <see cref="BpmnDocumentFailure.Message"/> carries the server's own message.</summary>
+    Unknown
+}

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentRevision.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentRevision.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// A workflow definition's whole <c>bpmnDefinitions</c> document, as the document <c>GET</c> returned it, and the strong
+/// <c>ETag</c> naming that revision — the value a later document <c>PUT</c> must send back verbatim as <c>If-Match</c>.
+/// </summary>
+/// <param name="Document">The document, held as JSON so everything Studio does not edit round-trips untouched.</param>
+/// <param name="ETag">The opaque strong <c>ETag</c>, quotes included.</param>
+public sealed record BpmnDocumentRevision(JsonObject Document, string ETag);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentSaveResult.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentSaveResult.cs
@@ -1,0 +1,9 @@
+namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+/// <summary>
+/// What a successful document <c>PUT</c> reported: the re-imported definition's identity and analysis, in the same
+/// shape <c>bpmn/import</c> returns, and the <c>ETag</c> of the draft the <c>PUT</c> stored.
+/// </summary>
+/// <param name="Import">The re-imported definition's identity and the findings the read produced.</param>
+/// <param name="ETag">The new revision's <c>ETag</c>, or <see langword="null"/> when the response did not carry one.</param>
+public sealed record BpmnDocumentSaveResult(BpmnImportResultModel Import, string? ETag);

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnErrorCodes.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnErrorCodes.cs
@@ -9,15 +9,14 @@ namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
 /// <see cref="Elsa.Studio.Workflows.Domain.Models.ValidationErrors"/> also carries).
 /// </summary>
 /// <remarks>
-/// Only <see cref="ImportCapabilityUnsupported"/>, <see cref="ExportNotImported"/>, <see cref="ExportSourceStale"/>
-/// and <see cref="ExportSourceVersionUnknown"/> are consumed today, by <c>RemoteBpmnInterchangeService</c> and
-/// <c>BpmnImportUiService</c>. The three document-endpoint codes are mirrored ahead of the document GET/PUT
-/// endpoints Studio's designer will call next, so that work does not have to duplicate this constants list.
+/// <c>RemoteBpmnInterchangeService</c> classifies the export refusals by these codes into
+/// <see cref="BpmnExportFailureReason"/>, and the document <c>GET</c>/<c>PUT</c> refusals into
+/// <see cref="BpmnDocumentFailureReason"/>; <c>BpmnImportUiService</c> reads <see cref="ImportCapabilityUnsupported"/>.
 /// </remarks>
 public static class BpmnErrorCodes
 {
     /// <summary>
-    /// <c>bpmn/import</c> (and, once Studio calls it, the document <c>PUT</c>) refuses a document that needs a BPMN
+    /// <c>bpmn/import</c> (and the document <c>PUT</c>) refuses a document that needs a BPMN
     /// host capability this deployment does not declare. Carries <c>data.capabilities</c> (the missing capability
     /// names) and <c>data.elementIds</c> (the offending element ids, combined across every missing capability).
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnProcessConstants.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnProcessConstants.cs
@@ -17,4 +17,11 @@ public static class BpmnProcessConstants
     /// which Studio cannot reference: the interpreter runs server-side and Studio never takes a dependency on it.
     /// </summary>
     public const string DoneOutcomeName = "Done";
+
+    /// <summary>
+    /// The workflow definition custom property elsa-core's <c>BpmnInterchangeDocumentService</c> stores the imported
+    /// BPMN document's source XML under. A definition that carries it was imported from BPMN, so its activity graph
+    /// is derived from that document and changes only through the document endpoints.
+    /// </summary>
+    public const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
 }

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/RemoteBpmnInterchangeService.cs
@@ -1,4 +1,7 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Models;
 using Elsa.Studio.Workflows.Client;
@@ -80,6 +83,91 @@ public class RemoteBpmnInterchangeService(IBackendApiClientProvider backendApiCl
         return new(new BpmnExportFailure(BpmnExportFailureReason.Unknown, message));
     }
 
+    /// <inheritdoc />
+    public async Task<Result<BpmnDocumentRevision, BpmnDocumentFailure>> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+        using var response = await api.GetDocumentAsync(definitionId, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+            return new(ClassifyDocumentFailure(response, body));
+
+        // Without it no edit could ever be written back: say so now, rather than let the first save fail with a 428
+        // the user cannot act on.
+        if (ReadETag(response) is not { } eTag)
+            return new(new BpmnDocumentFailure(BpmnDocumentFailureReason.MissingETag, "The server returned the BPMN document without an ETag, so an edit to it could not be saved. If Studio runs on a different origin than the server, the server's CORS policy must expose the ETag header."));
+
+        try
+        {
+            if (JsonNode.Parse(body) is JsonObject document)
+                return new(new BpmnDocumentRevision(document, eTag));
+        }
+        catch (JsonException)
+        {
+            // Reported below, the same as any other body that is not a document.
+        }
+
+        return new(new BpmnDocumentFailure(BpmnDocumentFailureReason.Unknown, "The server's response is not a BPMN document."));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, JsonObject document, string eTag, CancellationToken cancellationToken = default)
+    {
+        var api = await GetApiAsync(cancellationToken);
+
+        // Written as-is, with plain System.Text.Json defaults: the server binds this body with Bpmn.Model's own
+        // (default) options, never with the API-wide conventions a Refit-serialized body would go through.
+        using var content = new StringContent(document.ToJsonString(), Encoding.UTF8, "application/json");
+        using var response = await api.PutDocumentAsync(definitionId, content, eTag, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+            return new(ClassifyDocumentFailure(response, body));
+
+        var import = JsonSerializer.Deserialize<BpmnImportResultModel>(body, ResponseSerializerOptions) ?? new BpmnImportResultModel();
+        return new(new BpmnDocumentSaveResult(import, ReadETag(response)));
+    }
+
+    /// <summary>
+    /// Classifies a document <c>GET</c> or <c>PUT</c> refusal by the envelope's machine-readable <c>code</c> (see
+    /// <see cref="BpmnErrorCodes"/>), never by its wording. A response with no code — a plain <c>404</c>, or an older
+    /// server — falls back to the HTTP status where the status alone says what happened, and to
+    /// <see cref="BpmnDocumentFailureReason.Unknown"/>, carrying the server's message, otherwise.
+    /// </summary>
+    private static BpmnDocumentFailure ClassifyDocumentFailure(HttpResponseMessage response, string body)
+    {
+        var errors = ValidationApiExceptionExtensions.GetValidationErrorsFromContent(body);
+        var message = errors != null
+            ? string.Join(" ", errors.Errors.Select(error => error.ErrorMessage))
+            : string.IsNullOrWhiteSpace(body) ? response.ReasonPhrase ?? $"The server responded with status {(int)response.StatusCode}." : body;
+
+        var reason = errors?.Code switch
+        {
+            BpmnErrorCodes.DocumentNotFound => BpmnDocumentFailureReason.NotFound,
+            BpmnErrorCodes.DocumentPreconditionRequired => BpmnDocumentFailureReason.PreconditionRequired,
+            BpmnErrorCodes.DocumentPreconditionFailed => BpmnDocumentFailureReason.PreconditionFailed,
+            BpmnErrorCodes.ImportBindingInvalid => BpmnDocumentFailureReason.BindingInvalid,
+            BpmnErrorCodes.ImportCapabilityUnsupported => BpmnDocumentFailureReason.CapabilityUnsupported,
+            BpmnErrorCodes.ExportNotImported or BpmnErrorCodes.ExportSourceVersionUnknown => BpmnDocumentFailureReason.NotImportedFromBpmn,
+            BpmnErrorCodes.ExportSourceStale => BpmnDocumentFailureReason.SourceStale,
+            _ => response.StatusCode switch
+            {
+                HttpStatusCode.NotFound => BpmnDocumentFailureReason.NotFound,
+                HttpStatusCode.PreconditionFailed => BpmnDocumentFailureReason.PreconditionFailed,
+                HttpStatusCode.PreconditionRequired => BpmnDocumentFailureReason.PreconditionRequired,
+                _ => BpmnDocumentFailureReason.Unknown
+            }
+        };
+
+        var capabilityRefusal = reason == BpmnDocumentFailureReason.CapabilityUnsupported ? BpmnCapabilityRefusal.FromData(errors?.Data) : null;
+        return new(reason, message, capabilityRefusal);
+    }
+
+    /// <summary>The <c>ETag</c> header verbatim, quotes included, or <see langword="null"/> when there is none.</summary>
+    private static string? ReadETag(HttpResponseMessage response) =>
+        response.Headers.TryGetValues("ETag", out var values) ? values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) : null;
+
     /// <summary>
     /// Classifies the 422 refusals <c>BpmnInterchangeDocumentService.Export(WorkflowDefinition)</c> raises by their
     /// machine-readable <paramref name="code"/> (see <see cref="BpmnErrorCodes"/>), rather than by matching a phrase
@@ -97,6 +185,12 @@ public class RemoteBpmnInterchangeService(IBackendApiClientProvider backendApiCl
         BpmnErrorCodes.ExportSourceStale => BpmnExportFailureReason.DefinitionChangedSinceImport,
         _ => BpmnExportFailureReason.Unknown
     };
+
+    /// <summary>
+    /// The document <c>PUT</c>'s success body is an ordinary API response (the <c>bpmn/import</c> response shape), written
+    /// with the server's API-wide camelCase conventions, unlike the document itself.
+    /// </summary>
+    private static readonly JsonSerializerOptions ResponseSerializerOptions = new(JsonSerializerDefaults.Web);
 
     private async Task<IBpmnInterchangeApi> GetApiAsync(CancellationToken cancellationToken = default) =>
         await backendApiClientProvider.GetApiAsync<IBpmnInterchangeApi>(cancellationToken);

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/JsonObjectActivityTreeExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/JsonObjectActivityTreeExtensions.cs
@@ -38,4 +38,14 @@ public static class JsonObjectActivityTreeExtensions
 
         return false;
     }
+
+    /// <summary>
+    /// Finds the activity with the given ID: <paramref name="scope"/> itself, or, recursively, an activity in its
+    /// <c>activities</c> array — the shape a BPMN process scope and every scope nested in it share.
+    /// </summary>
+    /// <returns>The activity, or <c>null</c> when neither the scope nor any activity under it has that ID.</returns>
+    public static JsonObject? FindActivity(this JsonObject scope, string id) =>
+        scope.GetId() == id
+            ? scope
+            : (scope["activities"] as JsonArray ?? []).OfType<JsonObject>().Select(child => child.FindActivity(id)).FirstOrDefault(found => found != null);
 }

--- a/src/modules/Elsa.Studio.Workflows.Designer.Tests/BpmnDesignerSelectionMappingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer.Tests/BpmnDesignerSelectionMappingTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Extensions;
 using Xunit;
 
 namespace Elsa.Studio.Workflows.Designer.Tests;
@@ -18,7 +19,7 @@ public class BpmnDesignerSelectionMappingTests
         var boundActivity = CreateActivity("write-line-1", "Elsa.WriteLine");
         var root = CreateScope("root", ("ref-1", "write-line-1"), boundActivity);
 
-        var found = BpmnDesigner.FindActivityById(root, "write-line-1");
+        var found = root.FindActivity("write-line-1");
 
         Assert.Same(boundActivity, found);
     }
@@ -30,7 +31,7 @@ public class BpmnDesignerSelectionMappingTests
         var nestedScope = CreateScope("nested-scope", ("ref-1", "write-line-1"), boundActivity);
         var root = CreateScope("root", ("ref-nested", "nested-scope"), nestedScope);
 
-        var found = BpmnDesigner.FindActivityById(root, "write-line-1");
+        var found = root.FindActivity("write-line-1");
 
         Assert.Same(boundActivity, found);
     }
@@ -40,7 +41,7 @@ public class BpmnDesignerSelectionMappingTests
     {
         var root = CreateScope("root");
 
-        var found = BpmnDesigner.FindActivityById(root, "root");
+        var found = root.FindActivity("root");
 
         Assert.Same(root, found);
     }
@@ -51,7 +52,7 @@ public class BpmnDesignerSelectionMappingTests
         var nestedScope = CreateScope("nested-scope");
         var root = CreateScope("root", ("ref-nested", "nested-scope"), nestedScope);
 
-        var found = BpmnDesigner.FindActivityById(root, "nested-scope");
+        var found = root.FindActivity("nested-scope");
 
         Assert.Same(nestedScope, found);
     }
@@ -61,7 +62,7 @@ public class BpmnDesignerSelectionMappingTests
     {
         var root = CreateScope("root");
 
-        var found = BpmnDesigner.FindActivityById(root, "does-not-exist");
+        var found = root.FindActivity("does-not-exist");
 
         Assert.Null(found);
     }

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/__tests__/view-model.test.ts
@@ -322,6 +322,7 @@ describe('binding display', () => {
 
         expect(element(model, 'NotifyWarehouse').binding).toEqual({
             state: 'bound',
+            kind: 'unboundTask',
             bindingRef: 'node-NotifyWarehouse',
             activityId: 'order-process:node-NotifyWarehouse',
             activityType: 'Elsa.WriteLine',
@@ -379,6 +380,7 @@ describe('binding display', () => {
 
         expect(element(model, 'NotifyWarehouse').binding).toEqual({
             state: 'unbound',
+            kind: 'unboundTask',
             bindingRef: null,
             activityId: null,
             activityType: null,
@@ -421,6 +423,49 @@ describe('binding display', () => {
             state: 'unresolved',
             activityId: 'order-process:gone',
         });
+    });
+});
+
+// Which elements a user binds by hand. The dangerous direction is an automatically bound element that
+// looks authored: the "Performed by" section would offer to write an elsa:activityBinding onto it, and
+// elsa-core refuses that document at import. The opposite mistake -- an authored task shown as
+// automatic -- silently leaves the user with no way to bind it. Both directions are pinned here.
+describe('binding kind', () => {
+    it('marks every task that resolves no message as authored, and a message send or receive as automatic', () => {
+        const model = build('task-kinds-and-lanes');
+
+        for (const id of ['AbstractTask', 'ReviewOrder', 'ServiceWork', 'ScriptWork', 'PackBox', 'DecideRules']) {
+            expect(element(model, id).binding?.kind, id).toBe('unboundTask');
+        }
+
+        expect(element(model, 'SendShipped').binding?.kind).toBe('automatic');
+        expect(element(model, 'AwaitConfirm').binding?.kind).toBe('automatic');
+        expect(element(model, 'ArchiveOrder').binding?.kind).toBe('automatic');
+    });
+
+    it('marks a send or receive task that names no message as authored, the way the reader binds it', () => {
+        const fixture = loadFixture('task-kinds-and-lanes');
+        const activity = structuredClone(fixture.activity) as BpmnActivity;
+
+        for (const id of ['SendShipped', 'AwaitConfirm']) {
+            const task = activity.process!.elements.find(candidate => candidate.elementId === id)!;
+            (task as { properties: Record<string, string> }).properties = {};
+        }
+
+        const model = buildBpmnViewModel({ activity, sourceXml: fixture.sourceXml });
+
+        expect(element(model, 'SendShipped').binding?.kind).toBe('unboundTask');
+        expect(element(model, 'AwaitConfirm').binding?.kind).toBe('unboundTask');
+    });
+
+    it('marks timer and message boundaries, subprocesses and an event subprocess listener as automatic', () => {
+        const model = build('subprocess-boundary-events');
+
+        expect(element(model, 'Escalate').binding?.kind).toBe('unboundTask');
+        expect(element(model, 'Fulfil').binding?.kind).toBe('automatic');
+        expect(element(model, 'FulfilTimeout').binding?.kind).toBe('automatic');
+        expect(element(model, 'FulfilNudge').binding?.kind).toBe('automatic');
+        expect(element(model, 'OnRecall').listenerBinding?.kind).toBe('automatic');
     });
 });
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/element-kinds.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/element-kinds.ts
@@ -67,6 +67,27 @@ export function requiresWorkBinding(elementType: string): boolean {
 }
 
 /**
+ * The element `properties` key the reader records a send or receive task's resolved message name under
+ * (`Bpmn.Interchange.BpmnXmlReader.MessageNamePropertyKey`). Only that resolution ever sets it, which is
+ * what tells a message send or receive task -- bound automatically -- apart from one whose work the host
+ * has to supply.
+ */
+export const MESSAGE_NAME_PROPERTY_KEY = 'bpmn.messageName';
+
+/**
+ * Whether an element's work is *authored*: `Bpmn.Interchange`'s `BpmnWorkBinding.UnboundTask`, a task
+ * the document describes without saying how to perform it, whose Elsa activity comes from an
+ * `elsa:activityBinding` declaration on the element itself.
+ *
+ * Every task kind is one, except a send or receive task that resolved a message: that is a message
+ * publish or wait the binder binds on its own. The same rule elsa-core's `ValidateBpmnProcessBindings`
+ * applies when it decides which elements the publish gate checks.
+ */
+export function isUnboundTask(elementType: string, properties: Readonly<Record<string, string>> | null | undefined): boolean {
+    return TASK_ELEMENT_TYPES.includes(elementType) && properties?.[MESSAGE_NAME_PROPERTY_KEY] == null;
+}
+
+/**
  * The size a fallback layout gives an element of this kind, in BPMN DI units.
  *
  * These are the sizes the BPMN 2.0 DI examples and every mainstream modeller use, so a fallback

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/index.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/index.ts
@@ -11,8 +11,10 @@ export {
     GATEWAY_ELEMENT_TYPES,
     SUB_PROCESS_ELEMENT_TYPE,
     TASK_ELEMENT_TYPES,
+    MESSAGE_NAME_PROPERTY_KEY,
     classifyElementType,
     defaultSizeFor,
+    isUnboundTask,
     requiresWorkBinding,
 } from './element-kinds';
 export type {
@@ -20,6 +22,7 @@ export type {
     BpmnActivityDescriptor,
     BpmnActivityStats,
     BpmnBinding,
+    BpmnBindingKind,
     BpmnBindingState,
     BpmnBoundaryAttachment,
     BpmnDiagnostic,

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/model.ts
@@ -136,9 +136,25 @@ export type BpmnBindingState =
     /** The element declares a binding ref that `workBindings` -- or `activities` -- does not resolve. */
     | 'unresolved';
 
+/** Where the Elsa activity behind an element comes from. */
+export type BpmnBindingKind =
+    /**
+     * Authored: an `elsa:activityBinding` on the element declares the activity and its inputs
+     * (`Bpmn.Interchange`'s `BpmnWorkBinding.UnboundTask`). The only kind a user binds by hand.
+     */
+    | 'unboundTask'
+    /**
+     * Derived by elsa-core's binder from the document itself: a timer, message or signal wait, a
+     * message publish, a call activity or a nested process. An `elsa:activityBinding` on one of these
+     * is refused at import, so it is never edited as one.
+     */
+    | 'automatic';
+
 /** The bound Elsa activity behind one BPMN element, and how it should be named on the canvas. */
 export interface BpmnBinding {
     readonly state: BpmnBindingState;
+    /** Whether the activity is authored on the element or bound automatically; see {@link BpmnBindingKind}. */
+    readonly kind: BpmnBindingKind;
     /** The binding ref the document declares, or null when the element declares none. */
     readonly bindingRef: string | null;
     /** The Elsa activity id `workBindings` maps {@link bindingRef} to. */

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/bpmn/view-model.ts
@@ -13,6 +13,7 @@ import { readDiagramInterchange, type BpmnDiagramInterchange, type DiBounds } fr
 import {
     BOUNDARY_EVENT_ELEMENT_TYPE,
     classifyElementType,
+    isUnboundTask,
     requiresWorkBinding,
 } from './element-kinds';
 import { computeFallbackLayout, layoutKey, type LayoutRect, type LayoutScope } from './fallback-layout';
@@ -20,6 +21,7 @@ import type {
     BpmnActivity,
     BpmnActivityDescriptor,
     BpmnBinding,
+    BpmnBindingKind,
     BpmnBoundaryAttachment,
     BpmnDiagnostic,
     BpmnDiagnosticCode,
@@ -412,10 +414,10 @@ function buildElement(
     input: BpmnViewModelInput,
     report: Report): BpmnViewElement {
     const shape = diagram.shapes.get(element.elementId);
-    const binding = resolveBinding(element.bindingRef ?? null, element.elementType, scope, descriptorsByType);
+    const binding = resolveBinding(element.bindingRef ?? null, element, scope, descriptorsByType);
     const listenerBinding = element.listenerBindingRef == null
         ? null
-        : resolveBinding(element.listenerBindingRef, element.elementType, scope, descriptorsByType);
+        : resolveBinding(element.listenerBindingRef, element, scope, descriptorsByType);
 
     if (binding?.state === 'unbound') {
         report(
@@ -500,14 +502,17 @@ function buildElement(
  */
 function resolveBinding(
     bindingRef: string | null,
-    elementType: string,
+    element: BpmnElement,
     scope: ScopeNode,
     descriptorsByType: ReadonlyMap<string, BpmnActivityDescriptor>): BpmnBinding | null {
+    const kind: BpmnBindingKind = isUnboundTask(element.elementType, element.properties) ? 'unboundTask' : 'automatic';
+
     if (bindingRef == null) {
-        if (!requiresWorkBinding(elementType)) return null;
+        if (!requiresWorkBinding(element.elementType)) return null;
 
         return {
             state: 'unbound',
+            kind,
             bindingRef: null,
             activityId: null,
             activityType: null,
@@ -523,6 +528,7 @@ function resolveBinding(
     if (activity == null) {
         return {
             state: 'unresolved',
+            kind,
             bindingRef,
             activityId,
             activityType: null,
@@ -537,6 +543,7 @@ function resolveBinding(
 
     return {
         state: 'bound',
+        kind,
         bindingRef,
         activityId,
         activityType: activity.type,

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/__tests__/cells.test.ts
@@ -107,6 +107,16 @@ describe.each(FIXTURE_NAMES)('%s', name => {
         }
     });
 
+    // What .NET is told on selection: the "Performed by" section decides from this alone whether to
+    // offer the activity picker, so it has to be exactly the view model's own classification.
+    it('carries each element\'s binding kind onto its node, exactly as the view model classified it', () => {
+        for (const element of model.elements) {
+            const data = nodesById.get(element.id)!.data as BpmnElementCellData;
+
+            expect(data.bindingKind, element.id).toBe(element.binding?.kind ?? null);
+        }
+    });
+
     it('keeps every boundary event attached to a host that is on the canvas', () => {
         const boundaries = model.elements.filter(element => element.boundary != null);
 

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/cells.ts
@@ -14,6 +14,7 @@
 import type { Edge, Node } from '@antv/x6';
 import type {
     BpmnActivityStats,
+    BpmnBindingKind,
     BpmnBindingState,
     BpmnElementKind,
     BpmnElementStats,
@@ -91,6 +92,8 @@ export interface BpmnElementCellData {
     /** The bound Elsa activity, or null for an element that performs no work. */
     readonly activityId: string | null;
     readonly bindingState: BpmnBindingState | null;
+    /** Whether the bound activity is authored on the element or bound automatically, or null for no work. */
+    readonly bindingKind: BpmnBindingKind | null;
     /** Set only on a boundary event: the element it is drawn on. */
     readonly boundaryHostElementId: string | null;
     readonly childScopeId: string | null;
@@ -366,6 +369,7 @@ function nodeForElement(element: BpmnViewElement, context: BuildContext): Node.M
         scopeActivityId: context.activityIdByScopeId.get(element.scopeId) ?? '',
         activityId: element.binding?.activityId ?? null,
         bindingState: element.binding?.state ?? null,
+        bindingKind: element.binding?.kind ?? null,
         boundaryHostElementId: element.boundary?.hostElementId ?? null,
         childScopeId: element.childScopeId,
         stats: element.stats,

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/dotnet-bpmn-designer.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/dotnet-bpmn-designer.ts
@@ -28,6 +28,11 @@ export interface BpmnElementSelection {
     readonly activityId: string | null;
     /** How the binding resolves, or null for an element that performs no work. */
     readonly bindingState: string | null;
+    /**
+     * `unboundTask` when the element's activity is authored on it (an `elsa:activityBinding` the user
+     * binds by hand), `automatic` when the binder derives it from the document, or null for no work.
+     */
+    readonly bindingKind: string | null;
     /** The process id of the scope the element lives in. */
     readonly scopeId: string;
     /** The `Elsa.BpmnProcess` activity that runs that scope. */

--- a/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
+++ b/src/modules/Elsa.Studio.Workflows.Designer/ClientLib/src/designer/bpmn/mount.ts
@@ -253,6 +253,7 @@ function toSelection(data: BpmnElementCellData): BpmnElementSelection {
         name: data.name,
         activityId: data.activityId,
         bindingState: data.bindingState,
+        bindingKind: data.bindingKind,
         scopeId: data.scopeId,
         scopeActivityId: data.scopeActivityId,
         boundaryHostElementId: data.boundaryHostElementId,

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -249,22 +249,7 @@ public partial class BpmnDesigner : IAsyncDisposable
             return null;
 
         var targetId = selection.ActivityId ?? selection.ScopeActivityId;
-        return FindActivityById(_activity, targetId);
-    }
-
-    /// <summary>
-    /// Finds the activity with the specified id, in <paramref name="root"/> itself or, recursively,
-    /// among the activities bound to it and to any nested BPMN scope. Used to resolve both a bound
-    /// element's activity and a scope's own <c>Elsa.BpmnProcess</c> activity by the same lookup.
-    /// </summary>
-    internal static JsonObject? FindActivityById(JsonObject root, string id)
-    {
-        if (root.GetId() == id)
-            return root;
-
-        return root.GetActivities()
-            .Select(activity => FindActivityById(activity, id))
-            .FirstOrDefault(found => found != null);
+        return _activity.FindActivity(targetId);
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Components/BpmnDesigner.razor.cs
@@ -55,6 +55,13 @@ public partial class BpmnDesigner : IAsyncDisposable
     /// An event raised when the canvas, a lane or a pool is selected, i.e. nothing in particular.
     [Parameter] public EventCallback CanvasSelected { get; set; }
 
+    /// <summary>
+    /// An event raised with the BPMN element itself whenever one is selected, and with <see langword="null"/> when the
+    /// canvas, a lane or a pool is. Unlike <see cref="ActivitySelected"/>, which can only name an activity, this still
+    /// says which element was clicked when no activity is bound to it.
+    /// </summary>
+    [Parameter] public EventCallback<BpmnElementSelection?> ElementSelected { get; set; }
+
     [Inject] private DesignerJsInterop DesignerJsInterop { get; set; } = null!;
     [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
     [Inject] private IActivityDisplaySettingsRegistry ActivityDisplaySettingsRegistry { get; set; } = null!;
@@ -66,6 +73,9 @@ public partial class BpmnDesigner : IAsyncDisposable
     [JSInvokable]
     public async Task HandleActivitySelected(BpmnElementSelection selection)
     {
+        if (ElementSelected.HasDelegate)
+            await ElementSelected.InvokeAsync(selection);
+
         if (!ActivitySelected.HasDelegate)
             return;
 
@@ -96,6 +106,9 @@ public partial class BpmnDesigner : IAsyncDisposable
     [JSInvokable]
     public async Task HandleCanvasSelected()
     {
+        if (ElementSelected.HasDelegate)
+            await ElementSelected.InvokeAsync(null);
+
         if (CanvasSelected.HasDelegate)
             await CanvasSelected.InvokeAsync();
     }

--- a/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnElementSelection.cs
+++ b/src/modules/Elsa.Studio.Workflows.Designer/Models/BpmnElementSelection.cs
@@ -15,6 +15,12 @@ namespace Elsa.Studio.Workflows.Designer.Models;
 /// <param name="ScopeActivityId">The <c>Elsa.BpmnProcess</c> activity that runs that scope.</param>
 /// <param name="BoundaryHostElementId">For a boundary event, the element it is attached to.</param>
 /// <param name="ChildScopeId">For a subprocess, the process id of the scope it contains.</param>
+/// <param name="BindingKind">
+/// Where the element's Elsa activity comes from: <see cref="BpmnBindingKinds.UnboundTask"/> when it is authored on
+/// the element (an <c>elsa:activityBinding</c> the user binds by hand), <see cref="BpmnBindingKinds.Automatic"/>
+/// when elsa-core's binder derives it from the document, or <see langword="null"/> for an element that performs no
+/// work.
+/// </param>
 public record BpmnElementSelection(
     string ElementId,
     string ElementType,
@@ -25,4 +31,28 @@ public record BpmnElementSelection(
     string ScopeId,
     string ScopeActivityId,
     string? BoundaryHostElementId,
-    string? ChildScopeId);
+    string? ChildScopeId,
+    string? BindingKind = null)
+{
+    /// <summary>Whether the element's activity is authored on it, so the user binds it by hand.</summary>
+    public bool IsUnboundTask => BindingKind == BpmnBindingKinds.UnboundTask;
+}
+
+/// <summary>
+/// The <see cref="BpmnElementSelection.BindingKind"/> values the BPMN canvas sends. Mirrors the ClientLib's
+/// canvas-neutral <c>BpmnBindingKind</c> (<c>src/bpmn/model.ts</c>), which owns the classification.
+/// </summary>
+public static class BpmnBindingKinds
+{
+    /// <summary>
+    /// Authored: an <c>elsa:activityBinding</c> on the element declares the activity (<c>Bpmn.Interchange</c>'s
+    /// <c>BpmnWorkBinding.UnboundTask</c>).
+    /// </summary>
+    public const string UnboundTask = "unboundTask";
+
+    /// <summary>
+    /// Derived by elsa-core's binder from the document itself: a timer, message or signal wait, a message
+    /// publish, a call activity or a nested process.
+    /// </summary>
+    public const string Automatic = "automatic";
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingDraftTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingDraftTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Tests.Support;
+using Xunit;
+using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// The input round trip (D): a binding carries each input as the JSON Studio's own input editors wrote into the
+/// activity — no second encoder — and reading the binding back the way elsa-core does reconstructs every input value.
+/// Covered for both shapes the format has to carry: an <c>Input&lt;T&gt;</c>'s <c>{"typeName":…,"expression":…}</c>
+/// wrapper (here a JavaScript expression) and a plain <c>[Input]</c>'s own JSON (here <c>FlowSwitch.Cases</c>, an array).
+/// </summary>
+public class BpmnActivityBindingDraftTests
+{
+    /// <summary>What <c>InputsTab.HandleValueChangedAsync</c> serializes an editor's value with.</summary>
+    private static readonly JsonSerializerOptions EditorOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private readonly Elsa.Api.Client.Resources.ActivityDescriptors.Models.ActivityDescriptor _flowSwitch = Descriptor("Elsa.FlowSwitch", "Switch",
+        Input("Cases", "System.Collections.Generic.ICollection<Elsa.Workflows.Activities.Flowchart.Models.FlowSwitchCase>", isWrapped: false),
+        Input("Mode", "Elsa.Workflows.Activities.Flowchart.Models.SwitchMode", isWrapped: true),
+        Input("Label", "String", isWrapped: true));
+
+    [Fact]
+    public void ToBinding_CarriesAWrappedJavaScriptInputAndAPlainArrayInput_AsElsaCoreReadsThemBack()
+    {
+        var draft = BpmnActivityBindingDraft.Create(_flowSwitch, BoundActivityId);
+        EditAsInputsTabDoes(draft, "label", new WrappedInput { TypeName = "String", Expression = new Expression("JavaScript", "`Route ${getVariable('orderId')}` && x < y") });
+        EditAsInputsTabDoes(draft, "cases", new List<SwitchCase>
+        {
+            new() { Label = "Big order", Condition = new Expression("JavaScript", "getVariable('total') > 100") },
+            new() { Label = "Small order", Condition = new Expression("Literal", "true") }
+        });
+
+        var activityAsCoreBuildsIt = ReadAsElsaCore(draft.ToBinding());
+
+        Assert.Equal("Elsa.FlowSwitch", activityAsCoreBuildsIt["type"]!.GetValue<string>());
+        Assert.True(JsonNode.DeepEquals(draft.Activity["label"], activityAsCoreBuildsIt["label"]), activityAsCoreBuildsIt.ToJsonString());
+        Assert.True(JsonNode.DeepEquals(draft.Activity["cases"], activityAsCoreBuildsIt["cases"]), activityAsCoreBuildsIt.ToJsonString());
+        Assert.Equal(JsonValueKind.Array, activityAsCoreBuildsIt["cases"]!.GetValueKind());
+        Assert.Equal("JavaScript", activityAsCoreBuildsIt["label"]!["expression"]!["type"]!.GetValue<string>());
+
+        // An input nobody configured is left out, exactly as elsa-core's own writer leaves a null input out.
+        Assert.False(activityAsCoreBuildsIt.ContainsKey("mode"));
+    }
+
+    [Fact]
+    public void FromBinding_ThenToBinding_ReproducesTheAuthoredBindingExactly()
+    {
+        var authored = BpmnActivityBindingFormat.Find(BpmnDocumentFixtures.TaskElement(Document()))!;
+
+        var draft = BpmnActivityBindingDraft.FromBinding(BpmnActivityBindingFormat.Read(authored), WriteLine(), BoundActivityId);
+
+        Assert.Equal("Notifying the warehouse", draft.Activity["text"]!["expression"]!["value"]!.GetValue<string>());
+        Assert.True(JsonNode.DeepEquals(authored, draft.ToBinding()), draft.ToBinding().ToJsonString());
+    }
+
+    [Fact]
+    public void AnAcronymInput_IsNamedAsElsaCoreNamesIt_InTheBinding_AndAsTheEditorsKeyIt_InTheActivity()
+    {
+        // JsonNamingPolicy.CamelCase makes "URL" "url"; Humanizer's Camelize, which the input editors key on, makes it "uRL".
+        var descriptor = Descriptor("Acme.Fetch", "Fetch", Input("URL", "Uri", isWrapped: true));
+        var url = JsonNode.Parse("""{"typeName":"Uri","expression":{"type":"Literal","value":"https://example.com"}}""");
+        var binding = new BpmnActivityBinding("Acme.Fetch", [new("url", url)]);
+
+        var draft = BpmnActivityBindingDraft.FromBinding(binding, descriptor, "task");
+
+        Assert.True(JsonNode.DeepEquals(url, draft.Activity["uRL"]));
+        Assert.True(JsonNode.DeepEquals(url, ReadAsElsaCore(draft.ToBinding())["url"]));
+    }
+
+    [Fact]
+    public void AnInputStudiosCatalogueDoesNotDescribe_IsWrittenBackAsItWasRead()
+    {
+        // Studio's catalogue can be older than the server's; saving must not quietly drop what it cannot display.
+        var unknown = JsonNode.Parse("""{"typeName":"Int32","expression":{"type":"Literal","value":"3"}}""");
+        var binding = new BpmnActivityBinding("Elsa.WriteLine", [new("retries", unknown), new("text", JsonValue.Create("hello"))]);
+
+        var draft = BpmnActivityBindingDraft.FromBinding(binding, WriteLine(), "task");
+
+        Assert.False(draft.Activity.ContainsKey("retries"));
+        var written = ReadAsElsaCore(draft.ToBinding());
+        Assert.True(JsonNode.DeepEquals(unknown, written["retries"]));
+        Assert.Equal("hello", written["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Create_StartsFromTheDescriptorsConstructionProperties_AndBindsOnlyDeclaredInputs()
+    {
+        var descriptor = WriteLine() with
+        {
+            ConstructionProperties = new Dictionary<string, object> { ["Text"] = new { typeName = "String", expression = new { type = "Literal", value = "default" } }, ["Unrelated"] = 1 }
+        };
+
+        var draft = BpmnActivityBindingDraft.Create(descriptor, "task");
+
+        var written = ReadAsElsaCore(draft.ToBinding());
+        Assert.Equal("default", written["text"]!["expression"]!["value"]!.GetValue<string>());
+        Assert.False(written.ContainsKey("unrelated"));
+        Assert.Equal(["type", "text"], written.Select(property => property.Key));
+    }
+
+    private static void EditAsInputsTabDoes(BpmnActivityBindingDraft draft, string inputName, object value) =>
+        draft.Activity.SetProperty(value.SerializeToNode(EditorOptions), inputName);
+
+    /// <summary>
+    /// The activity JSON elsa-core's <c>BpmnActivityBindingFormat.Read</c> hands its activity serializer for a binding
+    /// element — <c>{"type": activityType, &lt;name&gt;: &lt;parsed input text&gt;, …}</c> — rebuilt here independently of
+    /// Studio's own reader, from the raw document shape, so the assertion does not rest on the code under test.
+    /// </summary>
+    private static JsonObject ReadAsElsaCore(JsonObject binding)
+    {
+        const string elsa = "https://elsaworkflows.io/schemas/bpmn/v1";
+
+        Assert.Equal(elsa, binding["name"]!["ns"]!.GetValue<string>());
+        Assert.Equal("activityBinding", binding["name"]!["localName"]!.GetValue<string>());
+
+        var activity = new JsonObject { ["type"] = UnqualifiedAttribute(binding, "activityType") };
+
+        foreach (var input in binding["children"]!.AsArray().Select(child => child!.AsObject()))
+        {
+            Assert.Equal(elsa, input["name"]!["ns"]!.GetValue<string>());
+            Assert.Equal("input", input["name"]!["localName"]!.GetValue<string>());
+
+            var name = UnqualifiedAttribute(input, "name");
+            Assert.False(activity.ContainsKey(name), $"The input '{name}' is declared twice.");
+            activity[name] = JsonNode.Parse(input["value"]!.GetValue<string>());
+        }
+
+        return activity;
+    }
+
+    private static string UnqualifiedAttribute(JsonObject element, string localName) =>
+        element["attributes"]!.AsArray()
+            .Select(attribute => attribute!.AsObject())
+            .Single(attribute => attribute["name"]!["ns"] is null && attribute["name"]!["localName"]!.GetValue<string>() == localName)["value"]!
+            .GetValue<string>();
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Tests.Support;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers Studio's side of the <c>elsa:activityBinding</c> compatibility surface on the library-format document the
+/// document endpoints exchange (D4): a binding edit touches the one extension entry that binds the task and nothing else
+/// in the document — not the task's <c>camunda:*</c> extensions, its foreign attributes, its documentation, the other
+/// elements, or the DI — and what Studio writes is the exact shape <c>Bpmn.Interchange</c>'s own reader produced for the
+/// same binding.
+/// </summary>
+public class BpmnActivityBindingFormatTests
+{
+    private readonly JsonObject _original = BpmnDocumentFixtures.Document();
+    private readonly JsonObject _document = BpmnDocumentFixtures.Document();
+
+    private JsonObject Task => BpmnDocumentFixtures.TaskElement(_document);
+    private JsonArray TaskExtensionElements => (JsonArray)Task["extensions"]!["extensionElements"]!;
+
+    [Fact]
+    public void Create_WritesExactlyTheShapeTheLibraryReaderProducesForTheSameBinding()
+    {
+        var authored = BpmnActivityBindingFormat.Find(Task)!;
+        var text = JsonNode.Parse("""{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}""");
+
+        var written = BpmnActivityBindingFormat.Create("Elsa.WriteLine", [KeyValuePair.Create("text", text)]);
+
+        Assert.True(JsonNode.DeepEquals(authored, written), written.ToJsonString());
+    }
+
+    [Fact]
+    public void Attach_ReplacesTheTasksBindingInPlace_AndChangesNothingElseInTheDocument()
+    {
+        var bindingIndex = TaskExtensionElements.IndexOf(BpmnActivityBindingFormat.Find(Task));
+        var replacement = BpmnActivityBindingFormat.Create("Elsa.HttpRequest", [KeyValuePair.Create<string, JsonNode?>("url", JsonNode.Parse("""{"typeName":"Uri","expression":{"type":"JavaScript","value":"getUrl()"}}"""))]);
+
+        BpmnActivityBindingFormat.Attach(Task, replacement);
+
+        Assert.Same(replacement, TaskExtensionElements[bindingIndex]);
+        Assert.False(JsonNode.DeepEquals(_original, _document));
+
+        // Putting the original entry back must restore the document exactly: the edit touched that one entry only.
+        TaskExtensionElements[bindingIndex] = BpmnActivityBindingFormat.Find(BpmnDocumentFixtures.TaskElement(_original))!.DeepClone();
+        Assert.True(JsonNode.DeepEquals(_original, _document));
+    }
+
+    [Fact]
+    public void Attach_AppendsABindingToAnElementThatHasNone_AndChangesNothingElse()
+    {
+        var startEvent = (JsonObject)_document["processes"]![0]!["elements"]![0]!;
+        var binding = BpmnActivityBindingFormat.Create("Elsa.WriteLine", []);
+
+        BpmnActivityBindingFormat.Attach(startEvent, binding);
+
+        var extensionElements = (JsonArray)startEvent["extensions"]!["extensionElements"]!;
+        Assert.Same(binding, Assert.Single(extensionElements));
+
+        extensionElements.Clear();
+        Assert.True(JsonNode.DeepEquals(_original, _document));
+    }
+
+    [Fact]
+    public void Attach_LeavesExactlyOneBinding_WhenTheElementCarriedTwo()
+    {
+        // A reader takes the first of two; leaving the older one behind would silently keep applying it.
+        TaskExtensionElements.Add(BpmnActivityBindingFormat.Create("Elsa.Stale", []));
+        var replacement = BpmnActivityBindingFormat.Create("Elsa.HttpRequest", []);
+
+        BpmnActivityBindingFormat.Attach(Task, replacement);
+
+        Assert.Same(replacement, BpmnActivityBindingFormat.Find(Task));
+        Assert.Equal(2, TaskExtensionElements.Count);
+        Assert.Equal("inputOutput", TaskExtensionElements[0]!["name"]!["localName"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Attach_CreatesTheExtensionsAnElementWithoutAnyNeeds()
+    {
+        var element = new JsonObject { ["elementId"] = "Added", ["elementType"] = "serviceTask" };
+
+        BpmnActivityBindingFormat.Attach(element, BpmnActivityBindingFormat.Create("Elsa.WriteLine", []));
+
+        Assert.NotNull(BpmnActivityBindingFormat.Find(element));
+        Assert.IsType<JsonArray>(element["extensions"]!["foreignAttributes"]);
+    }
+
+    [Fact]
+    public void Create_SkipsInputsWithNoValue_AndOrdersTheRestByName()
+    {
+        var binding = BpmnActivityBindingFormat.Create("Elsa.HttpRequest",
+        [
+            KeyValuePair.Create<string, JsonNode?>("url", JsonValue.Create("u")),
+            KeyValuePair.Create<string, JsonNode?>("method", null),
+            KeyValuePair.Create<string, JsonNode?>("body", JsonNode.Parse("null")),
+            KeyValuePair.Create<string, JsonNode?>("contentType", JsonValue.Create("c"))
+        ]);
+
+        Assert.Equal(["contentType", "url"], BpmnActivityBindingFormat.Read(binding).Inputs.Select(input => input.Name));
+    }
+
+    [Fact]
+    public void Read_ReadsTheAuthoredBinding()
+    {
+        var binding = BpmnActivityBindingFormat.Read(BpmnActivityBindingFormat.Find(Task)!);
+
+        Assert.Equal("Elsa.WriteLine", binding.ActivityType);
+        var input = Assert.Single(binding.Inputs);
+        Assert.Equal("text", input.Name);
+        Assert.Equal("Notifying the warehouse", input.Value!["expression"]!["value"]!.GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData("missing-activity-type")]
+    [InlineData("duplicate-input")]
+    [InlineData("unnamed-input")]
+    [InlineData("invalid-json")]
+    public void Read_RefusesWhatElsaCoreRefuses(string defect)
+    {
+        var binding = BpmnActivityBindingFormat.Create("Elsa.WriteLine", [KeyValuePair.Create<string, JsonNode?>("text", JsonValue.Create("x"))]);
+        var inputs = (JsonArray)binding["children"]!;
+
+        switch (defect)
+        {
+            case "missing-activity-type":
+                ((JsonArray)binding["attributes"]!).Clear();
+                break;
+            case "duplicate-input":
+                inputs.Add(inputs[0]!.DeepClone());
+                break;
+            case "unnamed-input":
+                ((JsonArray)inputs[0]!["attributes"]!).Clear();
+                break;
+            case "invalid-json":
+                inputs[0]!["value"] = "{ not json";
+                break;
+        }
+
+        Assert.Throws<BpmnActivityBindingFormatException>(() => BpmnActivityBindingFormat.Read(binding));
+    }
+
+    [Fact]
+    public void Find_IgnoresAnExtensionWithTheBindingsLocalNameInAnotherNamespace()
+    {
+        var foreign = BpmnActivityBindingFormat.Create("Elsa.WriteLine", []);
+        foreign["name"]!["ns"] = "http://camunda.org/schema/1.0/bpmn";
+        var element = new JsonObject { ["extensions"] = new JsonObject { ["extensionElements"] = new JsonArray(foreign) } };
+
+        Assert.Null(BpmnActivityBindingFormat.Find(element));
+    }
+
+    [Fact]
+    public void FindElement_FindsATaskOfAnyProcess_AndNothingForAnUnknownId()
+    {
+        Assert.Same(Task, BpmnDefinitionsDocument.FindElement(_document, BpmnDocumentFixtures.TaskId));
+        Assert.Null(BpmnDefinitionsDocument.FindElement(_document, "Nope"));
+    }
+
+    [Fact]
+    public void FindSubProcessIds_ReportsEverySubprocess_AndNoneForAFlatProcess()
+    {
+        Assert.Empty(BpmnDefinitionsDocument.FindSubProcessIds(_document));
+
+        ((JsonArray)_document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = BpmnDefinitionsDocument.SubProcessElementType });
+
+        Assert.Equal(["Fulfil"], BpmnDefinitionsDocument.FindSubProcessIds(_document));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -147,9 +147,12 @@ public class BpmnDocumentSessionTests
         BindHttpRequest();
 
         var saveTask = _session.SaveAsync();
+        var documentBeingSaved = (JsonObject)_session.Document!.DeepClone();
 
         Assert.True(_session.IsSaving);
-        Assert.Throws<InvalidOperationException>(() => BindHttpRequest());
+        var refusedBinding = BpmnActivityBindingFormat.Create("Elsa.WriteLine", []);
+        Assert.False(_session.SetBinding(TaskId, refusedBinding));
+        Assert.True(JsonNode.DeepEquals(documentBeingSaved, _session.Document));
 
         gate.SetResult();
         var result = await saveTask;

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Tests.Support;
+using Xunit;
+using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers <see cref="BpmnDocumentSession"/>: a binding edit is written back only through the document PUT, carrying the
+/// ETag of the revision it was made in; a refusal is reported and never retried; and a document whose subprocess bodies
+/// the PUT would empty is refused before anything is sent — in both directions, since a save that silently went through
+/// looks exactly like one that worked.
+/// </summary>
+public class BpmnDocumentSessionTests
+{
+    private const string ETag = "\"REVISION-1\"";
+    private readonly FakeBpmnDocumentService _service = new();
+    private readonly BpmnDocumentSession _session;
+
+    public BpmnDocumentSessionTests()
+    {
+        _service.ReturnsDocument(Document(), ETag);
+        _session = new(_service, DefinitionId);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PutsTheEditedDocumentWithTheETagItWasReadAt_ThenReadsTheServersViewBack()
+    {
+        await _session.EnsureLoadedAsync();
+        _service.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        var binding = BindHttpRequest();
+
+        var result = await _session.SaveAsync();
+
+        Assert.True(result.IsSuccess);
+        var put = Assert.Single(_service.Puts);
+        Assert.Equal((DefinitionId, ETag), (put.DefinitionId, put.IfMatch));
+        Assert.True(JsonNode.DeepEquals(binding, BpmnActivityBindingFormat.Find(BpmnDocumentFixtures.TaskElement(put.Document))));
+        Assert.Equal(2, _service.GetCount);
+        Assert.False(_session.IsDirty);
+        Assert.Empty(_session.EditedElementIds);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenTheRevisionMovedOn_ReportsTheConflict_KeepsTheEditAndDoesNotRetry()
+    {
+        await _session.EnsureLoadedAsync();
+        _service.RefusesPut(BpmnDocumentFailureReason.PreconditionFailed);
+        BindHttpRequest();
+
+        var result = await _session.SaveAsync();
+
+        Assert.Equal(BpmnDocumentFailureReason.PreconditionFailed, result.Failure!.Reason);
+        Assert.Equal(BpmnDocumentFailureReason.PreconditionFailed, _session.SaveFailure!.Reason);
+        Assert.Single(_service.Puts);
+        Assert.Equal(1, _service.GetCount);
+        Assert.True(_session.IsDirty);
+        Assert.Equal([TaskId], _session.EditedElementIds);
+    }
+
+    [Fact]
+    public async Task SaveAsync_RefusesADocumentWithASubprocess_WithoutSendingIt()
+    {
+        var document = Document();
+        ((JsonArray)document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = "subProcess" });
+        var service = new FakeBpmnDocumentService().ReturnsDocument(document, ETag).AcceptsPut("\"REVISION-2\"");
+        var session = new BpmnDocumentSession(service, DefinitionId);
+        await session.EnsureLoadedAsync();
+        session.SetBinding(TaskId, BpmnActivityBindingFormat.Create("Elsa.HttpRequest", []));
+
+        var result = await session.SaveAsync();
+
+        Assert.Equal(BpmnDocumentFailureReason.SubProcessContentNotCarried, result.Failure!.Reason);
+        Assert.Empty(service.Puts);
+        Assert.Equal(["Fulfil"], session.SubProcessIds);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SendsADocumentWithoutSubprocesses()
+    {
+        await _session.EnsureLoadedAsync();
+        _service.AcceptsPut("\"REVISION-2\"");
+        BindHttpRequest();
+
+        await _session.SaveAsync();
+
+        Assert.Single(_service.Puts);
+    }
+
+    [Fact]
+    public async Task Discard_RestoresTheRevisionTheServerReturned()
+    {
+        await _session.EnsureLoadedAsync();
+        BindHttpRequest();
+        Assert.True(_session.IsDirty);
+
+        _session.Discard();
+
+        Assert.False(_session.IsDirty);
+        Assert.True(JsonNode.DeepEquals(Document(), _session.Document));
+        Assert.Empty(_session.EditedElementIds);
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_ReportsAStaleDocument_AndLeavesNothingToEdit()
+    {
+        var service = new FakeBpmnDocumentService().RefusesGet(BpmnDocumentFailureReason.SourceStale);
+        var session = new BpmnDocumentSession(service, DefinitionId);
+
+        await session.EnsureLoadedAsync();
+
+        Assert.Equal(BpmnDocumentFailureReason.SourceStale, session.LoadFailure!.Reason);
+        Assert.Null(session.Document);
+        Assert.Equal(BpmnDocumentFailureReason.Unknown, (await session.SaveAsync()).Failure!.Reason);
+        Assert.Empty(service.Puts);
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_ReportsAnUnreachableServer_InsteadOfThrowing()
+    {
+        var service = new FakeBpmnDocumentService { GetException = new HttpRequestException("connection refused") };
+        var session = new BpmnDocumentSession(service, DefinitionId);
+
+        await session.EnsureLoadedAsync();
+
+        Assert.Equal("connection refused", session.LoadFailure!.Message);
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_ReadsOnce()
+    {
+        await _session.EnsureLoadedAsync();
+        await _session.EnsureLoadedAsync();
+
+        Assert.Equal(1, _service.GetCount);
+    }
+
+    private JsonObject BindHttpRequest()
+    {
+        var binding = BpmnActivityBindingFormat.Create("Elsa.HttpRequest", [KeyValuePair.Create<string, JsonNode?>("url", JsonNode.Parse("""{"typeName":"Uri","expression":{"type":"JavaScript","value":"getUrl()"}}"""))]);
+        _session.SetBinding(TaskId, binding);
+        return binding;
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -207,6 +207,32 @@ public class BpmnDocumentSessionTests
     }
 
     [Fact]
+    public async Task SaveAsync_WhenTheFirstSaveCompletesSynchronously_StillSendsTheSecondEdit()
+    {
+        // No PutGate: the PUT and the reload it triggers both complete synchronously, so SaveCoreAsync's task can
+        // finish — and its `finally` clear _saveTask — before SaveAsync's `_saveTask = SaveCoreAsync(...)` assignment
+        // itself runs. A single-flight check that trusts `_saveTask != null` alone would then see the just-cleared
+        // null, look fine, but a check that instead trusted a stale non-null `_saveTask` left behind would wrongly
+        // treat the second save as already in flight and never send it.
+        await _session.EnsureLoadedAsync();
+        _service.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        BindHttpRequest();
+
+        await _session.SaveAsync();
+
+        _service.AcceptsPut("\"REVISION-3\"").ReturnsDocument(Document(), "\"REVISION-3\"");
+        var secondBinding = BpmnActivityBindingFormat.Create("Elsa.WriteLine", []);
+        _session.SetBinding(TaskId, secondBinding);
+
+        var result = await _session.SaveAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, _service.Puts.Count);
+        var secondPut = _service.Puts[1];
+        Assert.True(JsonNode.DeepEquals(secondBinding, BpmnActivityBindingFormat.Find(BpmnDocumentFixtures.TaskElement(secondPut.Document))));
+    }
+
+    [Fact]
     public async Task RefreshRevisionAfterOrdinarySaveAsync_WhenASaveIsInFlight_WaitsForIt_ThenSucceedsAgainstTheReloadedRevision()
     {
         await _session.EnsureLoadedAsync();

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -182,6 +182,54 @@ public class BpmnDocumentSessionTests
     }
 
     [Fact]
+    public async Task SaveAsync_CalledAgainWhileASaveIsInFlight_SendsOnlyOnePut_AndBothCallsSeeItsResult()
+    {
+        await _session.EnsureLoadedAsync();
+        var gate = new TaskCompletionSource();
+        _service.PutGate = gate;
+        _service.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        BindHttpRequest();
+
+        var firstSave = _session.SaveAsync();
+        var secondSave = _session.SaveAsync();
+
+        Assert.Same(firstSave, secondSave);
+        Assert.True(_session.IsSaving);
+
+        gate.SetResult();
+        var firstResult = await firstSave;
+        var secondResult = await secondSave;
+
+        Assert.True(firstResult.IsSuccess);
+        Assert.Equal(firstResult.Success, secondResult.Success);
+        Assert.Single(_service.Puts);
+        Assert.False(_session.IsSaving);
+    }
+
+    [Fact]
+    public async Task RefreshRevisionAfterOrdinarySaveAsync_WhenASaveIsInFlight_WaitsForIt_ThenSucceedsAgainstTheReloadedRevision()
+    {
+        await _session.EnsureLoadedAsync();
+        var gate = new TaskCompletionSource();
+        _service.PutGate = gate;
+        _service.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        BindHttpRequest();
+
+        var saveTask = _session.SaveAsync();
+        var refreshTask = _session.RefreshRevisionAfterOrdinarySaveAsync();
+
+        Assert.False(refreshTask.IsCompleted);
+
+        gate.SetResult();
+        var saveResult = await saveTask;
+        var refreshed = await refreshTask;
+
+        Assert.True(saveResult.IsSuccess);
+        Assert.True(refreshed);
+        Assert.Null(_session.SaveFailure);
+    }
+
+    [Fact]
     public async Task RefreshRevisionAfterOrdinarySaveAsync_WhenTheContentIsUnchanged_AdoptsTheNewETag_SoTheSaveGoesThrough()
     {
         await _session.EnsureLoadedAsync();

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -137,6 +137,81 @@ public class BpmnDocumentSessionTests
         Assert.Equal(1, _service.GetCount);
     }
 
+    [Fact]
+    public async Task SaveAsync_WhileTheEditIsBeingSentAndReadBack_RefusesFurtherEdits_AndAllowsThemAgainOnceItFinishes()
+    {
+        await _session.EnsureLoadedAsync();
+        var gate = new TaskCompletionSource();
+        _service.PutGate = gate;
+        _service.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        BindHttpRequest();
+
+        var saveTask = _session.SaveAsync();
+
+        Assert.True(_session.IsSaving);
+        Assert.Throws<InvalidOperationException>(() => BindHttpRequest());
+
+        gate.SetResult();
+        var result = await saveTask;
+
+        Assert.True(result.IsSuccess);
+        Assert.False(_session.IsSaving);
+        Assert.False(_session.IsDirty);
+
+        // Refused while busy, not silently accepted and then lost to the reload: the session takes an edit again now.
+        var binding = BindHttpRequest();
+        Assert.True(JsonNode.DeepEquals(binding, BpmnActivityBindingFormat.Find(BpmnDocumentFixtures.TaskElement(_session.Document!))));
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenThePutSucceedsButTheFollowUpReadFails_ReportsItSavedButNotReloaded_RatherThanJustSucceeding()
+    {
+        await _session.EnsureLoadedAsync();
+        _service.AcceptsPut("\"REVISION-2\"").RefusesGet(BpmnDocumentFailureReason.SourceStale);
+        BindHttpRequest();
+
+        var result = await _session.SaveAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.True(_session.SavedButReloadFailed);
+        Assert.Equal(BpmnDocumentFailureReason.SourceStale, _session.LoadFailure!.Reason);
+        Assert.Null(_session.SaveFailure);
+    }
+
+    [Fact]
+    public async Task RefreshRevisionAfterOrdinarySaveAsync_WhenTheContentIsUnchanged_AdoptsTheNewETag_SoTheSaveGoesThrough()
+    {
+        await _session.EnsureLoadedAsync();
+        BindHttpRequest();
+        _service.ReturnsDocument(Document(), "\"REVISION-2\"").AcceptsPut("\"REVISION-3\"").ReturnsDocument(Document(), "\"REVISION-3\"");
+
+        var refreshed = await _session.RefreshRevisionAfterOrdinarySaveAsync();
+        Assert.True(refreshed);
+
+        var result = await _session.SaveAsync();
+
+        Assert.True(result.IsSuccess);
+        var put = Assert.Single(_service.Puts);
+        Assert.Equal("\"REVISION-2\"", put.IfMatch);
+    }
+
+    [Fact]
+    public async Task RefreshRevisionAfterOrdinarySaveAsync_WhenTheContentChanged_ReportsTheConflict_WithoutSendingAnything()
+    {
+        await _session.EnsureLoadedAsync();
+        BindHttpRequest();
+        var changedOnTheServer = Document();
+        BpmnDocumentFixtures.TaskElement(changedOnTheServer)["name"] = "Renamed on the server";
+        _service.ReturnsDocument(changedOnTheServer, "\"REVISION-2\"");
+
+        var refreshed = await _session.RefreshRevisionAfterOrdinarySaveAsync();
+
+        Assert.False(refreshed);
+        Assert.Equal(BpmnDocumentFailureReason.PreconditionFailed, _session.SaveFailure!.Reason);
+        Assert.Empty(_service.Puts);
+        Assert.True(_session.IsDirty);
+    }
+
     private JsonObject BindHttpRequest()
     {
         var binding = BpmnActivityBindingFormat.Create("Elsa.HttpRequest", [KeyValuePair.Create<string, JsonNode?>("url", JsonNode.Parse("""{"typeName":"Uri","expression":{"type":"JavaScript","value":"getUrl()"}}"""))]);

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementSelectionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnElementSelectionTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Extensions;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.Designer.Options;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor.Services;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers how the "Performed by" section learns which BPMN element was clicked. <c>ActivitySelected</c> can only name an
+/// activity, so a click on a task nothing is bound to yet looks exactly like a click on the empty canvas; the element
+/// itself has to reach the editor separately, including when no activity is bound to it, and a click on the canvas has
+/// to clear it.
+/// </summary>
+public sealed class BpmnElementSelectionTests : BunitContext, IAsyncLifetime
+{
+    private const string ProcessId = "order-process";
+    private static readonly BpmnElementSelection UnboundTask = new("NotifyWarehouse", "serviceTask", "task", "Notify Warehouse", null, "unbound", ProcessId, ProcessId, null, null, BpmnBindingKinds.UnboundTask);
+
+    private readonly List<BpmnElementSelection?> _elements = [];
+    private readonly List<JsonObject> _activities = [];
+
+    public BpmnElementSelectionTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        JSInterop.Setup<BpmnDiagnostic[]>("loadBpmnDiagram", _ => true).SetResult([]);
+        Services.AddMudServices();
+        Services.AddLogging();
+        Services.AddCoreInternal();
+        Services.AddWorkflowsCore();
+        Services.AddWorkflowsDesigner();
+        Services.AddSingleton<ILocalizer, TestLocalizer>();
+        Services.AddSingleton<IActivityRegistry, NoOpActivityRegistry>();
+        Services.Configure<DesignerOptions>(options => options.UseReactFlow = false);
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public async Task SelectingATaskNothingIsBoundTo_RaisesTheElement_WhileActivitySelectedCanOnlyNameTheScope()
+    {
+        var cut = Render<BpmnDesigner>(parameters => parameters
+            .Add(p => p.Activity, RootActivity())
+            .Add(p => p.ActivitySelected, EventCallback.Factory.Create<JsonObject>(this, _activities.Add))
+            .Add(p => p.ElementSelected, EventCallback.Factory.Create<BpmnElementSelection?>(this, _elements.Add)));
+
+        await cut.InvokeAsync(() => cut.Instance.HandleActivitySelected(UnboundTask));
+
+        Assert.Same(UnboundTask, Assert.Single(_elements));
+        Assert.Equal(ProcessId, Assert.Single(_activities)["id"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task SelectingTheCanvas_ClearsTheElement()
+    {
+        var cut = Render<BpmnDesigner>(parameters => parameters
+            .Add(p => p.Activity, RootActivity())
+            .Add(p => p.ElementSelected, EventCallback.Factory.Create<BpmnElementSelection?>(this, _elements.Add)));
+
+        await cut.InvokeAsync(() => cut.Instance.HandleCanvasSelected());
+
+        Assert.Null(Assert.Single(_elements));
+    }
+
+    [Fact]
+    public async Task TheWrapper_HandsTheCanvasTheReceiverAnEditorCascades()
+    {
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters
+            .Add(p => p.Activity, RootActivity())
+            .AddCascadingValue(BpmnDesignerWrapper.ElementSelectedCascadeName, EventCallback.Factory.Create<BpmnElementSelection?>(this, _elements.Add)));
+
+        var canvas = cut.FindComponent<BpmnDesigner>();
+        await cut.InvokeAsync(() => canvas.Instance.HandleActivitySelected(UnboundTask));
+        await cut.InvokeAsync(() => canvas.Instance.HandleCanvasSelected());
+
+        Assert.Equal([UnboundTask, null], _elements);
+    }
+
+    [Fact]
+    public void TheWrapper_RaisesNothing_WhereNoEditorCascadesAReceiver()
+    {
+        // The read-only viewers host the same canvas without a "Performed by" section to feed.
+        var cut = Render<BpmnDesignerWrapper>(parameters => parameters.Add(p => p.Activity, RootActivity()));
+
+        Assert.False(cut.FindComponent<BpmnDesigner>().Instance.ElementSelected.HasDelegate);
+    }
+
+    /// <summary>A scope whose one task nothing is bound to yet.</summary>
+    private static JsonObject RootActivity() => new()
+    {
+        ["id"] = ProcessId,
+        ["type"] = "Elsa.BpmnProcess",
+        ["version"] = 1,
+        ["workBindings"] = new JsonObject(),
+        ["activities"] = new JsonArray(),
+        ["process"] = new JsonObject
+        {
+            ["processId"] = ProcessId,
+            ["elements"] = new JsonArray(new JsonObject { ["elementId"] = "NotifyWarehouse", ["elementType"] = "serviceTask" })
+        }
+    };
+
+    private sealed class TestLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+
+    private sealed class NoOpActivityRegistry : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => [];
+        public ActivityDescriptor? Find(string activityType, int? version = default) => null;
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => [];
+
+        public void MarkStale()
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnImportUiServiceTests.cs
@@ -339,6 +339,12 @@ public sealed class BpmnImportUiServiceTests : BunitContext, IAsyncLifetime
 
         public Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
+
+        public Task<Result<BpmnDocumentRevision, BpmnDocumentFailure>> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, System.Text.Json.Nodes.JsonObject document, string eTag, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
     }
 
     /// <summary>

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -1,0 +1,295 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Tests.Support;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using MudBlazor;
+using Xunit;
+using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Covers the "Performed by" section: which elements it lets a user bind (an authored task) and which it only describes
+/// (an element the document binds automatically, or one that performs no work), that picking an activity and editing
+/// its inputs write the task's binding into the document and nothing else, and what it tells the user when the document
+/// cannot be read or a save is refused — each refusal with the one next step that applies to it.
+/// </summary>
+public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
+{
+    private static readonly BpmnElementSelection TaskSelection = new(TaskId, "serviceTask", "task", "Notify Warehouse", BoundActivityId, "bound", ProcessId, ProcessId, null, null, BpmnBindingKinds.UnboundTask);
+
+    private readonly FakeBpmnDocumentService _documentService = new();
+    private readonly IRenderedComponent<MudDialogProvider> _dialogProvider;
+    private int _documentChangedCount;
+    private int _reloadCount;
+
+    public BpmnPerformedByPanelTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddBpmnEditing(_documentService);
+        ComponentFactories.Add<InputsTab, InputsTabStandIn>();
+        Render<MudPopoverProvider>();
+        _dialogProvider = Render<MudDialogProvider>();
+        _documentService.ReturnsDocument(Document(), "\"REVISION-1\"");
+        Session = new(_documentService, DefinitionId);
+    }
+
+    private BpmnDocumentSession Session { get; set; }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void AnAuthoredTask_OffersThePicker_AndItsBoundActivitysOwnInputEditors()
+    {
+        var cut = RenderPanel(TaskSelection);
+
+        Assert.Contains("Write Line (Elsa.WriteLine)", cut.Find("[data-testid='bpmn-bound-activity']").TextContent);
+        Assert.Equal("Change activity", cut.Find("[data-testid='bpmn-pick-activity']").TextContent.Trim());
+        var inputs = cut.FindComponent<InputsTab>().Instance;
+        Assert.Equal("Elsa.WriteLine", inputs.ActivityDescriptor!.TypeName);
+        Assert.Equal("Notifying the warehouse", inputs.Activity!["text"]!["expression"]!["value"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void AnAuthoredTaskTheDocumentLeftUnbound_OffersThePickerToBindIt()
+    {
+        var document = Document();
+        ((JsonArray)BpmnDocumentFixtures.TaskElement(document)["extensions"]!["extensionElements"]!).RemoveAt(1);
+        UseDocument(document);
+
+        var cut = RenderPanel(TaskSelection with { ActivityId = null, BindingState = "unbound" });
+
+        Assert.Equal("Not bound", cut.Find("[data-testid='bpmn-bound-activity']").TextContent.Trim());
+        Assert.Equal("Choose activity", cut.Find("[data-testid='bpmn-pick-activity']").TextContent.Trim());
+        Assert.Empty(cut.FindComponents<InputsTab>());
+    }
+
+    [Fact]
+    public void AnAutomaticallyBoundElement_IsDescribed_ButOffersNothingToEdit()
+    {
+        var root = RootActivity();
+        ((JsonArray)root["activities"]!).Add(new JsonObject { ["id"] = "order-process:node-Timer", ["type"] = "Elsa.Delay", ["version"] = 1 });
+
+        var cut = RenderPanel(new BpmnElementSelection("Timer", "boundaryEvent", "event", "After 1 hour", "order-process:node-Timer", "bound", ProcessId, ProcessId, TaskId, null, BpmnBindingKinds.Automatic), root);
+
+        Assert.Contains("Delay (Elsa.Delay)", cut.Find("[data-testid='bpmn-bound-activity']").TextContent);
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-automatic-binding']"));
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+        Assert.Empty(cut.FindComponents<InputsTab>());
+    }
+
+    [Fact]
+    public void AnElementThatPerformsNoWork_SaysSo()
+    {
+        var cut = RenderPanel(new BpmnElementSelection("StartEvent_1", "startEvent", "event", "Order Received", null, null, ProcessId, ProcessId, null, null));
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-no-work']"));
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+    }
+
+    [Fact]
+    public async Task EditingAnInput_WritesItIntoTheTasksBinding_AndNothingElse()
+    {
+        var cut = RenderPanel(TaskSelection);
+        var inputs = cut.FindComponent<InputsTab>().Instance;
+
+        inputs.Activity!.SetProperty(new WrappedInput { TypeName = "String", Expression = new Expression("JavaScript", "getMessage()") }.SerializeToNode(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), "text");
+        await cut.InvokeAsync(() => inputs.OnActivityUpdated!(inputs.Activity!));
+
+        var binding = BpmnActivityBindingFormat.Read(BpmnActivityBindingFormat.Find(Session.FindElement(TaskId)!)!);
+        Assert.Equal("getMessage()", Assert.Single(binding.Inputs).Value!["expression"]!["value"]!.GetValue<string>());
+        Assert.Equal(1, _documentChangedCount);
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-unsaved']"));
+
+        // Everything but that one binding is exactly what the server sent.
+        var expected = Document();
+        BpmnActivityBindingFormat.Attach(BpmnDocumentFixtures.TaskElement(expected), BpmnActivityBindingFormat.Create("Elsa.WriteLine", binding.Inputs.Select(input => KeyValuePair.Create(input.Name, input.Value))));
+        Assert.True(JsonNode.DeepEquals(expected, Session.Document));
+    }
+
+    [Fact]
+    public async Task PickingAnActivity_RebindsTheTask_AndShowsThatActivitysInputs()
+    {
+        var cut = RenderPanel(TaskSelection);
+
+        await PickAsync(cut, "Elsa.HttpRequest");
+
+        Assert.Equal("Elsa.HttpRequest", BpmnActivityBindingFormat.Read(BpmnActivityBindingFormat.Find(Session.FindElement(TaskId)!)!).ActivityType);
+        cut.WaitForAssertion(() => Assert.Equal("Elsa.HttpRequest", cut.FindComponent<InputsTab>().Instance.ActivityDescriptor!.TypeName));
+        Assert.Equal(1, _documentChangedCount);
+    }
+
+    [Fact]
+    public async Task ThePicker_OffersLeafWorkOnly()
+    {
+        var cut = RenderPanel(TaskSelection);
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-pick-activity']").Click());
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+
+        var offered = _dialogProvider.FindAll("[data-activity-type]").Select(option => option.GetAttribute("data-activity-type")).ToHashSet();
+        Assert.Contains("Elsa.HttpRequest", offered);
+        Assert.Contains("Elsa.Delay", offered);
+        Assert.DoesNotContain("Elsa.Sequence", offered);
+        Assert.DoesNotContain("Elsa.If", offered);
+        Assert.Contains("PERFORMED BY", _dialogProvider.Markup);
+    }
+
+    [Fact]
+    public async Task CancellingThePicker_LeavesTheDocumentAsItWas()
+    {
+        var cut = RenderPanel(TaskSelection);
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-pick-activity']").Click());
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.FindAll("button").Single(button => button.TextContent.Trim() == "Cancel").Click();
+
+        cut.WaitForAssertion(() => Assert.Empty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        Assert.False(Session.IsDirty);
+        Assert.Equal(0, _documentChangedCount);
+    }
+
+    [Fact]
+    public void AStaleDocument_SaysTheWorkflowNeedsReImporting_AndOffersNothingToEdit()
+    {
+        UseService(new FakeBpmnDocumentService().RefusesGet(BpmnDocumentFailureReason.SourceStale));
+
+        var cut = RenderPanel(TaskSelection);
+
+        Assert.Contains("Import the BPMN file into this workflow again", cut.Find("[data-testid='bpmn-document-load-failure']").TextContent);
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+        Assert.Empty(cut.FindComponents<InputsTab>());
+    }
+
+    [Fact]
+    public async Task ASaveRefusedBecauseTheDefinitionMovedOn_SaysSo_AndOffersReloadRatherThanRetrying()
+    {
+        _documentService.RefusesPut(BpmnDocumentFailureReason.PreconditionFailed);
+        var cut = RenderPanel(TaskSelection);
+
+        await EditAndSaveAsync(cut);
+
+        Assert.Contains("was changed since its BPMN document was read", cut.Find("[data-testid='bpmn-document-save-failure']").TextContent);
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-reload']").Click());
+        Assert.Equal(1, _reloadCount);
+        Assert.Single(_documentService.Puts);
+    }
+
+    [Fact]
+    public async Task ASaveRefusedForWantOfAnETag_OffersReload()
+    {
+        _documentService.RefusesPut(BpmnDocumentFailureReason.PreconditionRequired);
+        var cut = RenderPanel(TaskSelection);
+
+        await EditAndSaveAsync(cut);
+
+        Assert.Contains("did not name the revision it replaces", cut.Find("[data-testid='bpmn-document-save-failure']").TextContent);
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-reload']"));
+    }
+
+    [Fact]
+    public async Task ARefusedBinding_ShowsTheServersMessageAgainstTheEditedTask()
+    {
+        const string message = "The 'Elsa.WriteLine' binding declares an input 'txt', which 'Elsa.WriteLine' does not have.";
+        _documentService.RefusesPut(BpmnDocumentFailureReason.BindingInvalid, message);
+        var cut = RenderPanel(TaskSelection);
+
+        await EditAndSaveAsync(cut);
+
+        var alert = cut.Find("[data-testid='bpmn-document-save-failure']").TextContent;
+        Assert.Contains($"'{TaskId}'", alert);
+        Assert.Contains(message, alert);
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-reload']"));
+    }
+
+    [Fact]
+    public void ADocumentWithASubprocess_SaysWhy_AndOffersNoEditItCouldNotSave()
+    {
+        var document = Document();
+        ((JsonArray)document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = "subProcess" });
+        UseDocument(document);
+
+        var cut = RenderPanel(TaskSelection);
+
+        Assert.Contains("Fulfil", cut.Find("[data-testid='bpmn-document-subprocesses']").TextContent);
+        Assert.Contains("Write Line (Elsa.WriteLine)", cut.Find("[data-testid='bpmn-bound-activity']").TextContent);
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+        Assert.Empty(cut.FindComponents<InputsTab>());
+    }
+
+    [Fact]
+    public void ATaskOutsideTheDocument_SaysItCannotBeEditedHere()
+    {
+        var cut = RenderPanel(TaskSelection with { ElementId = "InsideASubprocess" });
+
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-element-not-in-document']"));
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+    }
+
+    private IRenderedComponent<BpmnPerformedByPanel> RenderPanel(BpmnElementSelection selection, JsonObject? rootActivity = null) =>
+        Render<BpmnPerformedByPanel>(parameters => parameters
+            .Add(x => x.Selection, selection)
+            .Add(x => x.RootActivity, rootActivity ?? RootActivity())
+            .Add(x => x.Session, Session)
+            .Add(x => x.DocumentChanged, () =>
+            {
+                _documentChangedCount++;
+                return Task.CompletedTask;
+            })
+            .Add(x => x.SaveRequested, () => Session.SaveAsync())
+            .Add(x => x.ReloadRequested, () =>
+            {
+                _reloadCount++;
+                return Task.CompletedTask;
+            }));
+
+    private void UseDocument(JsonObject document) => UseService(new FakeBpmnDocumentService().ReturnsDocument(document, "\"REVISION-1\""));
+
+    private void UseService(FakeBpmnDocumentService service) => Session = new(service, DefinitionId);
+
+    private async Task PickAsync(IRenderedComponent<BpmnPerformedByPanel> cut, string activityType)
+    {
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-pick-activity']").Click());
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        _dialogProvider.FindAll("button").Single(button => button.TextContent.Contains("All activities", StringComparison.Ordinal)).Click();
+        _dialogProvider.Find($"[data-testid='state-machine-activity-option'][data-activity-type='{activityType}']").Click();
+        _dialogProvider.Find("[data-testid='state-machine-activity-picker-commit']").Click();
+        cut.WaitForAssertion(() => Assert.True(Session.IsDirty));
+    }
+
+    private static async Task EditAsync(IRenderedComponent<BpmnPerformedByPanel> cut)
+    {
+        var inputs = cut.FindComponent<InputsTab>().Instance;
+        inputs.Activity!["text"] = JsonNode.Parse("""{"typeName":"String","expression":{"type":"Literal","value":"edited"}}""");
+        await cut.InvokeAsync(() => inputs.OnActivityUpdated!(inputs.Activity!));
+    }
+
+    private static async Task EditAndSaveAsync(IRenderedComponent<BpmnPerformedByPanel> cut)
+    {
+        await EditAsync(cut);
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-save']").Click());
+    }
+
+    /// <summary>
+    /// Stands in for the real input editors, which need a browser: it keeps the parameters the section hands it, so a
+    /// test can edit the activity exactly as an editor would and raise <see cref="InputsTab.OnActivityUpdated"/>.
+    /// </summary>
+    private sealed class InputsTabStandIn : InputsTab
+    {
+        protected override Task OnParametersSetAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -199,6 +199,62 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
         Assert.False(cut.Find("[data-testid='bpmn-pick-activity']").HasAttribute("disabled"));
     }
 
+    /// <summary>
+    /// The real editor replaces its <c>BpmnDocumentSession</c> outright when a different definition is opened while the
+    /// panel stays mounted (<c>WorkflowEditor.AdoptServerDefinition</c>), rather than mutating the one the panel already
+    /// holds. <see cref="BpmnPerformedByPanel.SubscribeToSession"/> exists to move the panel's <c>Changed</c>
+    /// subscription along with it; this is what would break if that unsubscribe were dropped or reordered.
+    /// </summary>
+    [Fact]
+    public async Task SwappingTheSession_UnsubscribesFromTheOldOne_SoOnlyTheNewOnesSaveRendersThePanel()
+    {
+        var oldSession = Session;
+        var cut = RenderPanel(TaskSelection);
+        _documentService.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+
+        var newDocumentService = new FakeBpmnDocumentService().ReturnsDocument(Document(), "\"REVISION-1\"");
+        var newGate = new TaskCompletionSource();
+        newDocumentService.PutGate = newGate;
+        newDocumentService.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        var newSession = new BpmnDocumentSession(newDocumentService, DefinitionId);
+
+        cut.Render(parameters => parameters
+            .Add(x => x.Selection, TaskSelection)
+            .Add(x => x.RootActivity, RootActivity())
+            .Add(x => x.Session, newSession)
+            .Add(x => x.DocumentChanged, () =>
+            {
+                _documentChangedCount++;
+                return Task.CompletedTask;
+            })
+            .Add(x => x.SaveRequested, () => newSession.SaveAsync())
+            .Add(x => x.ReloadRequested, () =>
+            {
+                _reloadCount++;
+                return Task.CompletedTask;
+            }));
+        cut.WaitForAssertion(() => Assert.NotNull(newSession.Document));
+
+        // The panel is no longer subscribed to the old session: saving through it — flipping its IsSaving twice —
+        // never renders the panel, which shows neither the old nor the new session's binding.
+        var renderCountBeforeOldSave = cut.RenderCount;
+        await oldSession.SaveAsync();
+        Assert.Equal(renderCountBeforeOldSave, cut.RenderCount);
+
+        // The new session is what the panel is subscribed to now: saving through it re-renders the panel into its
+        // saving state, exactly as WhileTheDocumentIsBeingSaved shows for the session a panel starts mounted with.
+        await EditAsync(cut);
+        var renderCountBeforeNewSave = cut.RenderCount;
+        var saveTask = cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-save']").Click());
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-saving']")));
+        Assert.True(cut.RenderCount > renderCountBeforeNewSave);
+
+        newGate.SetResult();
+        await saveTask;
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("[data-testid='bpmn-saving']")));
+    }
+
     [Fact]
     public void AStaleDocument_SaysTheWorkflowNeedsReImporting_AndOffersNothingToEdit()
     {

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -160,6 +160,46 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task WhileTheDocumentIsBeingSaved_DisablesEditing_AndShowsSaving_ThenEditableAgainOnceItFinishes()
+    {
+        var gate = new TaskCompletionSource();
+        _documentService.PutGate = gate;
+        _documentService.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+
+        // As in the real editor, the click's own async chain yields — through the ordinary property save's own HTTP
+        // round trip — before the document PUT this test gates ever starts, so Blazor's single per-event render (right
+        // after the handler first suspends) cannot show the saving state on its own; only the section's own reaction to
+        // Session.Changed can.
+        var cut = Render<BpmnPerformedByPanel>(parameters => parameters
+            .Add(x => x.Selection, TaskSelection)
+            .Add(x => x.RootActivity, RootActivity())
+            .Add(x => x.Session, Session)
+            .Add(x => x.DocumentChanged, () =>
+            {
+                _documentChangedCount++;
+                return Task.CompletedTask;
+            })
+            .Add(x => x.SaveRequested, async () =>
+            {
+                await Task.Yield();
+                await Session.SaveAsync();
+            })
+            .Add(x => x.ReloadRequested, () => Task.CompletedTask));
+        await EditAsync(cut);
+
+        await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-save']").Click());
+
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-saving']")));
+        Assert.True(cut.Find("[data-testid='bpmn-pick-activity']").HasAttribute("disabled"));
+        Assert.Empty(cut.FindComponents<InputsTab>());
+
+        gate.SetResult();
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll("[data-testid='bpmn-saving']")));
+        Assert.False(cut.Find("[data-testid='bpmn-pick-activity']").HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void AStaleDocument_SaysTheWorkflowNeedsReImporting_AndOffersNothingToEdit()
     {
         UseService(new FakeBpmnDocumentService().RefusesGet(BpmnDocumentFailureReason.SourceStale));

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -170,21 +170,15 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
         // round trip — before the document PUT this test gates ever starts, so Blazor's single per-event render (right
         // after the handler first suspends) cannot show the saving state on its own; only the section's own reaction to
         // Session.Changed can.
-        var cut = Render<BpmnPerformedByPanel>(parameters => parameters
-            .Add(x => x.Selection, TaskSelection)
-            .Add(x => x.RootActivity, RootActivity())
-            .Add(x => x.Session, Session)
-            .Add(x => x.DocumentChanged, () =>
-            {
-                _documentChangedCount++;
-                return Task.CompletedTask;
-            })
-            .Add(x => x.SaveRequested, async () =>
+        var cut = Render<BpmnPerformedByPanel>(parameters => ApplyPanelParameters(
+            parameters,
+            TaskSelection,
+            saveRequested: async () =>
             {
                 await Task.Yield();
                 await Session.SaveAsync();
-            })
-            .Add(x => x.ReloadRequested, () => Task.CompletedTask));
+            },
+            reloadRequested: () => Task.CompletedTask));
         await EditAsync(cut);
 
         await cut.InvokeAsync(() => cut.Find("[data-testid='bpmn-save']").Click());
@@ -218,21 +212,11 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
         newDocumentService.AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
         var newSession = new BpmnDocumentSession(newDocumentService, DefinitionId);
 
-        cut.Render(parameters => parameters
-            .Add(x => x.Selection, TaskSelection)
-            .Add(x => x.RootActivity, RootActivity())
-            .Add(x => x.Session, newSession)
-            .Add(x => x.DocumentChanged, () =>
-            {
-                _documentChangedCount++;
-                return Task.CompletedTask;
-            })
-            .Add(x => x.SaveRequested, () => newSession.SaveAsync())
-            .Add(x => x.ReloadRequested, () =>
-            {
-                _reloadCount++;
-                return Task.CompletedTask;
-            }));
+        cut.Render(parameters => ApplyPanelParameters(
+            parameters,
+            TaskSelection,
+            session: newSession,
+            saveRequested: () => newSession.SaveAsync()));
         cut.WaitForAssertion(() => Assert.NotNull(newSession.Document));
 
         // The panel is no longer subscribed to the old session: saving through it — flipping its IsSaving twice —
@@ -333,21 +317,37 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
     }
 
     private IRenderedComponent<BpmnPerformedByPanel> RenderPanel(BpmnElementSelection selection, JsonObject? rootActivity = null) =>
-        Render<BpmnPerformedByPanel>(parameters => parameters
+        Render<BpmnPerformedByPanel>(parameters => ApplyPanelParameters(parameters, selection, rootActivity));
+
+    /// <summary>
+    /// Applies the parameters every rendering of <see cref="BpmnPerformedByPanel"/> in this fixture needs, with the
+    /// defaults <see cref="RenderPanel"/> uses; callers override only what differs.
+    /// </summary>
+    private ComponentParameterCollectionBuilder<BpmnPerformedByPanel> ApplyPanelParameters(
+        ComponentParameterCollectionBuilder<BpmnPerformedByPanel> parameters,
+        BpmnElementSelection selection,
+        JsonObject? rootActivity = null,
+        BpmnDocumentSession? session = null,
+        Func<Task>? saveRequested = null,
+        Func<Task>? reloadRequested = null)
+    {
+        var effectiveSession = session ?? Session;
+        return parameters
             .Add(x => x.Selection, selection)
             .Add(x => x.RootActivity, rootActivity ?? RootActivity())
-            .Add(x => x.Session, Session)
+            .Add(x => x.Session, effectiveSession)
             .Add(x => x.DocumentChanged, () =>
             {
                 _documentChangedCount++;
                 return Task.CompletedTask;
             })
-            .Add(x => x.SaveRequested, () => Session.SaveAsync())
-            .Add(x => x.ReloadRequested, () =>
+            .Add(x => x.SaveRequested, saveRequested ?? (() => effectiveSession.SaveAsync()))
+            .Add(x => x.ReloadRequested, reloadRequested ?? (() =>
             {
                 _reloadCount++;
                 return Task.CompletedTask;
             }));
+    }
 
     private void UseDocument(JsonObject document) => UseService(new FakeBpmnDocumentService().ReturnsDocument(document, "\"REVISION-1\""));
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Elsa.Studio.Workflows.Tests.csproj
@@ -51,6 +51,7 @@
         <None Include="..\Elsa.Studio.Workflows.Designer\ClientLib\src\bpmn\__fixtures__\camunda-order-process.activity.json"
               Link="DesignerAssets\camunda-order-process.activity.json"
               CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Fixtures\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Studio.Workflows.Tests/Fixtures/camunda-order-process.document.json
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Fixtures/camunda-order-process.document.json
@@ -1,0 +1,342 @@
+{
+  "id": "Definitions_order-process",
+  "targetNamespace": "http://bpmn.io/schema/bpmn",
+  "exporter": "Camunda Modeler",
+  "exporterVersion": "5.16.0",
+  "collaboration": null,
+  "processes": [
+    {
+      "processId": "order-process",
+      "name": "Order Process",
+      "isExecutable": true,
+      "isTransaction": false,
+      "elements": [
+        {
+          "elementId": "StartEvent_1",
+          "elementType": "startEvent",
+          "name": "Order Received",
+          "bindingRef": null,
+          "laneId": null,
+          "defaultFlowId": null,
+          "eventDefinitions": [],
+          "properties": {},
+          "attachedToRef": null,
+          "cancelActivity": true,
+          "loopCharacteristics": null,
+          "isForCompensation": false,
+          "compensationHandlerElementId": null,
+          "isTransaction": false,
+          "triggeredByEvent": false,
+          "listenerBindingRef": null,
+          "extensions": {
+            "documentation": [],
+            "extensionElements": [],
+            "foreignAttributes": [],
+            "foreignChildren": []
+          }
+        },
+        {
+          "elementId": "NotifyWarehouse",
+          "elementType": "serviceTask",
+          "name": "Notify Warehouse",
+          "bindingRef": "node-NotifyWarehouse",
+          "laneId": null,
+          "defaultFlowId": null,
+          "eventDefinitions": [],
+          "properties": {},
+          "attachedToRef": null,
+          "cancelActivity": true,
+          "loopCharacteristics": null,
+          "isForCompensation": false,
+          "compensationHandlerElementId": null,
+          "isTransaction": false,
+          "triggeredByEvent": false,
+          "listenerBindingRef": null,
+          "extensions": {
+            "documentation": [
+              {
+                "text": "Tells the warehouse an order needs picking.",
+                "textFormat": null
+              }
+            ],
+            "extensionElements": [
+              {
+                "name": {
+                  "ns": "http://camunda.org/schema/1.0/bpmn",
+                  "localName": "inputOutput"
+                },
+                "value": null,
+                "attributes": [],
+                "children": [
+                  {
+                    "name": {
+                      "ns": "http://camunda.org/schema/1.0/bpmn",
+                      "localName": "inputParameter"
+                    },
+                    "value": "${orderId}",
+                    "attributes": [
+                      {
+                        "name": {
+                          "ns": null,
+                          "localName": "name"
+                        },
+                        "value": "orderId"
+                      }
+                    ],
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "name": {
+                  "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                  "localName": "activityBinding"
+                },
+                "value": null,
+                "attributes": [
+                  {
+                    "name": {
+                      "ns": null,
+                      "localName": "activityType"
+                    },
+                    "value": "Elsa.WriteLine"
+                  }
+                ],
+                "children": [
+                  {
+                    "name": {
+                      "ns": "https://elsaworkflows.io/schemas/bpmn/v1",
+                      "localName": "input"
+                    },
+                    "value": "{\u0022typeName\u0022:\u0022String\u0022,\u0022expression\u0022:{\u0022type\u0022:\u0022Literal\u0022,\u0022value\u0022:\u0022Notifying the warehouse\u0022}}",
+                    "attributes": [
+                      {
+                        "name": {
+                          "ns": null,
+                          "localName": "name"
+                        },
+                        "value": "text"
+                      }
+                    ],
+                    "children": []
+                  }
+                ]
+              }
+            ],
+            "foreignAttributes": [
+              {
+                "name": {
+                  "ns": "http://camunda.org/schema/1.0/bpmn",
+                  "localName": "asyncBefore"
+                },
+                "value": "true"
+              }
+            ],
+            "foreignChildren": []
+          }
+        },
+        {
+          "elementId": "EndEvent_1",
+          "elementType": "endEvent",
+          "name": "Order Handled",
+          "bindingRef": null,
+          "laneId": null,
+          "defaultFlowId": null,
+          "eventDefinitions": [],
+          "properties": {},
+          "attachedToRef": null,
+          "cancelActivity": true,
+          "loopCharacteristics": null,
+          "isForCompensation": false,
+          "compensationHandlerElementId": null,
+          "isTransaction": false,
+          "triggeredByEvent": false,
+          "listenerBindingRef": null,
+          "extensions": {
+            "documentation": [],
+            "extensionElements": [],
+            "foreignAttributes": [],
+            "foreignChildren": []
+          }
+        }
+      ],
+      "sequenceFlows": [
+        {
+          "flowId": "Flow_1",
+          "sourceRef": "StartEvent_1",
+          "targetRef": "NotifyWarehouse",
+          "name": null,
+          "conditionOutcome": null,
+          "isDefault": false,
+          "extensions": {
+            "documentation": [],
+            "extensionElements": [],
+            "foreignAttributes": [],
+            "foreignChildren": []
+          }
+        },
+        {
+          "flowId": "Flow_2",
+          "sourceRef": "NotifyWarehouse",
+          "targetRef": "EndEvent_1",
+          "name": null,
+          "conditionOutcome": null,
+          "isDefault": false,
+          "extensions": {
+            "documentation": [],
+            "extensionElements": [],
+            "foreignAttributes": [],
+            "foreignChildren": []
+          }
+        }
+      ],
+      "lanes": [],
+      "variables": [],
+      "extensions": {
+        "documentation": [],
+        "extensionElements": [
+          {
+            "name": {
+              "ns": "http://camunda.org/schema/1.0/bpmn",
+              "localName": "properties"
+            },
+            "value": null,
+            "attributes": [],
+            "children": [
+              {
+                "name": {
+                  "ns": "http://camunda.org/schema/1.0/bpmn",
+                  "localName": "property"
+                },
+                "value": null,
+                "attributes": [
+                  {
+                    "name": {
+                      "ns": null,
+                      "localName": "name"
+                    },
+                    "value": "owner"
+                  },
+                  {
+                    "name": {
+                      "ns": null,
+                      "localName": "value"
+                    },
+                    "value": "fulfillment-team"
+                  }
+                ],
+                "children": []
+              }
+            ]
+          }
+        ],
+        "foreignAttributes": [
+          {
+            "name": {
+              "ns": "http://camunda.org/schema/1.0/bpmn",
+              "localName": "versionTag"
+            },
+            "value": "1.0"
+          }
+        ],
+        "foreignChildren": []
+      }
+    }
+  ],
+  "diagrams": [
+    {
+      "id": "BPMNDiagram_1",
+      "name": null,
+      "plane": {
+        "id": "BPMNPlane_1",
+        "bpmnElementRef": "order-process",
+        "shapes": [
+          {
+            "id": "StartEvent_1_di",
+            "bpmnElementRef": "StartEvent_1",
+            "bounds": {
+              "x": 152,
+              "y": 102,
+              "width": 36,
+              "height": 36
+            },
+            "isHorizontal": null,
+            "isExpanded": null,
+            "isMarkerVisible": null,
+            "label": null
+          },
+          {
+            "id": "NotifyWarehouse_di",
+            "bpmnElementRef": "NotifyWarehouse",
+            "bounds": {
+              "x": 240,
+              "y": 80,
+              "width": 100,
+              "height": 80
+            },
+            "isHorizontal": null,
+            "isExpanded": null,
+            "isMarkerVisible": null,
+            "label": null
+          },
+          {
+            "id": "EndEvent_1_di",
+            "bpmnElementRef": "EndEvent_1",
+            "bounds": {
+              "x": 392,
+              "y": 102,
+              "width": 36,
+              "height": 36
+            },
+            "isHorizontal": null,
+            "isExpanded": null,
+            "isMarkerVisible": null,
+            "label": null
+          }
+        ],
+        "edges": [
+          {
+            "id": "Flow_1_di",
+            "bpmnElementRef": "Flow_1",
+            "label": null,
+            "waypoints": [
+              {
+                "x": 188,
+                "y": 120
+              },
+              {
+                "x": 240,
+                "y": 120
+              }
+            ]
+          },
+          {
+            "id": "Flow_2_di",
+            "bpmnElementRef": "Flow_2",
+            "label": null,
+            "waypoints": [
+              {
+                "x": 340,
+                "y": 120
+              },
+              {
+                "x": 392,
+                "y": 120
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "messages": [],
+  "signals": [],
+  "errors": [],
+  "escalations": [],
+  "extensions": {
+    "documentation": [],
+    "extensionElements": [],
+    "foreignAttributes": [],
+    "foreignChildren": []
+  }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/RemoteBpmnInterchangeServiceTests.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
+using System.Text.Json.Nodes;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Workflows.Client;
 using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Domain.Services;
+using Elsa.Studio.Workflows.Tests.Support;
 using Refit;
 using Xunit;
 
@@ -173,6 +175,114 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         Assert.Equal(xml, await reader.ReadToEndAsync());
     }
 
+    [Fact]
+    public async Task GetDocumentAsync_ReturnsTheDocumentAndItsETagVerbatim()
+    {
+        _api.GetDocumentResponse = Json(HttpStatusCode.OK, BpmnDocumentFixtures.Document().ToJsonString(), eTag: "\"ABC123\"");
+
+        var result = await _service.GetDocumentAsync("wf-1");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("\"ABC123\"", result.Success!.ETag);
+        Assert.True(JsonNode.DeepEquals(BpmnDocumentFixtures.Document(), result.Success.Document));
+    }
+
+    /// <summary>
+    /// A document read without its ETag could never be written back (the PUT would be refused 428); across origins that
+    /// is what a CORS policy that does not expose the header produces, so it is reported as such, not as success.
+    /// </summary>
+    [Fact]
+    public async Task GetDocumentAsync_RefusesADocumentThatCameWithoutAnETag()
+    {
+        _api.GetDocumentResponse = Json(HttpStatusCode.OK, BpmnDocumentFixtures.Document().ToJsonString());
+
+        var result = await _service.GetDocumentAsync("wf-1");
+
+        Assert.Equal(BpmnDocumentFailureReason.MissingETag, result.Failure!.Reason);
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_ClassifiesAStaleDocumentByItsCode()
+    {
+        const string message = "Workflow definition 'wf-1' has changed since it was imported from BPMN.";
+        _api.GetDocumentResponse = UnprocessableEntity(message, BpmnErrorCodes.ExportSourceStale);
+
+        var result = await _service.GetDocumentAsync("wf-1");
+
+        Assert.Equal(BpmnDocumentFailureReason.SourceStale, result.Failure!.Reason);
+        Assert.Equal(message, result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task PutDocumentAsync_SendsTheDocumentAsPlainJson_WithTheETagAsIfMatch()
+    {
+        var document = BpmnDocumentFixtures.Document();
+        _api.PutDocumentResponse = Json(HttpStatusCode.OK, """{"id":"v2","definitionId":"wf-1","version":2,"analysis":{"processIds":["order-process"]}}""", eTag: "\"NEW\"");
+
+        var result = await _service.PutDocumentAsync("wf-1", document, "\"OLD\"");
+
+        Assert.Equal(("wf-1", "\"OLD\"", "application/json"), (_api.PutDefinitionId, _api.PutIfMatch, _api.PutContentType));
+        Assert.Equal(document.ToJsonString(), _api.PutBody);
+        Assert.Equal("\"NEW\"", result.Success!.ETag);
+        Assert.Equal(("v2", 2, "order-process"), (result.Success.Import.Id, result.Success.Import.Version, result.Success.Import.Analysis.ProcessIds.Single()));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.PreconditionFailed, BpmnErrorCodes.DocumentPreconditionFailed, BpmnDocumentFailureReason.PreconditionFailed)]
+    [InlineData(HttpStatusCode.PreconditionRequired, BpmnErrorCodes.DocumentPreconditionRequired, BpmnDocumentFailureReason.PreconditionRequired)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, BpmnErrorCodes.ImportBindingInvalid, BpmnDocumentFailureReason.BindingInvalid)]
+    [InlineData(HttpStatusCode.NotFound, BpmnErrorCodes.DocumentNotFound, BpmnDocumentFailureReason.NotFound)]
+    [InlineData(HttpStatusCode.PreconditionFailed, null, BpmnDocumentFailureReason.PreconditionFailed)]
+    [InlineData(HttpStatusCode.NotFound, null, BpmnDocumentFailureReason.NotFound)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, null, BpmnDocumentFailureReason.Unknown)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, "bpmn.import.some-future-code", BpmnDocumentFailureReason.Unknown)]
+    public async Task PutDocumentAsync_ClassifiesARefusalByItsCode_FallingBackToTheStatus(HttpStatusCode status, string? code, BpmnDocumentFailureReason expected)
+    {
+        const string message = "The server's own words.";
+        _api.PutDocumentResponse = Refusal(status, message, code);
+
+        var result = await _service.PutDocumentAsync("wf-1", BpmnDocumentFixtures.Document(), "\"OLD\"");
+
+        Assert.Equal(expected, result.Failure!.Reason);
+        Assert.Equal(message, result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task PutDocumentAsync_CarriesTheCapabilityRefusalsData()
+    {
+        _api.PutDocumentResponse = new(HttpStatusCode.UnprocessableEntity)
+        {
+            Content = new StringContent($$"""
+            {
+              "errors": { "generalErrors": ["Missing capabilities."] },
+              "code": "{{BpmnErrorCodes.ImportCapabilityUnsupported}}",
+              "data": { "capabilities": ["ScopeSignalling"], "elementIds": ["Gateway_1"] }
+            }
+            """)
+        };
+
+        var result = await _service.PutDocumentAsync("wf-1", BpmnDocumentFixtures.Document(), "\"OLD\"");
+
+        Assert.Equal(BpmnDocumentFailureReason.CapabilityUnsupported, result.Failure!.Reason);
+        Assert.Equal(["Gateway_1"], result.Failure.CapabilityRefusal!.ElementIds);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body, string? eTag = null)
+    {
+        var response = new HttpResponseMessage(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+        if (eTag != null)
+            response.Headers.ETag = new(eTag);
+
+        return response;
+    }
+
+    private static HttpResponseMessage Refusal(HttpStatusCode status, string message, string? code)
+    {
+        var codeProperty = code is null ? "" : $$""", "code": "{{code}}" """;
+        return new(status) { Content = new StringContent($$"""{ "errors": { "generalErrors": ["{{message}}"] }{{codeProperty}} }""") };
+    }
+
     private static HttpResponseMessage UnprocessableEntity(string message, string? code)
     {
         var codeProperty = code is null ? "" : $$""", "code": "{{code}}" """;
@@ -208,6 +318,12 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
         public ApiException? AnalyzeException { get; set; }
         public ApiException? ImportException { get; set; }
         public HttpResponseMessage? ExportResponse { get; set; }
+        public HttpResponseMessage? GetDocumentResponse { get; set; }
+        public HttpResponseMessage? PutDocumentResponse { get; set; }
+        public string? PutDefinitionId { get; private set; }
+        public string? PutIfMatch { get; private set; }
+        public string? PutBody { get; private set; }
+        public string? PutContentType { get; private set; }
 
         public Task<BpmnImportAnalysisModel> AnalyzeAsync(StreamPart file, CancellationToken cancellationToken = default) =>
             AnalyzeException != null ? throw AnalyzeException : Task.FromResult(new BpmnImportAnalysisModel());
@@ -217,6 +333,18 @@ public class RemoteBpmnInterchangeServiceTests : IDisposable
 
         public Task<HttpResponseMessage> ExportAsync(string definitionId, CancellationToken cancellationToken = default) =>
             Task.FromResult(ExportResponse ?? _defaultExportResponse);
+
+        public Task<HttpResponseMessage> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(GetDocumentResponse ?? throw new InvalidOperationException("No document response was set."));
+
+        public async Task<HttpResponseMessage> PutDocumentAsync(string definitionId, HttpContent document, string ifMatch, CancellationToken cancellationToken = default)
+        {
+            PutDefinitionId = definitionId;
+            PutIfMatch = ifMatch;
+            PutBody = await document.ReadAsStringAsync(cancellationToken);
+            PutContentType = document.Headers.ContentType?.MediaType;
+            return PutDocumentResponse ?? throw new InvalidOperationException("No document response was set.");
+        }
 
         public void Dispose()
         {

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -239,10 +239,35 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         Assert.False(dialog.Result.IsCompleted);
     }
 
+    /// <summary>
+    /// A host other than the StateMachine designer can narrow what the picker offers and say what the choice is for; the
+    /// default offering (browsable activities plus designer-backed roots) must not leak past the filter.
+    /// </summary>
+    [Fact]
+    public async Task Picker_OffersOnlyWhatTheHostsFilterAccepts_InTheHostsOwnContext()
+    {
+        var dialog = await ShowDialogAsync(configure: parameters =>
+        {
+            parameters.Add(x => x.DescriptorFilter, descriptor => descriptor.TypeName is "Elsa.WriteLine" or "Elsa.InternalActivity");
+            parameters.Add(x => x.ContextLabel, "PERFORMED BY");
+            parameters.Add(x => x.ContextHint, "Runs when the process reaches 'Notify Warehouse'");
+        });
+
+        _dialogProvider.WaitForAssertion(() => Assert.NotEmpty(_dialogProvider.FindAll("[data-testid='state-machine-activity-option']")));
+        Assert.Equal(["Elsa.InternalActivity", "Elsa.WriteLine"], _dialogProvider.FindAll("[data-activity-type]").Select(x => x.GetAttribute("data-activity-type")).Order());
+        Assert.Contains("PERFORMED BY", _dialogProvider.Markup);
+        Assert.Contains("Runs when the process reaches 'Notify Warehouse'", _dialogProvider.Markup);
+        Assert.DoesNotContain("THEN", _dialogProvider.Markup);
+
+        _dialogProvider.FindAll("button").Single(x => x.TextContent.Trim() == "Cancel").Click();
+        Assert.True((await dialog.Result)?.Canceled);
+    }
+
     private async Task<IDialogReference> ShowDialogAsync(
         string slotName = "action",
         IReadOnlyCollection<string>? recentActivityTypes = null,
-        bool isReplacing = false)
+        bool isReplacing = false,
+        Action<DialogParameters<StateMachineActivityPickerDialog>>? configure = null)
     {
         var dialogService = Services.GetRequiredService<IDialogService>();
         var parameters = new DialogParameters<StateMachineActivityPickerDialog>
@@ -251,6 +276,7 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
             { x => x.IsReplacing, isReplacing },
             { x => x.RecentActivityTypes, recentActivityTypes ?? [] }
         };
+        configure?.Invoke(parameters);
         var article = slotName == "trigger" ? "a" : "an";
         return await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<StateMachineActivityPickerDialog>($"Choose {article} {slotName} activity", parameters));
     }

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachineActivityPickerDialogTests.cs
@@ -4,8 +4,8 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Services;
+using Elsa.Studio.Workflows.Tests.Support;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using MudBlazor;
 using MudBlazor.Services;
 using Xunit;
@@ -81,7 +81,7 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         Services.AddMudServices();
         Services.AddSingleton<ILocalizer, TestLocalizer>();
         Services.AddSingleton<IWorkflowRootActivityTemplateProvider, DefaultWorkflowRootActivityTemplateProvider>();
-        Services.AddSingleton<IActivityRegistry>(new ActivityRegistryStub([_writeLine, _http, _sequence, _flowchart, _stateMachine, _internalActivity]));
+        Services.AddSingleton<IActivityRegistry>(new TestActivityRegistry([_writeLine, _http, _sequence, _flowchart, _stateMachine, _internalActivity]));
         Render<MudPopoverProvider>();
         _dialogProvider = Render<MudDialogProvider>();
     }
@@ -281,21 +281,4 @@ public sealed class StateMachineActivityPickerDialogTests : BunitContext, IAsync
         return await _dialogProvider.InvokeAsync(() => dialogService.ShowAsync<StateMachineActivityPickerDialog>($"Choose {article} {slotName} activity", parameters));
     }
 
-    private sealed class ActivityRegistryStub(IEnumerable<ActivityDescriptor> activities) : IActivityRegistry
-    {
-        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public IEnumerable<ActivityDescriptor> List() => activities;
-        public ActivityDescriptor? Find(string activityType, int? version = null) => activities.FirstOrDefault(x => x.TypeName == activityType);
-        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => activities.Where(x => x.TypeName == activityType);
-        public void MarkStale()
-        {
-        }
-    }
-
-    private sealed class TestLocalizer : ILocalizer
-    {
-        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
-        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
-    }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/StateMachines/StateMachinePresentationTests.cs
@@ -4,9 +4,9 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Designer;
 using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Elsa.Studio.Workflows.Tests.Support;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace Elsa.Studio.Workflows.Tests.StateMachines;
@@ -572,13 +572,5 @@ public sealed class StateMachinePresentationTests : BunitContext, IAsyncLifetime
             activity[name] = value;
 
         return activity;
-    }
-
-    private sealed class TestLocalizer : ILocalizer
-    {
-        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
-
-        public LocalizedString this[string? key, params object[] arguments] =>
-            new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnDocumentFixtures.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnDocumentFixtures.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+
+namespace Elsa.Studio.Workflows.Tests.Support;
+
+/// <summary>
+/// The BPMN document and activity fixtures of <c>camunda-order-process.bpmn</c>: a Camunda-authored process whose one
+/// service task, <see cref="TaskId"/>, carries both <c>camunda:*</c> extensions and an <c>elsa:activityBinding</c>.
+/// </summary>
+/// <remarks>
+/// <c>Fixtures/camunda-order-process.document.json</c> is not hand-written: it is
+/// <c>Bpmn.Interchange</c> 0.2.0's <c>BpmnXmlReader.Read(xml).Definitions</c> for the Designer ClientLib's
+/// <c>src/bpmn/__fixtures__/camunda-order-process.bpmn</c>, serialized with plain <c>System.Text.Json</c> defaults — exactly
+/// what elsa-core's document <c>GET</c> sends. Regenerate it the same way after a <c>Bpmn.Model</c> version bump.
+/// </remarks>
+internal static class BpmnDocumentFixtures
+{
+    public const string DefinitionId = "order-definition";
+    public const string ProcessId = "order-process";
+    public const string TaskId = "NotifyWarehouse";
+    public const string BoundActivityId = "order-process:node-NotifyWarehouse";
+
+    /// <summary>The document <c>GET</c> body for the fixture.</summary>
+    public static JsonObject Document() => Load("Fixtures", "camunda-order-process.document.json");
+
+    /// <summary>The root <c>Elsa.BpmnProcess</c> activity elsa-core imports the fixture as.</summary>
+    public static JsonObject RootActivity() => Load("DesignerAssets", "camunda-order-process.activity.json");
+
+    /// <summary>The fixture's task, in <paramref name="document"/>.</summary>
+    public static JsonObject TaskElement(JsonObject document) => (JsonObject)document["processes"]![0]!["elements"]![1]!;
+
+    /// <summary>A descriptor for <c>Elsa.WriteLine</c>, whose one input is the wrapped <c>Text</c>.</summary>
+    public static ActivityDescriptor WriteLine() => Descriptor("Elsa.WriteLine", "Write Line", Input("Text", "String", isWrapped: true));
+
+    public static ActivityDescriptor Descriptor(string typeName, string displayName, params InputDescriptor[] inputs) => new()
+    {
+        TypeName = typeName,
+        Name = typeName.Split('.').Last(),
+        DisplayName = displayName,
+        Category = "Test",
+        Version = 1,
+        IsBrowsable = true,
+        Inputs = inputs
+    };
+
+    public static InputDescriptor Input(string name, string typeName, bool isWrapped) => new()
+    {
+        Name = name,
+        TypeName = typeName,
+        IsWrapped = isWrapped,
+        UIHint = "single-line",
+        IsBrowsable = true
+    };
+
+    private static JsonObject Load(params string[] path) => (JsonObject)JsonNode.Parse(File.ReadAllText(Path.Combine([AppContext.BaseDirectory, .. path])))!;
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnEditingTestServices.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnEditingTestServices.cs
@@ -1,0 +1,76 @@
+using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.Scripting.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MudBlazor.Services;
+using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
+
+namespace Elsa.Studio.Workflows.Tests.Support;
+
+/// <summary>
+/// The services the BPMN "Performed by" section and the workflow editor that hosts it need in a bunit test: the real
+/// workflows module, with the backend-facing pieces — the activity catalogue, the expression catalogue and the BPMN
+/// document endpoints — replaced by in-memory stand-ins.
+/// </summary>
+internal static class BpmnEditingTestServices
+{
+    public static readonly ActivityDescriptor HttpRequest = Descriptor("Elsa.HttpRequest", "HTTP Request", Input("Url", "System.Uri", isWrapped: true), Input("Method", "String", isWrapped: true));
+
+    public static readonly ActivityDescriptor Sequence = WithEmbeddedPort(Descriptor("Elsa.Sequence", "Sequence"), container: true);
+
+    public static readonly ActivityDescriptor If = WithEmbeddedPort(Descriptor("Elsa.If", "If"), container: false);
+
+    public static readonly ActivityDescriptor Delay = Descriptor("Elsa.Delay", "Delay", Input("TimeSpan", "TimeSpan", isWrapped: true));
+
+    public static void AddBpmnEditing(this IServiceCollection services, IBpmnInterchangeService documentService)
+    {
+        services.AddMudServices();
+        services.AddLogging();
+        services.AddCoreInternal();
+        services.AddRemoteBackend();
+        services.AddWorkflowsModule();
+        services.AddSingleton<ILocalizer, PassThroughLocalizer>();
+        services.AddSingleton<IActivityRegistry>(new StubActivityRegistry([WriteLine(), HttpRequest, Sequence, If, Delay]));
+        services.AddSingleton<IExpressionService, StubExpressionService>();
+        services.AddSingleton(documentService);
+    }
+
+    private static ActivityDescriptor WithEmbeddedPort(ActivityDescriptor descriptor, bool container)
+    {
+        descriptor.IsContainer = container;
+        return descriptor with { Ports = [new Port { Name = "Body", Type = PortType.Embedded }] };
+    }
+
+    private sealed class StubActivityRegistry(IReadOnlyCollection<ActivityDescriptor> descriptors) : IActivityRegistry
+    {
+        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public IEnumerable<ActivityDescriptor> List() => descriptors;
+        public ActivityDescriptor? Find(string activityType, int? version = null) => descriptors.FirstOrDefault(x => x.TypeName == activityType);
+        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => descriptors.Where(x => x.TypeName == activityType);
+
+        public void MarkStale()
+        {
+        }
+    }
+
+    private sealed class StubExpressionService : IExpressionService
+    {
+        private static readonly ExpressionDescriptor[] Descriptors = [new("Literal", "Literal"), new("JavaScript", "JavaScript")];
+
+        public Task<IEnumerable<ExpressionDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<ExpressionDescriptor>>(Descriptors);
+        public Task<ExpressionDescriptor?> GetByTypeAsync(string type, CancellationToken cancellationToken = default) => Task.FromResult(Descriptors.FirstOrDefault(x => x.Type == type));
+    }
+
+    private sealed class PassThroughLocalizer : ILocalizer
+    {
+        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnEditingTestServices.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/BpmnEditingTestServices.cs
@@ -7,7 +7,6 @@ using Elsa.Studio.Localization;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Extensions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using MudBlazor.Services;
 using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
 
@@ -35,8 +34,8 @@ internal static class BpmnEditingTestServices
         services.AddCoreInternal();
         services.AddRemoteBackend();
         services.AddWorkflowsModule();
-        services.AddSingleton<ILocalizer, PassThroughLocalizer>();
-        services.AddSingleton<IActivityRegistry>(new StubActivityRegistry([WriteLine(), HttpRequest, Sequence, If, Delay]));
+        services.AddSingleton<ILocalizer, TestLocalizer>();
+        services.AddSingleton<IActivityRegistry>(new TestActivityRegistry([WriteLine(), HttpRequest, Sequence, If, Delay]));
         services.AddSingleton<IExpressionService, StubExpressionService>();
         services.AddSingleton(documentService);
     }
@@ -47,30 +46,11 @@ internal static class BpmnEditingTestServices
         return descriptor with { Ports = [new Port { Name = "Body", Type = PortType.Embedded }] };
     }
 
-    private sealed class StubActivityRegistry(IReadOnlyCollection<ActivityDescriptor> descriptors) : IActivityRegistry
-    {
-        public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public IEnumerable<ActivityDescriptor> List() => descriptors;
-        public ActivityDescriptor? Find(string activityType, int? version = null) => descriptors.FirstOrDefault(x => x.TypeName == activityType);
-        public IEnumerable<ActivityDescriptor> FindAll(string activityType) => descriptors.Where(x => x.TypeName == activityType);
-
-        public void MarkStale()
-        {
-        }
-    }
-
     private sealed class StubExpressionService : IExpressionService
     {
         private static readonly ExpressionDescriptor[] Descriptors = [new("Literal", "Literal"), new("JavaScript", "JavaScript")];
 
         public Task<IEnumerable<ExpressionDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<ExpressionDescriptor>>(Descriptors);
         public Task<ExpressionDescriptor?> GetByTypeAsync(string type, CancellationToken cancellationToken = default) => Task.FromResult(Descriptors.FirstOrDefault(x => x.Type == type));
-    }
-
-    private sealed class PassThroughLocalizer : ILocalizer
-    {
-        public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
-        public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
     }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/FakeBpmnDocumentService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/FakeBpmnDocumentService.cs
@@ -24,6 +24,9 @@ internal sealed class FakeBpmnDocumentService : IBpmnInterchangeService
     /// <summary>When set, every GET throws it, as a transport failure would.</summary>
     public Exception? GetException { get; set; }
 
+    /// <summary>When set, a PUT awaits it before answering, so a test can hold one open to observe the session mid-save.</summary>
+    public TaskCompletionSource? PutGate { get; set; }
+
     public FakeBpmnDocumentService ReturnsDocument(JsonObject document, string eTag) => ReturnsOnGet(new(new BpmnDocumentRevision(document, eTag)));
     public FakeBpmnDocumentService RefusesGet(BpmnDocumentFailureReason reason, string message = "refused") => ReturnsOnGet(new(new BpmnDocumentFailure(reason, message)));
     public FakeBpmnDocumentService AcceptsPut(string newETag) => ReturnsOnPut(new(new BpmnDocumentSaveResult(new BpmnImportResultModel(), newETag)));
@@ -37,10 +40,14 @@ internal sealed class FakeBpmnDocumentService : IBpmnInterchangeService
         return Task.FromResult(Next(_getResults, GetCount++));
     }
 
-    public Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, JsonObject document, string eTag, CancellationToken cancellationToken = default)
+    public async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, JsonObject document, string eTag, CancellationToken cancellationToken = default)
     {
         Puts.Add((definitionId, (JsonObject)document.DeepClone(), eTag));
-        return Task.FromResult(Next(_putResults, Puts.Count - 1));
+
+        if (PutGate != null)
+            await PutGate.Task;
+
+        return Next(_putResults, Puts.Count - 1);
     }
 
     public Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/FakeBpmnDocumentService.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/FakeBpmnDocumentService.cs
@@ -1,0 +1,64 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+namespace Elsa.Studio.Workflows.Tests.Support;
+
+/// <summary>
+/// An <see cref="IBpmnInterchangeService"/> whose document endpoints answer with results a test queues up — the last
+/// one repeating once the queue runs dry — and record every call; analyze, import and export throw to flag an
+/// unexpected call.
+/// </summary>
+internal sealed class FakeBpmnDocumentService : IBpmnInterchangeService
+{
+    private readonly List<Result<BpmnDocumentRevision, BpmnDocumentFailure>> _getResults = [];
+    private readonly List<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> _putResults = [];
+
+    /// <summary>Every document the service was asked to PUT, as it was sent, with the If-Match it carried.</summary>
+    public List<(string DefinitionId, JsonObject Document, string IfMatch)> Puts { get; } = [];
+
+    public int GetCount { get; private set; }
+
+    /// <summary>When set, every GET throws it, as a transport failure would.</summary>
+    public Exception? GetException { get; set; }
+
+    public FakeBpmnDocumentService ReturnsDocument(JsonObject document, string eTag) => ReturnsOnGet(new(new BpmnDocumentRevision(document, eTag)));
+    public FakeBpmnDocumentService RefusesGet(BpmnDocumentFailureReason reason, string message = "refused") => ReturnsOnGet(new(new BpmnDocumentFailure(reason, message)));
+    public FakeBpmnDocumentService AcceptsPut(string newETag) => ReturnsOnPut(new(new BpmnDocumentSaveResult(new BpmnImportResultModel(), newETag)));
+    public FakeBpmnDocumentService RefusesPut(BpmnDocumentFailureReason reason, string message = "refused") => ReturnsOnPut(new(new BpmnDocumentFailure(reason, message)));
+
+    public Task<Result<BpmnDocumentRevision, BpmnDocumentFailure>> GetDocumentAsync(string definitionId, CancellationToken cancellationToken = default)
+    {
+        if (GetException != null)
+            throw GetException;
+
+        return Task.FromResult(Next(_getResults, GetCount++));
+    }
+
+    public Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> PutDocumentAsync(string definitionId, JsonObject document, string eTag, CancellationToken cancellationToken = default)
+    {
+        Puts.Add((definitionId, (JsonObject)document.DeepClone(), eTag));
+        return Task.FromResult(Next(_putResults, Puts.Count - 1));
+    }
+
+    public Task<Result<BpmnImportAnalysisModel, ValidationErrors>> AnalyzeAsync(Stream content, string fileName, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public Task<Result<BpmnImportResultModel, ValidationErrors>> ImportAsync(Stream content, string fileName, string? definitionId, string? name, string? processId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public Task<Result<FileDownload, BpmnExportFailure>> ExportAsync(string definitionId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    private FakeBpmnDocumentService ReturnsOnGet(Result<BpmnDocumentRevision, BpmnDocumentFailure> result)
+    {
+        _getResults.Add(result);
+        return this;
+    }
+
+    private FakeBpmnDocumentService ReturnsOnPut(Result<BpmnDocumentSaveResult, BpmnDocumentFailure> result)
+    {
+        _putResults.Add(result);
+        return this;
+    }
+
+    private static T Next<T>(List<T> results, int index) =>
+        results.Count == 0 ? throw new InvalidOperationException("No result was queued for this call.") : results[Math.Min(index, results.Count - 1)];
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/Support/TestDoubles.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/Support/TestDoubles.cs
@@ -1,0 +1,33 @@
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Localization;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Microsoft.Extensions.Localization;
+
+namespace Elsa.Studio.Workflows.Tests.Support;
+
+/// <summary>
+/// An <see cref="ILocalizer"/> that passes every key straight through, formatting arguments where given, so tests
+/// can assert on the text a component renders without wiring up real localization resources.
+/// </summary>
+internal sealed class TestLocalizer : ILocalizer
+{
+    public LocalizedString this[string? key] => new(key ?? string.Empty, key ?? string.Empty);
+    public LocalizedString this[string? key, params object[] arguments] => new(key ?? string.Empty, string.Format(key ?? string.Empty, arguments));
+}
+
+/// <summary>
+/// An <see cref="IActivityRegistry"/> backed by a fixed, in-memory set of descriptors, for tests that need the
+/// registry's lookups without a real backend behind it.
+/// </summary>
+internal sealed class TestActivityRegistry(IEnumerable<ActivityDescriptor> activities) : IActivityRegistry
+{
+    public Task RefreshAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public IEnumerable<ActivityDescriptor> List() => activities;
+    public ActivityDescriptor? Find(string activityType, int? version = null) => activities.FirstOrDefault(x => x.TypeName == activityType);
+    public IEnumerable<ActivityDescriptor> FindAll(string activityType) => activities.Where(x => x.TypeName == activityType);
+
+    public void MarkStale()
+    {
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorBpmnSaveRoutingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorBpmnSaveRoutingTests.cs
@@ -1,0 +1,333 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Bunit;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.DomInterop.Contracts;
+using Elsa.Studio.DomInterop.Models;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components;
+using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Shared.Components;
+using Elsa.Studio.Workflows.Tests.Support;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using Xunit;
+using static Elsa.Studio.Workflows.Tests.Support.BpmnDocumentFixtures;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// The integration trap: a BPMN-imported workflow's activity graph is derived from its BPMN document, and elsa-core
+/// refuses to read or export that document once the ordinary workflow-definition save has rewritten the graph behind it.
+/// So the editor saves a binding change through the document PUT — with the ETag it read the document at — never
+/// through the ordinary save, and lets the ordinary save carry the workflow's other properties only, refusing any save
+/// that would send a changed graph. Both directions are pinned: the refusal, and the saves that must still go through.
+/// </summary>
+public sealed class WorkflowEditorBpmnSaveRoutingTests : BunitContext, IAsyncLifetime
+{
+    private const string ETag = "\"REVISION-1\"";
+
+    private readonly FakeBpmnDocumentService _documentService = new();
+    private readonly RecordingEditorService _editorService;
+    private readonly ReloadingDefinitionService _definitionService = new();
+    private readonly RecordingUserMessageService _messages = new();
+
+    public WorkflowEditorBpmnSaveRoutingTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        _editorService = new(() => _documentService.Puts.Count);
+        _documentService.ReturnsDocument(Document(), ETag);
+        Services.AddBpmnEditing(_documentService);
+        Services.AddSingleton<IWorkflowDefinitionEditorService>(_editorService);
+        Services.AddSingleton<IWorkflowDefinitionService>(_definitionService);
+        Services.AddSingleton<IDomAccessor, NoOpDomAccessor>();
+        Services.AddSingleton<IUserMessageService>(_messages);
+        ComponentFactories.Add<DiagramDesignerWrapper, DesignerStandIn>();
+        ComponentFactories.Add<ActivityPropertiesPanel, ActivityPropertiesPanelStandIn>();
+        ComponentFactories.Add<BpmnPerformedByPanel, PerformedByPanelStandIn>();
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await base.DisposeAsync();
+
+    [Fact]
+    public void ABpmnImportedWorkflow_ShowsThePerformedBySection_InPlaceOfTheActivityPropertiesPanel()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+
+        Assert.Equal(DefinitionId, cut.FindComponent<BpmnPerformedByPanel>().Instance.Session.DefinitionId);
+        Assert.Empty(cut.FindComponents<ActivityPropertiesPanel>());
+    }
+
+    [Fact]
+    public void ABpmnRootWithoutImportedSource_KeepsTheActivityPropertiesPanel_AndTheOrdinarySave()
+    {
+        // Built some other way: there is no document to keep in step, so nothing here may take the ordinary save away.
+        var definition = BpmnDefinition();
+        definition.CustomProperties.Remove(BpmnProcessConstants.SourceXmlCustomPropertyKey);
+
+        var cut = RenderEditor(definition);
+
+        Assert.NotEmpty(cut.FindComponents<ActivityPropertiesPanel>());
+        Assert.Empty(cut.FindComponents<BpmnPerformedByPanel>());
+    }
+
+    [Fact]
+    public async Task SavingABindingChange_PutsTheDocumentWithTheETagItWasReadAt_NeverTheOrdinarySave_ThenReloadsTheDefinition()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        var binding = await EditBindingAsync(cut);
+        _documentService.AcceptsPut("\"REVISION-2\"");
+        var reloaded = _definitionService.Latest = BpmnDefinition("Order Process, as re-imported");
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        var put = Assert.Single(_documentService.Puts);
+        Assert.Equal((DefinitionId, ETag), (put.DefinitionId, put.IfMatch));
+        Assert.True(JsonNode.DeepEquals(binding, BpmnActivityBindingFormat.Find(TaskElement(put.Document))));
+        Assert.Empty(_editorService.Saves);
+        Assert.Equal(1, _definitionService.FindCount);
+        Assert.Same(reloaded, cut.Instance.WorkflowDefinition);
+        Assert.False(Session(cut).IsDirty);
+    }
+
+    [Fact]
+    public async Task SavingOtherPropertiesAndABindingChange_SavesThePropertiesFirst_WithTheGraphUnchanged_ThenTheBinding()
+    {
+        var definition = BpmnDefinition();
+        var cut = RenderEditor(definition);
+        await EditBindingAsync(cut);
+        definition.Name = "Renamed";
+        await cut.InvokeAsync(() => cut.Instance.NotifyWorkflowChangedAsync());
+        _documentService.AcceptsPut("\"REVISION-2\"");
+        _definitionService.Latest = BpmnDefinition();
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        var save = Assert.Single(_editorService.Saves);
+        Assert.Equal(0, save.PutsBefore);
+        Assert.Equal("Renamed", save.Definition.Name);
+        Assert.True(JsonNode.DeepEquals(WithNodeIds(RootActivity()), save.Root));
+        Assert.Single(_documentService.Puts);
+    }
+
+    [Fact]
+    public async Task AnOrdinarySaveThatWouldChangeTheGraph_IsRefused_AndNothingIsSent()
+    {
+        var definition = BpmnDefinition();
+        var cut = RenderEditor(definition);
+        definition.Root!["activities"]![0]!["text"] = JsonValue.Create("edited outside the document");
+
+        await InvokeSaveChangesAsync(cut);
+
+        Assert.Empty(_editorService.Saves);
+        Assert.Contains(_messages.Messages, message => message.Contains("come from its BPMN document", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AnOrdinarySaveOfTheOtherProperties_GoesThrough_WithTheGraphAsTheServerSentIt()
+    {
+        var definition = BpmnDefinition();
+        var cut = RenderEditor(definition);
+        definition.Description = "Handles a customer order end to end.";
+
+        await InvokeSaveChangesAsync(cut);
+
+        var save = Assert.Single(_editorService.Saves);
+        Assert.Equal("Handles a customer order end to end.", save.Definition.Description);
+        Assert.True(JsonNode.DeepEquals(WithNodeIds(RootActivity()), save.Root));
+    }
+
+    [Fact]
+    public async Task ApplyingAGraphChangeFromTheCodeView_CannotBeSaved()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        var edited = BpmnDefinition();
+        edited.Root!["activities"]![0]!["text"] = JsonValue.Create("edited in the code view");
+
+        await cut.InvokeAsync(() => cut.Instance.ApplyWorkflowDefinitionAsync(edited));
+        await InvokeAsync(cut, "OnSaveClick");
+
+        Assert.Empty(_editorService.Saves);
+        Assert.Empty(_documentService.Puts);
+        Assert.Contains(_messages.Messages, message => message.Contains("come from its BPMN document", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AnOrdinarySave_ReadsTheDocumentAgain_SoAStaleDocumentIsReportedAtOnce()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        await Session(cut).EnsureLoadedAsync();
+        _documentService.RefusesGet(BpmnDocumentFailureReason.SourceStale);
+
+        await InvokeSaveChangesAsync(cut);
+
+        Assert.Single(_editorService.Saves);
+        Assert.Equal(BpmnDocumentFailureReason.SourceStale, Session(cut).LoadFailure!.Reason);
+    }
+
+    [Fact]
+    public async Task PublishingWithUnsavedBindingChanges_IsRefused()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        await EditBindingAsync(cut);
+
+        await InvokeAsync(cut, "OnPublishClicked");
+
+        Assert.Empty(_editorService.Saves);
+        Assert.Contains(_messages.Messages, message => message.Contains("before publishing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ASaveRefusedBecauseTheDefinitionMovedOn_IsNeitherRetriedNorReloaded()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        await EditBindingAsync(cut);
+        _documentService.RefusesPut(BpmnDocumentFailureReason.PreconditionFailed);
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        Assert.Single(_documentService.Puts);
+        Assert.Equal(0, _definitionService.FindCount);
+        Assert.Equal(BpmnDocumentFailureReason.PreconditionFailed, Session(cut).SaveFailure!.Reason);
+        Assert.True(Session(cut).IsDirty);
+    }
+
+    [Fact]
+    public async Task Reloading_ReplacesTheDefinitionAndTheDocument_DiscardingUnsavedBindingChanges()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        await EditBindingAsync(cut);
+        var reloaded = _definitionService.Latest = BpmnDefinition();
+
+        await cut.InvokeAsync(() => cut.FindComponent<BpmnPerformedByPanel>().Instance.ReloadRequested!());
+
+        Assert.Same(reloaded, cut.Instance.WorkflowDefinition);
+        Assert.Equal(2, _documentService.GetCount);
+        Assert.False(Session(cut).IsDirty);
+    }
+
+    private IRenderedComponent<WorkflowEditor> RenderEditor(WorkflowDefinition definition) =>
+        Render<WorkflowEditor>(parameters => parameters.Add(x => x.WorkflowDefinition, definition));
+
+    private static BpmnDocumentSession Session(IRenderedComponent<WorkflowEditor> cut) => cut.FindComponent<BpmnPerformedByPanel>().Instance.Session;
+
+    private static async Task<JsonObject> EditBindingAsync(IRenderedComponent<WorkflowEditor> cut)
+    {
+        var session = Session(cut);
+        await session.EnsureLoadedAsync();
+        var binding = BpmnActivityBindingFormat.Create("Elsa.HttpRequest", [KeyValuePair.Create<string, JsonNode?>("url", JsonNode.Parse("""{"typeName":"Uri","expression":{"type":"JavaScript","value":"getUrl()"}}"""))]);
+        session.SetBinding(TaskId, binding);
+        return binding;
+    }
+
+    private static Task InvokeSaveChangesAsync(IRenderedComponent<WorkflowEditor> cut) =>
+        InvokeAsync(cut, "SaveChangesAsync", true, false, false, null, null, null);
+
+    private static Task InvokeAsync(IRenderedComponent<WorkflowEditor> cut, string methodName, params object?[] arguments) =>
+        cut.InvokeAsync(() => (Task)typeof(WorkflowEditor).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(cut.Instance, arguments.Length == 0 ? null : arguments)!);
+
+    private static WorkflowDefinition BpmnDefinition(string name = "Order Process") => new()
+    {
+        Id = "version-1",
+        DefinitionId = DefinitionId,
+        Name = name,
+        Version = 1,
+        IsLatest = true,
+        Root = WithNodeIds(RootActivity()),
+        CustomProperties = new Dictionary<string, object> { [BpmnProcessConstants.SourceXmlCustomPropertyKey] = "<definitions />" }
+    };
+
+    /// <summary>
+    /// The fixture is the stored graph, which carries no node ids; a definition the API returns has one on every
+    /// activity, and the editor's activity graph is keyed on them.
+    /// </summary>
+    private static JsonObject WithNodeIds(JsonObject activity)
+    {
+        activity["nodeId"] = activity["id"]!.GetValue<string>();
+
+        foreach (var child in (activity["activities"] as JsonArray ?? []).OfType<JsonObject>())
+            WithNodeIds(child);
+
+        return activity;
+    }
+
+    private sealed class RecordingEditorService(Func<int> putsSoFar) : IWorkflowDefinitionEditorService
+    {
+        public List<(WorkflowDefinition Definition, JsonObject? Root, bool Publish, int PutsBefore)> Saves { get; } = [];
+
+        public Task<Result<SaveWorkflowDefinitionResponse, ValidationErrors>> SaveAsync(WorkflowDefinition workflowDefinition, bool publish, Func<WorkflowDefinition, Task>? workflowSavedCallback = null, CancellationToken cancellationToken = default)
+        {
+            Saves.Add((workflowDefinition, (JsonObject?)workflowDefinition.Root?.DeepClone(), publish, putsSoFar()));
+            return Task.FromResult(new Result<SaveWorkflowDefinitionResponse, ValidationErrors>(new SaveWorkflowDefinitionResponse(workflowDefinition, false, 0)));
+        }
+
+        public Task<SaveWorkflowDefinitionResponse> PublishAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowPublishedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<WorkflowDefinition, ValidationErrors>> RetractAsync(WorkflowDefinition workflowDefinition, Func<WorkflowDefinition, Task>? workflowRetractedCallback = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<FileDownload> ExportAsync(WorkflowDefinition workflowDefinition, bool includeConsumingWorkflows = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class ReloadingDefinitionService : ThrowingWorkflowDefinitionServiceBase
+    {
+        public WorkflowDefinition? Latest { get; set; }
+        public int FindCount { get; private set; }
+
+        public override Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions? versionOptions = null, CancellationToken cancellationToken = default)
+        {
+            FindCount++;
+            return Task.FromResult(Latest);
+        }
+    }
+
+    private sealed class RecordingUserMessageService : IUserMessageService
+    {
+        public List<string> Messages { get; } = [];
+        public void ShowSnackbarTextMessage(string message, Severity severity = Severity.Normal, Action<SnackbarOptions>? snackbarOptions = null) => Messages.Add(message);
+        public void ShowSnackbarTextMessage(IEnumerable<string> messages, Severity severity = Severity.Normal, Action<SnackbarOptions>? snackbarOptions = null) => Messages.AddRange(messages);
+    }
+
+    private sealed class NoOpDomAccessor : IDomAccessor
+    {
+        public Task<DomRect> GetBoundingClientRectAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(new DomRect());
+        public Task<double> GetVisibleHeightAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.FromResult(0d);
+        public Task ClickElementAsync(ElementRef elementRef, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class DesignerStandIn : DiagramDesignerWrapper
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    private sealed class ActivityPropertiesPanelStandIn : ActivityPropertiesPanel
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+
+    /// <summary>Keeps the parameters the editor hands the section, so a test can drive the session it was given.</summary>
+    private sealed class PerformedByPanelStandIn : BpmnPerformedByPanel
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+        protected override Task OnParametersSetAsync() => Task.CompletedTask;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorBpmnSaveRoutingTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowEditorBpmnSaveRoutingTests.cs
@@ -120,6 +120,72 @@ public sealed class WorkflowEditorBpmnSaveRoutingTests : BunitContext, IAsyncLif
         Assert.Single(_documentService.Puts);
     }
 
+    /// <summary>
+    /// The ordinary save re-serializes the root and, after a publish, may open a new draft version: either can advance
+    /// the document's own ETag (which the graph's serialized text feeds into) without changing what a BPMN import of it
+    /// would produce. Sending the binding PUT with the ETag the session read before that save would then be refused for
+    /// a change nobody made, so the session re-reads the document first and, finding it unchanged, adopts the new ETag.
+    /// </summary>
+    [Fact]
+    public async Task SavingOtherPropertiesAndABindingChange_WhenTheOrdinarySaveOnlyAdvancesTheETag_SendsThePutWithTheRefreshedETag()
+    {
+        var definition = BpmnDefinition();
+        var cut = RenderEditor(definition);
+        await EditBindingAsync(cut);
+        definition.Name = "Renamed";
+        await cut.InvokeAsync(() => cut.Instance.NotifyWorkflowChangedAsync());
+        _documentService.ReturnsDocument(Document(), "\"REVISION-1B\"").AcceptsPut("\"REVISION-2\"").ReturnsDocument(Document(), "\"REVISION-2\"");
+        _definitionService.Latest = BpmnDefinition();
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        var put = Assert.Single(_documentService.Puts);
+        Assert.Equal("\"REVISION-1B\"", put.IfMatch);
+        Assert.False(Session(cut).IsDirty);
+        Assert.Contains(_messages.Messages, message => message.Contains("Workflow saved", StringComparison.Ordinal));
+    }
+
+    /// <summary>The document the ordinary save's re-read turns up may genuinely have changed; that is still a conflict.</summary>
+    [Fact]
+    public async Task SavingOtherPropertiesAndABindingChange_WhenTheOrdinarySavesReReadFindsARealChange_ReportsTheConflict_WithoutSendingThePut()
+    {
+        var definition = BpmnDefinition();
+        var cut = RenderEditor(definition);
+        await EditBindingAsync(cut);
+        definition.Name = "Renamed";
+        await cut.InvokeAsync(() => cut.Instance.NotifyWorkflowChangedAsync());
+        var changedOnTheServer = Document();
+        TaskElement(changedOnTheServer)["name"] = "Changed by someone else";
+        _documentService.ReturnsDocument(changedOnTheServer, "\"REVISION-1B\"");
+        _definitionService.Latest = BpmnDefinition();
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        Assert.Single(_editorService.Saves);
+        Assert.Empty(_documentService.Puts);
+        Assert.Equal(BpmnDocumentFailureReason.PreconditionFailed, Session(cut).SaveFailure!.Reason);
+        Assert.True(Session(cut).IsDirty);
+        Assert.Contains(_messages.Messages, message => message.Contains("were not saved", StringComparison.Ordinal));
+    }
+
+    /// <summary>A PUT that succeeds is not the whole story if the read that should confirm it fails: saying only
+    /// "Workflow saved" would hide that the document panel now shows a load failure.</summary>
+    [Fact]
+    public async Task SavingABindingChange_WhenThePutSucceedsButTheFollowUpReadFails_SaysSoRatherThanJustThatItSaved()
+    {
+        var cut = RenderEditor(BpmnDefinition());
+        await EditBindingAsync(cut);
+        _documentService.AcceptsPut("\"REVISION-2\"").RefusesGet(BpmnDocumentFailureReason.SourceStale);
+        _definitionService.Latest = BpmnDefinition();
+
+        await InvokeAsync(cut, "OnSaveClick");
+
+        Assert.Single(_documentService.Puts);
+        Assert.True(Session(cut).SavedButReloadFailed);
+        Assert.Contains(_messages.Messages, message => message.Contains("could not be reloaded", StringComparison.Ordinal));
+        Assert.DoesNotContain(_messages.Messages, message => message == "Workflow saved");
+    }
+
     [Fact]
     public async Task AnOrdinarySaveThatWouldChangeTheGraph_IsRefused_AndNothingIsSent()
     {

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor
@@ -1,4 +1,5 @@
 @using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties
+@using Elsa.Studio.Workflows.DiagramDesigners.Bpmn
 @using Orientation = Radzen.Orientation
 @using Variant = MudBlazor.Variant
 @inherits WorkflowEditorComponentBase
@@ -6,6 +7,7 @@
 
 <RadzenSplitter Orientation="Orientation.Vertical" Style="height: calc(100vh - var(--mud-appbar-height) - 50px);" Resize="@OnResize">
     <RadzenSplitterPane Size="70%">
+        <CascadingValue Name="@BpmnDesignerWrapper.ElementSelectedCascadeName" Value="_bpmnElementSelected" IsFixed="true">
         <DiagramDesignerWrapper @ref="_diagramDesigner"
                                 WorkflowDefinitionVersionId="@_workflowDefinition?.Id"
                                 WorkflowDefinition="@_workflowDefinition"
@@ -19,7 +21,7 @@
                     <MudSwitch T="bool?" Value="@AutoSave" Color="Color.Primary" Label="@Localizer["Auto-save"]" LabelPlacement="Placement.Start" ValueChanged="@OnAutoSaveChanged" />
                 </MudTooltip>
                 <MudTooltip Text="@Localizer["Save"]" Delay="500">
-                    <MudBadge Color="@(_isDirty? Color.Warning: Color.Success)" Dot="true" Overlap="true" Origin="Origin.BottomRight" Bordered="true" Class="elsa-toolbar-icon">
+                    <MudBadge Color="@(IsDirty ? Color.Warning: Color.Success)" Dot="true" Overlap="true" Origin="Origin.BottomRight" Bordered="true" Class="elsa-toolbar-icon">
                         <MudIconButton Icon="@Icons.Material.Outlined.Save" OnClick="@OnSaveClick" />
                     </MudBadge>
                 </MudTooltip>
@@ -58,9 +60,21 @@
                 </MudTooltip>
             </CustomToolbarItems>
         </DiagramDesignerWrapper>
+        </CascadingValue>
     </RadzenSplitterPane>
     <RadzenSplitterPane Size="30%" @ref="ActivityPropertiesPane">
-        <ActivityPropertiesPanel @key="@SelectedActivityId" @ref="ActivityPropertiesPanel" WorkflowDefinition="@_workflowDefinition" Activity="@SelectedActivity" ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="@OnSelectedActivityUpdated" VisiblePaneHeight="@_activityPropertiesPaneHeight" />
+        @if (_bpmnDocumentSession is { } bpmnDocumentSession)
+        {
+            @* A BPMN-imported workflow's activities come from its BPMN document: they are bound in the document, never
+               edited in the activity properties panel, whose edits only the ordinary save could persist. *@
+            <BpmnPerformedByPanel WorkflowDefinition="@_workflowDefinition" RootActivity="@Activity" Selection="@_selectedBpmnElement" Session="@bpmnDocumentSession"
+                                  DocumentChanged="@OnBpmnDocumentChangedAsync" SaveRequested="@SaveBpmnDocumentBackedDefinitionAsync" ReloadRequested="@ReloadBpmnDocumentBackedDefinitionAsync"
+                                  VisiblePaneHeight="@_activityPropertiesPaneHeight" />
+        }
+        else
+        {
+            <ActivityPropertiesPanel @key="@SelectedActivityId" @ref="ActivityPropertiesPanel" WorkflowDefinition="@_workflowDefinition" Activity="@SelectedActivity" ActivityDescriptor="@ActivityDescriptor" OnActivityUpdated="@OnSelectedActivityUpdated" VisiblePaneHeight="@_activityPropertiesPaneHeight" />
+        }
     </RadzenSplitterPane>
 </RadzenSplitter>
 

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -696,14 +696,16 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         _serverRoot = (JsonObject?)workflowDefinition?.Root?.DeepClone();
 
-        if (!IsBpmnDocumentBacked(workflowDefinition))
+        // workflowDefinition is never null once it is BPMN-document-backed: IsBpmnDocumentBacked is null-safe and
+        // returns false for a null definition, so the flow analysis below can treat it as non-null from here on.
+        if (workflowDefinition is null || !IsBpmnDocumentBacked(workflowDefinition))
         {
             _bpmnDocumentSession = null;
             _selectedBpmnElement = null;
             return;
         }
 
-        if (_bpmnDocumentSession?.DefinitionId == workflowDefinition!.DefinitionId)
+        if (_bpmnDocumentSession?.DefinitionId == workflowDefinition.DefinitionId)
             return;
 
         _bpmnDocumentSession = new(BpmnInterchangeService, workflowDefinition.DefinitionId);
@@ -723,6 +725,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     private async Task SaveBpmnDocumentBackedDefinitionAsync()
     {
         var session = _bpmnDocumentSession!;
+        var ordinarySavePerformed = false;
 
         if (_isDirty || !session.IsDirty)
         {
@@ -743,10 +746,22 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
                 return;
             }
+
+            ordinarySavePerformed = true;
         }
 
         await ProgressAsync(async () =>
         {
+            // The ordinary save above may have advanced the document's ETag without changing what it describes — it
+            // re-serializes the root, and a publish opens a new draft version — so the PUT below would otherwise carry
+            // a stale If-Match and be refused for a change nobody made. Adopting the new ETag first, when the content
+            // is unchanged, avoids that; a genuine conflict is still reported as one.
+            if (ordinarySavePerformed && !await session.RefreshRevisionAfterOrdinarySaveAsync())
+            {
+                UserMessageService.ShowSnackbarTextMessage(Localizer["The binding changes were not saved."], Severity.Error);
+                return;
+            }
+
             var result = await session.SaveAsync();
 
             if (_disposed)
@@ -758,7 +773,12 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 return;
             }
 
-            if (await ReloadDefinitionFromServerAsync())
+            if (!await ReloadDefinitionFromServerAsync())
+                return;
+
+            if (session.SavedButReloadFailed)
+                UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow saved, but its BPMN document could not be reloaded. Use Reload in the Performed by panel to see its current bindings."], Severity.Warning);
+            else
                 UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow saved"], Severity.Success);
         });
     }

--- a/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/Components/WorkflowDefinitionEditor/Components/WorkflowEditor.razor.cs
@@ -2,6 +2,7 @@ using Elsa.Api.Client.Extensions;
 using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Responses;
+using Elsa.Api.Client.Shared.Models;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Contracts;
 using Elsa.Studio.Extensions;
@@ -10,8 +11,11 @@ using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.Activ
 using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.Models;
 using Elsa.Studio.Workflows.Contracts;
 using Elsa.Studio.Workflows.DiagramDesigners;
+using Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
 using Elsa.Studio.Workflows.Domain.Notifications;
 using Elsa.Studio.Workflows.Extensions;
 using Elsa.Studio.Workflows.Models;
@@ -47,6 +51,21 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     private RadzenSplitterPane _activityPropertiesPane = null!;
     private int _activityPropertiesPaneHeight = 300;
     private DiagramDesignerWrapper _diagramDesigner = null!;
+
+    /// <summary>
+    /// The root activity exactly as the server last delivered it. For a BPMN-imported workflow it is the only graph the
+    /// ordinary save may send back; see <see cref="SaveAsync"/>.
+    /// </summary>
+    private JsonObject? _serverRoot;
+
+    /// <summary>
+    /// The BPMN document of a BPMN-imported workflow — the only place its bindings are edited — or <see langword="null"/>
+    /// for any other workflow. See <see cref="AdoptServerDefinition"/>.
+    /// </summary>
+    private BpmnDocumentSession? _bpmnDocumentSession;
+
+    private BpmnElementSelection? _selectedBpmnElement;
+    private EventCallback<BpmnElementSelection?> _bpmnElementSelected;
 
     /// <inheritdoc />
     public WorkflowEditor()
@@ -92,6 +111,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     [Inject] private IWorkflowCloningDialogService WorkflowCloningService { get; set; } = null!;
     [Inject] private IWorkflowExportDialogService WorkflowExportDialogService { get; set; } = null!;
     [Inject] private IBpmnImportUiService BpmnImportUiService { get; set; } = null!;
+    [Inject] private IBpmnInterchangeService BpmnInterchangeService { get; set; } = null!;
     [Inject] private IOptions<WorkflowDefinitionOptions> WorkflowDefinitionOptions { get; set; } = null!;
 
     /// <summary>
@@ -105,6 +125,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     [JSInvokable] public async Task OnHotKeysCtrlShiftS() => await OnSaveAsClick();
 
     private JsonObject? Activity => _workflowDefinition?.Root;
+    private bool IsDirty => _isDirty || _bpmnDocumentSession?.IsDirty == true;
     private JsonObject? SelectedActivity { get; set; }
     private ActivityDescriptor? ActivityDescriptor { get; set; }
     private ActivityPropertiesPanel? ActivityPropertiesPanel { get; set; }
@@ -135,7 +156,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     /// <param name="workflowDefinition">The workflow definition to apply. Cannot be null.</param>
     public async Task ApplyWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition)
     {
-        await SetWorkflowDefinitionAsync(workflowDefinition, true);
+        await SetWorkflowDefinitionAsync(workflowDefinition, true, isServerDefinition: false);
         await HandleChangesAsync(false, true);
     }
 
@@ -150,7 +171,9 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         Mediator.Subscribe<ImportedWorkflowDefinition>(this);
 
+        _bpmnElementSelected = EventCallback.Factory.Create<BpmnElementSelection?>(this, OnBpmnElementSelectedAsync);
         _workflowDefinition = WorkflowDefinition;
+        AdoptServerDefinition(_workflowDefinition);
 
         await ActivityRegistry.EnsureLoadedAsync();
 
@@ -173,6 +196,7 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
         var workflowDefinition = _workflowDefinition = WorkflowDefinition;
         var expectedWorkflowDefinitionGeneration = _workflowDefinitionGeneration;
+        AdoptServerDefinition(workflowDefinition);
 
         if (workflowDefinition?.Root == null)
             return;
@@ -247,7 +271,17 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
     {
         var workflowDefinition = _workflowDefinition ?? new WorkflowDefinition();
 
-        if (readDiagram)
+        if (_bpmnDocumentSession != null)
+        {
+            // A BPMN-imported workflow's graph is derived from its BPMN document, and elsa-core refuses to read or export
+            // that document once an ordinary save has rewritten the graph behind it. Bindings are edited in the document
+            // and saved through the document PUT (SaveBpmnDocumentBackedDefinitionAsync); this save may carry the other
+            // properties only, sending the graph back exactly as the server delivered it. The designer is never read:
+            // the BPMN canvas cannot edit the graph, so it could only ever hand back this same root.
+            if (!JsonNode.DeepEquals(workflowDefinition.Root, _serverRoot))
+                return new(new ValidationErrors([new(Localizer["This workflow's activities come from its BPMN document, and this save would change them outside it, so nothing was saved. Bind tasks in the Performed by panel instead, and reload the workflow to discard the other activity changes."])]));
+        }
+        else if (readDiagram)
         {
             var root = await _diagramDesigner.GetActivityAsync();
 
@@ -364,6 +398,12 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
                 if (!IsCurrentWorkflowOperation(expectedWorkflowDefinitionGeneration))
                     return;
 
+                // The save may have moved what the document's ETag covers (a new draft version, say), or left the
+                // document stale; reading it again says which, rather than letting the next binding save find out. A
+                // working copy with unsaved edits is left alone: its save reports a moved ETag as a conflict itself.
+                if (_bpmnDocumentSession is { IsDirty: false } bpmnDocumentSession)
+                    await bpmnDocumentSession.ReloadAsync();
+
                 if (!string.IsNullOrEmpty(currentSelectedActivityId))
                 {
                     await RefreshSelectedActivityAsync(currentSelectedActivityId);
@@ -477,12 +517,16 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task SetWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition, bool isExternalReplacement = false)
+    private async Task SetWorkflowDefinitionAsync(WorkflowDefinition workflowDefinition, bool isExternalReplacement = false, bool isServerDefinition = true)
     {
         if (isExternalReplacement)
             InvalidateWorkflowDefinitionOperations();
 
         _workflowDefinition = WorkflowDefinition = workflowDefinition;
+
+        if (isServerDefinition)
+            AdoptServerDefinition(workflowDefinition);
+
         if (isExternalReplacement && WorkflowDefinitionReloaded != null)
             await WorkflowDefinitionReloaded();
         else if (WorkflowDefinitionUpdated != null)
@@ -575,6 +619,12 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task OnSaveClick()
     {
+        if (_bpmnDocumentSession != null)
+        {
+            await SaveBpmnDocumentBackedDefinitionAsync();
+            return;
+        }
+
         await SaveChangesAsync(true, true, false, _ =>
         {
             UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow saved"], Severity.Success);
@@ -596,6 +646,13 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
 
     private async Task OnPublishClicked()
     {
+        // Publishing would publish the graph the server has now, without the unsaved binding changes.
+        if (_bpmnDocumentSession?.IsDirty == true)
+        {
+            UserMessageService.ShowSnackbarTextMessage(Localizer["Save or discard the binding changes before publishing."], Severity.Warning);
+            return;
+        }
+
         await ProgressAsync(async () => await PublishAsync(async response =>
         {
             // Depending on whether the workflow contains Not Found activities, display a different message.
@@ -628,6 +685,124 @@ public partial class WorkflowEditor : WorkflowEditorComponentBase, INotification
         }));
     }
     
+    /// <summary>
+    /// Records <paramref name="workflowDefinition"/> as the server delivered it. For a BPMN-imported workflow — one
+    /// whose root is an <c>Elsa.BpmnProcess</c> and that carries its BPMN source — that is two things: the root exactly
+    /// as sent, the only graph an ordinary save of it may send back, and the session holding its BPMN document, the
+    /// only place its bindings are edited. Never called for a definition edited locally, such as one applied from the
+    /// code view.
+    /// </summary>
+    private void AdoptServerDefinition(WorkflowDefinition? workflowDefinition)
+    {
+        _serverRoot = (JsonObject?)workflowDefinition?.Root?.DeepClone();
+
+        if (!IsBpmnDocumentBacked(workflowDefinition))
+        {
+            _bpmnDocumentSession = null;
+            _selectedBpmnElement = null;
+            return;
+        }
+
+        if (_bpmnDocumentSession?.DefinitionId == workflowDefinition!.DefinitionId)
+            return;
+
+        _bpmnDocumentSession = new(BpmnInterchangeService, workflowDefinition.DefinitionId);
+        _selectedBpmnElement = null;
+    }
+
+    private static bool IsBpmnDocumentBacked(WorkflowDefinition? workflowDefinition) =>
+        workflowDefinition?.Root?.GetTypeName() == BpmnProcessConstants.ActivityTypeName
+        && workflowDefinition.CustomProperties.ContainsKey(BpmnProcessConstants.SourceXmlCustomPropertyKey);
+
+    /// <summary>
+    /// Saves a BPMN-imported workflow: unsaved changes to its other properties first, through the ordinary save (which
+    /// sends the graph back unchanged), then unsaved binding changes through the document PUT, against the ETag of the
+    /// document they were made in. In that order because a successful PUT reloads the definition, which would otherwise
+    /// replace properties nobody had saved yet.
+    /// </summary>
+    private async Task SaveBpmnDocumentBackedDefinitionAsync()
+    {
+        var session = _bpmnDocumentSession!;
+
+        if (_isDirty || !session.IsDirty)
+        {
+            var saved = false;
+
+            await SaveChangesAsync(false, true, false, _ =>
+            {
+                saved = true;
+                return Task.CompletedTask;
+            });
+
+            // A refused save has already said why; saving the bindings after it would reload the definition over the
+            // properties it did not save.
+            if (!saved || !session.IsDirty)
+            {
+                if (saved)
+                    UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow saved"], Severity.Success);
+
+                return;
+            }
+        }
+
+        await ProgressAsync(async () =>
+        {
+            var result = await session.SaveAsync();
+
+            if (_disposed)
+                return;
+
+            if (!result.IsSuccess)
+            {
+                UserMessageService.ShowSnackbarTextMessage(Localizer["The binding changes were not saved."], Severity.Error);
+                return;
+            }
+
+            if (await ReloadDefinitionFromServerAsync())
+                UserMessageService.ShowSnackbarTextMessage(Localizer["Workflow saved"], Severity.Success);
+        });
+    }
+
+    /// <summary>
+    /// Reloads a BPMN-imported workflow and its document from the server, discarding every unsaved change: what a user
+    /// does after the document was changed by someone else, or went stale.
+    /// </summary>
+    private async Task ReloadBpmnDocumentBackedDefinitionAsync()
+    {
+        await ProgressAsync(async () =>
+        {
+            if (await ReloadDefinitionFromServerAsync() && _bpmnDocumentSession != null)
+                await _bpmnDocumentSession.ReloadAsync();
+        });
+    }
+
+    /// <summary>
+    /// Replaces the edited definition with the server's latest version — after a document PUT, the graph it re-imported
+    /// — and redraws the designer from it, exactly as an import into this definition does.
+    /// </summary>
+    private async Task<bool> ReloadDefinitionFromServerAsync()
+    {
+        var definition = await WorkflowDefinitionService.FindByDefinitionIdAsync(_workflowDefinition!.DefinitionId, VersionOptions.Latest);
+
+        if (definition == null)
+        {
+            UserMessageService.ShowSnackbarTextMessage(Localizer["The workflow definition could not be reloaded."], Severity.Error);
+            return false;
+        }
+
+        _isDirty = false;
+        await SetImportedWorkflowDefinitionAsync(definition);
+        return true;
+    }
+
+    private async Task OnBpmnElementSelectedAsync(BpmnElementSelection? selection)
+    {
+        _selectedBpmnElement = selection;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task OnBpmnDocumentChangedAsync() => InvokeAsync(StateHasChanged);
+
     private async Task OnGraphUpdated() => await HandleChangesAsync(true);
     
     private async Task OnActivityUpdated(JsonObject activity)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor
@@ -12,6 +12,6 @@
     else
     {
         <BpmnDesigner @ref="@Designer" Activity="@Activity" SourceXml="@SourceXml" ActivityStats="@ActivityStats"
-            ActivitySelected="@ActivitySelected" ActivityDoubleClick="@ActivityDoubleClick" CanvasSelected="@OnCanvasSelected" />
+            ActivitySelected="@ActivitySelected" ActivityDoubleClick="@ActivityDoubleClick" CanvasSelected="@OnCanvasSelected" ElementSelected="@ElementSelected" />
     }
 </div>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDesignerWrapper.razor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Elsa.Studio.Workflows.Designer.Components;
+using Elsa.Studio.Workflows.Designer.Models;
 using Elsa.Studio.Workflows.Designer.Options;
 using Elsa.Studio.Workflows.Domain.Models;
 using Elsa.Studio.Workflows.Domain.Models.Bpmn;
@@ -17,6 +18,11 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 /// </summary>
 public partial class BpmnDesignerWrapper
 {
+    /// <summary>
+    /// The name an editor cascades its receiver of BPMN element selections under (see <see cref="ElementSelected"/>).
+    /// </summary>
+    public const string ElementSelectedCascadeName = "BpmnElementSelected";
+
     /// <summary>
     /// The root <c>Elsa.BpmnProcess</c> activity to display.
     /// </summary>
@@ -41,6 +47,13 @@ public partial class BpmnDesignerWrapper
     /// An event raised when an activity is double-clicked.
     /// </summary>
     [Parameter] public EventCallback<JsonObject> ActivityDoubleClick { get; set; }
+
+    /// <summary>
+    /// Receives the selected BPMN element itself, or <see langword="null"/> when nothing in particular is selected. An
+    /// editor that edits bindings — which has to know which element was clicked even when no activity is bound to it —
+    /// cascades one under <see cref="ElementSelectedCascadeName"/>; the viewers do not, so this stays unset there.
+    /// </summary>
+    [CascadingParameter(Name = ElementSelectedCascadeName)] public EventCallback<BpmnElementSelection?> ElementSelected { get; set; }
 
     [Inject] private IOptions<DesignerOptions> DesignerOptions { get; set; } = null!;
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDiagramDesigner.cs
@@ -30,11 +30,6 @@ public class BpmnDiagramDesigner(
     IFiles files,
     IUserMessageService userMessageService) : IDiagramDesignerToolboxProvider, IBpmnElementStatsSink
 {
-    /// <summary>
-    /// The custom property key elsa-core stores the imported BPMN document's source XML under.
-    /// </summary>
-    private const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
-
     private readonly Guid _id = Guid.NewGuid();
     private BpmnDesignerWrapper? _designerWrapper;
     private JsonObject _rootActivity = [];
@@ -222,7 +217,7 @@ public class BpmnDiagramDesigner(
     /// </summary>
     private static string? GetSourceXml(WorkflowDefinition? workflowDefinition)
     {
-        if (workflowDefinition == null || !workflowDefinition.CustomProperties.TryGetValue(SourceXmlCustomPropertyKey, out var value) || value == null!)
+        if (workflowDefinition == null || !workflowDefinition.CustomProperties.TryGetValue(BpmnProcessConstants.SourceXmlCustomPropertyKey, out var value) || value == null!)
             return null;
 
         return value switch

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -34,6 +34,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     private readonly SortedSet<string> _editedElementIds = new(StringComparer.Ordinal);
     private BpmnDocumentRevision? _revision;
     private Task? _loadTask;
+    private bool _isSaving;
 
     /// <summary>The workflow definition whose document this is.</summary>
     public string DefinitionId { get; } = definitionId;
@@ -44,11 +45,26 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// <summary>Whether a read is in flight.</summary>
     public bool IsLoading => _loadTask is { IsCompleted: false };
 
+    /// <summary>
+    /// Whether the working copy is being written back through the document <c>PUT</c>, or the read <see cref="SaveAsync"/>
+    /// follows it with. Set for that whole window, so an edit made after the body was serialized cannot be silently lost
+    /// to the reload that follows a successful <c>PUT</c>: <see cref="SetBinding"/> refuses while this is
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool IsSaving => _isSaving;
+
     /// <summary>Why the last read failed, or <see langword="null"/> when it did not.</summary>
     public BpmnDocumentFailure? LoadFailure { get; private set; }
 
     /// <summary>Why the last save failed, or <see langword="null"/> when it did not or an edit has been made since.</summary>
     public BpmnDocumentFailure? SaveFailure { get; private set; }
+
+    /// <summary>
+    /// Whether the last <see cref="SaveAsync"/> wrote the edit successfully — it is on the server — but the read that
+    /// should have refreshed the working copy with the server's own view of it then failed, leaving <see cref="Document"/>
+    /// cleared and <see cref="LoadFailure"/> set. Nothing was lost; only the local view of it could not be confirmed.
+    /// </summary>
+    public bool SavedButReloadFailed { get; private set; }
 
     /// <summary>The subprocesses the document declares; while there are any, <see cref="SaveAsync"/> refuses.</summary>
     public IReadOnlyList<string> SubProcessIds { get; private set; } = [];
@@ -72,9 +88,15 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// Makes <paramref name="binding"/> the activity binding of the element with <paramref name="elementId"/> in the
     /// working copy. Nothing else in the document changes, and nothing is sent until <see cref="SaveAsync"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException">The working copy has no such element.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The working copy has no such element, or a save is in flight (<see cref="IsSaving"/>): the document just sent is
+    /// being read back, and an edit applied to it now would be overwritten by that read without ever being saved.
+    /// </exception>
     public void SetBinding(string elementId, JsonObject binding)
     {
+        if (_isSaving)
+            throw new InvalidOperationException("The BPMN document is being saved, so its binding cannot be changed until the save finishes.");
+
         var element = FindElement(elementId) ?? throw new InvalidOperationException($"The BPMN document has no element '{elementId}'.");
 
         BpmnActivityBindingFormat.Attach(element, binding);
@@ -90,11 +112,14 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
 
         _editedElementIds.Clear();
         SaveFailure = null;
+        SavedButReloadFailed = false;
     }
 
     /// <summary>
     /// Writes the working copy back through the document <c>PUT</c>, against the revision it was edited from, then reads
-    /// the document back so the session holds the server's own view and the new <c>ETag</c>.
+    /// the document back so the session holds the server's own view and the new <c>ETag</c>. <see cref="IsSaving"/> is
+    /// set for the whole of that window, so an edit attempted while it runs is refused rather than silently lost to the
+    /// reload; see <see cref="SetBinding"/>.
     /// </summary>
     /// <returns>The server's result on success, or why the document was not saved.</returns>
     public async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveAsync(CancellationToken cancellationToken = default)
@@ -109,13 +134,65 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
                 $"The BPMN document declares the subprocess(es) {string.Join(", ", SubProcessIds.Select(id => $"'{id}'"))}, whose content the document does not carry, so saving it would empty them."));
         }
 
-        var result = await TryAsync(() => bpmnInterchangeService.PutDocumentAsync(DefinitionId, Document, _revision.ETag, cancellationToken));
+        SavedButReloadFailed = false;
+        _isSaving = true;
+
+        try
+        {
+            var result = await TryAsync(() => bpmnInterchangeService.PutDocumentAsync(DefinitionId, Document, _revision.ETag, cancellationToken));
+
+            if (!result.IsSuccess)
+                return Refuse(result.Failure!);
+
+            await ReloadAsync(cancellationToken);
+
+            // The PUT is on the server; only the read that was to confirm it locally failed. That is not the failure
+            // SaveFailure reports — a retry would resend an edit the server already has — so it is reported separately.
+            SavedButReloadFailed = LoadFailure != null;
+            return result;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    /// <summary>
+    /// Called after an ordinary workflow-definition save that may have advanced this document's revision without
+    /// changing what it describes — re-serializing the graph, or a publish that opens a new draft, can move the
+    /// <c>ETag</c> without changing the content a BPMN import would produce from it. Re-reads the document and, if its
+    /// content still equals the revision the working copy was built from, adopts the new <c>ETag</c> so
+    /// <see cref="SaveAsync"/> does not carry a stale one and get refused for a change nobody made. If the content
+    /// differs, that is a genuine conflict, reported the same way a stale <c>PUT</c> would be, without sending anything.
+    /// If the re-read itself fails, that failure is reported instead.
+    /// </summary>
+    /// <returns><see langword="true"/> if <see cref="SaveAsync"/> may proceed; otherwise the refusal is in <see cref="SaveFailure"/>.</returns>
+    public async Task<bool> RefreshRevisionAfterOrdinarySaveAsync(CancellationToken cancellationToken = default)
+    {
+        if (Document == null || _revision == null)
+            return false;
+
+        var result = await TryAsync(() => bpmnInterchangeService.GetDocumentAsync(DefinitionId, cancellationToken));
 
         if (!result.IsSuccess)
-            return Refuse(result.Failure!);
+        {
+            Refuse(result.Failure!);
+            return false;
+        }
 
-        await ReloadAsync(cancellationToken);
-        return result;
+        var fetched = result.Success!;
+
+        if (!JsonNode.DeepEquals(fetched.Document, _revision.Document))
+        {
+            Refuse(new(
+                BpmnDocumentFailureReason.PreconditionFailed,
+                "This workflow was changed since its BPMN document was read, by another save or another user, so the binding changes were not saved."));
+            return false;
+        }
+
+        _revision = fetched;
+        SaveFailure = null;
+        return true;
     }
 
     private async Task LoadAsync(CancellationToken cancellationToken)
@@ -127,6 +204,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
         SubProcessIds = _revision == null ? [] : BpmnDefinitionsDocument.FindSubProcessIds(_revision.Document);
         LoadFailure = result.Failure;
         SaveFailure = null;
+        SavedButReloadFailed = false;
         _editedElementIds.Clear();
     }
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -1,0 +1,154 @@
+using System.Text.Json.Nodes;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// One BPMN-imported workflow definition's <c>bpmnDefinitions</c> document, between the document <c>GET</c> that read
+/// it and the document <c>PUT</c> that writes an edit back: the revision the server last returned, and a working copy
+/// the "Performed by" section edits in place.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> A BPMN-imported definition's activity graph is derived from its document. An edit to a
+/// bound activity has to be written into the document and saved through the document <c>PUT</c>, which re-imports
+/// it; the ordinary workflow-definition save would rewrite the graph behind the document, which elsa-core then refuses
+/// to read or export as stale. This class is the only thing that writes a binding, and it only ever writes one
+/// through <see cref="SaveAsync"/>.
+/// </para>
+/// <para>
+/// <b>Optimistic concurrency.</b> Every <c>PUT</c> carries, as <c>If-Match</c>, the <c>ETag</c> of the revision the
+/// edit was made against. A refusal (<see cref="BpmnDocumentFailureReason.PreconditionFailed"/>) is reported, never
+/// retried: the working copy stays as it is until the user reloads, which discards it.
+/// </para>
+/// <para>
+/// <b>Subprocesses.</b> The document does not carry a subprocess's body, and elsa-core writes the XML from the document
+/// alone, so saving a document that declares a subprocess would empty it. <see cref="SaveAsync"/> refuses such a
+/// document before sending anything; see <see cref="BpmnDefinitionsDocument.FindSubProcessIds"/>.
+/// </para>
+/// </remarks>
+public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeService, string definitionId)
+{
+    private readonly SortedSet<string> _editedElementIds = new(StringComparer.Ordinal);
+    private BpmnDocumentRevision? _revision;
+    private Task? _loadTask;
+
+    /// <summary>The workflow definition whose document this is.</summary>
+    public string DefinitionId { get; } = definitionId;
+
+    /// <summary>The working copy, with every unsaved edit applied, or <see langword="null"/> until a read succeeds.</summary>
+    public JsonObject? Document { get; private set; }
+
+    /// <summary>Whether a read is in flight.</summary>
+    public bool IsLoading => _loadTask is { IsCompleted: false };
+
+    /// <summary>Why the last read failed, or <see langword="null"/> when it did not.</summary>
+    public BpmnDocumentFailure? LoadFailure { get; private set; }
+
+    /// <summary>Why the last save failed, or <see langword="null"/> when it did not or an edit has been made since.</summary>
+    public BpmnDocumentFailure? SaveFailure { get; private set; }
+
+    /// <summary>The subprocesses the document declares; while there are any, <see cref="SaveAsync"/> refuses.</summary>
+    public IReadOnlyList<string> SubProcessIds { get; private set; } = [];
+
+    /// <summary>The elements whose binding the working copy changed since the document was last read or discarded.</summary>
+    public IReadOnlyCollection<string> EditedElementIds => _editedElementIds;
+
+    /// <summary>Whether the working copy differs from the revision the server last returned.</summary>
+    public bool IsDirty => Document != null && _revision != null && !JsonNode.DeepEquals(Document, _revision.Document);
+
+    /// <summary>Reads the document, unless a read has already started.</summary>
+    public Task EnsureLoadedAsync(CancellationToken cancellationToken = default) => _loadTask ??= LoadAsync(cancellationToken);
+
+    /// <summary>Reads the document again, discarding the working copy and any unsaved edit in it.</summary>
+    public Task ReloadAsync(CancellationToken cancellationToken = default) => _loadTask = LoadAsync(cancellationToken);
+
+    /// <summary>The element of the working copy with <paramref name="elementId"/>, or <see langword="null"/>.</summary>
+    public JsonObject? FindElement(string elementId) => Document == null ? null : BpmnDefinitionsDocument.FindElement(Document, elementId);
+
+    /// <summary>
+    /// Makes <paramref name="binding"/> the activity binding of the element with <paramref name="elementId"/> in the
+    /// working copy. Nothing else in the document changes, and nothing is sent until <see cref="SaveAsync"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The working copy has no such element.</exception>
+    public void SetBinding(string elementId, JsonObject binding)
+    {
+        var element = FindElement(elementId) ?? throw new InvalidOperationException($"The BPMN document has no element '{elementId}'.");
+
+        BpmnActivityBindingFormat.Attach(element, binding);
+        _editedElementIds.Add(elementId);
+        SaveFailure = null;
+    }
+
+    /// <summary>Throws away every unsaved edit, restoring the revision the server last returned.</summary>
+    public void Discard()
+    {
+        if (_revision != null)
+            Document = (JsonObject)_revision.Document.DeepClone();
+
+        _editedElementIds.Clear();
+        SaveFailure = null;
+    }
+
+    /// <summary>
+    /// Writes the working copy back through the document <c>PUT</c>, against the revision it was edited from, then reads
+    /// the document back so the session holds the server's own view and the new <c>ETag</c>.
+    /// </summary>
+    /// <returns>The server's result on success, or why the document was not saved.</returns>
+    public async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveAsync(CancellationToken cancellationToken = default)
+    {
+        if (Document == null || _revision == null)
+            return Refuse(new(BpmnDocumentFailureReason.Unknown, "The BPMN document has not been read, so there is nothing to save."));
+
+        if (SubProcessIds.Count > 0)
+        {
+            return Refuse(new(
+                BpmnDocumentFailureReason.SubProcessContentNotCarried,
+                $"The BPMN document declares the subprocess(es) {string.Join(", ", SubProcessIds.Select(id => $"'{id}'"))}, whose content the document does not carry, so saving it would empty them."));
+        }
+
+        var result = await TryAsync(() => bpmnInterchangeService.PutDocumentAsync(DefinitionId, Document, _revision.ETag, cancellationToken));
+
+        if (!result.IsSuccess)
+            return Refuse(result.Failure!);
+
+        await ReloadAsync(cancellationToken);
+        return result;
+    }
+
+    private async Task LoadAsync(CancellationToken cancellationToken)
+    {
+        var result = await TryAsync(() => bpmnInterchangeService.GetDocumentAsync(DefinitionId, cancellationToken));
+
+        _revision = result.Success;
+        Document = (JsonObject?)_revision?.Document.DeepClone();
+        SubProcessIds = _revision == null ? [] : BpmnDefinitionsDocument.FindSubProcessIds(_revision.Document);
+        LoadFailure = result.Failure;
+        SaveFailure = null;
+        _editedElementIds.Clear();
+    }
+
+    /// <summary>
+    /// Reports a request that never got an answer — the server unreachable, the connection dropped — as a failure the
+    /// section shows, rather than an exception that would take the whole editor down with it.
+    /// </summary>
+    private static async Task<Result<T, BpmnDocumentFailure>> TryAsync<T>(Func<Task<Result<T, BpmnDocumentFailure>>> request)
+    {
+        try
+        {
+            return await request();
+        }
+        catch (HttpRequestException exception)
+        {
+            return new(new BpmnDocumentFailure(BpmnDocumentFailureReason.Unknown, exception.Message));
+        }
+    }
+
+    private Result<BpmnDocumentSaveResult, BpmnDocumentFailure> Refuse(BpmnDocumentFailure failure)
+    {
+        SaveFailure = failure;
+        return new(failure);
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -34,6 +34,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     private readonly SortedSet<string> _editedElementIds = new(StringComparer.Ordinal);
     private BpmnDocumentRevision? _revision;
     private Task? _loadTask;
+    private Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>>? _saveTask;
     private bool _isSaving;
 
     /// <summary>The workflow definition whose document this is.</summary>
@@ -132,26 +133,41 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// set for the whole of that window, so an edit attempted while it runs is refused rather than silently lost to the
     /// reload; see <see cref="SetBinding"/>.
     /// </summary>
+    /// <remarks>
+    /// Single-flight: a call made while a save is already in flight does not send a second <c>PUT</c>. It returns the
+    /// same task as the call already running, so both callers observe the one save's outcome. This is exact, not a
+    /// lossy best-effort, because <see cref="SetBinding"/> refuses edits for as long as <see cref="IsSaving"/> is
+    /// <see langword="true"/>: the working copy cannot have changed since the in-flight <c>PUT</c> was sent, so there is
+    /// nothing a second <c>PUT</c> could carry that the first one does not already.
+    /// </remarks>
     /// <returns>The server's result on success, or why the document was not saved.</returns>
-    public async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveAsync(CancellationToken cancellationToken = default)
+    public Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveAsync(CancellationToken cancellationToken = default)
     {
+        if (_saveTask != null)
+            return _saveTask;
+
         if (Document == null || _revision == null)
-            return Refuse(new(BpmnDocumentFailureReason.Unknown, "The BPMN document has not been read, so there is nothing to save."));
+            return Task.FromResult(Refuse(new(BpmnDocumentFailureReason.Unknown, "The BPMN document has not been read, so there is nothing to save.")));
 
         if (SubProcessIds.Count > 0)
         {
-            return Refuse(new(
+            return Task.FromResult(Refuse(new(
                 BpmnDocumentFailureReason.SubProcessContentNotCarried,
-                $"The BPMN document declares the subprocess(es) {string.Join(", ", SubProcessIds.Select(id => $"'{id}'"))}, whose content the document does not carry, so saving it would empty them."));
+                $"The BPMN document declares the subprocess(es) {string.Join(", ", SubProcessIds.Select(id => $"'{id}'"))}, whose content the document does not carry, so saving it would empty them.")));
         }
 
+        return _saveTask = SaveCoreAsync(Document, _revision, cancellationToken);
+    }
+
+    private async Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveCoreAsync(JsonObject document, BpmnDocumentRevision revision, CancellationToken cancellationToken)
+    {
         SavedButReloadFailed = false;
         _isSaving = true;
         Changed?.Invoke();
 
         try
         {
-            var result = await TryAsync(() => bpmnInterchangeService.PutDocumentAsync(DefinitionId, Document, _revision.ETag, cancellationToken));
+            var result = await TryAsync(() => bpmnInterchangeService.PutDocumentAsync(DefinitionId, document, revision.ETag, cancellationToken));
 
             if (!result.IsSuccess)
                 return Refuse(result.Failure!);
@@ -166,6 +182,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
         finally
         {
             _isSaving = false;
+            _saveTask = null;
             Changed?.Invoke();
         }
     }
@@ -182,6 +199,12 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// <returns><see langword="true"/> if <see cref="SaveAsync"/> may proceed; otherwise the refusal is in <see cref="SaveFailure"/>.</returns>
     public async Task<bool> RefreshRevisionAfterOrdinarySaveAsync(CancellationToken cancellationToken = default)
     {
+        // A save already in flight will itself re-read the document and adopt the revision it finds; racing a second
+        // read against that PUT could compare against a revision the PUT is about to make stale, and refuse this save
+        // for a change nobody but the in-flight save itself made. Waiting for it first compares against what it left.
+        if (_saveTask != null)
+            await _saveTask;
+
         if (Document == null || _revision == null)
             return false;
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -143,7 +143,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// <returns>The server's result on success, or why the document was not saved.</returns>
     public Task<Result<BpmnDocumentSaveResult, BpmnDocumentFailure>> SaveAsync(CancellationToken cancellationToken = default)
     {
-        if (_saveTask != null)
+        if (_saveTask is { IsCompleted: false })
             return _saveTask;
 
         if (Document == null || _revision == null)
@@ -202,7 +202,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
         // A save already in flight will itself re-read the document and adopt the revision it finds; racing a second
         // read against that PUT could compare against a revision the PUT is about to make stale, and refuse this save
         // for a change nobody but the in-flight save itself made. Waiting for it first compares against what it left.
-        if (_saveTask != null)
+        if (_saveTask is { IsCompleted: false })
             await _saveTask;
 
         if (Document == null || _revision == null)

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -39,6 +39,13 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// <summary>The workflow definition whose document this is.</summary>
     public string DefinitionId { get; } = definitionId;
 
+    /// <summary>
+    /// Raised whenever <see cref="IsSaving"/> flips, so a component holding this session across an <see langword="await"/>
+    /// — one that would otherwise not re-render until the whole operation that changed it has finished — can answer with
+    /// its own <c>InvokeAsync(StateHasChanged)</c> and show the saving state while it is current.
+    /// </summary>
+    public event Action? Changed;
+
     /// <summary>The working copy, with every unsaved edit applied, or <see langword="null"/> until a read succeeds.</summary>
     public JsonObject? Document { get; private set; }
 
@@ -88,20 +95,24 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// Makes <paramref name="binding"/> the activity binding of the element with <paramref name="elementId"/> in the
     /// working copy. Nothing else in the document changes, and nothing is sent until <see cref="SaveAsync"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// The working copy has no such element, or a save is in flight (<see cref="IsSaving"/>): the document just sent is
-    /// being read back, and an edit applied to it now would be overwritten by that read without ever being saved.
-    /// </exception>
-    public void SetBinding(string elementId, JsonObject binding)
+    /// <returns>
+    /// <see langword="false"/>, leaving the working copy unchanged, while a save is in flight (<see cref="IsSaving"/>):
+    /// the document just sent is being read back, and an edit applied to it now would be overwritten by that read
+    /// without ever being saved. The UI is expected to disable editing for that window; this is only the backstop for
+    /// an edit that reaches the session anyway. Otherwise <see langword="true"/>.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">The working copy has no element with <paramref name="elementId"/>.</exception>
+    public bool SetBinding(string elementId, JsonObject binding)
     {
         if (_isSaving)
-            throw new InvalidOperationException("The BPMN document is being saved, so its binding cannot be changed until the save finishes.");
+            return false;
 
         var element = FindElement(elementId) ?? throw new InvalidOperationException($"The BPMN document has no element '{elementId}'.");
 
         BpmnActivityBindingFormat.Attach(element, binding);
         _editedElementIds.Add(elementId);
         SaveFailure = null;
+        return true;
     }
 
     /// <summary>Throws away every unsaved edit, restoring the revision the server last returned.</summary>
@@ -136,6 +147,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
 
         SavedButReloadFailed = false;
         _isSaving = true;
+        Changed?.Invoke();
 
         try
         {
@@ -154,6 +166,7 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
         finally
         {
             _isSaving = false;
+            Changed?.Invoke();
         }
     }
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
@@ -87,28 +87,32 @@
                             <MudSpacer />
                             @if (CanEdit)
                             {
-                                <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="OnPickActivityClicked" data-testid="bpmn-pick-activity">@(BoundActivityName == null ? Localizer["Choose activity"] : Localizer["Change activity"])</MudButton>
+                                <MudButton Variant="Variant.Outlined" Size="Size.Small" Disabled="Session.IsSaving" OnClick="OnPickActivityClicked" data-testid="bpmn-pick-activity">@(BoundActivityName == null ? Localizer["Choose activity"] : Localizer["Change activity"])</MudButton>
                             }
                         </MudStack>
 
-                        @if (!CanEdit)
+                        @if (CanEdit)
                         {
-                            @* Nothing is offered that could not be saved; the alert above says why. *@
-                        }
-                        else if (_draft != null)
-                        {
-                            @if (_draft.Descriptor.Inputs.Any(input => input.IsBrowsable != false))
+                            @if (Session.IsSaving)
                             {
-                                <InputsTab @key="_draftGeneration" WorkflowDefinition="WorkflowDefinition" Activity="_draft.Activity" ActivityDescriptor="_draft.Descriptor" OnActivityUpdated="OnDraftUpdatedAsync" />
+                                @* The document just sent is being read back; editing it now could be lost to that reload. *@
+                                <MudText Typo="Typo.body2" data-testid="bpmn-saving">@Localizer["Saving…"]</MudText>
                             }
-                            else
+                            else if (_draft != null)
                             {
-                                <MudText Typo="Typo.body2">@Localizer["This activity does not have any input properties."]</MudText>
+                                @if (_draft.Descriptor.Inputs.Any(input => input.IsBrowsable != false))
+                                {
+                                    <InputsTab @key="_draftGeneration" WorkflowDefinition="WorkflowDefinition" Activity="_draft.Activity" ActivityDescriptor="_draft.Descriptor" OnActivityUpdated="OnDraftUpdatedAsync" />
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.body2">@Localizer["This activity does not have any input properties."]</MudText>
+                                }
                             }
-                        }
-                        else if (_binding != null)
-                        {
-                            <MudAlert Severity="Severity.Warning" data-testid="bpmn-activity-type-unavailable">@Localizer["The activity type '{0}' is not available in this Studio, so its inputs cannot be edited here.", _binding.ActivityType]</MudAlert>
+                            else if (_binding != null)
+                            {
+                                <MudAlert Severity="Severity.Warning" data-testid="bpmn-activity-type-unavailable">@Localizer["The activity type '{0}' is not available in this Studio, so its inputs cannot be edited here.", _binding.ActivityType]</MudAlert>
+                            }
                         }
                     }
                 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
@@ -1,0 +1,118 @@
+@using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.ActivityProperties.Tabs
+@using Elsa.Studio.Workflows.Domain.Models.Bpmn
+@using Variant = MudBlazor.Variant
+@inherits StudioComponentBase
+@inject ILocalizer Localizer
+
+<CascadingValue Value="_expressionDescriptorProvider">
+    <ScrollableWell MaxHeight="VisiblePaneHeight">
+        <MudStack Spacing="2" data-testid="bpmn-performed-by">
+            @if (Session.IsLoading)
+            {
+                <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+            }
+
+            @if (Session.LoadFailure is { } loadFailure)
+            {
+                <MudAlert Severity="Severity.Warning" data-testid="bpmn-document-load-failure">@DescribeLoadFailure(loadFailure)</MudAlert>
+            }
+
+            @if (Session.SubProcessIds.Count > 0)
+            {
+                <MudAlert Severity="Severity.Info" data-testid="bpmn-document-subprocesses">@Localizer["This process contains subprocesses ({0}). Studio cannot yet save its BPMN document without emptying them, so its bindings are shown here but cannot be saved.", string.Join(", ", Session.SubProcessIds)]</MudAlert>
+            }
+
+            @if (Session.SaveFailure is { } saveFailure)
+            {
+                <MudAlert Severity="Severity.Error" data-testid="bpmn-document-save-failure">@DescribeSaveFailure(saveFailure)</MudAlert>
+            }
+
+            @if (Session.LoadFailure != null || Session.SaveFailure?.Reason is BpmnDocumentFailureReason.PreconditionFailed or BpmnDocumentFailureReason.PreconditionRequired)
+            {
+                <div>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="OnReloadClicked" data-testid="bpmn-reload">@Localizer["Reload"]</MudButton>
+                </div>
+            }
+
+            @if (Session.IsDirty)
+            {
+                <MudStack Row="true" AlignItems="MudBlazor.AlignItems.Center" data-testid="bpmn-unsaved">
+                    <MudText Typo="Typo.body2">@Localizer["Unsaved binding changes"]</MudText>
+                    <MudSpacer />
+                    <MudButton Variant="Variant.Text" Size="Size.Small" Disabled="_isSaving" OnClick="OnDiscardClicked" data-testid="bpmn-discard">@Localizer["Discard"]</MudButton>
+                    <MudButton Variant="Variant.Filled" Size="Size.Small" Color="Color.Primary" Disabled="@(_isSaving || Session.SubProcessIds.Count > 0)" OnClick="OnSaveClicked" data-testid="bpmn-save">@Localizer["Save"]</MudButton>
+                </MudStack>
+            }
+
+            @if (Selection == null)
+            {
+                <MudText Typo="Typo.body2">@Localizer["Select a task on the canvas to choose the activity that performs it."]</MudText>
+            }
+            else if (Selection.BindingKind == null)
+            {
+                <MudText Typo="Typo.body2" data-testid="bpmn-no-work">@Localizer["'{0}' performs no work, so no activity is bound to it.", ElementLabel]</MudText>
+            }
+            else
+            {
+                <div>
+                    <MudText Typo="Typo.h6">@Localizer["Performed by"]</MudText>
+                    <MudText Typo="Typo.caption">@ElementLabel · @Selection.ElementType</MudText>
+                </div>
+
+                @if (!Selection.IsUnboundTask)
+                {
+                    <MudText data-testid="bpmn-bound-activity">@(DescribeActivity(GraphBoundActivity) ?? Localizer["Not bound"])</MudText>
+                    <MudText Typo="Typo.body2" data-testid="bpmn-automatic-binding">@Localizer["The BPMN document binds this element automatically, so its activity cannot be changed here."]</MudText>
+                }
+                else if (Session.Document == null)
+                {
+                    @* Without a document there is nothing to edit; say what the graph binds, and let the alert above say why. *@
+                    <MudText data-testid="bpmn-bound-activity">@(DescribeActivity(GraphBoundActivity) ?? Localizer["Not bound"])</MudText>
+                }
+                else
+                {
+                    @if (_element == null)
+                    {
+                        <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-not-in-document">@Localizer["'{0}' is not part of this workflow's BPMN document, so its binding cannot be edited here.", ElementLabel]</MudAlert>
+                    }
+                    else
+                    {
+                        @if (_bindingError != null)
+                        {
+                            <MudAlert Severity="Severity.Error" data-testid="bpmn-binding-unreadable">@Localizer["The binding the document declares for this task cannot be read: {0}", _bindingError]</MudAlert>
+                        }
+
+                        <MudStack Row="true" AlignItems="MudBlazor.AlignItems.Center">
+                            <MudText data-testid="bpmn-bound-activity">@(BoundActivityName ?? Localizer["Not bound"])</MudText>
+                            <MudSpacer />
+                            @if (CanEdit)
+                            {
+                                <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="OnPickActivityClicked" data-testid="bpmn-pick-activity">@(BoundActivityName == null ? Localizer["Choose activity"] : Localizer["Change activity"])</MudButton>
+                            }
+                        </MudStack>
+
+                        @if (!CanEdit)
+                        {
+                            @* Nothing is offered that could not be saved; the alert above says why. *@
+                        }
+                        else if (_draft != null)
+                        {
+                            @if (_draft.Descriptor.Inputs.Any(input => input.IsBrowsable != false))
+                            {
+                                <InputsTab @key="_draftGeneration" WorkflowDefinition="WorkflowDefinition" Activity="_draft.Activity" ActivityDescriptor="_draft.Descriptor" OnActivityUpdated="OnDraftUpdatedAsync" />
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.body2">@Localizer["This activity does not have any input properties."]</MudText>
+                            }
+                        }
+                        else if (_binding != null)
+                        {
+                            <MudAlert Severity="Severity.Warning" data-testid="bpmn-activity-type-unavailable">@Localizer["The activity type '{0}' is not available in this Studio, so its inputs cannot be edited here.", _binding.ActivityType]</MudAlert>
+                        }
+                    }
+                }
+            }
+        </MudStack>
+    </ScrollableWell>
+</CascadingValue>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
@@ -100,7 +100,7 @@
                             }
                             else if (_draft != null)
                             {
-                                @if (_draft.Descriptor.Inputs.Any(input => input.IsBrowsable != false))
+                                @if (_draft.Descriptor.Inputs.Any(input => input.IsBrowsable is not false))
                                 {
                                     <InputsTab @key="_draftGeneration" WorkflowDefinition="WorkflowDefinition" Activity="_draft.Activity" ActivityDescriptor="_draft.Descriptor" OnActivityUpdated="OnDraftUpdatedAsync" />
                                 }

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
@@ -1,0 +1,256 @@
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Workflows.Designer.Models;
+using Elsa.Studio.Workflows.DiagramDesigners.StateMachines.Presentation;
+using Elsa.Studio.Workflows.Domain.Contracts;
+using Elsa.Studio.Workflows.Domain.Models;
+using Elsa.Studio.Workflows.Domain.Models.Bpmn;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
+
+/// <summary>
+/// The "Performed by" section a BPMN-imported workflow's properties pane shows in place of the activity properties
+/// panel: for a task whose activity is authored on it, the activity picker and that activity's own input editors,
+/// written into the task's <c>elsa:activityBinding</c> in the workflow's BPMN document; for an element the document
+/// binds automatically, what it is bound to, read-only.
+/// </summary>
+/// <remarks>
+/// Every edit goes into <see cref="Session"/>'s working copy of the document and nowhere else. The activity the input
+/// editors edit is a draft of the panel's own (<see cref="BpmnActivityBindingDraft"/>), never a node of the workflow's
+/// activity graph, so nothing here can change the graph an ordinary workflow-definition save sends.
+/// </remarks>
+public partial class BpmnPerformedByPanel
+{
+    private readonly ExpressionDescriptorProvider _expressionDescriptorProvider = new();
+    private bool _isInitialized;
+    private string? _elementId;
+    private JsonObject? _element;
+    private BpmnActivityBinding? _binding;
+    private string? _bindingError;
+    private BpmnActivityBindingDraft? _draft;
+    private int _draftGeneration;
+    private bool _isSaving;
+
+    /// <summary>The workflow definition being edited, for input editors that read its variables.</summary>
+    [Parameter] public WorkflowDefinition? WorkflowDefinition { get; set; }
+
+    /// <summary>The workflow's root <c>Elsa.BpmnProcess</c> activity, to name what an element is bound to.</summary>
+    [Parameter] public JsonObject? RootActivity { get; set; }
+
+    /// <summary>The BPMN element selected on the canvas, or <see langword="null"/> when none is.</summary>
+    [Parameter] public BpmnElementSelection? Selection { get; set; }
+
+    /// <summary>The workflow's BPMN document, which every binding edit is written into.</summary>
+    [Parameter, EditorRequired] public BpmnDocumentSession Session { get; set; } = null!;
+
+    /// <summary>Invoked after the working copy of the document changed, so the editor can show it is unsaved.</summary>
+    [Parameter] public Func<Task>? DocumentChanged { get; set; }
+
+    /// <summary>Invoked to save the workflow, which is the only thing that writes the document back.</summary>
+    [Parameter] public Func<Task>? SaveRequested { get; set; }
+
+    /// <summary>Invoked to reload the workflow and its document from the server, discarding unsaved edits.</summary>
+    [Parameter] public Func<Task>? ReloadRequested { get; set; }
+
+    /// <summary>The visible height of the pane, in pixels.</summary>
+    [Parameter] public int VisiblePaneHeight { get; set; } = 300;
+
+    [Inject] private IActivityRegistry ActivityRegistry { get; set; } = null!;
+    [Inject] private IExpressionService ExpressionService { get; set; } = null!;
+    [Inject] private IDialogService DialogService { get; set; } = null!;
+
+    private string ElementLabel => string.IsNullOrWhiteSpace(Selection?.Name) ? Selection?.ElementId ?? string.Empty : Selection.Name;
+    /// <summary>The activity the workflow's graph binds the selected element to, as the server last delivered it.</summary>
+    private JsonObject? GraphBoundActivity => Selection?.ActivityId is { } activityId ? RootActivity?.FindActivity(activityId) : null;
+    private string? BoundActivityName => _draft != null ? DescribeDescriptor(_draft.Descriptor) : _binding?.ActivityType;
+
+    /// <summary>Whether a binding edit could be saved at all; while it could not, none is offered.</summary>
+    private bool CanEdit => Session.Document != null && Session.SubProcessIds.Count == 0;
+
+    /// <summary>
+    /// Leaf work: an activity that performs one unit of work itself. A container or a composite schedules other
+    /// activities, which a single BPMN task cannot hold.
+    /// </summary>
+    internal static bool IsLeafWork(ActivityDescriptor descriptor) =>
+        descriptor.IsBrowsable
+        && !descriptor.IsContainer
+        && descriptor.TypeName != BpmnProcessConstants.ActivityTypeName
+        && descriptor.Ports.All(port => port.Type != PortType.Embedded);
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        _expressionDescriptorProvider.AddRange(await ExpressionService.ListDescriptorsAsync());
+        await ActivityRegistry.EnsureLoadedAsync();
+        _isInitialized = true;
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnParametersSetAsync()
+    {
+        await Session.EnsureLoadedAsync();
+        SyncDraft();
+    }
+
+    /// <summary>
+    /// Re-reads the selected task's binding whenever the task, or the working copy it lives in, is a different one — a
+    /// new selection, a reload, a discard — and keeps the draft otherwise, so an edit in progress keeps its editors.
+    /// </summary>
+    private void SyncDraft()
+    {
+        var elementId = Selection is { IsUnboundTask: true } ? Selection.ElementId : null;
+        var element = elementId == null || !_isInitialized ? null : Session.FindElement(elementId);
+
+        if (elementId == _elementId && ReferenceEquals(element, _element))
+            return;
+
+        _elementId = elementId;
+        _element = element;
+        _binding = null;
+        _bindingError = null;
+        SetDraft(null);
+
+        if (element == null || BpmnActivityBindingFormat.Find(element) is not { } bindingElement)
+            return;
+
+        try
+        {
+            _binding = BpmnActivityBindingFormat.Read(bindingElement);
+        }
+        catch (BpmnActivityBindingFormatException exception)
+        {
+            _bindingError = exception.Message;
+            return;
+        }
+
+        if (LatestDescriptorOf(_binding.ActivityType) is { } descriptor)
+            SetDraft(BpmnActivityBindingDraft.FromBinding(_binding, descriptor, DraftActivityId()));
+    }
+
+    /// <summary>A binding names no version, and elsa-core builds the latest one it has, so that is the one to edit.</summary>
+    private ActivityDescriptor? LatestDescriptorOf(string activityType) => ActivityRegistry.FindAll(activityType).MaxBy(descriptor => descriptor.Version);
+
+    private void SetDraft(BpmnActivityBindingDraft? draft)
+    {
+        _draft = draft;
+        _draftGeneration++;
+    }
+
+    /// <summary>The id the input editors key the draft on: the bound activity's own, once there is one.</summary>
+    private string DraftActivityId() => Selection!.ActivityId ?? Selection.ElementId;
+
+    private async Task OnPickActivityClicked()
+    {
+        var parameters = new DialogParameters<StateMachineActivityPickerDialog>
+        {
+            { x => x.IsReplacing, BoundActivityName != null },
+            { x => x.DescriptorFilter, IsLeafWork },
+            { x => x.ContextLabel, Localizer["PERFORMED BY"].Value },
+            { x => x.ContextHint, Localizer["Runs when the process reaches '{0}'", ElementLabel].Value }
+        };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            CloseButton = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Large
+        };
+
+        var dialog = await DialogService.ShowAsync<StateMachineActivityPickerDialog>(Localizer["Choose the activity that performs this task"], parameters, options);
+        var result = await dialog.Result;
+
+        // Nothing changes until the picker returns an explicit choice: cancelling keeps the existing binding as it is.
+        if (result is not { Canceled: false, Data: ActivityDescriptor descriptor } || _element == null)
+            return;
+
+        _binding = null;
+        _bindingError = null;
+        SetDraft(BpmnActivityBindingDraft.Create(LatestDescriptorOf(descriptor.TypeName) ?? descriptor, DraftActivityId()));
+        await ApplyDraftAsync();
+    }
+
+    private Task OnDraftUpdatedAsync(JsonObject activity) => ApplyDraftAsync();
+
+    private async Task ApplyDraftAsync()
+    {
+        Session.SetBinding(_elementId!, _draft!.ToBinding());
+
+        if (DocumentChanged != null)
+            await DocumentChanged();
+
+        StateHasChanged();
+    }
+
+    private async Task OnSaveClicked()
+    {
+        _isSaving = true;
+
+        try
+        {
+            if (SaveRequested != null)
+                await SaveRequested();
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task OnDiscardClicked()
+    {
+        Session.Discard();
+        SyncDraft();
+
+        if (DocumentChanged != null)
+            await DocumentChanged();
+    }
+
+    private async Task OnReloadClicked()
+    {
+        if (ReloadRequested != null)
+            await ReloadRequested();
+    }
+
+    private string? DescribeActivity(JsonObject? activity)
+    {
+        if (activity == null)
+            return null;
+
+        var typeName = activity.GetTypeName();
+        var name = activity.GetName();
+
+        if (!string.IsNullOrWhiteSpace(name))
+            return $"{name} ({typeName})";
+
+        return ActivityRegistry.Find(typeName, activity.GetVersion()) is { } descriptor ? DescribeDescriptor(descriptor) : typeName;
+    }
+
+    private string DescribeDescriptor(ActivityDescriptor descriptor) => $"{Localizer[descriptor.DisplayName ?? descriptor.Name]} ({descriptor.TypeName})";
+
+    private string DescribeLoadFailure(BpmnDocumentFailure failure) => failure.Reason switch
+    {
+        BpmnDocumentFailureReason.SourceStale => Localizer["This workflow was changed outside its BPMN document since it was imported, so the document no longer describes it. Import the BPMN file into this workflow again to edit its bindings."],
+        BpmnDocumentFailureReason.NotImportedFromBpmn => Localizer["This workflow has no BPMN document to edit: it was not imported from BPMN, or a later save removed the document."],
+        BpmnDocumentFailureReason.MissingETag => Localizer["The server returned the BPMN document without an ETag, so a binding change could not be saved. If Studio runs on a different origin than the server, the server's CORS policy must expose the ETag header."],
+        BpmnDocumentFailureReason.NotFound => Localizer["This workflow definition no longer exists."],
+        _ => Localizer["The BPMN document could not be read: {0}", failure.Message]
+    };
+
+    private string DescribeSaveFailure(BpmnDocumentFailure failure) => failure.Reason switch
+    {
+        BpmnDocumentFailureReason.PreconditionFailed => Localizer["This workflow was changed since its BPMN document was read, by another save or another user, so the binding changes were not saved. Reload to continue from the current version; unsaved binding changes will be lost."],
+        BpmnDocumentFailureReason.PreconditionRequired => Localizer["The server refused the save because it did not name the revision it replaces, so nothing was saved. Reload and make the change again."],
+        BpmnDocumentFailureReason.BindingInvalid => Localizer["The server refused the binding of {0}, so nothing was saved: {1}", string.Join(", ", Session.EditedElementIds.Select(id => $"'{id}'")), failure.Message],
+        BpmnDocumentFailureReason.CapabilityUnsupported => Localizer["The server cannot run this process, so nothing was saved: {0}", failure.Message],
+        BpmnDocumentFailureReason.SubProcessContentNotCarried => Localizer["Nothing was saved: this process contains subprocesses, and saving its BPMN document from Studio would empty them."],
+        BpmnDocumentFailureReason.NotFound => Localizer["This workflow definition no longer exists."],
+        _ => Localizer["The binding changes could not be saved: {0}", failure.Message]
+    };
+}

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
@@ -26,7 +26,7 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 /// editors edit is a draft of the panel's own (<see cref="BpmnActivityBindingDraft"/>), never a node of the workflow's
 /// activity graph, so nothing here can change the graph an ordinary workflow-definition save sends.
 /// </remarks>
-public partial class BpmnPerformedByPanel
+public partial class BpmnPerformedByPanel : IDisposable
 {
     private readonly ExpressionDescriptorProvider _expressionDescriptorProvider = new();
     private bool _isInitialized;
@@ -37,6 +37,7 @@ public partial class BpmnPerformedByPanel
     private BpmnActivityBindingDraft? _draft;
     private int _draftGeneration;
     private bool _isSaving;
+    private BpmnDocumentSession? _subscribedSession;
 
     /// <summary>The workflow definition being edited, for input editors that read its variables.</summary>
     [Parameter] public WorkflowDefinition? WorkflowDefinition { get; set; }
@@ -95,8 +96,36 @@ public partial class BpmnPerformedByPanel
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
+        SubscribeToSession();
         await Session.EnsureLoadedAsync();
         SyncDraft();
+    }
+
+    /// <summary>
+    /// Keeps the panel subscribed to <see cref="Session"/>'s <see cref="BpmnDocumentSession.Changed"/> event, so it
+    /// re-renders while a save is in flight rather than only before and after — an editor around it that shows progress
+    /// with a single <c>StateHasChanged</c> before and after the whole save would otherwise never render the window
+    /// where <see cref="BpmnDocumentSession.IsSaving"/> is <see langword="true"/>.
+    /// </summary>
+    private void SubscribeToSession()
+    {
+        if (ReferenceEquals(_subscribedSession, Session))
+            return;
+
+        if (_subscribedSession != null)
+            _subscribedSession.Changed -= OnSessionChanged;
+
+        Session.Changed += OnSessionChanged;
+        _subscribedSession = Session;
+    }
+
+    private void OnSessionChanged() => InvokeAsync(StateHasChanged);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_subscribedSession != null)
+            _subscribedSession.Changed -= OnSessionChanged;
     }
 
     /// <summary>
@@ -180,7 +209,11 @@ public partial class BpmnPerformedByPanel
 
     private async Task ApplyDraftAsync()
     {
-        Session.SetBinding(_elementId!, _draft!.ToBinding());
+        // The UI already disables editing while Session.IsSaving; this is only the backstop for an edit — a debounced
+        // input, a pending dialog result — that reaches here anyway. It is simply dropped: the working copy did not
+        // change, and the section already shows the saving state instead of the editors that produced it.
+        if (!Session.SetBinding(_elementId!, _draft!.ToBinding()))
+            return;
 
         if (DocumentChanged != null)
             await DocumentChanged();

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/StateMachines/Presentation/StateMachineActivityPickerDialog.razor.cs
@@ -36,6 +36,19 @@ public partial class StateMachineActivityPickerDialog
     [Parameter] public bool IsReplacing { get; set; }
     [Parameter] public IReadOnlyCollection<string> RecentActivityTypes { get; set; } = [];
 
+    /// <summary>
+    /// Restricts the offered activities to the descriptors this predicate accepts, in place of the default set (every
+    /// browsable activity plus the designer-backed root activities). Lets a host other than the StateMachine designer
+    /// reuse this picker for a narrower purpose — the BPMN "Performed by" section offers only leaf work.
+    /// </summary>
+    [Parameter] public Func<ActivityDescriptor, bool>? DescriptorFilter { get; set; }
+
+    /// <summary>Replaces the short context label derived from <see cref="SlotName"/> (e.g. <c>THEN</c>).</summary>
+    [Parameter] public string? ContextLabel { get; set; }
+
+    /// <summary>Replaces the context sentence derived from <see cref="SlotName"/> (e.g. <c>Runs after source exit</c>).</summary>
+    [Parameter] public string? ContextHint { get; set; }
+
     private string SearchInputId => $"{_id}-search";
     private string ResultsId => $"{_id}-results";
     private string DetailsId => $"{_id}-details";
@@ -50,14 +63,14 @@ public partial class StateMachineActivityPickerDialog
         "trigger" => Localizer["trigger"],
         _ => Localizer["action"]
     };
-    private string ContextKicker => SlotName.ToLowerInvariant() switch
+    private string ContextKicker => ContextLabel ?? SlotName.ToLowerInvariant() switch
     {
         "entry" => Localizer["ON ENTRY"],
         "exit" => Localizer["ON EXIT"],
         "trigger" => Localizer["WHEN"],
         _ => Localizer["THEN"]
     };
-    private string ContextDescription => SlotName.ToLowerInvariant() switch
+    private string ContextDescription => ContextHint ?? SlotName.ToLowerInvariant() switch
     {
         "entry" => Localizer["Runs when this state becomes active"],
         "exit" => Localizer["Runs before an accepted transition leaves this state"],
@@ -130,8 +143,11 @@ public partial class StateMachineActivityPickerDialog
                 .ToHashSet(StringComparer.Ordinal);
             var designerBackedRoots = allDescriptors.Where(x => _rootActivityTypeNames.Contains(x.TypeName));
 
-            _descriptors = browsableDescriptors
-                .Concat(designerBackedRoots)
+            var offeredDescriptors = DescriptorFilter != null
+                ? allDescriptors.Where(DescriptorFilter)
+                : browsableDescriptors.Concat(designerBackedRoots);
+
+            _descriptors = offeredDescriptors
                 .DistinctBy(x => x.TypeName, StringComparer.Ordinal)
                 .OrderBy(GetDisplayName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Closes #1001. Part of elsa-workflows/elsa-core#7909 (W11, D5). Builds on elsa-workflows/elsa-core#8060 (document GET/PUT), #8063 (PUT preserves metadata), #8065 (content-based staleness), #8067 (refusal codes), and Studio #1029.

## What changed

A BPMN task can now be bound to the Elsa activity that performs it without hand-editing XML.

- **Performed by.** Selecting an authored task (`task`, `serviceTask`, `userTask`, `scriptTask`, `manualTask`, `businessRuleTask`, `sendTask`, and a `receiveTask` that names no message, following the library reader's own rule) shows a Performed-by section in place of the activity properties panel. The existing activity picker is filtered to leaf work, and the picked activity's own input editors render inline, exactly as in the flowchart panel. Elements the binder binds automatically (timers, message and signal waits, message publish, call activities, subprocesses) show their binding read-only.
- **Written into the document, in place.** The section edits a working copy of the whole `bpmnDefinitions` document fetched with `GET bpmn/definitions/{id}/document`. It sets only that element's `elsa:activityBinding`, in the exact format elsa-core's `BpmnActivityBindingFormat` reads. Input JSON is what the flowchart's input editors already produce; there is no second encoder. A test compares the document before and after: only the target element's extension changes.
- **Saved only through the document PUT.** Save, including toolbar Save and Ctrl+S, sends the document with `If-Match` set to the ETag it was read at, then reloads the definition. For a BPMN-imported workflow, `WorkflowEditor` never reads the designer into an ordinary save. It refuses any ordinary save whose root differs from the one the server last delivered, so a graph change cannot slip through the ordinary save and make the document stale. Property-only saves (name, variables) still go through the ordinary path. Publishing with unsaved binding changes is refused.
- **Refusals.** A `412` keeps the working copy, explains that someone else changed the workflow, and offers Reload with no blind retry. A `428` shows a message and Reload. A `422 bpmn.import.binding-invalid` shows the server's message against the edited tasks. A GET `422` for a stale source explains that the workflow must be re-imported and offers no editing.
- Client: `IBpmnInterchangeApi` / `IBpmnInterchangeService` gain the document GET and PUT with `ETag` / `If-Match`.

## Known limitations

- **Documents with subprocesses are read-only in Studio.** elsa-core's document GET/PUT currently drops the content of subprocesses, transactions and event subprocesses: the document JSON lists only top-level processes, and nested bodies are not written back. Studio refuses to PUT such a document before sending anything, and explains why. The core fix is filed and is next in this run.
- **Publish-gate element ids are not clickable.** W8 sends them only in message text, so the server's messages are shown as they are. Making them clickable needs the ids as structured data from core.
- Out of scope: the optional vendor-extension suggestion on import, visual editing (W14), and whether import accepts unbound tasks (a pending maintainer decision; a save can never leave a task unbound).

## Verification

```
cd src/modules/Elsa.Studio.Workflows.Designer/ClientLib && npm run check:generated && npm test && npm run build   # 253/253
dotnet build Elsa.Studio.sln --configuration Release                                                                   # 0 errors
dotnet test src/modules/Elsa.Studio.Workflows.Tests --configuration Release --no-build --framework net10.0            # 434/434
dotnet test src/modules/Elsa.Studio.Workflows.Designer.Tests --configuration Release --no-build --framework net10.0   # 83/83
```

Tests cover:

- The ordinary editor save is never called for a binding edit on a BPMN root; disabling the guard fails 5 of 11 routing tests.
- The PUT carries the GET's ETag.
- Only the target element's extension changes.
- An `Input<string>` expression and a plain `[Input]` collection round-trip through the binding format.
- Each refusal produces its UI outcome.
- The subprocess refusal happens before any request is sent.
- A reload follows a successful PUT.

Offline, the real Bpmn.Interchange 0.2.0 reader and writer show a Studio-written binding reads back intact with the Camunda extensions untouched. The live end-to-end run against the sample server follows after merge.

Review: two iterations on the standards and spec axes. Resolved: a duplicate activity-tree lookup and a third copy of test stubs, now one shared set. Won't-fix: `receiveTask` is included, per the library's rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
