### PR TITLE
feat(workflows): save BPMN documents with subprocesses

### DIFF
--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
@@ -11,9 +11,6 @@ namespace Elsa.Studio.Workflows.Domain.Models.Bpmn;
 /// </summary>
 public static class BpmnDefinitionsDocument
 {
-    /// <summary>The <c>elementType</c> of an embedded subprocess, a transaction and an event subprocess alike.</summary>
-    public const string SubProcessElementType = "subProcess";
-
     /// <summary>
     /// The BPMN element with <paramref name="elementId"/>, from any process's <c>elements</c>, or
     /// <see langword="null"/> when the document has none.
@@ -21,26 +18,11 @@ public static class BpmnDefinitionsDocument
     /// <remarks>
     /// Only the elements of the document's own <c>&lt;process&gt;</c> elements are here. The body of a subprocess is
     /// not part of this document at all — <c>Bpmn.Interchange</c>'s reader carries it only in the work bindings it
-    /// returns alongside, which the document endpoints do not send — so an element inside one is never found; see
-    /// <see cref="FindSubProcessIds"/>.
+    /// returns alongside, which the document endpoints do not send — so an element inside one is never found. Editing
+    /// such an element is a server limitation, tracked in elsa-workflows/elsa-core#8076.
     /// </remarks>
     public static JsonObject? FindElement(JsonObject document, string elementId) =>
         Elements(document).FirstOrDefault(element => element["elementId"]?.GetValue<string>() == elementId);
-
-    /// <summary>
-    /// The id of every subprocess — embedded, transaction or event subprocess — the document's processes declare.
-    /// </summary>
-    /// <remarks>
-    /// Writing such a document back through the document <c>PUT</c> loses every one of these bodies: the body is not
-    /// in the document (see <see cref="FindElement"/>), and elsa-core writes the XML from the document alone, which
-    /// <c>BpmnXmlWriter</c> documents as writing each subprocess empty. A caller that would <c>PUT</c> must refuse
-    /// while this is non-empty rather than discard the content silently.
-    /// </remarks>
-    public static IReadOnlyList<string> FindSubProcessIds(JsonObject document) =>
-        Elements(document)
-            .Where(element => element["elementType"]?.GetValue<string>() == SubProcessElementType)
-            .Select(element => element["elementId"]?.GetValue<string>() ?? string.Empty)
-            .ToList();
 
     private static IEnumerable<JsonObject> Elements(JsonObject document) =>
         (document["processes"] as JsonArray ?? [])

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDefinitionsDocument.cs
@@ -24,6 +24,16 @@ public static class BpmnDefinitionsDocument
     public static JsonObject? FindElement(JsonObject document, string elementId) =>
         Elements(document).FirstOrDefault(element => element["elementId"]?.GetValue<string>() == elementId);
 
+    /// <summary>
+    /// Whether <paramref name="processId"/> names one of the document's own <c>&lt;process&gt;</c> elements — the
+    /// scope a top-level BPMN element lives in — rather than a nested one (a subprocess, transaction, or event
+    /// subprocess), whose id never appears here because its body is not part of this document at all.
+    /// </summary>
+    public static bool HasTopLevelProcess(JsonObject document, string processId) =>
+        (document["processes"] as JsonArray ?? [])
+        .OfType<JsonObject>()
+        .Any(process => process["processId"]?.GetValue<string>() == processId);
+
     private static IEnumerable<JsonObject> Elements(JsonObject document) =>
         (document["processes"] as JsonArray ?? [])
         .OfType<JsonObject>()

--- a/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentFailure.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Domain/Models/Bpmn/BpmnDocumentFailure.cs
@@ -54,13 +54,6 @@ public enum BpmnDocumentFailureReason
     /// </summary>
     MissingETag,
 
-    /// <summary>
-    /// Refused by Studio before anything was sent: the document declares a subprocess, whose body the document does
-    /// not carry, so a <c>PUT</c> would have the server write that subprocess empty. See
-    /// <see cref="BpmnDefinitionsDocument.FindSubProcessIds"/>.
-    /// </summary>
-    SubProcessContentNotCarried,
-
     /// <summary>Any other failure; <see cref="BpmnDocumentFailure.Message"/> carries the server's own message.</summary>
     Unknown
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
@@ -157,5 +157,4 @@ public class BpmnActivityBindingFormatTests
         Assert.Same(Task, BpmnDefinitionsDocument.FindElement(_document, BpmnDocumentFixtures.TaskId));
         Assert.Null(BpmnDefinitionsDocument.FindElement(_document, "Nope"));
     }
