### PR TITLE
fix(workflows): authenticate the BPMN API client

### DIFF
--- a/samples/BlazorApp1/Program.cs
+++ b/samples/BlazorApp1/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddCore();
 builder.Services.AddShell();
 builder.Services.AddRemoteBackend(backendApiConfig);
 builder.Services.Replace(ServiceDescriptor.Scoped<IRemoteBackendAccessor, ComponentRemoteBackendAccessor>());
-builder.Services.AddWorkflowsModule();
+builder.Services.AddWorkflowsModule(backendApiConfig);
 
 var app = builder.Build();
 

--- a/src/hosts/Elsa.Studio.Host.CustomElements/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.CustomElements/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddShell();
 builder.Services.AddRemoteBackend(backendApiConfig);
 builder.Services.Replace(ServiceDescriptor.Scoped<IRemoteBackendAccessor, ComponentRemoteBackendAccessor>());
 builder.Services.AddScoped<IHttpConnectionOptionsConfigurator, BackendServiceHttpConnectionOptionsConfigurator>();
-builder.Services.AddWorkflowsModule();
+builder.Services.AddWorkflowsModule(backendApiConfig);
 builder.Services.AddSecretsModule(backendApiConfig);
 builder.Services.AddUserTasksModule(backendApiConfig);
 builder.Services.AddLocalizationModule(localizationConfig);

--- a/src/hosts/Elsa.Studio.Host.Server/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Server/Program.cs
@@ -163,7 +163,7 @@ builder.Services.AddExternalAuthenticationModule(backendApiConfig);
 
 builder.Services.AddDashboardModule(backendApiConfig);
 builder.Services.AddWeaverModule(backendApiConfig);
-builder.Services.AddWorkflowsModule();
+builder.Services.AddWorkflowsModule(backendApiConfig);
 builder.Services.AddWorkflowsDashboardModule();
 builder.Services.AddAlterationsModule();
 builder.Services.AddOpenTelemetryDiagnosticsModule(backendApiConfig);

--- a/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
+++ b/src/hosts/Elsa.Studio.Host.Wasm/Program.cs
@@ -131,7 +131,7 @@ services.AddExternalAuthenticationModule(backendApiConfig);
 
 services.AddDashboardModule(backendApiConfig);
 services.AddWeaverModule(backendApiConfig);
-services.AddWorkflowsModule();
+services.AddWorkflowsModule(backendApiConfig);
 services.AddWorkflowsDashboardModule();
 services.AddAlterationsModule();
 services.AddOpenTelemetryDiagnosticsModule(backendApiConfig);

