### PR TITLE
chore: bump Elsa.Api.Client to 3.8.1

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -76,7 +76,7 @@ jobs:
           PUBLISH: ${{ github.event.inputs.publish }}
         run: |
           set -euo pipefail
-          version_re='^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$'
+          version_re='^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'
 
           if [[ "${PUBLISH:-}" == "true" ]]; then
             if [[ -z "${VERSION:-}" || ! "$VERSION" =~ $version_re ]]; then

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa.Api.Client" Version="3.8.0" />
+    <PackageVersion Include="Elsa.Api.Client" Version="3.8.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Bump the central `Elsa.Api.Client` pin from 3.8.0 to 3.8.1 so Studio Packages can republish against nuget.org Elsa core 3.8.1. Also tighten the Packages workflow version override regex so extra-dot values like `3.8.1.foo` are rejected before npm pack.

---

## Scope

Select one primary concern:

- [x] Dependency / build update

---

## Description

### Problem

Elsa core 3.8.1 is on nuget.org. Studio still targets `Elsa.Api.Client` 3.8.0 via Central Package Management. Separately, `packages.yml` Set VERSION accepted `3.8.1.foo` (`[.-]` after patch), which npm pack then rejects once publish is enabled.

### Solution

1. One-line bump in `Directory.Packages.props`. That is the only Elsa.* NuGet version pin in this repo (`Elsa.Studio.Core` references `Elsa.Api.Client` without a local version).
2. Tighten `version_re` to `^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$` so `3.8.1` and `3.8.0-preview.1` pass, `3.8.1.foo` fails.

No other Elsa.* PackageReferences, no npm version changes, no publish/retag.

**Changed**
- `Directory.Packages.props`: `Elsa.Api.Client` `3.8.0` → `3.8.1`
- `.github/workflows/packages.yml`: `version_re` now hyphen-led prerelease only

---

## Verification

Steps:
1. `dotnet restore Elsa.Studio.sln` — succeeded (66 projects)
2. Restore graph shows `Elsa.Api.Client/3.8.1` from nuget.org
3. `dotnet build src/framework/Elsa.Studio.Core/Elsa.Studio.Core.csproj -c Release -f net9.0` — succeeded
4. Regex check: `3.8.1` and `3.8.0-preview.1` pass; `3.8.1.foo` fails

Expected outcome: restore and the consuming project build succeed against 3.8.1; invalid extra-dot overrides are rejected.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] No unrelated cleanup included
- [x] Restore verified

This PR does not retag or publish Studio packages.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff7c6cba-2c55-5504-9633-6fe946d7018c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff7c6cba-2c55-5504-9633-6fe946d7018c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