-
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnActivityBindingFormatTests.cs
@@ -158,13 +158,4 @@ public class BpmnActivityBindingFormatTests
         Assert.Null(BpmnDefinitionsDocument.FindElement(_document, "Nope"));
     }
 
-    [Fact]
-    public void FindSubProcessIds_ReportsEverySubprocess_AndNoneForAFlatProcess()
-    {
-        Assert.Empty(BpmnDefinitionsDocument.FindSubProcessIds(_document));
-
-        ((JsonArray)_document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = BpmnDefinitionsDocument.SubProcessElementType });
-
-        Assert.Equal(["Fulfil"], BpmnDefinitionsDocument.FindSubProcessIds(_document));
-    }
 }

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnDocumentSessionTests.cs
@@ -9,9 +9,8 @@ namespace Elsa.Studio.Workflows.Tests;
 
 /// <summary>
 /// Covers <see cref="BpmnDocumentSession"/>: a binding edit is written back only through the document PUT, carrying the
-/// ETag of the revision it was made in; a refusal is reported and never retried; and a document whose subprocess bodies
-/// the PUT would empty is refused before anything is sent — in both directions, since a save that silently went through
-/// looks exactly like one that worked.
+/// ETag of the revision it was made in; a refusal is reported and never retried; and a document that declares a
+/// subprocess is saved like any other, since elsa-core keeps its body across the PUT.
 /// </summary>
 public class BpmnDocumentSessionTests
 {
@@ -61,7 +60,7 @@ public class BpmnDocumentSessionTests
     }
 
     [Fact]
-    public async Task SaveAsync_RefusesADocumentWithASubprocess_WithoutSendingIt()
+    public async Task SaveAsync_SendsADocumentWithASubprocess()
     {
         var document = Document();
         ((JsonArray)document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = "subProcess" });
@@ -72,9 +71,8 @@ public class BpmnDocumentSessionTests
 
         var result = await session.SaveAsync();
 
-        Assert.Equal(BpmnDocumentFailureReason.SubProcessContentNotCarried, result.Failure!.Reason);
-        Assert.Empty(service.Puts);
-        Assert.Equal(["Fulfil"], session.SubProcessIds);
+        Assert.True(result.IsSuccess);
+        Assert.Single(service.Puts);
     }
 
     [Fact]

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -314,9 +314,27 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
     [Fact]
     public void AnElementInsideASubprocess_IsStillNotEditable_AndNamesTheCoreLimitation()
     {
-        var cut = RenderPanel(TaskSelection with { ElementId = "InsideASubprocess" });
+        var cut = RenderPanel(TaskSelection with { ElementId = "InsideASubprocess", ScopeId = "Fulfil", ScopeActivityId = "order-process:node-Fulfil" });
 
         Assert.Contains("elsa-core#8076", cut.Find("[data-testid='bpmn-element-not-in-document']").TextContent);
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+    }
+
+    /// <summary>
+    /// An element missing from the document is not always one the document never carries because it lives in a
+    /// subprocess: the canvas and the document can simply be out of step (a stale or unknown id). When the selection's
+    /// own scope is one of the document's top-level processes, that is what this is, and elsa-core#8076 — which is
+    /// about content the document never carries at all — does not apply.
+    /// </summary>
+    [Fact]
+    public void AnUnknownElementInATopLevelScope_SaysTheDocumentDoesNotHaveIt_WithoutBlamingTheSubprocessLimitation()
+    {
+        var cut = RenderPanel(TaskSelection with { ElementId = "StaleElementId" });
+
+        var alert = cut.Find("[data-testid='bpmn-element-missing']").TextContent;
+        Assert.Contains("not in the BPMN document", alert);
+        Assert.DoesNotContain("elsa-core#8076", alert);
+        Assert.Empty(cut.FindAll("[data-testid='bpmn-element-not-in-document']"));
         Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
     }
 