--- a/src/modules/Elsa.Studio.Dashboard/README.md
+++ b/src/modules/Elsa.Studio.Dashboard/README.md
@@ -65,7 +65,7 @@ Install the dashboard shell and the companion modules you want:
 
 ```csharp
 services.AddDashboardModule(backendApiConfig);
-services.AddWorkflowsModule();
+services.AddWorkflowsModule(backendApiConfig);
 services.AddWorkflowsDashboardModule();
 services.AddConsoleLogsModule(backendApiConfig);
 services.AddConsoleLogsDashboardModule();

--- a/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Elsa.Studio.Contracts;
 using Elsa.Studio.Extensions;
 using Elsa.Studio.Services;
-using Elsa.Studio.Workflows.Client;
 using Elsa.Studio.Workflows.Domain.Contracts;
 using Elsa.Studio.Workflows.Domain.Providers;
 using Elsa.Studio.Workflows.Domain.Services;
@@ -54,7 +53,6 @@ public static class ServiceCollectionExtensions
             .AddScoped<IActivityResolver, DefaultActivityResolver>()
             .AddScoped<IWorkflowJsonDetector, CompatWorkflowJsonDetector>()
             .AddScoped<IBpmnInterchangeService, RemoteBpmnInterchangeService>()
-            .AddRemoteApi<IBpmnInterchangeApi>()
             ;
 
         services.AddActivityDisplaySettingsProvider<DefaultActivityDisplaySettingsProvider>();

--- a/src/modules/Elsa.Studio.Workflows.Tests/WorkflowsModuleAuthenticationTests.cs
+++ b/src/modules/Elsa.Studio.Workflows.Tests/WorkflowsModuleAuthenticationTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Elsa.Studio.Contracts;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+using Elsa.Studio.Workflows.Client;
+using Elsa.Studio.Workflows.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Elsa.Studio.Workflows.Tests;
+
+/// <summary>
+/// Regression coverage for elsa-workflows/elsa-studio#1034: <c>AddWorkflowsModule()</c> registered
+/// <see cref="IBpmnInterchangeApi"/>'s Refit client without a <see cref="BackendApiConfig"/>, so it never picked up
+/// the host's <c>AuthenticationHandler</c> and every BPMN call came back 401 even though the rest of the session was
+/// authenticated. The existing tests around <see cref="Domain.Services.RemoteBpmnInterchangeService"/> fake
+/// <see cref="IBackendApiClientProvider"/> directly, so they never exercised the real HTTP pipeline this bug lived
+/// in; this test wires the module the same way a host does and inspects what the pipeline actually sends.
+/// </summary>
+public class WorkflowsModuleAuthenticationTests : IDisposable
+{
+    private readonly RecordingHandler _primaryHandler = new();
+    private readonly ServiceProvider _serviceProvider;
+
+    public WorkflowsModuleAuthenticationTests()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCoreInternal();
+
+        var backendApiConfig = new BackendApiConfig
+        {
+            ConfigureBackendOptions = options => options.Url = new Uri("https://backend.example"),
+            ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(StampingAuthenticationHandler)
+        };
+
+        services.AddRemoteBackend(backendApiConfig);
+        services.AddWorkflowsModule(backendApiConfig);
+
+        // Swap in a stub transport so the assertion can see what actually went out, without a real server.
+        services.AddHttpClient(nameof(IBpmnInterchangeApi)).ConfigurePrimaryHttpMessageHandler(() => _primaryHandler);
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    [Fact]
+    public async Task BpmnInterchangeApi_CarriesTheHostsConfiguredAuthenticationHandler()
+    {
+        var provider = _serviceProvider.GetRequiredService<IBackendApiClientProvider>();
+        var api = await provider.GetApiAsync<IBpmnInterchangeApi>();
+
+        await api.ExportAsync("wf-1");
+
+        Assert.NotNull(_primaryHandler.LastRequest);
+        Assert.Equal("stamped", _primaryHandler.LastRequest!.Headers.GetValues(StampingAuthenticationHandler.HeaderName).Single());
+    }
+
+    /// <summary>
+    /// Stands in for a host's real authentication handler (e.g. <c>AuthenticatingApiHttpMessageHandler</c>): it stamps
+    /// every outgoing request, so its absence from the pipeline is observable.
+    /// </summary>
+    private sealed class StampingAuthenticationHandler : DelegatingHandler
+    {
+        public const string HeaderName = "X-Test-Authenticated";
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Add(HeaderName, "stamped");
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") });
+        }
+    }
+}

--- a/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,10 @@ using Elsa.Studio.ActivityPortProviders.Extensions;
 using Elsa.Studio.Contracts;
 using Elsa.Studio.DomInterop.Extensions;
 using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
 using Elsa.Studio.UIHints.Extensions;
 using Elsa.Studio.Workflows.ActivityPickers.Accordion;
+using Elsa.Studio.Workflows.Client;
 using Elsa.Studio.Workflows.Components.WorkflowDefinitionEditor.Components.Models;
 using Elsa.Studio.Workflows.Components.WorkflowInstanceList.Models;
 using Elsa.Studio.Workflows.Contracts;
@@ -74,5 +76,15 @@ public static class ServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds the workflows module with remote backend BPMN interchange API support.
+    /// </summary>
+    public static IServiceCollection AddWorkflowsModule(this IServiceCollection services, BackendApiConfig backendApiConfig)
+    {
+        return services
+            .AddWorkflowsModule()
+            .AddRemoteApi<IBpmnInterchangeApi>(backendApiConfig);
     }
 }


### PR DESCRIPTION
Closes #1034. Part of elsa-workflows/elsa-core#7909.

## Problem

In a live run (Elsa.Server.Web plus Elsa.Studio.Host.Server, signed in as admin), every BPMN call from Studio returned **401**, while the other clients on the same session got 200:

```
System.Net.Http.HttpClient.IWorkflowDefinitionsApi.ClientHandler  Received HTTP response headers - 200
System.Net.Http.HttpClient.IBpmnInterchangeApi.ClientHandler     Received HTTP response headers - 401
```

`AddWorkflowsCore` registered the local Refit client as `.AddRemoteApi<IBpmnInterchangeApi>()` without a `BackendApiConfig`, so the client never got the host's `AuthenticationHandler`. Import BPMN, Export BPMN and the Performed-by panel were all unusable against an authenticated server. The bug came in with #1012. The unit tests missed it because they fake `IBackendApiClientProvider`.

## Fix

This follows the `AddDashboardModule` / `AddDashboardModule(BackendApiConfig)` pattern:

- A new overload, `AddWorkflowsModule(BackendApiConfig backendApiConfig)`, registers the module and then `AddRemoteApi<IBpmnInterchangeApi>(backendApiConfig)`.
- The config-less registration is removed from `AddWorkflowsCore`. `Microsoft.Extensions.Http` registrations for the same client name add up rather than replace each other, so keeping it would have left two competing pipelines.
- Every host now passes the `backendApiConfig` it already builds: `Host.Server`, `Host.Wasm`, `Host.CustomElements` and `samples/BlazorApp1`. `Host.HostedWasm` does not call the module. The snippet in the Dashboard README is updated, since it is the only doc that shows the call.

**Compatibility note:** a third-party host that keeps calling the parameterless `AddWorkflowsModule()` still gets an unauthenticated BPMN client. That is the same behaviour as the parameterless `AddDashboardModule()` today. Such hosts should switch to the config overload, as every host in this repo now does.

## Tests

- `WorkflowsModuleAuthenticationTests` builds the container the way a real host does (`AddRemoteBackend` plus `AddWorkflowsModule(backendApiConfig)`) and swaps only the primary `HttpMessageHandler`. It then calls the real registered client and asserts that the header stamped by the configured authentication handler is present.
- **Mutation:** reverting to the config-less registration turns it red ("The given header was not found").
- `Elsa.Studio.Workflows.Tests`: 447/447. The full solution builds on all TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