--- a/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/BpmnPerformedByPanelTests.cs
@@ -293,26 +293,30 @@ public sealed class BpmnPerformedByPanelTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void ADocumentWithASubprocess_SaysWhy_AndOffersNoEditItCouldNotSave()
+    public async Task ADocumentWithASubprocess_StillOffersEditingAndSavingTheTopLevelTask()
     {
         var document = Document();
         ((JsonArray)document["processes"]![0]!["elements"]!).Add(new JsonObject { ["elementId"] = "Fulfil", ["elementType"] = "subProcess" });
-        UseDocument(document);
+        var service = new FakeBpmnDocumentService().ReturnsDocument(document, "\"REVISION-1\"").AcceptsPut("\"REVISION-2\"");
+        UseService(service);
 
         var cut = RenderPanel(TaskSelection);
 
-        Assert.Contains("Fulfil", cut.Find("[data-testid='bpmn-document-subprocesses']").TextContent);
         Assert.Contains("Write Line (Elsa.WriteLine)", cut.Find("[data-testid='bpmn-bound-activity']").TextContent);
-        Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
-        Assert.Empty(cut.FindComponents<InputsTab>());
+        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
+        Assert.NotEmpty(cut.FindComponents<InputsTab>());
+
+        await EditAndSaveAsync(cut);
+
+        Assert.Single(service.Puts);
     }
 
     [Fact]
-    public void ATaskOutsideTheDocument_SaysItCannotBeEditedHere()
+    public void AnElementInsideASubprocess_IsStillNotEditable_AndNamesTheCoreLimitation()
     {
         var cut = RenderPanel(TaskSelection with { ElementId = "InsideASubprocess" });
 
-        Assert.NotEmpty(cut.FindAll("[data-testid='bpmn-element-not-in-document']"));
+        Assert.Contains("elsa-core#8076", cut.Find("[data-testid='bpmn-element-not-in-document']").TextContent);
         Assert.Empty(cut.FindAll("[data-testid='bpmn-pick-activity']"));
     }
 

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnDocumentSession.cs
@@ -23,11 +23,6 @@ namespace Elsa.Studio.Workflows.DiagramDesigners.Bpmn;
 /// edit was made against. A refusal (<see cref="BpmnDocumentFailureReason.PreconditionFailed"/>) is reported, never
 /// retried: the working copy stays as it is until the user reloads, which discards it.
 /// </para>
-/// <para>
-/// <b>Subprocesses.</b> The document does not carry a subprocess's body, and elsa-core writes the XML from the document
-/// alone, so saving a document that declares a subprocess would empty it. <see cref="SaveAsync"/> refuses such a
-/// document before sending anything; see <see cref="BpmnDefinitionsDocument.FindSubProcessIds"/>.
-/// </para>
 /// </remarks>
 public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeService, string definitionId)
 {
@@ -73,9 +68,6 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
     /// cleared and <see cref="LoadFailure"/> set. Nothing was lost; only the local view of it could not be confirmed.
     /// </summary>
     public bool SavedButReloadFailed { get; private set; }
-
-    /// <summary>The subprocesses the document declares; while there are any, <see cref="SaveAsync"/> refuses.</summary>
-    public IReadOnlyList<string> SubProcessIds { get; private set; } = [];
 
     /// <summary>The elements whose binding the working copy changed since the document was last read or discarded.</summary>
     public IReadOnlyCollection<string> EditedElementIds => _editedElementIds;
@@ -148,13 +140,6 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
 
         if (Document == null || _revision == null)
             return Task.FromResult(Refuse(new(BpmnDocumentFailureReason.Unknown, "The BPMN document has not been read, so there is nothing to save.")));
-
-        if (SubProcessIds.Count > 0)
-        {
-            return Task.FromResult(Refuse(new(
-                BpmnDocumentFailureReason.SubProcessContentNotCarried,
-                $"The BPMN document declares the subprocess(es) {string.Join(", ", SubProcessIds.Select(id => $"'{id}'"))}, whose content the document does not carry, so saving it would empty them.")));
-        }
 
         return _saveTask = SaveCoreAsync(Document, _revision, cancellationToken);
     }
@@ -237,7 +222,6 @@ public sealed class BpmnDocumentSession(IBpmnInterchangeService bpmnInterchangeS
 
         _revision = result.Success;
         Document = (JsonObject?)_revision?.Document.DeepClone();
-        SubProcessIds = _revision == null ? [] : BpmnDefinitionsDocument.FindSubProcessIds(_revision.Document);
         LoadFailure = result.Failure;
         SaveFailure = null;
         SavedButReloadFailed = false;

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
@@ -68,7 +68,14 @@
                 {
                     @if (_element == null)
                     {
-                        <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-not-in-document">@Localizer["'{0}' is inside a subprocess, whose content Studio cannot see, so its binding cannot be edited here — a server limitation tracked in elsa-workflows/elsa-core#8076.", ElementLabel]</MudAlert>
+                        @if (ElementIsInSubprocess)
+                        {
+                            <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-not-in-document">@Localizer["'{0}' is inside a subprocess, whose content Studio cannot see, so its binding cannot be edited here — a server limitation tracked in elsa-workflows/elsa-core#8076.", ElementLabel]</MudAlert>
+                        }
+                        else
+                        {
+                            <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-missing">@Localizer["'{0}' is not in the BPMN document Studio loaded. Reload the document; if it persists, re-import the BPMN file.", ElementLabel]</MudAlert>
+                        }
                     }
                     else
                     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor
@@ -17,11 +17,6 @@
                 <MudAlert Severity="Severity.Warning" data-testid="bpmn-document-load-failure">@DescribeLoadFailure(loadFailure)</MudAlert>
             }
 
-            @if (Session.SubProcessIds.Count > 0)
-            {
-                <MudAlert Severity="Severity.Info" data-testid="bpmn-document-subprocesses">@Localizer["This process contains subprocesses ({0}). Studio cannot yet save its BPMN document without emptying them, so its bindings are shown here but cannot be saved.", string.Join(", ", Session.SubProcessIds)]</MudAlert>
-            }
-
             @if (Session.SaveFailure is { } saveFailure)
             {
                 <MudAlert Severity="Severity.Error" data-testid="bpmn-document-save-failure">@DescribeSaveFailure(saveFailure)</MudAlert>
@@ -40,7 +35,7 @@
                     <MudText Typo="Typo.body2">@Localizer["Unsaved binding changes"]</MudText>
                     <MudSpacer />
                     <MudButton Variant="Variant.Text" Size="Size.Small" Disabled="_isSaving" OnClick="OnDiscardClicked" data-testid="bpmn-discard">@Localizer["Discard"]</MudButton>
-                    <MudButton Variant="Variant.Filled" Size="Size.Small" Color="Color.Primary" Disabled="@(_isSaving || Session.SubProcessIds.Count > 0)" OnClick="OnSaveClicked" data-testid="bpmn-save">@Localizer["Save"]</MudButton>
+                    <MudButton Variant="Variant.Filled" Size="Size.Small" Color="Color.Primary" Disabled="_isSaving" OnClick="OnSaveClicked" data-testid="bpmn-save">@Localizer["Save"]</MudButton>
                 </MudStack>
             }
 
@@ -73,7 +68,7 @@
                 {
                     @if (_element == null)
                     {
-                        <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-not-in-document">@Localizer["'{0}' is not part of this workflow's BPMN document, so its binding cannot be edited here.", ElementLabel]</MudAlert>
+                        <MudAlert Severity="Severity.Warning" data-testid="bpmn-element-not-in-document">@Localizer["'{0}' is inside a subprocess, whose content Studio cannot see, so its binding cannot be edited here — a server limitation tracked in elsa-workflows/elsa-core#8076.", ElementLabel]</MudAlert>
                     }
                     else
                     {

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
@@ -76,6 +76,17 @@ public partial class BpmnPerformedByPanel : IDisposable
     private bool CanEdit => Session.Document != null;
 
     /// <summary>
+    /// Whether the selected element's absence from the document (<see cref="_element"/> is <see langword="null"/>) is
+    /// explained by it living in a nested scope — a subprocess, transaction, or event subprocess — whose body the
+    /// document never carries (elsa-workflows/elsa-core#8076), rather than some other mismatch between the canvas and
+    /// the document (a stale or unknown element id).
+    /// </summary>
+    private bool ElementIsInSubprocess =>
+        Selection != null
+        && Session.Document != null
+        && !BpmnDefinitionsDocument.HasTopLevelProcess(Session.Document, Selection.ScopeId);
+
+    /// <summary>
     /// Leaf work: an activity that performs one unit of work itself. A container or a composite schedules other
     /// activities, which a single BPMN task cannot hold.
     /// </summary>

--- a/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
+++ b/src/modules/Elsa.Studio.Workflows/DiagramDesigners/Bpmn/BpmnPerformedByPanel.razor.cs
@@ -73,7 +73,7 @@ public partial class BpmnPerformedByPanel : IDisposable
     private string? BoundActivityName => _draft != null ? DescribeDescriptor(_draft.Descriptor) : _binding?.ActivityType;
 
     /// <summary>Whether a binding edit could be saved at all; while it could not, none is offered.</summary>
-    private bool CanEdit => Session.Document != null && Session.SubProcessIds.Count == 0;
+    private bool CanEdit => Session.Document != null;
 
     /// <summary>
     /// Leaf work: an activity that performs one unit of work itself. A container or a composite schedules other
@@ -282,7 +282,6 @@ public partial class BpmnPerformedByPanel : IDisposable
         BpmnDocumentFailureReason.PreconditionRequired => Localizer["The server refused the save because it did not name the revision it replaces, so nothing was saved. Reload and make the change again."],
         BpmnDocumentFailureReason.BindingInvalid => Localizer["The server refused the binding of {0}, so nothing was saved: {1}", string.Join(", ", Session.EditedElementIds.Select(id => $"'{id}'")), failure.Message],
         BpmnDocumentFailureReason.CapabilityUnsupported => Localizer["The server cannot run this process, so nothing was saved: {0}", failure.Message],
-        BpmnDocumentFailureReason.SubProcessContentNotCarried => Localizer["Nothing was saved: this process contains subprocesses, and saving its BPMN document from Studio would empty them."],
         BpmnDocumentFailureReason.NotFound => Localizer["This workflow definition no longer exists."],
         _ => Localizer["The binding changes could not be saved: {0}", failure.Message]
     };


### PR DESCRIPTION
Closes #1032. Part of elsa-workflows/elsa-core#7909.

## Why

#1031 refused to save a BPMN document that declared a subprocess, transaction or event subprocess. The core document PUT used to write those bodies empty. elsa-workflows/elsa-core#8077 fixed that: the PUT now restores each kept subprocess's stored body, with every binding inside it, by element id. The contract is unchanged.

## What changed

- Removed the save refusal: `BpmnDocumentFailureReason.SubProcessContentNotCarried`, the `SubProcessIds` check in `BpmnDocumentSession.SaveAsync`, and the panel's `CanEdit` / Save-button gating and info alert. Top-level tasks in a process with subprocesses are now editable and saveable.
- Removed `BpmnDefinitionsDocument.FindSubProcessIds` and `SubProcessElementType`, which were dead code after the above.
- An element *inside* a subprocess is still not editable, because its body is not in the document. The message now names the server limitation (elsa-workflows/elsa-core#8076) instead of implying a Studio one.
- The single-flight save and saving state from #1031 are untouched.

## Compatibility

The document endpoints exist only in elsa-core 3.8 preview builds. Preview builds made between elsa-core #8060 and #8077 serve them without the fix, and saving from Studio against those builds would still empty subprocesses. No stable release is affected.

## Tests

- Session: `SaveAsync` on a document with a subprocess sends the PUT.
- bUnit: in a document with a subprocess, a top-level task shows its editors and Save sends the PUT.
- bUnit: an element inside a subprocess is still not editable, and the message names the core limitation.
- Full `Elsa.Studio.Workflows.Tests` run: 445/445.
- A test-host crash in `WorkflowInstanceDesignerDisconnectRefreshTests` (from #992) appeared once under heavy machine load. It did not reproduce in 2 runs on this branch or 2 runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
